### PR TITLE
THU-64: Fix infinite loading loop when incomplete tool call states exist

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -18,16 +18,17 @@ import { createAnthropic } from '@ai-sdk/anthropic'
 
 import { createFlowerProvider } from '@/flower'
 import {
+  type ToolSet,
   convertToModelMessages,
   type experimental_createMCPClient,
   stepCountIs,
   streamText,
   wrapLanguageModel,
-  type ToolSet,
 } from 'ai'
 import { eq } from 'drizzle-orm'
 import { createConfiguredFlowerClient } from './flower'
 import { createDefaultMiddleware, createFlowerMiddleware } from './middleware/default'
+import { filterIncompleteAssistantMessage } from './utils'
 
 export type MCPClient = Awaited<ReturnType<typeof experimental_createMCPClient>>
 
@@ -189,7 +190,8 @@ export const aiFetchStreamingResponse = async ({
       temperature: 0.25,
       model: wrappedModel,
       system: systemPrompt,
-      messages: convertToModelMessages(messages),
+      // Remove the last assistant message if it contains tool calls that have not completed yet.
+      messages: convertToModelMessages(filterIncompleteAssistantMessage(messages)),
       tools: supportsTools ? toolset : undefined,
       stopWhen: stepCountIs(20),
       abortSignal,

--- a/src/ai/utils.test.ts
+++ b/src/ai/utils.test.ts
@@ -1,0 +1,209 @@
+import type { ThunderboltUIMessage } from '@/types'
+import { describe, expect, it } from 'vitest'
+import { filterIncompleteAssistantMessage } from './utils'
+
+describe('filterIncompleteAssistantMessage', () => {
+  it('returns messages unchanged when no assistant message exists', () => {
+    const messages: ThunderboltUIMessage[] = [
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+      { id: '2', role: 'user', parts: [{ type: 'text', text: 'How are you?' }] },
+    ]
+
+    const result = filterIncompleteAssistantMessage(messages)
+    expect(result).toBe(messages) // should return same reference
+  })
+
+  it('returns messages unchanged when assistant message has completed tool calls', () => {
+    const messages: ThunderboltUIMessage[] = [
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'Search for cats' }] },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          { type: 'step-start' },
+          {
+            type: 'tool-search_ddg',
+            toolCallId: 'call_123',
+            state: 'output-available',
+            input: { query: 'cats' },
+            output: 'Found 3 results about cats',
+          },
+          { type: 'text', text: 'Here are some results about cats', state: 'done' },
+        ],
+      },
+    ]
+
+    const result = filterIncompleteAssistantMessage(messages)
+    expect(result).toBe(messages) // should return same reference
+  })
+
+  it('removes assistant message with incomplete tool calls (input-available state)', () => {
+    const messages: ThunderboltUIMessage[] = [
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'Search for dogs' }] },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          { type: 'step-start' },
+          {
+            type: 'tool-search_ddg',
+            toolCallId: 'call_456',
+            state: 'input-available', // incomplete state
+            input: { query: 'dogs' },
+          },
+        ],
+      },
+      { id: '3', role: 'user', parts: [{ type: 'text', text: 'What happened?' }] },
+    ]
+
+    const result = filterIncompleteAssistantMessage(messages)
+    expect(result).toEqual([{ id: '1', role: 'user', parts: [{ type: 'text', text: 'Search for dogs' }] }])
+  })
+
+  it('removes assistant message with incomplete tool calls (input-streaming state)', () => {
+    const messages: ThunderboltUIMessage[] = [
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'Check calendar' }] },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          { type: 'step-start' },
+          {
+            type: 'tool-google_check_calendar',
+            toolCallId: 'call_789',
+            state: 'input-streaming', // incomplete state
+            input: { days_ahead: 7 },
+          },
+        ],
+      },
+    ]
+
+    const result = filterIncompleteAssistantMessage(messages)
+    expect(result).toEqual([{ id: '1', role: 'user', parts: [{ type: 'text', text: 'Check calendar' }] }])
+  })
+
+  it('handles multiple assistant messages, only checking the most recent one', () => {
+    const messages: ThunderboltUIMessage[] = [
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'First question' }] },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-search_ddg',
+            toolCallId: 'call_old',
+            state: 'input-available', // incomplete, but not the most recent
+            input: { query: 'old search' },
+          },
+        ],
+      },
+      { id: '3', role: 'user', parts: [{ type: 'text', text: 'Second question' }] },
+      {
+        id: '4',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-search_ddg',
+            toolCallId: 'call_new',
+            state: 'output-available', // complete
+            input: { query: 'new search' },
+            output: 'Results found',
+          },
+          { type: 'text', text: 'Here are the results', state: 'done' },
+        ],
+      },
+    ]
+
+    const result = filterIncompleteAssistantMessage(messages)
+    expect(result).toBe(messages) // should return same reference since most recent is complete
+  })
+
+  it('removes most recent incomplete assistant and subsequent messages', () => {
+    const messages: ThunderboltUIMessage[] = [
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'First question' }] },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-search_ddg',
+            toolCallId: 'call_complete',
+            state: 'output-available',
+            input: { query: 'complete search' },
+            output: 'Results',
+          },
+          { type: 'text', text: 'First answer', state: 'done' },
+        ],
+      },
+      { id: '3', role: 'user', parts: [{ type: 'text', text: 'Second question' }] },
+      {
+        id: '4',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-search_ddg',
+            toolCallId: 'call_incomplete',
+            state: 'input-available', // incomplete
+            input: { query: 'incomplete search' },
+          },
+        ],
+      },
+      { id: '5', role: 'user', parts: [{ type: 'text', text: 'Follow-up question' }] },
+    ]
+
+    const result = filterIncompleteAssistantMessage(messages)
+    expect(result).toEqual([
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'First question' }] },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-search_ddg',
+            toolCallId: 'call_complete',
+            state: 'output-available',
+            input: { query: 'complete search' },
+            output: 'Results',
+          },
+          { type: 'text', text: 'First answer', state: 'done' },
+        ],
+      },
+      { id: '3', role: 'user', parts: [{ type: 'text', text: 'Second question' }] },
+    ])
+  })
+
+  it('handles empty messages array', () => {
+    const messages: ThunderboltUIMessage[] = []
+    const result = filterIncompleteAssistantMessage(messages)
+    expect(result).toBe(messages) // should return same reference
+  })
+
+  it('handles assistant message with mixed tool states (incomplete wins)', () => {
+    const messages: ThunderboltUIMessage[] = [
+      { id: '1', role: 'user', parts: [{ type: 'text', text: 'Multi-tool request' }] },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          { type: 'step-start' },
+          {
+            type: 'tool-search_ddg',
+            toolCallId: 'call_complete',
+            state: 'output-available',
+            input: { query: 'complete' },
+            output: 'Done',
+          },
+          {
+            type: 'tool-google_check_calendar',
+            toolCallId: 'call_incomplete',
+            state: 'input-available', // this makes the whole message incomplete
+            input: { days_ahead: 1 },
+          },
+        ],
+      },
+    ]
+
+    const result = filterIncompleteAssistantMessage(messages)
+    expect(result).toEqual([{ id: '1', role: 'user', parts: [{ type: 'text', text: 'Multi-tool request' }] }])
+  })
+})

--- a/src/ai/utils.ts
+++ b/src/ai/utils.ts
@@ -1,0 +1,28 @@
+import type { ThunderboltUIMessage } from '@/types'
+import { lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
+
+/**
+ * Remove the most recent assistant message (and any messages that follow it)
+ * whenever that assistant message still has unfinished tool calls (state !== 'output-available').
+ *
+ * This prevents `convertToModelMessages` from throwing `Unsupported tool part state: input-available`.
+ */
+export const filterIncompleteAssistantMessage = (messages: ThunderboltUIMessage[]): ThunderboltUIMessage[] => {
+  // Walk backwards to locate the most-recent assistant message without allocating
+  let assistantIdx = -1
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'assistant') {
+      assistantIdx = i
+      break
+    }
+  }
+
+  if (assistantIdx === -1) return messages // no assistant message found
+
+  const assistantMessage = messages[assistantIdx]
+
+  // Evaluate completeness on that single message only – cheaper than scanning full history
+  const isComplete = lastAssistantMessageIsCompleteWithToolCalls({ messages: [assistantMessage] })
+
+  return isComplete ? messages : messages.slice(0, assistantIdx)
+}


### PR DESCRIPTION
https://linear.app/mozilla-thunderbolt/issue/THU-64/fix-infinite-loading-loop-bug-when-there-are-incomplete-tool-calls

This PR fixes the infinite loading loop described in THU-64, but currently it has a bug that causes the LLM to respond to the first message twice:
<img width="785" height="589" alt="Screenshot 2025-09-11 at 5 14 14 PM" src="https://github.com/user-attachments/assets/26de9d7f-bcb9-49dd-90bc-93394abf3b7d" />
