### PR TITLE
THU-84: Fix weather location bugs

### DIFF
--- a/backend/src/pro/routes.test.ts
+++ b/backend/src/pro/routes.test.ts
@@ -59,7 +59,7 @@ describe('Pro Tools Routes', () => {
       new Request('http://localhost/pro/weather/current', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ location: 'London', region: 'United Kingdom', country: 'England' }),
+        body: JSON.stringify({ location: 'London', region: 'England', country: 'United Kingdom' }),
       }),
     )
     expect(response.status).toBe(200)
@@ -74,7 +74,7 @@ describe('Pro Tools Routes', () => {
       new Request('http://localhost/pro/weather/forecast', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ location: 'London', region: 'United Kingdom', country: 'England', days: 3 }),
+        body: JSON.stringify({ location: 'London', region: 'England', country: 'United Kingdom', days: 3 }),
       }),
     )
     expect(response.status).toBe(200)
@@ -89,7 +89,7 @@ describe('Pro Tools Routes', () => {
       new Request('http://localhost/pro/locations/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query: 'London', region: 'United Kingdom', country: 'England' }),
+        body: JSON.stringify({ query: 'London', region: 'England', country: 'United Kingdom' }),
       }),
     )
     expect(response.status).toBe(200)

--- a/backend/src/pro/routes.test.ts
+++ b/backend/src/pro/routes.test.ts
@@ -59,7 +59,7 @@ describe('Pro Tools Routes', () => {
       new Request('http://localhost/pro/weather/current', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ location: 'London' }),
+        body: JSON.stringify({ location: 'London', region: 'United Kingdom', country: 'England' }),
       }),
     )
     expect(response.status).toBe(200)
@@ -74,7 +74,7 @@ describe('Pro Tools Routes', () => {
       new Request('http://localhost/pro/weather/forecast', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ location: 'London', days: 3 }),
+        body: JSON.stringify({ location: 'London', region: 'United Kingdom', country: 'England', days: 3 }),
       }),
     )
     expect(response.status).toBe(200)
@@ -89,7 +89,7 @@ describe('Pro Tools Routes', () => {
       new Request('http://localhost/pro/locations/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query: 'London' }),
+        body: JSON.stringify({ query: 'London', region: 'United Kingdom', country: 'England' }),
       }),
     )
     expect(response.status).toBe(200)

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -35,7 +35,7 @@ export const createProToolsRoutes = () => {
       async ({ body }): Promise<WeatherCurrentResponse> => {
         try {
           const ctx = new SimpleContext()
-          const weatherData = await weatherClient.getCurrentWeather(body.location, ctx)
+          const weatherData = await weatherClient.getCurrentWeather(body.location, body.region, body.country, ctx)
 
           return {
             data: weatherData,
@@ -52,6 +52,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           location: t.String(),
+          region: t.String(),
+          country: t.String(),
           days: t.Optional(t.Number({ default: 3 })),
         }),
       },
@@ -64,7 +66,13 @@ export const createProToolsRoutes = () => {
 
         try {
           const ctx = new SimpleContext()
-          const weatherData = await weatherClient.getWeatherForecast(request.location, request.days, ctx)
+          const weatherData = await weatherClient.getWeatherForecast(
+            request.location,
+            request.region,
+            request.country,
+            request.days,
+            ctx,
+          )
 
           return {
             data: weatherData,
@@ -81,6 +89,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           location: t.String(),
+          region: t.String(),
+          country: t.String(),
           days: t.Optional(t.Number({ default: 3 })),
         }),
       },
@@ -93,7 +103,7 @@ export const createProToolsRoutes = () => {
 
         try {
           const ctx = new SimpleContext()
-          const locations = await weatherClient.searchLocations(request.query, ctx)
+          const locations = await weatherClient.searchLocations(request.query, request.region, request.country, ctx)
 
           if (!locations || locations.length === 0) {
             return {
@@ -143,6 +153,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           query: t.String(),
+          region: t.String(),
+          country: t.String(),
         }),
       },
     )

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -52,8 +52,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           location: t.String(),
-          region: t.String(),
-          country: t.String(),
+          region: t.MaybeEmpty(t.String()),
+          country: t.MaybeEmpty(t.String()),
           days: t.Optional(t.Number({ default: 3 })),
         }),
       },
@@ -89,8 +89,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           location: t.String(),
-          region: t.String(),
-          country: t.String(),
+          region: t.MaybeEmpty(t.String()),
+          country: t.MaybeEmpty(t.String()),
           days: t.Optional(t.Number({ default: 3 })),
         }),
       },
@@ -153,8 +153,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           query: t.String(),
-          region: t.String(),
-          country: t.String(),
+          region: t.MaybeEmpty(t.String()),
+          country: t.MaybeEmpty(t.String()),
         }),
       },
     )

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -52,8 +52,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           location: t.String(),
-          region: t.MaybeEmpty(t.String()),
-          country: t.MaybeEmpty(t.String()),
+          region: t.String(),
+          country: t.String(),
           days: t.Optional(t.Number({ default: 3 })),
         }),
       },
@@ -89,8 +89,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           location: t.String(),
-          region: t.MaybeEmpty(t.String()),
-          country: t.MaybeEmpty(t.String()),
+          region: t.String(),
+          country: t.String(),
           days: t.Optional(t.Number({ default: 3 })),
         }),
       },
@@ -103,7 +103,7 @@ export const createProToolsRoutes = () => {
 
         try {
           const ctx = new SimpleContext()
-          const locations = await weatherClient.searchLocations(request.query, request.region, request.country, ctx)
+          const locations = await weatherClient.searchLocations(request.query, null, null, ctx)
 
           if (!locations || locations.length === 0) {
             return {
@@ -153,8 +153,6 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           query: t.String(),
-          region: t.MaybeEmpty(t.String()),
-          country: t.MaybeEmpty(t.String()),
         }),
       },
     )

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -103,7 +103,7 @@ export const createProToolsRoutes = () => {
 
         try {
           const ctx = new SimpleContext()
-          const locations = await weatherClient.searchLocations(request.query, null, null, ctx)
+          const locations = await weatherClient.searchLocations(request.query, request.region, request.country, ctx)
 
           if (!locations || locations.length === 0) {
             return {
@@ -153,6 +153,8 @@ export const createProToolsRoutes = () => {
       {
         body: t.Object({
           query: t.String(),
+          region: t.String(),
+          country: t.String(),
         }),
       },
     )

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -56,8 +56,8 @@ export type FetchContentResponse = {
  */
 export const weatherRequestSchema = z.object({
   location: z.string(),
-  region: z.string(),
-  country: z.string(),
+  region: z.string().nullable(),
+  country: z.string().nullable(),
   days: z.number().default(3), // Only used for forecast
 })
 

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -56,8 +56,8 @@ export type FetchContentResponse = {
  */
 export const weatherRequestSchema = z.object({
   location: z.string(),
-  region: z.string().nullable(),
-  country: z.string().nullable(),
+  region: z.string(),
+  country: z.string(),
   days: z.number().default(3), // Only used for forecast
 })
 
@@ -92,8 +92,6 @@ export type WeatherForecastResponse = z.infer<typeof weatherForecastResponseSche
  */
 export const locationSearchRequestSchema = z.object({
   query: z.string(),
-  region: z.string().nullable(),
-  country: z.string().nullable(),
 })
 
 export const locationSearchResponseSchema = baseApiResponseSchema(z.string())

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -56,6 +56,8 @@ export type FetchContentResponse = {
  */
 export const weatherRequestSchema = z.object({
   location: z.string(),
+  region: z.string(),
+  country: z.string(),
   days: z.number().default(3), // Only used for forecast
 })
 
@@ -90,6 +92,8 @@ export type WeatherForecastResponse = z.infer<typeof weatherForecastResponseSche
  */
 export const locationSearchRequestSchema = z.object({
   query: z.string(),
+  region: z.string().nullable(),
+  country: z.string().nullable(),
 })
 
 export const locationSearchResponseSchema = baseApiResponseSchema(z.string())

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -92,6 +92,8 @@ export type WeatherForecastResponse = z.infer<typeof weatherForecastResponseSche
  */
 export const locationSearchRequestSchema = z.object({
   query: z.string(),
+  region: z.string(),
+  country: z.string(),
 })
 
 export const locationSearchResponseSchema = baseApiResponseSchema(z.string())

--- a/backend/src/pro/weather.test.ts
+++ b/backend/src/pro/weather.test.ts
@@ -97,6 +97,290 @@ describe('Pro - OpenMeteoWeather', () => {
         'https://geocoding-api.open-meteo.com/v1/search?name=New+York&count=10&language=en&format=json',
       )
     })
+
+    describe('disambiguateLocation', () => {
+      const mockLocations = [
+        {
+          name: 'London',
+          admin1: 'England',
+          country: 'United Kingdom',
+          latitude: 51.5074,
+          longitude: -0.1278,
+          elevation: 25,
+        },
+        {
+          name: 'London',
+          admin1: 'Ontario',
+          country: 'Canada',
+          latitude: 42.9849,
+          longitude: -81.2453,
+          elevation: 251,
+        },
+        {
+          name: 'London',
+          admin1: 'Kentucky',
+          country: 'United States',
+          latitude: 37.1289,
+          longitude: -84.0833,
+          elevation: 300,
+        },
+        {
+          name: 'Paris',
+          admin1: 'Île-de-France',
+          country: 'France',
+          latitude: 48.8566,
+          longitude: 2.3522,
+          elevation: 35,
+        },
+        {
+          name: 'Paris',
+          admin1: 'Texas',
+          country: 'United States',
+          latitude: 33.6609,
+          longitude: -95.5555,
+          elevation: 180,
+        },
+      ]
+
+      it('should filter by region when provided', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', 'England', null, mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].admin1).toBe('England')
+        expect(results[0].country).toBe('United Kingdom')
+      })
+
+      it('should filter by country when provided', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', null, 'Canada', mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].admin1).toBe('Ontario')
+        expect(results[0].country).toBe('Canada')
+      })
+
+      it('should filter by both region and country when provided', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', 'England', 'United Kingdom', mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].admin1).toBe('England')
+        expect(results[0].country).toBe('United Kingdom')
+      })
+
+      it('should return all locations when no region or country provided', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', null, null, mockContext)
+
+        expect(results).toHaveLength(5) // All locations (London and Paris)
+        expect(results.every((loc) => loc.name === 'London' || loc.name === 'Paris')).toBe(true)
+      })
+
+      it('should handle case-insensitive region matching', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', 'ENGLAND', null, mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].admin1).toBe('England')
+      })
+
+      it('should handle case-insensitive country matching', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', null, 'CANADA', mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].country).toBe('Canada')
+      })
+
+      it('should handle partial region matching', async () => {
+        const locationsWithPartialMatch = [
+          {
+            name: 'Springfield',
+            admin1: 'Massachusetts',
+            country: 'United States',
+            latitude: 42.1015,
+            longitude: -72.5898,
+          },
+          {
+            name: 'Springfield',
+            admin1: 'Missouri',
+            country: 'United States',
+            latitude: 37.2083,
+            longitude: -93.2923,
+          },
+        ]
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: locationsWithPartialMatch }),
+        } as Response)
+
+        const results = await weather.searchLocations('Springfield', 'Mass', null, mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].admin1).toBe('Massachusetts')
+      })
+
+      it('should handle partial country matching', async () => {
+        const locationsWithPartialMatch = [
+          {
+            name: 'Manchester',
+            admin1: 'England',
+            country: 'United Kingdom',
+            latitude: 53.4808,
+            longitude: -2.2426,
+          },
+          {
+            name: 'Manchester',
+            admin1: 'New Hampshire',
+            country: 'United States',
+            latitude: 42.9956,
+            longitude: -71.4548,
+          },
+        ]
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: locationsWithPartialMatch }),
+        } as Response)
+
+        const results = await weather.searchLocations('Manchester', null, 'United', mockContext)
+
+        expect(results).toHaveLength(2) // Both United Kingdom and United States
+      })
+
+      it('should handle whitespace trimming in region and country', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', '  England  ', '  United Kingdom  ', mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].admin1).toBe('England')
+        expect(results[0].country).toBe('United Kingdom')
+      })
+
+      it('should return all locations when no region matches found', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', 'NonExistentRegion', null, mockContext)
+
+        // When no region matches are found, the method returns all locations (permissive behavior)
+        expect(results).toHaveLength(5)
+        expect(results.every((loc) => loc.name === 'London' || loc.name === 'Paris')).toBe(true)
+      })
+
+      it('should return all locations when no country matches found', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', null, 'NonExistentCountry', mockContext)
+
+        // When no country matches are found, the method returns all locations (permissive behavior)
+        expect(results).toHaveLength(5)
+        expect(results.every((loc) => loc.name === 'London' || loc.name === 'Paris')).toBe(true)
+      })
+
+      it('should handle locations with missing admin1 field', async () => {
+        const locationsWithMissingAdmin = [
+          {
+            name: 'TestCity',
+            country: 'TestCountry',
+            latitude: 40.0,
+            longitude: -74.0,
+          },
+          {
+            name: 'TestCity',
+            admin1: 'TestRegion',
+            country: 'TestCountry',
+            latitude: 41.0,
+            longitude: -75.0,
+          },
+        ]
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: locationsWithMissingAdmin }),
+        } as Response)
+
+        const results = await weather.searchLocations('TestCity', 'TestRegion', null, mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].admin1).toBe('TestRegion')
+      })
+
+      it('should handle locations with missing country field', async () => {
+        const locationsWithMissingCountry = [
+          {
+            name: 'TestCity',
+            admin1: 'TestRegion',
+            latitude: 40.0,
+            longitude: -74.0,
+          },
+          {
+            name: 'TestCity',
+            admin1: 'TestRegion',
+            country: 'TestCountry',
+            latitude: 41.0,
+            longitude: -75.0,
+          },
+        ]
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: locationsWithMissingCountry }),
+        } as Response)
+
+        const results = await weather.searchLocations('TestCity', null, 'TestCountry', mockContext)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].country).toBe('TestCountry')
+      })
+
+      it('should handle empty region and country strings', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ results: mockLocations }),
+        } as Response)
+
+        const results = await weather.searchLocations('London', '', '', mockContext)
+
+        expect(results).toHaveLength(5) // All locations (London and Paris)
+        expect(results.every((loc) => loc.name === 'London' || loc.name === 'Paris')).toBe(true)
+      })
+    })
   })
 
   describe('getCurrentWeather', () => {

--- a/backend/src/pro/weather.test.ts
+++ b/backend/src/pro/weather.test.ts
@@ -47,9 +47,9 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockLocationData,
       } as Response)
 
-      const results = await weather.searchLocations('London', 'United Kingdom', 'England', mockContext)
+      const results = await weather.searchLocations('London', 'England', 'United Kingdom', mockContext)
 
-      expect(results).toEqual(mockLocationData.results)
+      expect(results).toEqual([mockLocationData.results[0]]) // Should only return London, England
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://geocoding-api.open-meteo.com/v1/search?name=London&count=10&language=en&format=json',
@@ -80,7 +80,7 @@ describe('Pro - OpenMeteoWeather', () => {
       const networkError = new Error('Network failure')
       mockFetch.mockRejectedValueOnce(networkError)
 
-      await expect(weather.searchLocations('London', 'United Kingdom', 'England', mockContext)).rejects.toThrow(
+      await expect(weather.searchLocations('London', 'England', 'United Kingdom', mockContext)).rejects.toThrow(
         'Network failure',
       )
     })
@@ -429,7 +429,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockWeatherData,
       } as Response)
 
-      const result = await weather.getCurrentWeather('London', 'United Kingdom', 'England', mockContext)
+      const result = await weather.getCurrentWeather('London', 'England', 'United Kingdom', mockContext)
 
       expect(result).toContain('Current weather for London, England, United Kingdom:')
       expect(result).toContain('Temperature: 15.2°C')
@@ -475,7 +475,7 @@ describe('Pro - OpenMeteoWeather', () => {
         status: 500,
       } as Response)
 
-      await expect(weather.getCurrentWeather('London', 'United Kingdom', 'England', mockContext)).rejects.toThrow(
+      await expect(weather.getCurrentWeather('London', 'England', 'United Kingdom', mockContext)).rejects.toThrow(
         'Weather API error: 500',
       )
     })
@@ -554,7 +554,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockForecastData,
       } as Response)
 
-      const result = await weather.getWeatherForecast('London', 'United Kingdom', 'England', 3, mockContext)
+      const result = await weather.getWeatherForecast('London', 'England', 'United Kingdom', 3, mockContext)
 
       expect(result).toEqual({
         location: 'London, England, United Kingdom',
@@ -630,7 +630,7 @@ describe('Pro - OpenMeteoWeather', () => {
         }),
       } as Response)
 
-      const result = await weather.getWeatherForecast('London', 'United Kingdom', 'England', 1, mockContext)
+      const result = await weather.getWeatherForecast('London', 'England', 'United Kingdom', 1, mockContext)
 
       expect(result.location).toBe('London, England, United Kingdom')
       expect(result.days).toHaveLength(1)
@@ -663,7 +663,7 @@ describe('Pro - OpenMeteoWeather', () => {
         status: 500,
       } as Response)
 
-      await expect(weather.getWeatherForecast('London', 'United Kingdom', 'England', 3, mockContext)).rejects.toThrow(
+      await expect(weather.getWeatherForecast('London', 'England', 'United Kingdom', 3, mockContext)).rejects.toThrow(
         'Weather API error: 500',
       )
     })
@@ -679,7 +679,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockForecastData,
       } as Response)
 
-      const result = await weather.getWeatherForecast('London', 'United Kingdom', 'England', 3, mockContext)
+      const result = await weather.getWeatherForecast('London', 'England', 'United Kingdom', 3, mockContext)
 
       // Check that dates are returned in the structured format
       expect(result.days[0].date).toBe('2024-01-15')
@@ -713,7 +713,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => emptyForecast,
       } as Response)
 
-      const result = await weather.getWeatherForecast('London', 'United Kingdom', 'England', 3, mockContext)
+      const result = await weather.getWeatherForecast('London', 'England', 'United Kingdom', 3, mockContext)
 
       expect(result.location).toBe('London, England, United Kingdom')
       expect(result.days).toEqual([])

--- a/backend/src/pro/weather.test.ts
+++ b/backend/src/pro/weather.test.ts
@@ -47,7 +47,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockLocationData,
       } as Response)
 
-      const results = await weather.searchLocations('London', mockContext)
+      const results = await weather.searchLocations('London', 'United Kingdom', 'England', mockContext)
 
       expect(results).toEqual(mockLocationData.results)
 
@@ -62,7 +62,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => ({}),
       } as Response)
 
-      const results = await weather.searchLocations('NonexistentPlace', mockContext)
+      const results = await weather.searchLocations('NonexistentPlace', '', '', mockContext)
 
       expect(results).toEqual([])
     })
@@ -73,14 +73,16 @@ describe('Pro - OpenMeteoWeather', () => {
         status: 400,
       } as Response)
 
-      await expect(weather.searchLocations('Invalid', mockContext)).rejects.toThrow('Geocoding API error: 400')
+      await expect(weather.searchLocations('Invalid', '', '', mockContext)).rejects.toThrow('Geocoding API error: 400')
     })
 
     it('should handle network errors', async () => {
       const networkError = new Error('Network failure')
       mockFetch.mockRejectedValueOnce(networkError)
 
-      await expect(weather.searchLocations('London', mockContext)).rejects.toThrow('Network failure')
+      await expect(weather.searchLocations('London', 'United Kingdom', 'England', mockContext)).rejects.toThrow(
+        'Network failure',
+      )
     })
 
     it('should construct correct URL with query parameters', async () => {
@@ -89,7 +91,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => ({ results: [] }),
       } as Response)
 
-      await weather.searchLocations('New York', mockContext)
+      await weather.searchLocations('New York', 'NY', 'United States', mockContext)
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://geocoding-api.open-meteo.com/v1/search?name=New+York&count=10&language=en&format=json',
@@ -143,7 +145,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockWeatherData,
       } as Response)
 
-      const result = await weather.getCurrentWeather('London', mockContext)
+      const result = await weather.getCurrentWeather('London', 'United Kingdom', 'England', mockContext)
 
       expect(result).toContain('Current weather for London, England, United Kingdom:')
       expect(result).toContain('Temperature: 15.2°C')
@@ -170,7 +172,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => ({ results: [] }),
       } as Response)
 
-      const result = await weather.getCurrentWeather('NonexistentPlace', mockContext)
+      const result = await weather.getCurrentWeather('NonexistentPlace', '', '', mockContext)
 
       expect(result).toBe('No location found matching: NonexistentPlace')
       expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -189,7 +191,9 @@ describe('Pro - OpenMeteoWeather', () => {
         status: 500,
       } as Response)
 
-      await expect(weather.getCurrentWeather('London', mockContext)).rejects.toThrow('Weather API error: 500')
+      await expect(weather.getCurrentWeather('London', 'United Kingdom', 'England', mockContext)).rejects.toThrow(
+        'Weather API error: 500',
+      )
     })
 
     it('should handle location with minimal data', async () => {
@@ -213,7 +217,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockWeatherData,
       } as Response)
 
-      const result = await weather.getCurrentWeather('TestCity', mockContext)
+      const result = await weather.getCurrentWeather('TestCity', 'TestRegion', 'TestCountry', mockContext)
 
       expect(result).toContain('Current weather for TestCity:')
     })
@@ -266,7 +270,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockForecastData,
       } as Response)
 
-      const result = await weather.getWeatherForecast('London', 3, mockContext)
+      const result = await weather.getWeatherForecast('London', 'United Kingdom', 'England', 3, mockContext)
 
       expect(result).toEqual({
         location: 'London, England, United Kingdom',
@@ -311,7 +315,9 @@ describe('Pro - OpenMeteoWeather', () => {
 
       // Check forecast API call
       const forecastCall = mockFetch.mock.calls[1][0] as string
-      expect(forecastCall).toContain('daily=weather_code%2Ctemperature_2m_max%2Ctemperature_2m_min%2Capparent_temperature_max%2Capparent_temperature_min%2Cprecipitation_sum%2Cprecipitation_probability_max%2Cwind_speed_10m_max')
+      expect(forecastCall).toContain(
+        'daily=weather_code%2Ctemperature_2m_max%2Ctemperature_2m_min%2Capparent_temperature_max%2Capparent_temperature_min%2Cprecipitation_sum%2Cprecipitation_probability_max%2Cwind_speed_10m_max',
+      )
       expect(forecastCall).toContain('forecast_days=3')
     })
 
@@ -340,7 +346,7 @@ describe('Pro - OpenMeteoWeather', () => {
         }),
       } as Response)
 
-      const result = await weather.getWeatherForecast('London', 1, mockContext)
+      const result = await weather.getWeatherForecast('London', 'United Kingdom', 'England', 1, mockContext)
 
       expect(result.location).toBe('London, England, United Kingdom')
       expect(result.days).toHaveLength(1)
@@ -356,8 +362,8 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => ({ results: [] }),
       } as Response)
 
-      await expect(weather.getWeatherForecast('NonexistentPlace', 3, mockContext)).rejects.toThrow(
-        "Could not fetch forecast data: Error: Could not find coordinates for location 'NonexistentPlace'"
+      await expect(weather.getWeatherForecast('NonexistentPlace', '', '', 3, mockContext)).rejects.toThrow(
+        "Could not fetch forecast data: Error: Could not find coordinates for location 'NonexistentPlace'",
       )
       expect(mockFetch).toHaveBeenCalledTimes(1)
     })
@@ -373,7 +379,9 @@ describe('Pro - OpenMeteoWeather', () => {
         status: 500,
       } as Response)
 
-      await expect(weather.getWeatherForecast('London', 3, mockContext)).rejects.toThrow('Weather API error: 500')
+      await expect(weather.getWeatherForecast('London', 'United Kingdom', 'England', 3, mockContext)).rejects.toThrow(
+        'Weather API error: 500',
+      )
     })
 
     it('should format dates correctly', async () => {
@@ -387,7 +395,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => mockForecastData,
       } as Response)
 
-      const result = await weather.getWeatherForecast('London', 3, mockContext)
+      const result = await weather.getWeatherForecast('London', 'United Kingdom', 'England', 3, mockContext)
 
       // Check that dates are returned in the structured format
       expect(result.days[0].date).toBe('2024-01-15')
@@ -421,7 +429,7 @@ describe('Pro - OpenMeteoWeather', () => {
         json: async () => emptyForecast,
       } as Response)
 
-      const result = await weather.getWeatherForecast('London', 3, mockContext)
+      const result = await weather.getWeatherForecast('London', 'United Kingdom', 'England', 3, mockContext)
 
       expect(result.location).toBe('London, England, United Kingdom')
       expect(result.days).toEqual([])

--- a/backend/src/pro/weather.ts
+++ b/backend/src/pro/weather.ts
@@ -17,103 +17,131 @@ export class OpenMeteoWeather {
   private readonly geocodingUrl = 'https://geocoding-api.open-meteo.com/v1/search'
   private readonly weatherUrl = 'https://api.open-meteo.com/v1/forecast'
 
+  private disambiguateLocation(locations: Location[], region: string | null, country: string | null): Location[] {
+    const regionNorm = region?.trim().toLowerCase()
+    const countryNorm = country?.trim().toLowerCase()
+
+    let matches = [...locations]
+
+    // If region is provided, try to match admin1 (state/region)
+    if (regionNorm) {
+      const regionMatches = matches.filter((r) => r.admin1?.toLowerCase().includes(regionNorm))
+      if (regionMatches.length > 0) {
+        matches = regionMatches
+      }
+    }
+
+    // If country is provided, match against country field
+    if (countryNorm) {
+      const countryMatches = matches.filter((r) => r.country?.toLowerCase().includes(countryNorm))
+      if (countryMatches.length > 0) {
+        matches = countryMatches
+      }
+    }
+
+    return matches
+  }
+
   /**
    * Search for locations by name
    */
-  async searchLocations(query: string, ctx: SimpleContext): Promise<Location[]> {
-    try {
-      const url = new URL(this.geocodingUrl)
-      url.searchParams.set('name', query)
-      url.searchParams.set('count', '10')
-      url.searchParams.set('language', 'en')
-      url.searchParams.set('format', 'json')
+  async searchLocations(
+    query: string,
+    region: string | null,
+    country: string | null,
+    ctx: SimpleContext,
+  ): Promise<Location[]> {
+    const url = new URL(this.geocodingUrl)
+    url.searchParams.set('name', query)
+    url.searchParams.set('count', '10')
+    url.searchParams.set('language', 'en')
+    url.searchParams.set('format', 'json')
 
-      const response = await fetch(url.toString())
+    const response = await fetch(url.toString())
 
-      if (!response.ok) {
-        throw new Error(`Geocoding API error: ${response.status}`)
-      }
-
-      const data = (await response.json()) as { results?: Location[] }
-      const locations = data.results || []
-
-      return locations
-    } catch (error) {
-      throw error
+    if (!response.ok) {
+      throw new Error(`Geocoding API error: ${response.status}`)
     }
+
+    const data = (await response.json()) as { results?: Location[] }
+    const locations = data.results || []
+
+    return this.disambiguateLocation(locations, region, country)
   }
 
   /**
    * Get current weather for a location
    */
-  async getCurrentWeather(location: string, ctx: SimpleContext): Promise<string> {
-    try {
-      // First, search for the location
-      const locations = await this.searchLocations(location, ctx)
-      if (locations.length === 0) {
-        return `No location found matching: ${location}`
-      }
-
-      const loc = locations[0]
-
-      // Get current weather
-      const url = new URL(this.weatherUrl)
-      url.searchParams.set('latitude', loc.latitude.toString())
-      url.searchParams.set('longitude', loc.longitude.toString())
-      url.searchParams.set(
-        'current',
-        'temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m',
-      )
-      url.searchParams.set('timezone', 'auto')
-
-      const response = await fetch(url.toString())
-
-      if (!response.ok) {
-        throw new Error(`Weather API error: ${response.status}`)
-      }
-
-      const data = (await response.json()) as {
-        current: {
-          temperature_2m: number
-          relative_humidity_2m: number
-          apparent_temperature: number
-          weather_code: number
-          wind_speed_10m: number
-          wind_direction_10m: number
-          time: string
-        }
-        current_units: Record<string, string>
-      }
-
-      const current = data.current
-      const units = data.current_units
-
-      // Format the weather data
-      const locationStr = [loc.name, loc.admin1, loc.country].filter(Boolean).join(', ')
-
-      const result = [
-        `Current weather for ${locationStr}:`,
-        `Temperature: ${current.temperature_2m}${units.temperature_2m}`,
-        `Feels like: ${current.apparent_temperature}${units.apparent_temperature}`,
-        `Humidity: ${current.relative_humidity_2m}${units.relative_humidity_2m}`,
-        `Wind: ${current.wind_speed_10m}${units.wind_speed_10m} at ${current.wind_direction_10m}°`,
-        `Conditions: ${this.getWeatherDescription(current.weather_code)} (Code ${current.weather_code})`,
-        `Last updated: ${current.time}`,
-      ]
-
-      return result.join('\n')
-    } catch (error) {
-      throw error
+  async getCurrentWeather(location: string, region: string, country: string, ctx: SimpleContext): Promise<string> {
+    // First, search for the location
+    const locations = await this.searchLocations(location, region, country, ctx)
+    if (locations.length === 0) {
+      return `No location found matching: ${location}`
     }
+
+    const loc = locations[0]
+
+    // Get current weather
+    const url = new URL(this.weatherUrl)
+    url.searchParams.set('latitude', loc.latitude.toString())
+    url.searchParams.set('longitude', loc.longitude.toString())
+    url.searchParams.set(
+      'current',
+      'temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m',
+    )
+    url.searchParams.set('timezone', 'auto')
+
+    const response = await fetch(url.toString())
+
+    if (!response.ok) {
+      throw new Error(`Weather API error: ${response.status}`)
+    }
+
+    const data = (await response.json()) as {
+      current: {
+        temperature_2m: number
+        relative_humidity_2m: number
+        apparent_temperature: number
+        weather_code: number
+        wind_speed_10m: number
+        wind_direction_10m: number
+        time: string
+      }
+      current_units: Record<string, string>
+    }
+
+    const current = data.current
+    const units = data.current_units
+
+    // Format the weather data
+    const locationStr = [loc.name, loc.admin1, loc.country].filter(Boolean).join(', ')
+
+    const result = [
+      `Current weather for ${locationStr}:`,
+      `Temperature: ${current.temperature_2m}${units.temperature_2m}`,
+      `Feels like: ${current.apparent_temperature}${units.apparent_temperature}`,
+      `Humidity: ${current.relative_humidity_2m}${units.relative_humidity_2m}`,
+      `Wind: ${current.wind_speed_10m}${units.wind_speed_10m} at ${current.wind_direction_10m}°`,
+      `Conditions: ${this.getWeatherDescription(current.weather_code)} (Code ${current.weather_code})`,
+      `Last updated: ${current.time}`,
+    ]
+
+    return result.join('\n')
   }
 
   /**
    * Get weather forecast for a location
    */
-  async getWeatherForecast(location: string, days: number, ctx: SimpleContext): Promise<WeatherForecastData> {
+  async getWeatherForecast(
+    location: string,
+    region: string,
+    country: string,
+    days: number,
+    ctx: SimpleContext,
+  ): Promise<WeatherForecastData> {
     try {
       // First, search for the location
-      const locations = await this.searchLocations(location, ctx)
+      const locations = await this.searchLocations(location, region, country, ctx)
       if (locations.length === 0) {
         const errorMsg = `Could not find coordinates for location '${location}'`
         throw new Error(errorMsg)

--- a/backend/src/pro/weather.ts
+++ b/backend/src/pro/weather.ts
@@ -72,7 +72,12 @@ export class OpenMeteoWeather {
   /**
    * Get current weather for a location
    */
-  async getCurrentWeather(location: string, region: string, country: string, ctx: SimpleContext): Promise<string> {
+  async getCurrentWeather(
+    location: string,
+    region: string | null,
+    country: string | null,
+    ctx: SimpleContext,
+  ): Promise<string> {
     // First, search for the location
     const locations = await this.searchLocations(location, region, country, ctx)
     if (locations.length === 0) {
@@ -134,8 +139,8 @@ export class OpenMeteoWeather {
    */
   async getWeatherForecast(
     location: string,
-    region: string,
-    country: string,
+    region: string | null,
+    country: string | null,
     days: number,
     ctx: SimpleContext,
   ): Promise<WeatherForecastData> {

--- a/src/integrations/thunderbolt-pro/tools.ts
+++ b/src/integrations/thunderbolt-pro/tools.ts
@@ -31,8 +31,8 @@ export const weatherSchema = z
     location: z
       .string()
       .describe('The location name to get weather for. Only include the city name, not the state or country.'),
-    region: z.string().optional().describe("The location's state or region."),
-    country: z.string().optional().describe("The location's country."),
+    region: z.string().describe("The location's state or region."),
+    country: z.string().describe("The location's country."),
     days: z.number().describe('Number of days to forecast (1-16)'),
   })
   .strict()

--- a/src/integrations/thunderbolt-pro/tools.ts
+++ b/src/integrations/thunderbolt-pro/tools.ts
@@ -23,6 +23,8 @@ export const fetchContentSchema = z
 export const searchLocationSchema = z
   .object({
     query: z.string().describe('The location name to search for'),
+    region: z.string().describe("The location's state or region."),
+    country: z.string().describe("The location's country."),
   })
   .strict()
 
@@ -167,6 +169,8 @@ export const searchLocations = async (params: SearchLocationParams): Promise<str
       .post(`${cloudUrl}/pro/locations/search`, {
         json: {
           query: params.query,
+          region: params.region,
+          country: params.country,
         },
       })
       .json<{ data: string; success: boolean; error?: string }>()

--- a/src/integrations/thunderbolt-pro/tools.ts
+++ b/src/integrations/thunderbolt-pro/tools.ts
@@ -31,6 +31,8 @@ export const weatherSchema = z
     location: z
       .string()
       .describe('The location name to get weather for. Only include the city name, not the state or country.'),
+    region: z.string().optional().describe("The location's state or region."),
+    country: z.string().optional().describe("The location's country."),
     days: z.number().describe('Number of days to forecast (1-16)'),
   })
   .strict()
@@ -109,6 +111,8 @@ export const getCurrentWeather = async (params: WeatherParams): Promise<string> 
       .post(`${cloudUrl}/pro/weather/current`, {
         json: {
           location: params.location,
+          region: params.region,
+          country: params.country,
         },
       })
       .json<{ data: string; success: boolean; error?: string }>()
@@ -134,6 +138,8 @@ export const getWeatherForecast = async (params: WeatherParams): Promise<Weather
       .post(`${cloudUrl}/pro/weather/forecast`, {
         json: {
           location: params.location,
+          region: params.region,
+          country: params.country,
           days: params.days || 3,
         },
       })
@@ -198,6 +204,8 @@ export const configs: ToolConfig[] = [
     name: 'get_current_weather',
     description: `Return the current weather (today only) as text.
 - Use this tool when the user asks about the weather "now" or "today".
+- Provide the structured parameters (location, region, country).
+- - if you are not sure about the state/region and/or country ask the user to confirm this information.
 - Provide a concise one-day summary (temperature, condition, highs/lows).
 - Do not render a component.`,
     verb: 'Write current weather for {location}',
@@ -212,6 +220,8 @@ This tool is a **fallback** when, for some reason, rendering a component is not 
 (e.g. the user explicitly asks for a text forecast).
 
 - Output a clear day-by-day breakdown (one line per day with condition + high/low).
+- Provide the structured parameters (location, region, country).
+- - if you are not sure about the state/region and/or country ask the user to confirm this information.
 - Optionally add a brief overall summary and friendly suggestions after the breakdown.
 - If the user did not explicitly request a text-only format, prefer 'display-weather_forecast' instead.`,
     verb: 'Write 7-day text forecast for {location}',
@@ -227,7 +237,8 @@ This tool is a **fallback** when, for some reason, rendering a component is not 
 
 Use this tool whenever the user asks for a forecast that spans more than one day.
 - This is the **preferred tool** for multi-day forecasts (2–7 days).
-- Provide the structured parameters (location, days, forecast details).
+- Provide the structured parameters (location, region, country, days, forecast details).
+- - if you are not sure about the state/region and/or country ask the user to confirm this information.
 - Do NOT include a day-by-day breakdown in text when this tool is used.
 - You may still write a short overview (2–4 sentences) and friendly suggestions (bulleted).`,
     verb: 'Display 7-day forecast for {location}',


### PR DESCRIPTION
### Description

This PR improves the accuracy of weather forecasts by enhancing how locations are resolved when multiple cities share the same name.

### Backend

Added a new disambiguateLocation method to filter geocoding results more precisely.

The method now considers both region (state/region) and country parameters when provided.

### Frontend

Updated LLM prompts so the assistant can detect and provide region and country fields along with the location.

These additional fields are now passed in the weather request, enabling more accurate disambiguation in the backend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds region and country to weather and location search requests, implementing server-side disambiguation and updating client schemas, routes, and tests.
> 
> - **Backend**:
>   - **Routes (`backend/src/pro/routes.ts`)**: Weather endpoints now require `region` and `country` in request bodies and forward them to `OpenMeteoWeather`.
>   - **Weather client (`backend/src/pro/weather.ts`)**: 
>     - Add `disambiguateLocation` to filter geocoding results by `admin1` (region) and `country` (case-insensitive, partial ok).
>     - Update `searchLocations`, `getCurrentWeather`, and `getWeatherForecast` to accept `(location, region, country, ...)` and use them for lookup.
>   - **Types (`backend/src/pro/types.ts`)**: Extend `weatherRequestSchema` and `locationSearchRequestSchema` with `region` and `country`.
>   - **Tests**:
>     - Update requests to include `region`/`country` (`routes.test.ts`).
>     - Expand weather tests with extensive disambiguation cases and adjust expectations (`weather.test.ts`).
> - **Frontend/Integrations**:
>   - **Thunderbolt Pro tools (`src/integrations/thunderbolt-pro/tools.ts`)**: 
>     - Extend `weatherSchema` and `searchLocationSchema` with `region`/`country` and pass them in API calls.
>     - Update tool descriptions to require structured params and prompt for missing region/country.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c3e33c43c3b33ee48d24c11fb6272d62f934951. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->