### PR TITLE
THU-50: Revamp Settings -> Models page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "thunderbolt",
       "dependencies": {
         "@ai-sdk-tool/parser": "2.0.12",
+        "@ai-sdk/anthropic": "^2.0.15",
         "@ai-sdk/openai": "^2.0.19",
         "@ai-sdk/openai-compatible": "^1.0.11",
         "@ai-sdk/provider-utils": "^3.0.5",
@@ -116,6 +117,8 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
     "@ai-sdk-tool/parser": ["@ai-sdk-tool/parser@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.3" } }, "sha512-Y7w3z1AGXHnXn7qLHeLBEM4ANP88RX1a2AiLBd8tt3P8cp0O0eTaBI0Jn+ZRkw7mzm5guK0KchYHJOKO7NPNfA=="],
+
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.15", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-MxNGoYvKyF7IqMU0k9gogyiJi0/ogwg6i2Baw862BMjM2KJuBcCPqh6/lrpwiDg6pqphGUc+LfjPd6PRFARnng=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-JKagBcP5JZ3gVLcXGWTiNf7nqIeCD0L4SmwnX66/ZpkLnrH3e0mj1l2BxDaDSbP2wr3XxnrOyBkVOHWgeCtBAw=="],
 
@@ -1906,6 +1909,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
     "@ai-sdk-tool/parser/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.3", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.3", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw=="],
+
+    "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.8", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-cDj1iigu7MW2tgAQeBzOiLhjHOUM9vENsgh4oAVitek0d//WdgfPCsKO3euP7m7LyO/j9a1vr/So+BGNdpFXYw=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@ai-sdk-tool/parser": "2.0.12",
+    "@ai-sdk/anthropic": "^2.0.15",
     "@ai-sdk/openai": "^2.0.19",
     "@ai-sdk/openai-compatible": "^1.0.11",
     "@ai-sdk/provider-utils": "^3.0.5",

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -9,6 +9,7 @@ import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import type { LanguageModelV2 } from '@ai-sdk/provider'
+import { createAnthropic } from '@ai-sdk/anthropic'
 
 // Currently @openrouter/ai-sdk-provider is NOT compatible with Vercel AI SDK v5. If you enable this, you will get the following error:
 // > [Error] Chat error: – Error: Unhandled chunk type: text-start — run-tools-transformation.ts:275
@@ -71,6 +72,16 @@ export const createModel = async (modelConfig: Model): Promise<LanguageModelV2> 
         fetch,
       })
       return openaiCompatible(modelConfig.model)
+    }
+    case 'anthropic': {
+      const anthropic = createAnthropic({
+        apiKey: modelConfig.apiKey || '',
+        fetch,
+        headers: {
+          'anthropic-dangerous-direct-browser-access': 'true',
+        },
+      })
+      return anthropic(modelConfig.model)
     }
     case 'openai': {
       if (!modelConfig.apiKey) throw new Error('No API key provided')

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground cursor-pointer',
+      'peer h-4 w-4 shrink-0 rounded-[4px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground cursor-pointer',
       className,
     )}
     {...props}

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -99,7 +99,7 @@ export const tasksTable = sqliteTable('tasks', {
 export const modelsTable = sqliteTable('models', {
   id: text('id').primaryKey().notNull().unique(),
   provider: text('provider', {
-    enum: ['openai', 'custom', 'openrouter', 'thunderbolt', 'flower'],
+    enum: ['openai', 'custom', 'openrouter', 'thunderbolt', 'anthropic', 'flower'],
   }).notNull(),
   name: text('name').notNull(),
   model: text('model').notNull(),

--- a/src/settings/models/detail.tsx
+++ b/src/settings/models/detail.tsx
@@ -28,7 +28,7 @@ import { getModelById } from '@/lib/dal'
 
 const formSchema = z
   .object({
-    provider: z.enum(['thunderbolt', 'openai', 'custom', 'openrouter', 'flower']),
+    provider: z.enum(['thunderbolt', 'anthropic', 'openai', 'custom', 'openrouter', 'flower']),
     name: z.string().min(1, { message: 'Name is required.' }),
     model: z.string().min(1, { message: 'Model name is required.' }),
     url: z.string().optional(),

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -27,7 +27,7 @@ import { generateText } from 'ai'
 import { eq } from 'drizzle-orm'
 import ky from 'ky'
 import { Check, ChevronsUpDown, Loader2, Lock, Plus, Trash2, X } from 'lucide-react'
-import { useEffect, useReducer, useRef, type KeyboardEvent } from 'react'
+import { useEffect, useMemo, useReducer, useRef, type KeyboardEvent } from 'react'
 import { useForm } from 'react-hook-form'
 import { v7 as uuidv7 } from 'uuid'
 import { z } from 'zod'
@@ -168,7 +168,7 @@ function modelReducer(state: ModelState, action: ModelAction): ModelState {
 
 const formSchema = z
   .object({
-    provider: z.enum(['thunderbolt', 'openai', 'custom', 'openrouter', 'flower']),
+    provider: z.enum(['thunderbolt', 'anthropic', 'openai', 'custom', 'openrouter', 'flower']),
     name: z.string().min(1, { message: 'Name is required.' }),
     model: z.string().min(1, { message: 'Model name is required.' }),
     customModel: z.string().optional(),
@@ -477,6 +477,57 @@ export default function ModelsPage() {
           dispatch({ type: 'FETCH_MODELS_SUCCESS', models: thunderboltModels })
           return
         }
+        case 'anthropic': {
+          const anthropicModels = [
+            {
+              id: 'claude-opus-4-1-20250805',
+              name: 'Claude Opus 4.1',
+              supports_tools: true,
+            },
+            {
+              id: 'claude-opus-4-20250514',
+              name: 'Claude Opus 4',
+              supports_tools: true,
+            },
+            {
+              id: 'claude-sonnet-4-20250514',
+              name: 'Claude Sonnet 4',
+              supports_tools: true,
+            },
+            {
+              id: 'claude-3-7-sonnet-20250219',
+              name: 'Claude Sonnet 3.7',
+              supports_tools: true,
+            },
+            {
+              id: 'claude-3-5-sonnet-20241022',
+              name: 'Claude Sonnet 3.5 (New)',
+              supports_tools: true,
+            },
+            {
+              id: 'claude-3-5-haiku-20241022',
+              name: 'Claude Haiku 3.5',
+              supports_tools: true,
+            },
+            {
+              id: 'claude-3-5-sonnet-20240620',
+              name: 'Claude Sonnet 3.5 (Old)',
+              supports_tools: true,
+            },
+            {
+              id: 'claude-3-haiku-20240307',
+              name: 'Claude Haiku 3',
+              supports_tools: true,
+            },
+            {
+              id: 'claude-3-opus-20240229',
+              name: 'Claude Opus 3',
+              supports_tools: true,
+            },
+          ]
+          dispatch({ type: 'FETCH_MODELS_SUCCESS', models: anthropicModels })
+          return
+        }
       }
 
       if (endpoint) {
@@ -619,7 +670,7 @@ export default function ModelsPage() {
       form.setValue('toolUsage', true, { shouldValidate: false, shouldDirty: false })
 
       // Fetch models if we have the necessary credentials
-      if (currentProvider === 'thunderbolt') {
+      if (['thunderbolt', 'anthropic'].includes(currentProvider)) {
         fetchAvailableModels(currentProvider)
       }
 
@@ -637,7 +688,10 @@ export default function ModelsPage() {
     const apiKey = watchedApiKey
     const url = watchedUrl
 
-    if (provider && (provider === 'thunderbolt' || (provider && apiKey) || (provider === 'custom' && url))) {
+    if (
+      provider &&
+      (['thunderbolt', 'anthropic'].includes(provider) || (provider && apiKey) || (provider === 'custom' && url))
+    ) {
       fetchAvailableModels(provider, apiKey, url)
     }
   }, [watchedApiKey, watchedUrl, form])
@@ -647,6 +701,8 @@ export default function ModelsPage() {
       case 'thunderbolt':
       case 'flower':
         return 'Thunderbolt'
+      case 'anthropic':
+        return 'Anthropic'
       case 'openai':
         return 'OpenAI'
       case 'custom':
@@ -688,6 +744,16 @@ export default function ModelsPage() {
     return (model as any)?.supports_tools === true
   })()
 
+  const watchedModel = form.watch('model')
+
+  const canTestConnection = useMemo(() => {
+    if (watchedProvider === 'anthropic') {
+      return !!watchedModel && watchedApiKey
+    }
+
+    return !!watchedModel
+  }, [watchedApiKey, watchedModel, watchedProvider])
+
   return (
     <div className="flex flex-col gap-4 p-4 pb-12 w-full max-w-[760px] mx-auto">
       <div className="flex items-center justify-between">
@@ -720,6 +786,7 @@ export default function ModelsPage() {
                             <SelectItem value="thunderbolt">Thunderbolt</SelectItem>
                             <SelectItem value="openai">OpenAI</SelectItem>
                             <SelectItem value="openrouter">OpenRouter</SelectItem>
+                            <SelectItem value="anthropic">Anthropic</SelectItem>
                             <SelectItem value="custom">Custom</SelectItem>
                           </SelectContent>
                         </Select>
@@ -782,11 +849,14 @@ export default function ModelsPage() {
 
                   // Show model selection if:
                   // 1. Thunderbolt (no API key needed)
+                  // 1. Anthropic (API key required for testing - model list is hardwired)
                   // 2. Other providers with API key
                   // 3. OpenAI Compatible with URL (API key optional)
                   const showModelSelection =
                     !modelLoadError &&
-                    (provider === 'thunderbolt' || (provider && apiKey) || (provider === 'custom' && url))
+                    (['thunderbolt', 'anthropic'].includes(provider) ||
+                      (provider && apiKey) ||
+                      (provider === 'custom' && url))
 
                   if (!showModelSelection) return null
 
@@ -925,7 +995,7 @@ export default function ModelsPage() {
                 )}
 
                 {/* Display Name - Only show when model is selected */}
-                {(form.watch('model') || selectedModelId === 'custom') && (
+                {(watchedModel || selectedModelId === 'custom') && (
                   <>
                     <FormField
                       control={form.control}
@@ -959,7 +1029,7 @@ export default function ModelsPage() {
                 )}
 
                 {/* Warning when model lacks tool support */}
-                {!supportsToolsSelected && (form.watch('model') || selectedModelId === 'custom') && (
+                {!supportsToolsSelected && (watchedModel || selectedModelId === 'custom') && (
                   <StatusCard
                     title={
                       <>
@@ -972,7 +1042,7 @@ export default function ModelsPage() {
                 )}
 
                 {/* Test Connection Button */}
-                {form.watch('model') && (
+                {canTestConnection && (
                   <Button
                     type="button"
                     onClick={testConnection}

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -999,14 +999,12 @@ export default function ModelsPage() {
                   <>
                     <FormField
                       control={form.control}
-                      name="toolUsage"
+                      name="name"
                       render={({ field }) => (
                         <FormItem>
+                          <FormLabel>Display Name</FormLabel>
                           <FormControl>
-                            <div className="flex items-center gap-3">
-                              <Checkbox checked={field.value} onCheckedChange={field.onChange} id="toolUsage" />
-                              <FormLabel htmlFor="toolUsage">Supports tools</FormLabel>
-                            </div>
+                            <Input {...field} placeholder="e.g., GPT-4 Turbo" />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -1014,12 +1012,14 @@ export default function ModelsPage() {
                     />
                     <FormField
                       control={form.control}
-                      name="name"
+                      name="toolUsage"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Display Name</FormLabel>
                           <FormControl>
-                            <Input {...field} placeholder="e.g., GPT-4 Turbo" />
+                            <div className="flex items-center gap-3">
+                              <Checkbox checked={field.value} onCheckedChange={field.onChange} id="toolUsage" />
+                              <FormLabel htmlFor="toolUsage">Enable tool use</FormLabel>
+                            </div>
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -1117,7 +1117,18 @@ export default function ModelsPage() {
                     </div>
                     <div className="min-w-0 flex-1">
                       <CardTitle className="text-lg font-medium flex flex-row items-center gap-2">
-                        {!!model.isConfidential && <Lock className="size-3.5" />}
+                        {!!model.isConfidential && (
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Lock className="size-3.5" />
+                              </TooltipTrigger>
+                              <TooltipContent side="bottom">
+                                <p>Encrypted</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        )}
                         {model.name}
                       </CardTitle>
                       <p className="text-sm text-muted-foreground">

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -644,6 +644,7 @@ export default function ModelsPage() {
   const getProviderDisplay = (provider: string) => {
     switch (provider) {
       case 'thunderbolt':
+      case 'flower':
         return 'Thunderbolt'
       case 'openai':
         return 'OpenAI'
@@ -651,8 +652,6 @@ export default function ModelsPage() {
         return 'Custom'
       case 'openrouter':
         return 'OpenRouter'
-      case 'flower':
-        return 'Flower'
       default:
         return provider
     }
@@ -1129,7 +1128,7 @@ export default function ModelsPage() {
                         <span className="text-sm font-mono truncate max-w-[300px]">{model.url}</span>
                       </div>
                     )}
-                    {model.provider === 'thunderbolt' && (
+                    {['thunderbolt', 'flower'].includes(model.provider) && (
                       <div className="text-sm text-muted-foreground">Uses Thunderbolt cloud service</div>
                     )}
                   </div>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -1092,7 +1092,7 @@ export default function ModelsPage() {
                   <Button variant="outline" onClick={() => handleDialogOpenChange(false)}>
                     Cancel
                   </Button>
-                  <Button type="submit" disabled={addModelMutation.isPending || connectionStatus !== 'success'}>
+                  <Button type="submit" disabled={addModelMutation.isPending}>
                     {addModelMutation.isPending ? 'Adding...' : 'Add Model'}
                   </Button>
                 </div>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -32,6 +32,7 @@ import { useForm } from 'react-hook-form'
 import { v7 as uuidv7 } from 'uuid'
 import { z } from 'zod'
 import { getAllModels } from '@/lib/dal'
+import type { Model } from '@/types'
 
 interface AvailableModel {
   id: string
@@ -657,8 +658,8 @@ export default function ModelsPage() {
     }
   }
 
-  const getProviderInitial = (provider: string) => {
-    return provider[0].toUpperCase()
+  const getModelInitial = (model: Model) => {
+    return model.name[0].toUpperCase()
   }
 
   const handleDeleteModel = (modelId: string) => {
@@ -1026,7 +1027,7 @@ export default function ModelsPage() {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3 min-w-0 flex-1">
                     <div className="flex items-center justify-center bg-primary text-primary-foreground size-8 rounded-md font-medium flex-shrink-0">
-                      {getProviderInitial(model.provider)}
+                      {getModelInitial(model)}
                     </div>
                     <div className="min-w-0 flex-1">
                       <CardTitle className="text-lg font-medium">{model.name}</CardTitle>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -33,6 +33,7 @@ import { v7 as uuidv7 } from 'uuid'
 import { z } from 'zod'
 import { getAllModels } from '@/lib/dal'
 import type { Model } from '@/types'
+import { Checkbox } from '@/components/ui/checkbox'
 
 interface AvailableModel {
   id: string
@@ -925,19 +926,36 @@ export default function ModelsPage() {
 
                 {/* Display Name - Only show when model is selected */}
                 {(form.watch('model') || selectedModelId === 'custom') && (
-                  <FormField
-                    control={form.control}
-                    name="name"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Display Name</FormLabel>
-                        <FormControl>
-                          <Input {...field} placeholder="e.g., GPT-4 Turbo" />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                  <>
+                    <FormField
+                      control={form.control}
+                      name="toolUsage"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormControl>
+                            <div className="flex items-center gap-3">
+                              <Checkbox checked={field.value} onCheckedChange={field.onChange} id="toolUsage" />
+                              <FormLabel htmlFor="toolUsage">Supports tools</FormLabel>
+                            </div>
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="name"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Display Name</FormLabel>
+                          <FormControl>
+                            <Input {...field} placeholder="e.g., GPT-4 Turbo" />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </>
                 )}
 
                 {/* Warning when model lacks tool support */}

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -719,7 +719,6 @@ export default function ModelsPage() {
                             <SelectItem value="thunderbolt">Thunderbolt</SelectItem>
                             <SelectItem value="openai">OpenAI</SelectItem>
                             <SelectItem value="openrouter">OpenRouter</SelectItem>
-                            <SelectItem value="flower">Flower</SelectItem>
                             <SelectItem value="custom">Custom</SelectItem>
                           </SelectContent>
                         </Select>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -26,7 +26,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { generateText } from 'ai'
 import { eq } from 'drizzle-orm'
 import ky from 'ky'
-import { Check, ChevronsUpDown, Loader2, Plus, Trash2, X } from 'lucide-react'
+import { Check, ChevronsUpDown, Loader2, Lock, Plus, Trash2, X } from 'lucide-react'
 import { useEffect, useReducer, useRef, type KeyboardEvent } from 'react'
 import { useForm } from 'react-hook-form'
 import { v7 as uuidv7 } from 'uuid'
@@ -1030,7 +1030,10 @@ export default function ModelsPage() {
                       {getModelInitial(model)}
                     </div>
                     <div className="min-w-0 flex-1">
-                      <CardTitle className="text-lg font-medium">{model.name}</CardTitle>
+                      <CardTitle className="text-lg font-medium flex flex-row items-center gap-2">
+                        {!!model.isConfidential && <Lock className="size-3.5" />}
+                        {model.name}
+                      </CardTitle>
                       <p className="text-sm text-muted-foreground">
                         {getProviderDisplay(model.provider)} - {model.model}
                       </p>


### PR DESCRIPTION
### Changes
- Removed automatic tool support check (no more test prompt requirement).
- Added **“Supports tools”** checkbox when adding/editing a model.  
  - Default state is based on existing logic, but users can override it.
- Removed **Flower** provider type (now part of Thunderbolt).
- Added **Anthropic** as a provider option (using AI SDK provider).
- Updated model list:
  - Show first letter of model name as icon.
  - Show lock icon for encrypted models.
- Removed status validation on adding a model

### Preview
<img width="524" height="550" alt="image" src="https://github.com/user-attachments/assets/c02667bc-a903-4b5e-bca3-e25a7121d98e" />
