### PR TITLE
THU-8 Tool Calling UX Experiments

### DIFF
--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -1,8 +1,10 @@
 import { UIMessage } from 'ai'
+import { useState } from 'react'
 import { ReasoningPart } from './reasoning-part'
 import { SyntheticLoadingPart } from './synthetic-loading-part'
 import { TextPart } from './text-part'
 import { ToolInvocationPart } from './tool-invocation-part'
+import { ToolsSummaryPart } from './tools-summary-part'
 import { StackedExpandables } from '../ui/stacked-expandables'
 
 interface AssistantMessageProps {
@@ -17,13 +19,18 @@ const supportedPartTypes = ['reasoning', 'tool-invocation', 'text']
 
 export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps) => {
   const filteredParts = message.parts.filter((part) => supportedPartTypes.includes(part.type))
+  const [toolsStartTime] = useState(() => Date.now())
 
-  const partGroups: { expandables: React.ReactElement[]; others: React.ReactElement[] }[] = []
-  let currentGroup: { expandables: React.ReactElement[]; others: React.ReactElement[] } = { expandables: [], others: [] }
+  const partGroups: { expandables: React.ReactElement[]; others: React.ReactElement[]; hasTools: boolean }[] = []
+  let currentGroup: { expandables: React.ReactElement[]; others: React.ReactElement[]; hasTools: boolean } = { expandables: [], others: [], hasTools: false }
 
   if (filteredParts.length === 0) {
     currentGroup.others.push(<SyntheticLoadingPart isStreaming={true} />)
   }
+
+  // Track tool indices for each group
+  const toolIndicesByGroup: number[][] = []
+  let currentToolIndices: number[] = []
 
   filteredParts.forEach((part, index) => {
     const isLastPart = index === filteredParts.length - 1
@@ -37,13 +44,20 @@ export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps
           : <ToolInvocationPart key={`${part.type}-${index}`} part={part} isStreaming={isPartStreaming} />
         
         currentGroup.expandables.push(element)
+        
+        if (part.type === 'tool-invocation') {
+          currentGroup.hasTools = true
+          currentToolIndices.push(index)
+        }
         break
       }
       case 'text': {
         // If we have expandables, save current group and start a new one
         if (currentGroup.expandables.length > 0) {
           partGroups.push(currentGroup)
-          currentGroup = { expandables: [], others: [] }
+          toolIndicesByGroup.push(currentToolIndices)
+          currentGroup = { expandables: [], others: [], hasTools: false }
+          currentToolIndices = []
         }
         currentGroup.others.push(<TextPart key={`${part.type}-${index}`} part={part} isStreaming={isPartStreaming} />)
         break
@@ -54,24 +68,71 @@ export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps
   // Add the last group if it has content
   if (currentGroup.expandables.length > 0 || currentGroup.others.length > 0) {
     partGroups.push(currentGroup)
+    toolIndicesByGroup.push(currentToolIndices)
   }
+
+  // Check if all tools in all groups are completed
+  const allToolsCompleted = filteredParts.every((part) => {
+    if (part.type === 'tool-invocation') {
+      const toolInvocation = (part as any).toolInvocation
+      return 'result' in toolInvocation || 'error' in toolInvocation
+    }
+    return true
+  })
+
+  // Count total tools
+  const totalToolCount = filteredParts.filter(part => part.type === 'tool-invocation').length
+  
+  // Find the last tool index
+  let lastToolIndex = -1
+  filteredParts.forEach((part, index) => {
+    if (part.type === 'tool-invocation') {
+      lastToolIndex = index
+    }
+  })
+  
+  // Check if we've streamed past all tools
+  const currentStreamingIndex = filteredParts.length - 1
+  const pastAllTools = lastToolIndex === -1 || currentStreamingIndex > lastToolIndex
 
   return (
     <div>
-      {partGroups.map((group, groupIndex) => (
-        <div key={groupIndex}>
-          {group.expandables.length > 0 && (
-            <StackedExpandables className={groupIndex === 0 ? animationClasses : ''}>
-              {group.expandables}
-            </StackedExpandables>
-          )}
-          {group.others.map((element, index) => (
-            <div key={`other-${groupIndex}-${index}`} className={groupIndex === 0 && index === 0 ? animationClasses : ''}>
-              {element}
-            </div>
-          ))}
-        </div>
-      ))}
+      {partGroups.map((group, groupIndex) => {
+        // Check if this is the last group with tools
+        const isLastToolGroup = group.hasTools && 
+          partGroups.slice(groupIndex + 1).every(g => !g.hasTools)
+        
+        // Show summary if:
+        // 1. This is the last group with tools
+        // 2. All tools are completed (have results)
+        // 3. We've streamed past all tool invocations
+        const shouldShowSummary = isLastToolGroup && allToolsCompleted && totalToolCount > 0 && pastAllTools
+        
+        return (
+          <div key={groupIndex}>
+            {group.expandables.length > 0 && (
+              <StackedExpandables className={groupIndex === 0 ? animationClasses : ''}>
+                {[
+                  ...group.expandables,
+                  // Add tools summary only to the last group with tools, when all tools are done
+                  ...(shouldShowSummary
+                    ? [<ToolsSummaryPart 
+                        key="tools-summary"
+                        toolCount={totalToolCount}
+                        duration={Date.now() - toolsStartTime}
+                      />]
+                    : [])
+                ]}
+              </StackedExpandables>
+            )}
+            {group.others.map((element, index) => (
+              <div key={`other-${groupIndex}-${index}`} className={groupIndex === 0 && index === 0 ? animationClasses : ''}>
+                {element}
+              </div>
+            ))}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -21,6 +21,7 @@ export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps
   const filteredParts = message.parts.filter((part) => supportedPartTypes.includes(part.type))
   const [toolsStartTime] = useState(() => Date.now())
   const toolsEndTimeRef = useRef<number | null>(null)
+  const toolTimingsRef = useRef<Map<number, { name: string; args: any; startTime: number; endTime?: number }>>(new Map())
 
   const partGroups: { expandables: React.ReactElement[]; others: React.ReactElement[]; hasTools: boolean }[] = []
   let currentGroup: { expandables: React.ReactElement[]; others: React.ReactElement[]; hasTools: boolean } = { expandables: [], others: [], hasTools: false }
@@ -96,6 +97,30 @@ export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps
   const currentStreamingIndex = filteredParts.length - 1
   const pastAllTools = lastToolIndex === -1 || currentStreamingIndex > lastToolIndex
   
+  // Track individual tool timings
+  useEffect(() => {
+    filteredParts.forEach((part, index) => {
+      if (part.type === 'tool-invocation') {
+        const toolInvocation = (part as any).toolInvocation
+        const timing = toolTimingsRef.current.get(index)
+        
+        // Record start time when tool appears
+        if (!timing) {
+          toolTimingsRef.current.set(index, {
+            name: toolInvocation.toolName,
+            args: toolInvocation.args,
+            startTime: Date.now()
+          })
+        }
+        
+        // Record end time when tool completes
+        if (timing && !timing.endTime && ('result' in toolInvocation || 'error' in toolInvocation)) {
+          timing.endTime = Date.now()
+        }
+      }
+    })
+  }, [filteredParts])
+  
   // Capture the end time when all tools are completed and we've moved past them
   useEffect(() => {
     if (allToolsCompleted && pastAllTools && totalToolCount > 0 && !toolsEndTimeRef.current) {
@@ -128,6 +153,14 @@ export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps
                         key="tools-summary"
                         toolCount={totalToolCount}
                         duration={(toolsEndTimeRef.current || Date.now()) - toolsStartTime}
+                        tools={Array.from(toolTimingsRef.current.entries())
+                          .map(([_, timing]) => ({
+                            name: timing.name,
+                            args: timing.args,
+                            startTime: timing.startTime,
+                            endTime: timing.endTime || Date.now()
+                          }))
+                          .sort((a, b) => a.startTime - b.startTime)}
                       />]
                     : [])
                 ]}

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -3,6 +3,7 @@ import { ReasoningPart } from './reasoning-part'
 import { SyntheticLoadingPart } from './synthetic-loading-part'
 import { TextPart } from './text-part'
 import { ToolInvocationPart } from './tool-invocation-part'
+import { StackedExpandables } from '../ui/stacked-expandables'
 
 interface AssistantMessageProps {
   message: UIMessage
@@ -17,10 +18,11 @@ const supportedPartTypes = ['reasoning', 'tool-invocation', 'text']
 export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps) => {
   const filteredParts = message.parts.filter((part) => supportedPartTypes.includes(part.type))
 
-  const partElements = []
+  const partGroups: { expandables: React.ReactElement[]; others: React.ReactElement[] }[] = []
+  let currentGroup: { expandables: React.ReactElement[]; others: React.ReactElement[] } = { expandables: [], others: [] }
 
   if (filteredParts.length === 0) {
-    partElements.push(<SyntheticLoadingPart isStreaming={true} />)
+    currentGroup.others.push(<SyntheticLoadingPart isStreaming={true} />)
   }
 
   filteredParts.forEach((part, index) => {
@@ -29,22 +31,45 @@ export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps
 
     switch (part.type) {
       case 'reasoning':
-        partElements.push(<ReasoningPart part={part} isStreaming={isPartStreaming} />)
+      case 'tool-invocation': {
+        const element = part.type === 'reasoning' 
+          ? <ReasoningPart key={`${part.type}-${index}`} part={part} isStreaming={isPartStreaming} />
+          : <ToolInvocationPart key={`${part.type}-${index}`} part={part} isStreaming={isPartStreaming} />
+        
+        currentGroup.expandables.push(element)
         break
-      case 'tool-invocation':
-        partElements.push(<ToolInvocationPart part={part} isStreaming={isPartStreaming} />)
+      }
+      case 'text': {
+        // If we have expandables, save current group and start a new one
+        if (currentGroup.expandables.length > 0) {
+          partGroups.push(currentGroup)
+          currentGroup = { expandables: [], others: [] }
+        }
+        currentGroup.others.push(<TextPart key={`${part.type}-${index}`} part={part} isStreaming={isPartStreaming} />)
         break
-      case 'text':
-        partElements.push(<TextPart part={part} isStreaming={isPartStreaming} />)
-        break
+      }
     }
   })
 
+  // Add the last group if it has content
+  if (currentGroup.expandables.length > 0 || currentGroup.others.length > 0) {
+    partGroups.push(currentGroup)
+  }
+
   return (
     <div>
-      {partElements.map((part, index) => (
-        <div key={index} className={index === 1 ? '' : animationClasses}>
-          {part}
+      {partGroups.map((group, groupIndex) => (
+        <div key={groupIndex}>
+          {group.expandables.length > 0 && (
+            <StackedExpandables className={groupIndex === 0 ? animationClasses : ''}>
+              {group.expandables}
+            </StackedExpandables>
+          )}
+          {group.others.map((element, index) => (
+            <div key={`other-${groupIndex}-${index}`} className={groupIndex === 0 && index === 0 ? animationClasses : ''}>
+              {element}
+            </div>
+          ))}
         </div>
       ))}
     </div>

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -1,5 +1,5 @@
 import { UIMessage } from 'ai'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ReasoningPart } from './reasoning-part'
 import { SyntheticLoadingPart } from './synthetic-loading-part'
 import { TextPart } from './text-part'
@@ -20,6 +20,7 @@ const supportedPartTypes = ['reasoning', 'tool-invocation', 'text']
 export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps) => {
   const filteredParts = message.parts.filter((part) => supportedPartTypes.includes(part.type))
   const [toolsStartTime] = useState(() => Date.now())
+  const toolsEndTimeRef = useRef<number | null>(null)
 
   const partGroups: { expandables: React.ReactElement[]; others: React.ReactElement[]; hasTools: boolean }[] = []
   let currentGroup: { expandables: React.ReactElement[]; others: React.ReactElement[]; hasTools: boolean } = { expandables: [], others: [], hasTools: false }
@@ -94,6 +95,13 @@ export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps
   // Check if we've streamed past all tools
   const currentStreamingIndex = filteredParts.length - 1
   const pastAllTools = lastToolIndex === -1 || currentStreamingIndex > lastToolIndex
+  
+  // Capture the end time when all tools are completed and we've moved past them
+  useEffect(() => {
+    if (allToolsCompleted && pastAllTools && totalToolCount > 0 && !toolsEndTimeRef.current) {
+      toolsEndTimeRef.current = Date.now()
+    }
+  }, [allToolsCompleted, pastAllTools, totalToolCount])
 
   return (
     <div>
@@ -119,7 +127,7 @@ export const AssistantMessage = ({ message, isStreaming }: AssistantMessageProps
                     ? [<ToolsSummaryPart 
                         key="tools-summary"
                         toolCount={totalToolCount}
-                        duration={Date.now() - toolsStartTime}
+                        duration={(toolsEndTimeRef.current || Date.now()) - toolsStartTime}
                       />]
                     : [])
                 ]}

--- a/src/components/chat/tool-invocation-part.tsx
+++ b/src/components/chat/tool-invocation-part.tsx
@@ -1,7 +1,7 @@
 import { getToolMetadata, getToolMetadataSync } from '@/lib/tool-metadata'
 import { useQuery } from '@tanstack/react-query'
 import type { ToolInvocationUIPart } from 'ai'
-import { Check, Loader2, X } from 'lucide-react'
+import { Loader2, X } from 'lucide-react'
 import { Expandable } from '../ui/expandable'
 import { ChatMessagePreview } from './message-preview'
 
@@ -15,9 +15,8 @@ function getToolIcon(status: 'running' | 'complete' | 'error') {
 
   switch (status) {
     case 'running':
-      return <Loader2 className={`${baseClass} animate-spin text-blue-600 dark:text-blue-400`} />
     case 'complete':
-      return <Check className={`${baseClass} text-green-600 dark:text-green-400`} />
+      return <Loader2 className={`${baseClass} animate-spin text-blue-600 dark:text-blue-400`} />
     case 'error':
       return <X className={`${baseClass} text-red-600 dark:text-red-400`} />
     default:

--- a/src/components/chat/tools-summary-part.tsx
+++ b/src/components/chat/tools-summary-part.tsx
@@ -1,9 +1,18 @@
+import { getToolMetadataSync } from '@/lib/tool-metadata'
 import { Clock, Zap } from 'lucide-react'
 import { Expandable } from '../ui/expandable'
+
+export type ToolInfo = {
+  name: string
+  args?: any
+  startTime: number
+  endTime: number
+}
 
 export type ToolsSummaryPartProps = {
   toolCount: number
   duration: number // in milliseconds
+  tools?: ToolInfo[]
 }
 
 const formatDuration = (ms: number): string => {
@@ -14,7 +23,7 @@ const formatDuration = (ms: number): string => {
   return `${seconds.toFixed(1)}s`
 }
 
-export const ToolsSummaryPart = ({ toolCount, duration }: ToolsSummaryPartProps) => {
+export const ToolsSummaryPart = ({ toolCount, duration, tools = [] }: ToolsSummaryPartProps) => {
   const icon = <Zap className="h-4 w-4 text-green-600 dark:text-green-400" />
   
   const title = (
@@ -30,15 +39,44 @@ export const ToolsSummaryPart = ({ toolCount, duration }: ToolsSummaryPartProps)
       defaultOpen={false}
       title={title}
     >
-      <div className="space-y-2 text-sm text-muted-foreground">
-        <div className="flex items-center gap-2">
-          <Clock className="h-3 w-3" />
-          <span>Total execution time: {formatDuration(duration)}</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <Zap className="h-3 w-3" />
-          <span>{toolCount} tool invocation{toolCount !== 1 ? 's' : ''} completed</span>
-        </div>
+      <div className="space-y-3">
+        {tools.length > 0 ? (
+          <div className="relative">
+            {tools.map((tool, index) => {
+              const toolDuration = tool.endTime - tool.startTime
+              const metadata = getToolMetadataSync(tool.name, tool.args)
+              const displayName = metadata?.displayName || tool.name
+              
+              return (
+                <div key={index} className="relative flex items-start gap-3 text-sm mb-6 last:mb-0">
+                  <div className="relative flex flex-col items-center">
+                    <div className="h-2 w-2 rounded-full bg-blue-600 dark:bg-blue-400 flex-shrink-0 mt-1 z-10 bg-background" />
+                    {index < tools.length - 1 && (
+                      <div className="w-px bg-border absolute top-3 h-8" />
+                    )}
+                  </div>
+                  <div className="flex-1 pt-0.5">
+                    <div className="font-medium text-foreground">{displayName}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {formatDuration(toolDuration)}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Clock className="h-3 w-3" />
+              <span>Total execution time: {formatDuration(duration)}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Zap className="h-3 w-3" />
+              <span>{toolCount} tool invocation{toolCount !== 1 ? 's' : ''} completed</span>
+            </div>
+          </div>
+        )}
       </div>
     </Expandable>
   )

--- a/src/components/chat/tools-summary-part.tsx
+++ b/src/components/chat/tools-summary-part.tsx
@@ -1,0 +1,45 @@
+import { Clock, Zap } from 'lucide-react'
+import { Expandable } from '../ui/expandable'
+
+export type ToolsSummaryPartProps = {
+  toolCount: number
+  duration: number // in milliseconds
+}
+
+const formatDuration = (ms: number): string => {
+  const seconds = ms / 1000
+  if (seconds < 1) {
+    return `${Math.round(ms)}ms`
+  }
+  return `${seconds.toFixed(1)}s`
+}
+
+export const ToolsSummaryPart = ({ toolCount, duration }: ToolsSummaryPartProps) => {
+  const icon = <Zap className="h-4 w-4 text-green-600 dark:text-green-400" />
+  
+  const title = (
+    <span className="flex items-center gap-2 text-green-700 dark:text-green-300">
+      <span>Used {toolCount} tool{toolCount !== 1 ? 's' : ''} in {formatDuration(duration)}</span>
+    </span>
+  )
+
+  return (
+    <Expandable
+      className="shadow-none tool-summary-card rounded-lg overflow-hidden transition-colors"
+      icon={icon}
+      defaultOpen={false}
+      title={title}
+    >
+      <div className="space-y-2 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <Clock className="h-3 w-3" />
+          <span>Total execution time: {formatDuration(duration)}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Zap className="h-3 w-3" />
+          <span>{toolCount} tool invocation{toolCount !== 1 ? 's' : ''} completed</span>
+        </div>
+      </div>
+    </Expandable>
+  )
+}

--- a/src/components/ui/stacked-expandables.tsx
+++ b/src/components/ui/stacked-expandables.tsx
@@ -1,0 +1,55 @@
+import { cn } from '@/lib/utils'
+import { AnimatePresence, motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+
+type StackedExpandablesProps = {
+  children: React.ReactNode[]
+  className?: string
+}
+
+/**
+ * Container that manages multiple expandable components in a stack.
+ * Shows the latest expandable on top and animates transitions.
+ */
+export const StackedExpandables = ({ children, className }: StackedExpandablesProps) => {
+  const [activeIndex, setActiveIndex] = useState(children.length - 1)
+
+  useEffect(() => {
+    setActiveIndex(children.length - 1)
+  }, [children.length])
+
+  return (
+    <div className={cn('relative', className)}>
+      <AnimatePresence mode="wait">
+        {children.map((child, index) => {
+          const isActive = index === activeIndex
+          const isBelow = index < activeIndex
+
+          return (
+            <motion.div
+              key={index}
+              initial={{ y: 20, opacity: 0 }}
+              animate={{
+                y: isActive ? 0 : isBelow ? -10 : 20,
+                opacity: isActive ? 1 : 0,
+                scale: isActive ? 1 : 0.98,
+                zIndex: isActive ? 10 : isBelow ? index : 0,
+              }}
+              exit={{ y: -20, opacity: 0 }}
+              transition={{
+                duration: 0.3,
+                ease: [0.4, 0, 0.2, 1], // Custom easing function
+              }}
+              className={cn(
+                'w-full',
+                !isActive && 'pointer-events-none absolute inset-0',
+              )}
+            >
+              {child}
+            </motion.div>
+          )
+        })}
+      </AnimatePresence>
+    </div>
+  )
+}


### PR DESCRIPTION
https://linear.app/mozilla-thunderbolt/issue/THU-8/improve-tool-call-ux-seeking-feedback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Groups reasoning/tool invocations into stacked expandables, tracks tool timings, and shows a summary after completion; adjusts tool invocation status icon.
> 
> - **Chat UI**:
>   - **AssistantMessage (`src/components/chat/assistant-message.tsx`)**: Groups parts into expandables (reasoning/tool-invocation) and others (text) using `StackedExpandables`; tracks per-tool timings and overall duration; shows `ToolsSummaryPart` for the last tool group once all tools complete; retains entry animations.
>   - **ToolsSummaryPart (`src/components/chat/tools-summary-part.tsx`)**: New expandable summarizing tool usage (count, total duration) with per-tool timeline (name via metadata, duration), with fallback summary when no per-tool data.
>   - **ToolInvocationPart (`src/components/chat/tool-invocation-part.tsx`)**: Tweaks status icon logic (running/complete use spinner; error uses X); removes unused `Check` import.
> - **UI**:
>   - **StackedExpandables (`src/components/ui/stacked-expandables.tsx`)**: New container to stack and animate multiple expandables with framer-motion, showing the latest on top.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1882501319e434f55cf46b93537164763386d199. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->