### PR TITLE
Show confirmation dialog before clearing all chats or a single chat

### DIFF
--- a/src/components/DestructiveDialog.tsx
+++ b/src/components/DestructiveDialog.tsx
@@ -1,0 +1,59 @@
+import { forwardRef, useImperativeHandle, useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog' // adjust import to your project
+import { Button } from './ui/button'
+
+export type DestructiveDialogRef = {
+  open: () => void
+  close: () => void
+}
+
+type DestructiveDialogProps = {
+  confirmText: string
+  description: string
+  onCancel?: () => void
+  onConfirm: () => void
+  title: string
+}
+
+export const DestructiveDialog = forwardRef<DestructiveDialogRef, DestructiveDialogProps>(
+  ({ confirmText, description, onCancel, onConfirm, title }, ref) => {
+    const [open, setOpen] = useState(false)
+
+    const handleCancel = () => {
+      setOpen(false)
+      onCancel?.()
+    }
+
+    useImperativeHandle(ref, () => ({
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+    }))
+
+    return (
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{title}</AlertDialogTitle>
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
+            <Button variant="destructive" onClick={onConfirm}>
+              {confirmText}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    )
+  },
+)
+
+DestructiveDialog.displayName = 'DestructiveDialog'

--- a/src/components/delete-all-chats-dialog.tsx
+++ b/src/components/delete-all-chats-dialog.tsx
@@ -36,7 +36,7 @@ export const DeleteAllChatsDialog = forwardRef<DeleteAllChatsDialogRef, DeleteAl
       <AlertDialog open={open} onOpenChange={setOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogTitle>Delete all chats?</AlertDialogTitle>
             <AlertDialogDescription>This will permanently delete all your chats.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/delete-all-chats-dialog.tsx
+++ b/src/components/delete-all-chats-dialog.tsx
@@ -7,7 +7,7 @@ import {
   AlertDialogTitle,
   AlertDialogDescription,
   AlertDialogCancel,
-} from '@/components/ui/alert-dialog' // adjust import to your project
+} from '@/components/ui/alert-dialog'
 import { Button } from './ui/button'
 
 export type DeleteAllChatsDialogRef = {
@@ -37,14 +37,12 @@ export const DeleteAllChatsDialog = forwardRef<DeleteAllChatsDialogRef, DeleteAl
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete all your chats.
-            </AlertDialogDescription>
+            <AlertDialogDescription>This will permanently delete all your chats.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
             <Button variant="destructive" onClick={onConfirm}>
-              Clear all chats
+              Delete All Chats
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/delete-all-chats-dialog.tsx
+++ b/src/components/delete-all-chats-dialog.tsx
@@ -1,0 +1,56 @@
+import { forwardRef, useImperativeHandle, useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog' // adjust import to your project
+import { Button } from './ui/button'
+
+export type DeleteAllChatsDialogRef = {
+  open: () => void
+  close: () => void
+}
+
+type DeleteAllChatsDialogProps = {
+  onConfirm: () => void
+}
+
+export const DeleteAllChatsDialog = forwardRef<DeleteAllChatsDialogRef, DeleteAllChatsDialogProps>(
+  ({ onConfirm }, ref) => {
+    const [open, setOpen] = useState(false)
+
+    const handleCancel = () => {
+      setOpen(false)
+    }
+
+    useImperativeHandle(ref, () => ({
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+    }))
+
+    return (
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete all your chats.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
+            <Button variant="destructive" onClick={onConfirm}>
+              Clear all chats
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    )
+  },
+)
+
+DeleteAllChatsDialog.displayName = 'DeleteAllChatsDialog'

--- a/src/components/delete-chat-dialog.tsx
+++ b/src/components/delete-chat-dialog.tsx
@@ -38,7 +38,7 @@ export const DeleteChatDialog = forwardRef<DeleteChatDialogRef, DeleteChatDialog
       <AlertDialog open={open} onOpenChange={setOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogTitle>Delete this chat?</AlertDialogTitle>
             <AlertDialogDescription>This will permanently delete this chat.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/delete-chat-dialog.tsx
+++ b/src/components/delete-chat-dialog.tsx
@@ -10,21 +10,18 @@ import {
 } from '@/components/ui/alert-dialog' // adjust import to your project
 import { Button } from './ui/button'
 
-export type DestructiveDialogRef = {
+export type DeleteChatDialogRef = {
   open: () => void
   close: () => void
 }
 
-type DestructiveDialogProps = {
-  confirmText: string
-  description: string
+type DeleteChatDialogProps = {
   onCancel?: () => void
   onConfirm: () => void
-  title: string
 }
 
-export const DestructiveDialog = forwardRef<DestructiveDialogRef, DestructiveDialogProps>(
-  ({ confirmText, description, onCancel, onConfirm, title }, ref) => {
+export const DeleteChatDialog = forwardRef<DeleteChatDialogRef, DeleteChatDialogProps>(
+  ({ onCancel, onConfirm }, ref) => {
     const [open, setOpen] = useState(false)
 
     const handleCancel = () => {
@@ -41,13 +38,15 @@ export const DestructiveDialog = forwardRef<DestructiveDialogRef, DestructiveDia
       <AlertDialog open={open} onOpenChange={setOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{title}</AlertDialogTitle>
-            <AlertDialogDescription>{description}</AlertDialogDescription>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete this chat.
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
             <Button variant="destructive" onClick={onConfirm}>
-              {confirmText}
+              Delete chat
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -56,4 +55,4 @@ export const DestructiveDialog = forwardRef<DestructiveDialogRef, DestructiveDia
   },
 )
 
-DestructiveDialog.displayName = 'DestructiveDialog'
+DeleteChatDialog.displayName = 'DeleteChatDialog'

--- a/src/components/delete-chat-dialog.tsx
+++ b/src/components/delete-chat-dialog.tsx
@@ -7,7 +7,7 @@ import {
   AlertDialogTitle,
   AlertDialogDescription,
   AlertDialogCancel,
-} from '@/components/ui/alert-dialog' // adjust import to your project
+} from '@/components/ui/alert-dialog'
 import { Button } from './ui/button'
 
 export type DeleteChatDialogRef = {
@@ -39,14 +39,12 @@ export const DeleteChatDialog = forwardRef<DeleteChatDialogRef, DeleteChatDialog
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete this chat.
-            </AlertDialogDescription>
+            <AlertDialogDescription>This will permanently delete this chat.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
             <Button variant="destructive" onClick={onConfirm}>
-              Delete chat
+              Delete Chat
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from '@/components/ui/sidebar'
+import { DestructiveDialog, DestructiveDialogRef } from '@/components/DestructiveDialog'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { chatThreadsTable } from '@/db/tables'
 import { useDatabase } from '@/hooks/use-database'
@@ -37,6 +38,7 @@ import {
   SquarePen,
   Zap,
 } from 'lucide-react'
+import { useRef } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router'
 
 export default function ChatSidebar() {
@@ -46,6 +48,9 @@ export default function ChatSidebar() {
   const queryClient = useQueryClient()
   const { setOpenMobile } = useSidebar()
   const isMobile = useIsMobile()
+  const deleteAllChatsDialogRef = useRef<DestructiveDialogRef>(null)
+  const deleteChatDialogRef = useRef<DestructiveDialogRef>(null)
+  const threadIdRef = useRef<string>(null)
 
   const { chatThreadId: currentChatThreadId } = useParams()
 
@@ -64,6 +69,8 @@ export default function ChatSidebar() {
       await db.delete(chatThreadsTable).where(eq(chatThreadsTable.id, id))
     },
     onSuccess: () => {
+      deleteChatDialogRef.current?.close()
+      threadIdRef.current = null
       queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
     },
   })
@@ -76,6 +83,7 @@ export default function ChatSidebar() {
       return chatThreadId
     },
     onSuccess: async (chatThreadId) => {
+      deleteAllChatsDialogRef.current?.close()
       // Invalidate queries after the new thread is created
       await queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
       navigate(`/chats/${chatThreadId}`)
@@ -277,7 +285,7 @@ export default function ChatSidebar() {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <SidebarMenuButton
-                    onClick={() => deleteAllChatsMutation.mutate()}
+                    onClick={() => deleteAllChatsDialogRef.current?.open()}
                     className="w-fit pr-0 pl-0 aspect-square items-center justify-center cursor-pointer"
                     disabled={deleteAllChatsMutation.isPending}
                   >
@@ -314,7 +322,8 @@ export default function ChatSidebar() {
                   <DropdownMenuContent side="right" align="start" className="min-w-56 rounded-lg">
                     <DropdownMenuItem
                       onClick={() => {
-                        deleteChatMutation.mutate({ id: thread.id })
+                        threadIdRef.current = thread.id
+                        deleteChatDialogRef.current?.open()
                       }}
                       disabled={deleteChatMutation.isPending}
                     >
@@ -330,6 +339,23 @@ export default function ChatSidebar() {
         <SidebarFooter />
       </SidebarContent>
       <SidebarRail />
+      <DestructiveDialog
+        confirmText="Clear all chats"
+        description="This action cannot be undone. This will permanently delete all your chats."
+        onConfirm={() => deleteAllChatsMutation.mutate()}
+        ref={deleteAllChatsDialogRef}
+        title="Are you absolutely sure?"
+      />
+      <DestructiveDialog
+        confirmText="Delete chat"
+        description="This action cannot be undone. This will permanently delete this chat."
+        onCancel={() => {
+          threadIdRef.current = null
+        }}
+        onConfirm={() => threadIdRef.current && deleteChatMutation.mutate({ id: threadIdRef.current })}
+        ref={deleteChatDialogRef}
+        title="Are you absolutely sure?"
+      />
     </Sidebar>
   )
 }

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -15,7 +15,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from '@/components/ui/sidebar'
-import { DestructiveDialog, DestructiveDialogRef } from '@/components/DestructiveDialog'
+import { DeleteAllChatsDialog, DeleteAllChatsDialogRef } from '@/components/delete-all-chats-dialog'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { chatThreadsTable } from '@/db/tables'
 import { useDatabase } from '@/hooks/use-database'
@@ -40,6 +40,7 @@ import {
 } from 'lucide-react'
 import { useRef } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router'
+import { DeleteChatDialog, DeleteChatDialogRef } from '@/components/delete-chat-dialog'
 
 export default function ChatSidebar() {
   const navigate = useNavigate()
@@ -48,8 +49,8 @@ export default function ChatSidebar() {
   const queryClient = useQueryClient()
   const { setOpenMobile } = useSidebar()
   const isMobile = useIsMobile()
-  const deleteAllChatsDialogRef = useRef<DestructiveDialogRef>(null)
-  const deleteChatDialogRef = useRef<DestructiveDialogRef>(null)
+  const deleteAllChatsDialogRef = useRef<DeleteAllChatsDialogRef>(null)
+  const deleteChatDialogRef = useRef<DeleteChatDialogRef>(null)
   const threadIdRef = useRef<string>(null)
 
   const { chatThreadId: currentChatThreadId } = useParams()
@@ -339,22 +340,13 @@ export default function ChatSidebar() {
         <SidebarFooter />
       </SidebarContent>
       <SidebarRail />
-      <DestructiveDialog
-        confirmText="Clear all chats"
-        description="This action cannot be undone. This will permanently delete all your chats."
-        onConfirm={() => deleteAllChatsMutation.mutate()}
-        ref={deleteAllChatsDialogRef}
-        title="Are you absolutely sure?"
-      />
-      <DestructiveDialog
-        confirmText="Delete chat"
-        description="This action cannot be undone. This will permanently delete this chat."
+      <DeleteAllChatsDialog onConfirm={() => deleteAllChatsMutation.mutate()} ref={deleteAllChatsDialogRef} />
+      <DeleteChatDialog
         onCancel={() => {
           threadIdRef.current = null
         }}
         onConfirm={() => threadIdRef.current && deleteChatMutation.mutate({ id: threadIdRef.current })}
         ref={deleteChatDialogRef}
-        title="Are you absolutely sure?"
       />
     </Sidebar>
   )


### PR DESCRIPTION
## Description

This PR introduces **`DeleteAllChatsDialog `** and **`DeleteChatDialog `** components.

It is now used for:

- **Delete All Chats** — confirms before removing all chat history.  
- **Delete Single Chat** — confirms before removing an individual chat. *(This was not part of the original issue, but I added it for consistency and safety.)*  

The dialogs use **`useImperativeHandle`** to expose `open()` and `close()` methods, allowing parent components to trigger it imperatively. This approach avoids unnecessary re-renders in the parent when opening or closing the dialog.

---

## Render Preview

https://github.com/user-attachments/assets/13f089fb-a59d-4b8b-9f1c-ad5da02b0712

---

## Related Issue

Closes [#7](https://github.com/thunderbird/thunderbolt/issues/7)