### PR TITLE
THU-76: Enable PostHog error tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,19 @@ jobs:
           # TODO: Investigate Bun module mocking behavior in CI environment
           bun test --test-name-pattern="^(?!.*Google Utils).*$"
 
+      # Upload source maps to PostHog only for main branch
+      - name: Build application with source maps
+        run: bun run build
+        env:
+          NODE_ENV: production
+
+      - name: Inject & upload source maps to PostHog
+        uses: PostHog/upload-source-maps@v0.4.6
+        with:
+          directory: dist
+          env-id: ${{ secrets.POSTHOG_CLI_ENV_ID }}
+          cli-token: ${{ secrets.POSTHOG_CLI_TOKEN }}
+
   rust:
     needs: detect-changes
     if: needs.detect-changes.outputs.rust == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
         run: bun run build
         env:
           NODE_ENV: production
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Inject & upload source maps to PostHog
         uses: PostHog/upload-source-maps@v0.4.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,12 +123,14 @@ jobs:
 
       # Upload source maps to PostHog only for main branch
       - name: Build application with source maps
+        if: github.ref == 'refs/heads/main'
         run: bun run build
         env:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Inject & upload source maps to PostHog
+        if: github.ref == 'refs/heads/main'
         uses: PostHog/upload-source-maps@v0.4.6
         with:
           directory: dist

--- a/src/lib/analytics.tsx
+++ b/src/lib/analytics.tsx
@@ -56,6 +56,7 @@ export const initPosthog = async (): Promise<PostHog | null> => {
       api_host: apiHost,
       debug: enableDebug,
       autocapture: false,
+      capture_exceptions: true,
       capture_pageview: false,
       capture_pageleave: false,
       persistence: 'localStorage',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,9 @@ const shouldAnalyze = process.env.ANALYZE?.toLowerCase() === 'true' || process.a
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    sourcemap: true, // This enables source map generation
+  },
   plugins: [
     {
       name: 'bundle-migrations',


### PR DESCRIPTION
## Changes
- **CI Workflow**: Combined source map upload into main CI workflow, only runs on main branch pushes (not PRs)
- **Source Maps**: Vite config already has `sourcemap: true` enabled for production builds
- **Error Tracking**: PostHog will now capture exceptions with proper source map support for better debugging

## Benefits
- Reuses existing bun installation in CI (no duplicate setup)
- Source maps only uploaded for main branch (saves CI time on PRs)
- Better error tracking with readable stack traces in PostHog
- Simplified workflow management (removed separate sourcemap workflow)
