### PR TITLE
THU-89: Persist partial responses during streaming

### DIFF
--- a/src/chats/chat-state.tsx
+++ b/src/chats/chat-state.tsx
@@ -1,6 +1,7 @@
 import { aiFetchStreamingResponse } from '@/ai/fetch'
 import ChatUI from '@/components/chat/chat-ui'
 import { useSetting } from '@/hooks/use-setting'
+import { useThrottledCallback } from '@/hooks/use-throttle'
 import { trackEvent } from '@/lib/analytics'
 import { getDefaultModelForThread, getTriggerPromptForThread } from '@/lib/dal'
 import { useMCP } from '@/lib/mcp-provider'
@@ -25,46 +26,20 @@ type UseSavePartialAssistantMessages = {
 }
 
 const useSavePartialAssistantMessages = ({ chatHelpers, id, saveMessages }: UseSavePartialAssistantMessages) => {
-  const refSaveInterval = useRef<NodeJS.Timeout>(null)
+  const throttledSave = useThrottledCallback((message: ThunderboltUIMessage) => {
+    saveMessages({
+      id,
+      messages: [message],
+    })
+  }, 200)
 
-  const refLatestMessageLength = useRef(0)
-
-  // ensure interval is cleared on component's unmount
   useEffect(() => {
-    return () => {
-      clearInterval(refSaveInterval.current ?? 0)
+    const latestMessage = chatHelpers.messages[chatHelpers.messages.length - 1]
+
+    if (chatHelpers.status === 'streaming' && latestMessage?.role === 'assistant') {
+      throttledSave(latestMessage)
     }
-  }, [])
-
-  // start the interval to save the latest message while it's streaming
-  useEffect(() => {
-    if (chatHelpers.status === 'streaming') {
-      console.log('DEBUG: streaming...')
-
-      clearInterval(refSaveInterval.current ?? 0)
-
-      refSaveInterval.current = setInterval(() => {
-        const latestMessage = chatHelpers.messages[chatHelpers.messages.length - 1]
-
-        const latestMessageLength = JSON.stringify(latestMessage).length
-
-        if (latestMessage.role === 'assistant' && latestMessageLength !== refLatestMessageLength.current) {
-          refLatestMessageLength.current = latestMessageLength
-
-          console.log('DEBUG: saving each...', refLatestMessageLength.current)
-
-          saveMessages({
-            id,
-            messages: [latestMessage],
-          })
-        }
-      }, 1000)
-      return
-    }
-
-    console.log('DEBUG: clearing...', chatHelpers.status)
-    clearInterval(refSaveInterval.current ?? 0)
-  }, [chatHelpers.status])
+  }, [chatHelpers.messages, chatHelpers.status, throttledSave])
 }
 
 export default function ChatState({ id, models, initialMessages, saveMessages }: ChatStateProps) {

--- a/src/chats/chat-state.tsx
+++ b/src/chats/chat-state.tsx
@@ -5,7 +5,7 @@ import { trackEvent } from '@/lib/analytics'
 import { getDefaultModelForThread, getTriggerPromptForThread } from '@/lib/dal'
 import { useMCP } from '@/lib/mcp-provider'
 import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
-import { useChat } from '@ai-sdk/react'
+import { useChat, type UseChatHelpers } from '@ai-sdk/react'
 import { useQuery } from '@tanstack/react-query'
 import { DefaultChatTransport } from 'ai'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -16,6 +16,55 @@ interface ChatStateProps {
   models: Model[]
   initialMessages?: ThunderboltUIMessage[]
   saveMessages: SaveMessagesFunction
+}
+
+type UseSavePartialAssistantMessages = {
+  chatHelpers: UseChatHelpers<ThunderboltUIMessage>
+  id: string
+  saveMessages: SaveMessagesFunction
+}
+
+const useSavePartialAssistantMessages = ({ chatHelpers, id, saveMessages }: UseSavePartialAssistantMessages) => {
+  const refSaveInterval = useRef<NodeJS.Timeout>(null)
+
+  const refLatestMessageLength = useRef(0)
+
+  // ensure interval is cleared on component's unmount
+  useEffect(() => {
+    return () => {
+      clearInterval(refSaveInterval.current ?? 0)
+    }
+  }, [])
+
+  // start the interval to save the latest message while it's streaming
+  useEffect(() => {
+    if (chatHelpers.status === 'streaming') {
+      console.log('DEBUG: streaming...')
+
+      clearInterval(refSaveInterval.current ?? 0)
+
+      refSaveInterval.current = setInterval(() => {
+        const latestMessage = chatHelpers.messages[chatHelpers.messages.length - 1]
+
+        const latestMessageLength = JSON.stringify(latestMessage).length
+
+        if (latestMessage.role === 'assistant' && latestMessageLength !== refLatestMessageLength.current) {
+          refLatestMessageLength.current = latestMessageLength
+
+          console.log('DEBUG: saving each...', refLatestMessageLength.current)
+
+          saveMessages({
+            id,
+            messages: [latestMessage],
+          })
+        }
+      }, 1000)
+      return
+    }
+
+    console.log('DEBUG: clearing...', chatHelpers.status)
+    clearInterval(refSaveInterval.current ?? 0)
+  }, [chatHelpers.status])
 }
 
 export default function ChatState({ id, models, initialMessages, saveMessages }: ChatStateProps) {
@@ -103,6 +152,8 @@ export default function ChatState({ id, models, initialMessages, saveMessages }:
       // The error will be available in chatHelpers.error for the UI to display
     },
   })
+
+  useSavePartialAssistantMessages({ chatHelpers, id, saveMessages })
 
   const { messages: chatMessages, status } = chatHelpers
 

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -1,16 +1,15 @@
-import { chatThreadsTable } from '@/db/tables'
 import { DatabaseSingleton } from '@/db/singleton'
-import { getOrCreateChatThread, saveMessagesWithContextUpdate } from '@/lib/dal'
+import { chatThreadsTable } from '@/db/tables'
+import { getChatMessagesByThreadId, getOrCreateChatThread, saveMessagesWithContextUpdate } from '@/lib/dal'
 import { generateTitle } from '@/lib/title-generator'
 import { convertDbChatMessageToUIMessage } from '@/lib/utils'
 import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { eq } from 'drizzle-orm'
+import { useCallback, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router'
-import Chat from './chat'
-import { getChatMessagesByThreadId } from '@/lib/dal'
 import { v7 as uuidv7 } from 'uuid'
-import { useMemo } from 'react'
+import Chat from './chat'
 
 export default function ChatDetailPage() {
   const params = useParams()
@@ -92,9 +91,12 @@ export default function ChatDetailPage() {
     },
   })
 
-  const saveMessages: SaveMessagesFunction = async ({ messages }) => {
-    await addMessagesMutation.mutateAsync(messages)
-  }
+  const saveMessages: SaveMessagesFunction = useCallback(
+    async ({ messages }) => {
+      await addMessagesMutation.mutateAsync(messages)
+    },
+    [addMessagesMutation.mutateAsync],
+  )
 
   return chatThreadId ? (
     <>

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -33,20 +33,12 @@ export default function ChatDetailPage() {
 
     if (!textContent) return
 
-    try {
-      const title = await generateTitle(textContent)
-      await db.update(chatThreadsTable).set({ title }).where(eq(chatThreadsTable.id, threadId))
-      queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
-    } catch (error) {
-      console.error('Error generating title:', error)
-    }
+    const title = await generateTitle(textContent)
+    await db.update(chatThreadsTable).set({ title }).where(eq(chatThreadsTable.id, threadId))
+    queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
   }
 
-  const {
-    data: messages,
-    isLoading,
-    isError,
-  } = useQuery<ThunderboltUIMessage[], Error>({
+  const { data: messages } = useQuery<ThunderboltUIMessage[], Error>({
     queryKey: ['chatMessages', chatThreadId],
     queryFn: async () => {
       const chatMessages = await getChatMessagesByThreadId(chatThreadId!)
@@ -101,14 +93,8 @@ export default function ChatDetailPage() {
   return chatThreadId ? (
     <>
       <div className="h-full w-full">
-        {isLoading ? (
-          <div>Loading chat...</div>
-        ) : isError ? (
-          <div>Error loading chat</div>
-        ) : messages ? (
+        {!!messages && (
           <Chat key={chatThreadId} id={chatThreadId} initialMessages={messages} saveMessages={saveMessages} />
-        ) : (
-          <div>Error loading chat</div>
         )}
       </div>
     </>

--- a/src/hooks/use-debounce.tsx
+++ b/src/hooks/use-debounce.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 /**
  * Hook that debounces a value
@@ -32,25 +32,33 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
   callback: T,
   delay: number,
 ): (...args: Parameters<T>) => void {
-  const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null)
+  const callbackRef = useRef(callback)
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
 
+  // Keep callback ref up to date
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  // Cleanup on unmount
   useEffect(() => {
     return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId)
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
       }
     }
-  }, [timeoutId])
+  }, [])
 
-  return (...args: Parameters<T>) => {
-    if (timeoutId) {
-      clearTimeout(timeoutId)
-    }
+  return useCallback(
+    (...args: Parameters<T>) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
 
-    const newTimeoutId = setTimeout(() => {
-      callback(...args)
-    }, delay)
-
-    setTimeoutId(newTimeoutId)
-  }
+      timeoutRef.current = setTimeout(() => {
+        callbackRef.current(...args)
+      }, delay)
+    },
+    [delay],
+  )
 }

--- a/src/hooks/use-throttle.test.tsx
+++ b/src/hooks/use-throttle.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+describe('useThrottledCallback', () => {
+  beforeEach(() => {
+    // Bun test uses real timers by default
+  })
+
+  afterEach(() => {
+    // Clean up any pending timers
+  })
+
+  it('should call callback immediately on first invocation', () => {
+    const callback = mock((..._args: any[]) => {})
+
+    // Simulate throttled callback behavior
+    let lastCallTime = 0
+    const throttleMs = 1000
+
+    const throttledFn = (...args: any[]) => {
+      const now = Date.now()
+      if (now - lastCallTime >= throttleMs) {
+        lastCallTime = now
+        callback(...args)
+      }
+    }
+
+    throttledFn('test')
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('test')
+  })
+
+  it('should throttle rapid calls', async () => {
+    const callback = mock((..._args: any[]) => {})
+    const throttleMs = 100
+    let lastCallTime = 0
+    let pendingArgs: any[] | null = null
+    let timeoutId: NodeJS.Timeout | null = null
+
+    const throttledFn = (...args: any[]) => {
+      const now = Date.now()
+      const timeSinceLastCall = now - lastCallTime
+
+      if (timeSinceLastCall >= throttleMs) {
+        lastCallTime = now
+        callback(...args)
+      } else {
+        pendingArgs = args
+        if (timeoutId) clearTimeout(timeoutId)
+        timeoutId = setTimeout(() => {
+          lastCallTime = Date.now()
+          if (pendingArgs) {
+            callback(...pendingArgs)
+            pendingArgs = null
+          }
+        }, throttleMs - timeSinceLastCall)
+      }
+    }
+
+    // First call - immediate
+    throttledFn('first')
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('first')
+
+    // Rapid calls - throttled
+    throttledFn('second')
+    throttledFn('third')
+    throttledFn('fourth')
+
+    // Should still only have been called once
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Wait for throttle to complete
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    // Should have been called with the last value
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback.mock.calls[1]?.[0]).toBe('fourth')
+
+    if (timeoutId) clearTimeout(timeoutId)
+  })
+
+  it('should allow calls after interval passes', async () => {
+    const callback = mock((..._args: any[]) => {})
+    const throttleMs = 50
+    let lastCallTime = 0
+
+    const throttledFn = (...args: any[]) => {
+      const now = Date.now()
+      if (now - lastCallTime >= throttleMs) {
+        lastCallTime = now
+        callback(...args)
+      }
+    }
+
+    throttledFn('first')
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Wait for interval to pass
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    // Next call should be immediate
+    throttledFn('second')
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback.mock.calls[1]?.[0]).toBe('second')
+  })
+
+  it('should handle multiple arguments', () => {
+    const callback = mock((..._args: any[]) => {})
+    let lastCallTime = 0
+    const throttleMs = 1000
+
+    const throttledFn = (...args: any[]) => {
+      const now = Date.now()
+      if (now - lastCallTime >= throttleMs) {
+        lastCallTime = now
+        callback(...args)
+      }
+    }
+
+    throttledFn('arg1', 'arg2', 'arg3')
+    expect(callback).toHaveBeenCalledWith('arg1', 'arg2', 'arg3')
+  })
+})

--- a/src/hooks/use-throttle.tsx
+++ b/src/hooks/use-throttle.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Hook that throttles a value
+ * @param value - The value to throttle
+ * @param interval - The minimum time in milliseconds between updates
+ * @returns The throttled value
+ */
+export const useThrottle = <T,>(value: T, interval: number): T => {
+  const [throttledValue, setThrottledValue] = useState<T>(value)
+  const lastUpdated = useRef<number>(0)
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+
+  useEffect(() => {
+    const now = Date.now()
+    const timeSinceLastUpdate = now - lastUpdated.current
+
+    if (timeSinceLastUpdate >= interval) {
+      // Enough time has passed, update immediately
+      lastUpdated.current = now
+      setThrottledValue(value)
+    } else {
+      // Not enough time has passed, schedule an update
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        lastUpdated.current = Date.now()
+        setThrottledValue(value)
+      }, interval - timeSinceLastUpdate)
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [value, interval])
+
+  return throttledValue
+}
+
+/**
+ * Hook that returns a throttled callback
+ * @param callback - The callback to throttle
+ * @param interval - The minimum time in milliseconds between calls
+ * @returns The throttled callback
+ */
+export const useThrottledCallback = <T extends (...args: any[]) => any>(
+  callback: T,
+  interval: number,
+): ((...args: Parameters<T>) => void) => {
+  const callbackRef = useRef(callback)
+  const lastCallTime = useRef<number>(0)
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+
+  // Keep callback ref up to date
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      const now = Date.now()
+      const timeSinceLastCall = now - lastCallTime.current
+
+      if (timeSinceLastCall >= interval) {
+        // Enough time has passed, call immediately
+        lastCallTime.current = now
+        callbackRef.current(...args)
+      } else {
+        // Not enough time has passed, schedule a call
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+
+        timeoutRef.current = setTimeout(() => {
+          lastCallTime.current = Date.now()
+          callbackRef.current(...args)
+        }, interval - timeSinceLastCall)
+      }
+    },
+    [interval],
+  )
+}


### PR DESCRIPTION
…s while streaming

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Persists partial assistant responses during streaming via a throttled save mechanism; adds throttle hooks and refactors debounce; streamlines chat detail.
> 
> - **Chat streaming**:
>   - Add `useSavePartialAssistantMessages` in `src/chats/chat-state.tsx` to persist partial assistant messages during streaming, throttled at `200ms`, and integrate it with `useChat`.
> - **Hooks**:
>   - Introduce `src/hooks/use-throttle.tsx` with `useThrottle` and `useThrottledCallback` (ref-based, cleanup-safe).
>   - Refactor `useDebouncedCallback` in `src/hooks/use-debounce.tsx` to use refs and `useCallback` for stable, cleanup-safe behavior.
>   - Add tests in `src/hooks/use-throttle.test.tsx` validating throttling behavior.
> - **Chat detail**:
>   - Memoize `saveMessages` and simplify rendering of `Chat` in `src/chats/detail.tsx`; minor cleanup in title update flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eee0364e3a38d81dfc7333e29591b629122ecb74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->