### PR TITLE
Fix unused mutable variables in libsql

### DIFF
--- a/src-tauri/thunderbolt_libsql/src/lib.rs
+++ b/src-tauri/thunderbolt_libsql/src/lib.rs
@@ -101,7 +101,7 @@ pub mod commands {
 
         let connection_arc = pool.get_connection().await;
         let connection = connection_arc.lock().await;
-        let mut stmt = connection.prepare(&query).await.map_err(|e| e.to_string())?;
+        let stmt = connection.prepare(&query).await.map_err(|e| e.to_string())?;
 
         let rows_affected_usize: usize = if let Some(params) = values {
             let libsql_params: Vec<libsql::Value> = params
@@ -146,7 +146,7 @@ pub mod commands {
 
         let connection_arc = pool.get_connection().await;
         let connection = connection_arc.lock().await;
-        let mut stmt = connection.prepare(&query).await.map_err(|e| e.to_string())?;
+        let stmt = connection.prepare(&query).await.map_err(|e| e.to_string())?;
 
         let rows = if let Some(params) = values {
             let libsql_params: Vec<libsql::Value> = params


### PR DESCRIPTION
Remove unnecessary `mut` keywords from `stmt` variable declarations to fix Rust `unused-mut` compilation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-63e6337b-d7fb-4ad9-bbbe-e9a29d4f56e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63e6337b-d7fb-4ad9-bbbe-e9a29d4f56e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

