### PR TITLE
Skip rust build when no rust files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect file changes to optimize CI performance (THU-28)
+  # Skip Rust build step when no Rust-related files have changed
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect changed files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust:
+              - 'src-tauri/**/*.rs'
+              - 'src-tauri/**/Cargo.toml'
+              - 'src-tauri/**/Cargo.lock'
+              - 'src-tauri/build.rs'
+              - 'src-tauri/rust-toolchain.toml'
+              - 'src-tauri/.cargo/**'
+
   typescript:
     runs-on: ubuntu-latest
     permissions:
@@ -99,6 +122,8 @@ jobs:
           bun test --test-name-pattern="^(?!.*Google Utils).*$"
 
   rust:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Skip Rust CI build when no Rust files are changed to speed up PR merge times.

The CI workflow now includes a `detect-changes` job that uses `dorny/paths-filter@v3` to identify changes in Rust source files, Cargo manifests, lock files, build scripts, and toolchain configurations. The `rust` job is then conditionally executed based on these detected changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-794757bc-fab2-4ef7-8798-ce3337c02640">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-794757bc-fab2-4ef7-8798-ce3337c02640">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

