### PR TITLE
Fix fetch-content endpoint

### DIFF
--- a/backend/src/pro/exa.test.ts
+++ b/backend/src/pro/exa.test.ts
@@ -232,8 +232,7 @@ describe('Pro - Exa', () => {
         },
       })
       
-      const parsed = JSON.parse(result)
-      expect(parsed).toEqual({
+      expect(result).toEqual({
         url: 'https://example.com',
         title: 'Test Page',
         text: 'This is the fetched content from the webpage',
@@ -256,9 +255,10 @@ describe('Pro - Exa', () => {
 
       const result = await fetchContentExa('https://example.com', mockContext)
 
-      const parsed = JSON.parse(result)
-      expect(parsed.text).toBe('')
-      expect(parsed.url).toBe('https://example.com')
+      expect(result).toMatchObject({
+        text: '',
+        url: 'https://example.com',
+      })
     })
 
     it('should handle no results', async () => {
@@ -266,7 +266,7 @@ describe('Pro - Exa', () => {
 
       const result = await fetchContentExa('https://example.com', mockContext)
 
-      expect(result).toBe('Error: No content found for the provided URL')
+      expect(result).toEqual({ error: 'Error: No content found for the provided URL' })
     })
 
     it('should handle missing text field', async () => {
@@ -280,8 +280,9 @@ describe('Pro - Exa', () => {
 
       const result = await fetchContentExa('https://example.com', mockContext)
 
-      const parsed = JSON.parse(result)
-      expect(parsed.text).toBe('')
+      expect(result).toMatchObject({
+        text: '',
+      })
     })
 
     it('should return error message when API key is not configured', async () => {
@@ -291,7 +292,7 @@ describe('Pro - Exa', () => {
 
       const result = await fetchContentExa('https://example.com', mockContext)
 
-      expect(result).toBe('Error: Exa API key not configured')
+      expect(result).toEqual({ error: 'Error: Exa API key not configured' })
       expect(mockExa.getContents).not.toHaveBeenCalled()
     })
 
@@ -301,7 +302,7 @@ describe('Pro - Exa', () => {
 
       const result = await fetchContentExa('https://example.com', mockContext)
 
-      expect(result).toBe('Error: Error: Network error') // fetchContentExa adds "Error: " prefix to String(error)
+      expect(result).toEqual({ error: 'Error: Error: Network error' }) // fetchContentExa adds "Error: " prefix to String(error)
       // Error handling tested by checking return value
     })
 
@@ -310,7 +311,7 @@ describe('Pro - Exa', () => {
 
       const result = await fetchContentExa('https://example.com', mockContext)
 
-      expect(result).toBe('Error: String error')
+      expect(result).toEqual({ error: 'Error: String error' })
     })
 
     it('should use correct configuration parameters', async () => {

--- a/backend/src/pro/exa.ts
+++ b/backend/src/pro/exa.ts
@@ -62,10 +62,18 @@ export const searchExa = async (
  * Fetch content from a URL using Exa's privacy-protected proxy
  * Returns a JSON string with content, favicon, and image
  */
-export const fetchContentExa = async (url: string, ctx: SimpleContext): Promise<string> => {
+export const fetchContentExa = async (url: string, ctx: SimpleContext): Promise<{
+        url: string
+        title: string | null
+        text: string
+        favicon: string | null
+        image: string | null
+        author: string | null
+        published_date: string | null
+      } | { error:string }> => {
   const client = createExaClient()
   if (!client) {
-    return 'Error: Exa API key not configured'
+    return {error: 'Error: Exa API key not configured'}
   }
 
   try {
@@ -89,12 +97,12 @@ export const fetchContentExa = async (url: string, ctx: SimpleContext): Promise<
         author: content.author || null,
         published_date: content.publishedDate || null,
       }
-      return JSON.stringify(result, null, 2)
+      return result
     } else {
-      return 'Error: No content found for the provided URL'
+      return {error: 'Error: No content found for the provided URL'}
     }
   } catch (error) {
     await ctx.error(`Exa content fetch error: ${String(error)}`)
-    return `Error: ${String(error)}`
+    return {error: `Error: ${String(error)}`}
   }
 }

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -98,7 +98,7 @@ export const createProToolsRoutes = () => {
         const content = await fetchContentExa(request.url, ctx)
 
         // Check if Exa returned an error message
-        if (content.error) {
+        if ('error' in content) {
           return {
             data: null,
             success: false,

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -98,11 +98,11 @@ export const createProToolsRoutes = () => {
         const content = await fetchContentExa(request.url, ctx)
 
         // Check if Exa returned an error message
-        if (content.startsWith('Error:')) {
+        if (content.error) {
           return {
             data: null,
             success: false,
-            error: content,
+            error: content.error,
           }
         }
 

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -36,9 +36,20 @@ export const fetchContentRequestSchema = z.object({
   url: z.string(),
 })
 
-export const fetchContentResponseSchema = baseApiResponseSchema(z.string())
+export const fetchContentDataSchema = z.object({
+  url: z.string(),
+  title: z.string().nullable(),
+  text: z.string(),
+  favicon: z.string().nullable(),
+  image: z.string().nullable(),
+  author: z.string().nullable(),
+  published_date: z.string().nullable(),
+})
+
+export const fetchContentResponseSchema = baseApiResponseSchema(fetchContentDataSchema)
 
 export type FetchContentRequest = z.infer<typeof fetchContentRequestSchema>
+export type FetchContentData = z.infer<typeof fetchContentDataSchema>
 export type FetchContentResponse = z.infer<typeof fetchContentResponseSchema>
 
 /**

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -1,10 +1,10 @@
 import { getToolMetadataSync } from '@/lib/tool-metadata'
-import { splitPartType } from '@/lib/utils'
+import { cn, splitPartType } from '@/lib/utils'
 import type { ToolUIPart } from 'ai'
+import { motion } from 'framer-motion'
 import { Loader2 } from 'lucide-react'
 import { Avatar, AvatarFallback } from '../ui/avatar'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
-import { motion } from 'framer-motion'
 import { useObjectView } from './object-view-provider'
 
 type ToolGroupProps = {
@@ -20,7 +20,8 @@ export const ToolGroup = ({ tools }: ToolGroupProps) => {
         const [, toolName] = splitPartType(tool.type)
         const metadata = getToolMetadataSync(toolName, tool.input)
         const Icon = metadata.icon
-        const isLoading = tool.state !== 'output-available' || !tool.output
+        const isError = tool.state === 'output-error'
+        const isLoading = (tool.state !== 'output-available' || !tool.output) && !isError
         const tooltipKey = tool.toolCallId ?? `${toolName}-${index}`
 
         return (
@@ -34,7 +35,7 @@ export const ToolGroup = ({ tools }: ToolGroupProps) => {
               >
                 <Avatar
                   className="border-2 border-background size-9 cursor-pointer"
-                  onClick={() => !isLoading && openObjectSidebar(tool)}
+                  onClick={() => !isLoading && !isError && openObjectSidebar(tool)}
                 >
                   <AvatarFallback>
                     {isLoading ? (
@@ -57,7 +58,7 @@ export const ToolGroup = ({ tools }: ToolGroupProps) => {
                         }}
                         exit={{ scale: 0 }}
                       >
-                        <Icon className="size-4" />
+                        <Icon className={cn('size-4', isError && 'text-yellow-500')} />
                       </motion.div>
                     ) : (
                       metadata.initials

--- a/src/integrations/thunderbolt-pro/tools.ts
+++ b/src/integrations/thunderbolt-pro/tools.ts
@@ -40,6 +40,16 @@ export type FetchContentParams = z.infer<typeof fetchContentSchema>
 export type WeatherParams = z.infer<typeof weatherSchema>
 export type SearchLocationParams = z.infer<typeof searchLocationSchema>
 
+type FetchContentData = {
+  url: string
+  title: string | null
+  text: string
+  favicon: string | null
+  image: string | null
+  author: string | null
+  published_date: string | null
+}
+
 /**
  * Search the web and return formatted results
  */
@@ -68,7 +78,7 @@ export const search = async (params: SearchParams): Promise<string> => {
 /**
  * Fetch and parse content from a webpage URL
  */
-export const fetchContent = async (params: FetchContentParams): Promise<string> => {
+export const fetchContent = async (params: FetchContentParams): Promise<FetchContentData> => {
   try {
     const cloudUrl = await getCloudUrl()
     const response = await ky
@@ -77,12 +87,11 @@ export const fetchContent = async (params: FetchContentParams): Promise<string> 
           url: params.url,
         },
       })
-      .json<{ data: string; success: boolean; error?: string }>()
+      .json<{ data: FetchContentData; success: boolean; error?: string }>()
 
     if (!response.success) {
       throw new Error(response.error || 'Fetch content failed')
     }
-
     return response.data
   } catch (error) {
     console.error('Fetch content error:', error)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches fetch-content to return a structured object with an explicit error field and updates backend types/routes, client integration, tests, and UI to handle error state.
> 
> - **Backend**:
>   - **Fetch Content**: `fetchContentExa` now returns a structured object (`url`, `title`, `text`, `favicon`, `image`, `author`, `published_date`) or `{ error }` instead of a JSON string.
>   - **Routes**: `/pro/fetch-content` checks `'error' in content` and propagates `content.error`.
>   - **Types**: Introduces `fetchContentDataSchema` and updates `fetchContentResponseSchema` to use it; adds `FetchContentData` type.
>   - **Tests**: Update `exa.test.ts` to assert object returns and `{ error }` cases (remove `JSON.parse`).
> - **Integrations**:
>   - **Thunderbolt Pro**: `fetchContent` now returns `FetchContentData`; updates response typing from `string` to structured data.
> - **UI**:
>   - **ToolGroup**: Adds error state handling (`output-error`), disables click on error, and tints icon on error; refines loading logic and uses `cn` for classes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17d575d13ea146e0405a1a842b310a4b6e225486. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->