### PR TITLE
Fix flower qwen 3 stream error

### DIFF
--- a/src/flower/flower-hermes.test.ts
+++ b/src/flower/flower-hermes.test.ts
@@ -1,0 +1,48 @@
+import { readUIMessageStream, streamText, wrapLanguageModel } from 'ai'
+import { describe, expect, it } from 'bun:test'
+import { createFlowerProvider } from './flower'
+import { createFlowerMiddleware } from '@/src/ai/middleware/default'
+
+// Simple mock Flower client that streams the supplied chunks
+const createMockFlowerClient = (chunks: string[]) => {
+  return {
+    async chat(args: any) {
+      if (!args.stream) {
+        return { content: chunks.join('') }
+      }
+
+      for (const chunk of chunks) {
+        await new Promise<void>((r) => setTimeout(r, 0))
+        args.onStreamEvent?.({ chunk })
+      }
+    },
+  }
+}
+
+describe('Flower provider + Hermes tool middleware', () => {
+  it('streams without throwing when hermesToolMiddleware is enabled', async () => {
+    const chunks = ['Hi', ' there', '!']
+    const mockClient = createMockFlowerClient(chunks)
+
+    const provider = createFlowerProvider({ client: mockClient })
+    const model = provider('qwen/qwen3-235b')
+
+    const wrappedModel = wrapLanguageModel({
+      model,
+      middleware: createFlowerMiddleware(false),
+    })
+
+    const result = streamText({ model: wrappedModel, prompt: 'Hello' })
+
+    // Consume the UI stream to ensure no runtime errors occur
+    const uiStream = result.toUIMessageStream({ sendReasoning: true })
+    const reader = readUIMessageStream({ stream: uiStream })
+
+    for await (const _msg of reader) {
+      /* just iterate to completion */
+    }
+
+    const finalText = await result.text
+    expect(finalText).toBe('Hi there!')
+  })
+})

--- a/src/flower/flower.ts
+++ b/src/flower/flower.ts
@@ -106,9 +106,25 @@ class FlowerLanguageModel implements LanguageModelV2 {
     const stream = new ReadableStream<LanguageModelV2StreamPart>({
       start(controller) {
         let finished = false
-        let hasStarted = false
 
-        // Start the chat asynchronously
+        // We need an ID that is guaranteed to be available for `text-start`, any deltas and the final
+        // `text-end`.  Some downstream middlewares (e.g. `hermesToolMiddleware`) expect the `text-start`
+        // to have been emitted *before* they perform any processing of the first text token.  If we wait
+        // until the first chunk arrives there is a race where the middleware might transform the stream
+        // (dropping or buffering the very first token) and therefore never see the `text-start` event.
+        // This ultimately leads to `process-ui-message-stream` not having an entry in
+        // `state.activeTextParts` when it later receives the `text-end` event resulting in a runtime
+        // error (THU-24).
+
+        // To avoid this we eagerly enqueue the `text-start` event as soon as the stream starts so that
+        // every consumer is guaranteed to have initialised its internal bookkeeping before any deltas
+        // are emitted.
+
+        controller.enqueue({
+          type: 'text-start',
+          id: streamId,
+        } as LanguageModelV2StreamPart)
+
         const chatArgs: any = {
           messages,
           model: modelId,
@@ -122,16 +138,6 @@ class FlowerLanguageModel implements LanguageModelV2 {
               const textChunk = event.chunk
 
               try {
-                // Send text-start on the first chunk
-                if (!hasStarted) {
-                  hasStarted = true
-                  controller.enqueue({
-                    type: 'text-start',
-                    id: streamId,
-                  } as LanguageModelV2StreamPart)
-                }
-
-                // Send the text delta
                 controller.enqueue({
                   type: 'text-delta',
                   id: streamId,
@@ -164,23 +170,11 @@ class FlowerLanguageModel implements LanguageModelV2 {
             if (!finished) {
               finished = true
               try {
-                // Send text-end if we started
-                if (hasStarted) {
-                  controller.enqueue({
-                    type: 'text-end',
-                    id: streamId,
-                  } as LanguageModelV2StreamPart)
-                } else {
-                  // If we never started, send an empty response
-                  controller.enqueue({
-                    type: 'text-start',
-                    id: streamId,
-                  } as LanguageModelV2StreamPart)
-                  controller.enqueue({
-                    type: 'text-end',
-                    id: streamId,
-                  } as LanguageModelV2StreamPart)
-                }
+                // We always emit `text-start` eagerly, so we can safely close with a single `text-end`.
+                controller.enqueue({
+                  type: 'text-end',
+                  id: streamId,
+                } as LanguageModelV2StreamPart)
 
                 // Send finish event
                 controller.enqueue({


### PR DESCRIPTION
Fixes `undefined is not an object` error when using Flower with Hermes tool middleware.

The error occurred because the `text-start` event was not guaranteed to be emitted before the first `text-delta` chunk from Flower. This created a race condition where the AI SDK's UI stream processor might not have initialized its internal state when a subsequent `text-end` event arrived, leading to a runtime error. This PR ensures `text-start` is always emitted eagerly at the beginning of the stream.

---
<a href="https://cursor.com/background-agent?bcId=bc-152d89bf-e8de-45f9-9356-ac6cd96e00fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-152d89bf-e8de-45f9-9356-ac6cd96e00fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

