### PR TITLE
Fix Google Drive tool call errors

### DIFF
--- a/src/integrations/google/tools.test.ts
+++ b/src/integrations/google/tools.test.ts
@@ -17,6 +17,7 @@ import {
   searchDrive,
   searchEmails,
 } from './tools'
+import { transformDriveQuery } from './utils'
 
 // Custom error type for HTTP error mocking
 interface HTTPError extends Error {
@@ -1132,6 +1133,61 @@ describe('Google Tools', () => {
 
       expect(result.truncated).toBe(true)
       expect(mockTruncateText).toHaveBeenCalledWith(longContent, 50000)
+    })
+  })
+
+  describe('transformDriveQuery', () => {
+    it('should handle simple text searches by wrapping in name contains', () => {
+      expect(transformDriveQuery('alessandro')).toBe("name contains 'alessandro'")
+      expect(transformDriveQuery('meeting notes')).toBe("name contains 'meeting notes'")
+      expect(transformDriveQuery('  simple text  ')).toBe("name contains 'simple text'")
+    })
+
+    it('should handle name field specifiers correctly', () => {
+      expect(transformDriveQuery('name:alessandro')).toBe("name contains 'alessandro'")
+      expect(transformDriveQuery("name:'my document'")).toBe("name contains 'my document'")
+    })
+
+    it('should handle type field specifiers correctly', () => {
+      expect(transformDriveQuery('type:pdf')).toBe("mimeType='application/pdf'")
+      expect(transformDriveQuery('type:document')).toBe("mimeType='application/vnd.google-apps.document'")
+      expect(transformDriveQuery('type:image')).toBe("mimeType contains 'image/'")
+    })
+
+    it('should handle complex queries with logical operators', () => {
+      expect(transformDriveQuery('name:contract and type:pdf')).toBe("name contains 'contract' and mimeType='application/pdf'")
+      expect(transformDriveQuery('type:document or type:spreadsheet')).toBe("mimeType='application/vnd.google-apps.document' or mimeType='application/vnd.google-apps.spreadsheet'")
+    })
+
+    it('should handle date transformations correctly', () => {
+      expect(transformDriveQuery('modifiedTime>2024-01-01')).toBe("modifiedTime>'2024-01-01T00:00:00Z'")
+      expect(transformDriveQuery('createdTime<=2024-12-31')).toBe("createdTime<='2024-12-31T00:00:00Z'")
+    })
+
+    it('should preserve existing RFC 3339 dates', () => {
+      expect(transformDriveQuery('modifiedTime>2024-01-01T10:30:00Z')).toBe("modifiedTime>'2024-01-01T10:30:00Z'")
+    })
+
+    it('should handle empty queries', () => {
+      expect(transformDriveQuery('')).toBe('')
+      expect(transformDriveQuery('   ')).toBe('')
+    })
+
+    it('should handle queries that already contain field specifications', () => {
+      expect(transformDriveQuery("name contains 'alessandro'")).toBe("name contains 'alessandro'")
+      expect(transformDriveQuery("mimeType='application/pdf'")).toBe("mimeType='application/pdf'")
+    })
+
+    it('should handle complex mixed queries', () => {
+      expect(transformDriveQuery('name:contract modifiedTime>2024-01-01 and type:pdf')).toBe(
+        "name contains 'contract' modifiedTime>'2024-01-01T00:00:00Z' and mimeType='application/pdf'"
+      )
+    })
+
+    it('should not break queries that are already properly formatted', () => {
+      expect(transformDriveQuery("name contains 'test' and trashed=false")).toBe(
+        "name contains 'test' and trashed=false"
+      )
     })
   })
 })

--- a/src/integrations/google/utils.ts
+++ b/src/integrations/google/utils.ts
@@ -177,11 +177,22 @@ export const ensureValidGoogleToken = async (credentials: {
  * - name:foo -> name contains 'foo'
  * - type:document -> mimeType='application/vnd.google-apps.document'
  * - modifiedTime>2024-01-01 -> modifiedTime>'2024-01-01T00:00:00Z'
+ * - simple text -> name contains 'text'
  */
 export const transformDriveQuery = (query: string): string => {
   if (!query.trim()) return ''
 
-  // A more robust way to split the query string by spaces, while respecting quoted content.
+  // Check if this is a simple text search (no field specifiers or operators)
+  const hasFieldSpecifiers = /(?:name|type|mimeType|modifiedTime|createdTime|trashed|starred|shared|ownedByMe)[:><=]/.test(query)
+  const hasQuotes = /'.*'/.test(query)
+  const hasLogicalOperators = /\s+(and|or)\s+/i.test(query)
+  
+  // If it's a simple text search without field specifiers, wrap it in name contains
+  if (!hasFieldSpecifiers && !hasQuotes && !hasLogicalOperators) {
+    return `name contains '${query.trim()}'`
+  }
+
+  // For more complex queries, parse parts more carefully
   const parts = query.match(/('.*?'|[^'\s]+)+(?=\s*|\s*$)/g) || []
 
   const typeMapping: Record<string, string> = {
@@ -198,6 +209,11 @@ export const transformDriveQuery = (query: string): string => {
   }
 
   const transformedParts = parts.map((part) => {
+    // Skip logical operators (and, or) as they should remain as-is
+    if (/^(and|or)$/i.test(part)) {
+      return part.toLowerCase()
+    }
+
     // Note: The order of replacements is important.
     // 1. Transform name shorthand (e.g., name:doc) to "name contains 'doc'"
     let transformed = part.replace(/name:'([^']+)'/g, "name contains '$1'")
@@ -228,5 +244,6 @@ export const transformDriveQuery = (query: string): string => {
     return transformed
   })
 
-  return transformedParts.join(' and ')
+  // Join parts with spaces, not ' and ' - let existing logical operators handle the joining
+  return transformedParts.join(' ')
 }


### PR DESCRIPTION
Fixes failing Google Drive tool calls by correctly formatting simple text queries and improving complex query construction in `transformDriveQuery`.

The Google Drive API was returning "Invalid Value" errors because direct text inputs (e.g., "alessandro") were not translated into valid Drive QL (e.g., "name contains 'alessandro'"). Additionally, the previous logic incorrectly joined all query parts with " and ", leading to malformed queries when explicit logical operators were already present. This PR ensures queries are properly formatted for the Drive API.

---
<a href="https://cursor.com/background-agent?bcId=bc-24be8592-2712-4ecb-99f4-08fea1058348">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24be8592-2712-4ecb-99f4-08fea1058348">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

