### PR TITLE
Defer OAuth redirect to preserve router state

### DIFF
--- a/src/components/oauth-callback.tsx
+++ b/src/components/oauth-callback.tsx
@@ -1,6 +1,6 @@
+import Loading from '@/loading'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router'
-import { Loader2 } from 'lucide-react'
 
 export default function OAuthCallback() {
   const navigate = useNavigate()
@@ -59,9 +59,7 @@ export default function OAuthCallback() {
   return (
     <div className="flex flex-1 flex-col items-center justify-center min-h-screen bg-background">
       <div className="text-center space-y-4">
-        <Loader2 className="h-8 w-8 animate-spin mx-auto text-primary" />
-        <h1 className="text-xl font-semibold">Completing Authentication...</h1>
-        <p className="text-muted-foreground">Please wait while we complete the authentication process.</p>
+        <Loading />
       </div>
     </div>
   )

--- a/src/components/oauth-callback.tsx
+++ b/src/components/oauth-callback.tsx
@@ -4,7 +4,7 @@ import { Loader2 } from 'lucide-react'
 
 export default function OAuthCallback() {
   const navigate = useNavigate()
-  
+
   useEffect(() => {
     // Parse the URL parameters
     const params = new URLSearchParams(window.location.search)
@@ -12,44 +12,56 @@ export default function OAuthCallback() {
     const state = params.get('state')
     const error = params.get('error')
     const errorDescription = params.get('error_description')
-    
+
     // Send message to parent window if this was opened as a popup
     if (window.opener && !window.opener.closed) {
       if (error) {
-        window.opener.postMessage({
-          type: 'oauth-callback',
-          error: errorDescription || error
-        }, '*')
+        window.opener.postMessage(
+          {
+            type: 'oauth-callback',
+            error: errorDescription || error,
+          },
+          '*',
+        )
       } else if (code && state) {
-        window.opener.postMessage({
-          type: 'oauth-callback',
-          code,
-          state
-        }, '*')
+        window.opener.postMessage(
+          {
+            type: 'oauth-callback',
+            code,
+            state,
+          },
+          '*',
+        )
       }
-      
+
       // Close this window after a short delay
       setTimeout(() => {
         window.close()
       }, 1000)
     } else {
-      // If not a popup, redirect back to integrations page
-      navigate('/settings/integrations', { 
-        state: { 
-          oauth: { code, state, error: errorDescription || error } 
-        } 
-      })
+      /**
+       * defer OAuth redirect to fix the race condition issue
+       * @todo try to switch to a sessionStorage envelope or a popup + postMessage flow, so this delay can be removed
+       */
+      const t = setTimeout(() => {
+        // If not a popup, redirect back to integrations page
+        navigate('/settings/integrations', {
+          state: {
+            oauth: { code, state, error: errorDescription || error },
+          },
+        })
+      }, 500)
+
+      return () => clearTimeout(t)
     }
   }, [navigate])
-  
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-background">
+    <div className="flex flex-1 flex-col items-center justify-center min-h-screen bg-background">
       <div className="text-center space-y-4">
         <Loader2 className="h-8 w-8 animate-spin mx-auto text-primary" />
         <h1 className="text-xl font-semibold">Completing Authentication...</h1>
-        <p className="text-muted-foreground">
-          Please wait while we complete the authentication process.
-        </p>
+        <p className="text-muted-foreground">Please wait while we complete the authentication process.</p>
       </div>
     </div>
   )


### PR DESCRIPTION
## Description

This PR fixes a race condition where the OAuth callback immediately navigated to /settings/integrations, but a subsequent navigation/replace in the same macrotask cleared location.state, causing the oauth payload to be null a few seconds later.

---

## Render Preview

https://github.com/user-attachments/assets/15723a8c-5900-4fad-b6aa-1e7613f55a66

---

## Related Issue

Closes [THU-30](https://linear.app/mozilla-thunderbolt/issue/THU-30/connect-googles-connected-state-is-not-updating-after-successfully)
