### PR TITLE
THU-77: Data reset fails in Tauri Mac

### DIFF
--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -72,11 +72,16 @@ const resetAppDirOpfs = async (): Promise<void> => {
     throw new Error('OPFS is not available')
   }
 
-  const appDataDirPath = await createAppDirOpfs()
-  const root = await navigator.storage.getDirectory()
+  const appDataDirPath = await createAppDir()
+  const root: any = await navigator.storage.getDirectory()
 
-  await root.removeEntry(appDataDirPath, { recursive: true })
-  await root.getDirectoryHandle(appDataDirPath, { create: true })
+  for await (const [name] of root.entries()) {
+    await root.removeEntry(name, { recursive: true })
+  }
+
+  if (!isTauri()) {
+    await root.getDirectoryHandle(appDataDirPath, { create: true })
+  }
 }
 
 /**
@@ -95,9 +100,11 @@ export const resetAppDir = async (): Promise<void> => {
     return
   }
 
-  if (isTauri()) {
+  if (databaseType === 'libsql-tauri') {
     await resetAppDirTauri()
-  } else {
+  } else if (databaseType === 'sqlocal') {
     await resetAppDirOpfs()
+  } else {
+    throw new Error(`Unsupported database type: ${databaseType}`)
   }
 }


### PR DESCRIPTION
### Description
Refactor reset logic in `fs.ts` to branch on **database type** rather than whether the app is running in Tauri.  

Previously, reset assumed `isTauri` always meant `libsql`, which broke once sqlocal started being used inside Tauri. This change makes the logic explicit:
- `libsql-tauri` → use Tauri FS to reset the app data dir.
- `sqlocal` → wipe OPFS entries directly.

### Changes
- Updated `resetAppDir` to check `databaseType` instead of `isTauri`.
- Updated `resetAppDirOpfs` to:
  - Remove all OPFS entries at the root.
  - Only recreate the app-data directory in the browser (skip in Tauri, since
    sqlocal manages the DB file itself).
- Keeps reset consistent across environments and avoids the
  `TypeError: Name is invalid` error in Tauri.

### Result
- Reset now works reliably in both browser and Tauri with sqlocal.
- Libsql reset continues to work via Tauri FS.
- Cleaner separation of logic by backend, not runtime.
