### PR TITLE
THU-85: Fix blank screen when selected model doesn't exist

### DIFF
--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -61,7 +61,8 @@ export const getAvailableModels = async (): Promise<Model[]> => {
 export const getModelById = async (id: string): Promise<Model | null> => {
   const db = DatabaseSingleton.instance.db
   const model = await db.select().from(modelsTable).where(eq(modelsTable.id, id)).get()
-  return model ? mapModel(model) : null
+
+  return model?.id ? mapModel(model) : null
 }
 
 /**


### PR DESCRIPTION
The method `getModelById` was returning a model object with all properties undefined instead of return `null` which was breaking the validation.
