### PR TITLE
Sidebar Chat Thread Section - Basic Search

### DIFF
--- a/src/automations/index.tsx
+++ b/src/automations/index.tsx
@@ -11,12 +11,10 @@ import {
 import { Button } from '@/components/ui/button'
 import { ButtonGroup, ButtonGroupItem } from '@/components/ui/button-group'
 import { Card, CardContent } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { DatabaseSingleton } from '@/db/singleton'
 import { promptsTable, triggersTable } from '@/db/tables'
-import { useDebounce } from '@/hooks/use-debounce'
 import { useBooleanSetting } from '@/hooks/use-setting'
 import { cn } from '@/lib/utils'
 import type { Prompt, Trigger } from '@/types'
@@ -27,17 +25,18 @@ import { memo, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import AutomationFormModal from './automation-form-modal'
 import { runAutomation } from './runner'
+import { SearchInput } from '@/components/ui/search-input'
 
 export default function AutomationsPage() {
   const db = DatabaseSingleton.instance.db
 
   const queryClient = useQueryClient()
   const navigate = useNavigate()
-  const [searchQuery, setSearchQuery] = useState('')
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [editingPrompt, setEditingPrompt] = useState<Prompt | null>(null)
   const [deletingPromptId, setDeletingPromptId] = useState<string | null>(null)
-  const debouncedSearchQuery = useDebounce(searchQuery, 50)
+
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
 
   const { data: prompts = [], isLoading } = useQuery({
     queryKey: ['prompts', debouncedSearchQuery],
@@ -94,15 +93,10 @@ export default function AutomationsPage() {
           </div>
 
           {/* Search */}
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder="Search automations..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9"
-            />
-          </div>
+          <SearchInput
+            placeholder="Search automations..."
+            debouncedOnChange={(value) => setDebouncedSearchQuery(value)}
+          />
 
           {/* Content */}
           <div className="flex-1">

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -38,15 +38,19 @@ export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
     VariantProps<typeof inputVariants> {}
 
-function Input({ className, type, variant, inputSize, state, ...props }: InputProps) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(inputVariants({ variant, inputSize, state, className }))}
-      {...props}
-    />
-  )
-}
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, variant, inputSize, state, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        data-slot="input"
+        className={cn(inputVariants({ variant, inputSize, state, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
 
 export { Input, inputVariants }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,8 @@ const inputVariants = cva(
     variants: {
       variant: {
         default: 'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-        filled: 'bg-muted/50 focus-visible:bg-transparent focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        filled:
+          'bg-muted/50 focus-visible:bg-transparent focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
         outline: 'border-2 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[2px]',
         ghost: 'border-none focus-visible:bg-accent/50 focus-visible:ring-0',
       },
@@ -30,13 +31,22 @@ const inputVariants = cva(
       inputSize: 'default',
       state: 'default',
     },
-  }
+  },
 )
 
-interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>, VariantProps<typeof inputVariants> {}
+export interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
+    VariantProps<typeof inputVariants> {}
 
 function Input({ className, type, variant, inputSize, state, ...props }: InputProps) {
-  return <input type={type} data-slot="input" className={cn(inputVariants({ variant, inputSize, state, className }))} {...props} />
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(inputVariants({ variant, inputSize, state, className }))}
+      {...props}
+    />
+  )
 }
 
 export { Input, inputVariants }

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -1,30 +1,91 @@
-import { Search } from 'lucide-react'
-import { Input, InputProps } from './input'
-import { cn } from '@/lib/utils'
 import { useDebouncedCallback } from '@/hooks/use-debounce'
-import { ChangeEvent } from 'react'
+import { cn } from '@/lib/utils'
+import { Search, X } from 'lucide-react'
+import { ChangeEvent, forwardRef, useState } from 'react'
+import { Input, InputProps } from './input'
 
 type SearchInputProps = InputProps & {
   containerClassName?: string
   debouncedOnChange?: (value: string) => void
   delay?: number
+  showIcon?: boolean
 }
 
-export function SearchInput({
-  className,
-  containerClassName,
-  debouncedOnChange,
-  delay = 50,
-  ...props
-}: SearchInputProps) {
-  const debouncedCallback = useDebouncedCallback((event: ChangeEvent<HTMLInputElement>) => {
-    debouncedOnChange?.(event.target.value)
-  }, delay)
+export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
+  (
+    {
+      className,
+      containerClassName,
+      debouncedOnChange,
+      delay = 50,
+      showIcon = false,
+      value,
+      onChange,
+      defaultValue,
+      ...props
+    },
+    ref,
+  ) => {
+    const [internalValue, setInternalValue] = useState(defaultValue?.toString() || '')
+    const isControlled = value !== undefined
+    const displayValue = isControlled ? value : internalValue
 
-  return (
-    <div className={cn('relative', containerClassName)}>
-      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-      <Input className={cn('pl-9', className)} onChange={debouncedCallback} {...props} />
-    </div>
-  )
-}
+    const debouncedCallback = useDebouncedCallback((value: string) => {
+      debouncedOnChange?.(value)
+    }, delay)
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value
+      if (!isControlled) {
+        setInternalValue(newValue)
+      }
+      onChange?.(event)
+      debouncedCallback(newValue)
+    }
+
+    const handleClear = () => {
+      if (!isControlled) {
+        setInternalValue('')
+      }
+      if (onChange && ref && 'current' in ref && ref.current) {
+        // Create a proper synthetic event by setting the input value and triggering change
+        ref.current.value = ''
+        const event = new Event('change', { bubbles: true }) as unknown as ChangeEvent<HTMLInputElement>
+        Object.defineProperty(event, 'target', { value: ref.current, enumerable: true })
+        onChange(event)
+      }
+      debouncedOnChange?.('')
+    }
+
+    const hasValue = displayValue && displayValue.toString().length > 0
+
+    return (
+      <div className={cn('relative', containerClassName)}>
+        {showIcon && <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />}
+        <Input
+          ref={ref}
+          value={displayValue}
+          className={cn(showIcon ? 'pl-9' : '', hasValue ? 'pr-9' : '', className)}
+          onChange={handleChange}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck="false"
+          data-1p-ignore
+          data-lpignore="true"
+          {...props}
+        />
+        {hasValue && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/80 hover:text-foreground transition-colors focus:outline-none cursor-pointer"
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    )
+  },
+)

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -1,0 +1,30 @@
+import { Search } from 'lucide-react'
+import { Input, InputProps } from './input'
+import { cn } from '@/lib/utils'
+import { useDebouncedCallback } from '@/hooks/use-debounce'
+import { ChangeEvent } from 'react'
+
+type SearchInputProps = InputProps & {
+  containerClassName?: string
+  debouncedOnChange?: (value: string) => void
+  delay?: number
+}
+
+export function SearchInput({
+  className,
+  containerClassName,
+  debouncedOnChange,
+  delay = 50,
+  ...props
+}: SearchInputProps) {
+  const debouncedCallback = useDebouncedCallback((event: ChangeEvent<HTMLInputElement>) => {
+    debouncedOnChange?.(event.target.value)
+  }, delay)
+
+  return (
+    <div className={cn('relative', containerClassName)}>
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <Input className={cn('pl-9', className)} onChange={debouncedCallback} {...props} />
+    </div>
+  )
+}

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -1,6 +1,7 @@
 import { SidebarFooter } from '@/components/sidebar-footer'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { NavLink } from '@/components/ui/nav-link'
+import { SearchInput } from '@/components/ui/search-input'
 import {
   Sidebar,
   SidebarContent,
@@ -38,7 +39,7 @@ import {
   SquarePen,
   Zap,
 } from 'lucide-react'
-import { useRef } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router'
 import { DeleteChatDialog, DeleteChatDialogRef } from '@/components/delete-chat-dialog'
 
@@ -58,12 +59,22 @@ export default function ChatSidebar() {
   // Simple route check: any /settings/* path triggers the settings sidebar variant on mobile
   const isSettingsRoute = location.pathname.startsWith('/settings')
 
-  const { data: chatThreads = [] } = useQuery({
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
+
+  const { data } = useQuery({
     queryKey: ['chatThreads'],
     queryFn: async () => {
       return db.select().from(chatThreadsTable).orderBy(desc(chatThreadsTable.id))
     },
   })
+
+  const chatThreads = useMemo(() => {
+    if (!data) {
+      return []
+    }
+
+    return data.filter((thread) => thread.title?.toLowerCase().includes(debouncedSearchQuery?.toLowerCase()))
+  }, [data, debouncedSearchQuery])
 
   const deleteChatMutation = useMutation({
     mutationFn: async ({ id }: { id: string }) => {
@@ -280,6 +291,12 @@ export default function ChatSidebar() {
         <SidebarSeparator className="m-0" />
 
         <SidebarGroup className="flex-1 overflow-y-auto">
+          <SearchInput
+            className="bg-muted"
+            containerClassName="mb-2"
+            placeholder="Search chats..."
+            debouncedOnChange={setDebouncedSearchQuery}
+          />
           <div className="flex items-center justify-between">
             <SidebarGroupLabel>Recent Chats</SidebarGroupLabel>
             <TooltipProvider>
@@ -334,6 +351,11 @@ export default function ChatSidebar() {
                 </SidebarMenuItem>
               </DropdownMenu>
             ))}
+            {chatThreads.length === 0 && debouncedSearchQuery && (
+              <div className="text-center text-sm py-12 px-4 text-muted-foreground">
+                No chats found matching "{debouncedSearchQuery}"
+              </div>
+            )}
           </SidebarMenu>
         </SidebarGroup>
 

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -66,6 +66,7 @@ export default function ChatSidebar() {
     queryFn: async () => {
       return db.select().from(chatThreadsTable).orderBy(desc(chatThreadsTable.id))
     },
+    placeholderData: (previousData) => previousData,
   })
 
   const chatThreads = useMemo(() => {
@@ -320,7 +321,7 @@ export default function ChatSidebar() {
               </Tooltip>
             </TooltipProvider>
           </div>
-          <SidebarMenu>
+          <SidebarMenu className="flex-1 overflow-y-auto">
             {chatThreads.map((thread) => (
               <DropdownMenu key={thread.id}>
                 <SidebarMenuItem>

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -33,13 +33,14 @@ import {
   Lock,
   MoreHorizontal,
   Plug,
+  Search,
   Server,
   Settings,
   SlidersHorizontal,
   SquarePen,
   Zap,
 } from 'lucide-react'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router'
 import { DeleteChatDialog, DeleteChatDialogRef } from '@/components/delete-chat-dialog'
 
@@ -60,6 +61,17 @@ export default function ChatSidebar() {
   const isSettingsRoute = location.pathname.startsWith('/settings')
 
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
+  const [showSearch, setShowSearch] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (showSearch && searchInputRef.current) {
+      // Small delay to ensure the element is visible before focusing
+      setTimeout(() => {
+        searchInputRef.current?.focus()
+      }, 100)
+    }
+  }, [showSearch])
 
   const { data } = useQuery({
     queryKey: ['chatThreads'],
@@ -292,36 +304,59 @@ export default function ChatSidebar() {
         <SidebarSeparator className="m-0" />
 
         <SidebarGroup className="flex-1 overflow-y-auto">
-          <SearchInput
-            className="bg-muted"
-            containerClassName="mb-2"
-            placeholder="Search chats..."
-            debouncedOnChange={setDebouncedSearchQuery}
-          />
           <div className="flex items-center justify-between">
             <SidebarGroupLabel>Recent Chats</SidebarGroupLabel>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <SidebarMenuButton
-                    onClick={() => deleteAllChatsDialogRef.current?.open()}
-                    className="w-fit pr-0 pl-0 aspect-square items-center justify-center cursor-pointer"
-                    disabled={deleteAllChatsMutation.isPending}
-                  >
-                    {deleteAllChatsMutation.isPending ? (
-                      <Loader2 className="size-4 animate-spin" />
-                    ) : (
-                      <Flame className="size-4" />
-                    )}
-                  </SidebarMenuButton>
-                </TooltipTrigger>
-                <TooltipContent side="right">
-                  <p>Clear all chats</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <div className="flex items-center gap-0.5">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SidebarMenuButton
+                      onClick={() => setShowSearch(!showSearch)}
+                      className="w-fit pr-0 pl-0 aspect-square items-center justify-center cursor-pointer"
+                    >
+                      <Search className={`size-4 ${debouncedSearchQuery ? 'text-blue-500' : ''}`} />
+                    </SidebarMenuButton>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    <p>Search chats</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SidebarMenuButton
+                      onClick={() => deleteAllChatsDialogRef.current?.open()}
+                      className="w-fit pr-0 pl-0 aspect-square items-center justify-center cursor-pointer"
+                      disabled={deleteAllChatsMutation.isPending}
+                    >
+                      {deleteAllChatsMutation.isPending ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : (
+                        <Flame className="size-4" />
+                      )}
+                    </SidebarMenuButton>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    <p>Clear all chats</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
           </div>
-          <SidebarMenu className="flex-1 overflow-y-auto">
+          <div
+            className={`transition-all duration-300 ease-in-out ${
+              showSearch ? 'max-h-12 opacity-100 mt-2' : 'max-h-0 opacity-0 overflow-hidden'
+            }`}
+          >
+            <SearchInput
+              ref={searchInputRef}
+              containerClassName="mb-1"
+              placeholder="Search chats..."
+              debouncedOnChange={setDebouncedSearchQuery}
+            />
+          </div>
+          <SidebarMenu className="flex-1 overflow-y-auto mt-2">
             {chatThreads.map((thread) => (
               <DropdownMenu key={thread.id}>
                 <SidebarMenuItem>
@@ -354,7 +389,7 @@ export default function ChatSidebar() {
             ))}
             {chatThreads.length === 0 && debouncedSearchQuery && (
               <div className="text-center text-sm py-12 px-4 text-muted-foreground">
-                No chats found matching "{debouncedSearchQuery}"
+                No matches for "{debouncedSearchQuery}"
               </div>
             )}
           </SidebarMenu>

--- a/src/tasks/index.tsx
+++ b/src/tasks/index.tsx
@@ -28,7 +28,7 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { and, asc, desc, eq, like, sql } from 'drizzle-orm'
-import { CheckCircle2, GripVertical, Plus, Search, Square } from 'lucide-react'
+import { CheckCircle2, GripVertical, Plus, Square } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { v7 as uuidv7 } from 'uuid'
 

--- a/src/tasks/index.tsx
+++ b/src/tasks/index.tsx
@@ -1,10 +1,9 @@
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
+import { SearchInput } from '@/components/ui/search-input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { tasksTable } from '@/db/tables'
 import { useDatabase } from '@/hooks/use-database'
-import { useDebounce } from '@/hooks/use-debounce'
 import { cn } from '@/lib/utils'
 import { Task } from '@/types'
 import type { DropAnimation } from '@dnd-kit/core'
@@ -245,13 +244,12 @@ export default function TasksPage() {
   const queryClient = useQueryClient()
 
   // State
-  const [searchQuery, setSearchQuery] = useState('')
   const [isAddingNew, setIsAddingNew] = useState(false)
   const [completingTasks, setCompletingTasks] = useState<Set<string>>(new Set())
   const [activeId, setActiveId] = useState<string | null>(null)
   const [optimisticOrder, setOptimisticOrder] = useState<string[]>([])
 
-  const debouncedSearchQuery = useDebounce(searchQuery, 30)
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
 
   // Drag and drop sensors
   const sensors = useSensors(
@@ -478,7 +476,7 @@ export default function TasksPage() {
   const activeTask = useMemo(() => tasks.find((t) => t.id === activeId), [tasks, activeId])
 
   // Check if we should show empty state
-  const showEmptyState = !isLoading && !isPlaceholderData && totalCount === 0 && !searchQuery && !isAddingNew
+  const showEmptyState = !isLoading && !isPlaceholderData && totalCount === 0 && !debouncedSearchQuery && !isAddingNew
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -504,15 +502,7 @@ export default function TasksPage() {
           </div>
 
           {/* Search - always visible to maintain focus and avoid flicker */}
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder="Search tasks..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9"
-            />
-          </div>
+          <SearchInput placeholder="Search tasks..." debouncedOnChange={(value) => setDebouncedSearchQuery(value)} />
 
           {showEmptyState ? (
             <div className="flex items-center justify-center p-16">
@@ -561,9 +551,9 @@ export default function TasksPage() {
                         />
                       ))}
 
-                      {tasks.length === 0 && searchQuery && (
+                      {tasks.length === 0 && debouncedSearchQuery && (
                         <div className="text-center py-12 text-muted-foreground">
-                          No tasks found matching "{searchQuery}"
+                          No tasks found matching "{debouncedSearchQuery}"
                         </div>
                       )}
 


### PR DESCRIPTION
## Description

This PR implements the **search action for chats in the sidebar** as described in issue #96.  
To support this, it introduces a **reusable search input component** with a `debouncedOnChange` prop, enabling built-in debounce logic for consistent and efficient search handling across multiple pages.

Updates include:
- **Sidebar Chats**
  - Adds search functionality using the new component.
  - Keeps the **search input**, **"Recent Chats"** label, and **"Delete All"** (fire icon) **sticky at the top** of the section to remain visible while scrolling.
- **Refactors** the search inputs in the **Tasks** and **Automations** pages to use the new reusable component.

---

## Render Preview

https://github.com/user-attachments/assets/7a895fb1-f304-49a5-8711-4995ea4e6b6e

---

## Related Issue

Closes [#96](https://github.com/thunderbird/thunderbolt/issues/96)
