### PR TITLE
THU-90: Refactor chat creation flow with /chat/new route

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,7 +21,6 @@ import { useKeyboardInset } from '@/hooks/use-keyboard-inset'
 import { useMcpSync } from '@/hooks/use-mcp-sync'
 import ChatLayout from '@/layout/main-layout'
 import { PostHogProvider } from '@/lib/analytics'
-import { getOrCreateChatThread } from '@/lib/dal'
 import { seedAccounts, seedModels, seedPrompts, seedSettings, seedTasks } from '@/lib/seed'
 import { ThemeProvider } from '@/lib/theme-provider'
 import AccountsSettingsPage from '@/settings/accounts'
@@ -71,7 +70,7 @@ function AppContent({ initData }: { initData: InitData }) {
   )
 }
 
-function AppRoutes({ initData }: { initData: InitData }) {
+function AppRoutes(_: { initData: InitData }) {
   usePageTracking()
 
   const [isTasksEnabled] = useBooleanSetting('experimental_feature_tasks')
@@ -81,7 +80,7 @@ function AppRoutes({ initData }: { initData: InitData }) {
       <Route path="/" element={<Layout />}>
         {/* Home routes with HomeLayout */}
         <Route element={<ChatLayout />}>
-          <Route index element={<Navigate to={`/chats/${initData.initialThreadId}`} replace />} />
+          <Route index element={<Navigate to="/chats/new" replace />} />
           <Route path="chats/:chatThreadId" element={<ChatDetailPage />} />
           {isTasksEnabled && <Route path="tasks" element={<TasksPage />} />}
           <Route path="automations" element={<AutomationsPage />} />
@@ -165,14 +164,11 @@ const init = async (): Promise<InitData> => {
     }
   }
 
-  const initialThreadId = await getOrCreateChatThread()
-
   return {
     imap,
     imapSync,
     sideviewType,
     sideviewId,
-    initialThreadId,
     ...tray,
   }
 }

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -1,6 +1,6 @@
 import { chatThreadsTable } from '@/db/tables'
 import { DatabaseSingleton } from '@/db/singleton'
-import { getChatThreadById, saveMessagesWithContextUpdate } from '@/lib/dal'
+import { getOrCreateChatThreadById, saveMessagesWithContextUpdate } from '@/lib/dal'
 import { generateTitle } from '@/lib/title-generator'
 import { convertDbChatMessageToUIMessage } from '@/lib/utils'
 import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
@@ -9,9 +9,17 @@ import { eq } from 'drizzle-orm'
 import { useParams } from 'react-router'
 import Chat from './chat'
 import { getChatMessagesByThreadId } from '@/lib/dal'
+import { v7 as uuidv7 } from 'uuid'
+import { useMemo } from 'react'
 
 export default function ChatDetailPage() {
   const params = useParams()
+
+  const chatThreadId = useMemo(
+    () => (params.chatThreadId === 'new' ? uuidv7() : params.chatThreadId),
+    [params.chatThreadId],
+  )
+
   const db = DatabaseSingleton.instance.db
   const queryClient = useQueryClient()
 
@@ -40,39 +48,39 @@ export default function ChatDetailPage() {
     isLoading,
     isError,
   } = useQuery<ThunderboltUIMessage[], Error>({
-    queryKey: ['chatMessages', params.chatThreadId],
+    queryKey: ['chatMessages', chatThreadId],
     queryFn: async () => {
-      const chatMessages = await getChatMessagesByThreadId(params.chatThreadId!)
+      const chatMessages = await getChatMessagesByThreadId(chatThreadId!)
       return chatMessages.map(convertDbChatMessageToUIMessage) as ThunderboltUIMessage[]
     },
-    enabled: !!params.chatThreadId,
+    enabled: !!chatThreadId,
   })
 
   const addMessagesMutation = useMutation({
     mutationFn: async (messages: ThunderboltUIMessage[]) => {
-      if (!params.chatThreadId) {
+      if (!chatThreadId) {
         throw new Error('No chat thread ID')
       }
 
-      // Save messages and update context size using DAL
-      const dbChatMessages = await saveMessagesWithContextUpdate(params.chatThreadId, messages)
-
       // Fetch thread info to check if we need to generate a title
-      const thread = await getChatThreadById(params.chatThreadId)
+      const thread = await getOrCreateChatThreadById(chatThreadId)
+
+      // Save messages and update context size using DAL
+      const dbChatMessages = await saveMessagesWithContextUpdate(chatThreadId, messages)
 
       // Generate title in background if needed
       if (thread?.title === 'New Chat') {
-        updateThreadTitle(messages, params.chatThreadId)
+        updateThreadTitle(messages, chatThreadId)
       }
 
       // Invalidate context size query to trigger re-fetch
-      queryClient.invalidateQueries({ queryKey: ['contextSize', params.chatThreadId] })
+      queryClient.invalidateQueries({ queryKey: ['contextSize', chatThreadId] })
 
       return dbChatMessages
     },
     onSuccess: () => {
       // Invalidate and refetch messages after adding a new one
-      queryClient.invalidateQueries({ queryKey: ['chatMessages', params.chatThreadId] })
+      queryClient.invalidateQueries({ queryKey: ['chatMessages', chatThreadId] })
       // Also invalidate chat threads to update the sidebar
       queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
     },
@@ -82,7 +90,7 @@ export default function ChatDetailPage() {
     await addMessagesMutation.mutateAsync(messages)
   }
 
-  return params.chatThreadId ? (
+  return chatThreadId ? (
     <>
       <div className="h-full w-full">
         {isLoading ? (
@@ -90,12 +98,7 @@ export default function ChatDetailPage() {
         ) : isError ? (
           <div>Error loading chat</div>
         ) : messages ? (
-          <Chat
-            key={params.chatThreadId}
-            id={params.chatThreadId}
-            initialMessages={messages}
-            saveMessages={saveMessages}
-          />
+          <Chat key={chatThreadId} id={chatThreadId} initialMessages={messages} saveMessages={saveMessages} />
         ) : (
           <div>Error loading chat</div>
         )}

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -67,16 +67,16 @@ export default function ChatDetailPage() {
       // Fetch thread info to check if we need to generate a title
       const thread = await getOrCreateChatThreadById(chatThreadId)
 
-      if (params.chatThreadId === 'new') {
-        navigate(`/chats/${chatThreadId}`, { relative: 'path' })
-      }
-
       // Save messages and update context size using DAL
       const dbChatMessages = await saveMessagesWithContextUpdate(chatThreadId, messages)
 
       // Generate title in background if needed
       if (thread?.title === 'New Chat') {
         updateThreadTitle(messages, chatThreadId)
+      }
+
+      if (params.chatThreadId === 'new') {
+        navigate(`/chats/${chatThreadId}`, { relative: 'path' })
       }
 
       // Invalidate context size query to trigger re-fetch

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -1,6 +1,6 @@
 import { chatThreadsTable } from '@/db/tables'
 import { DatabaseSingleton } from '@/db/singleton'
-import { getOrCreateChatThreadById, saveMessagesWithContextUpdate } from '@/lib/dal'
+import { getOrCreateChatThread, saveMessagesWithContextUpdate } from '@/lib/dal'
 import { generateTitle } from '@/lib/title-generator'
 import { convertDbChatMessageToUIMessage } from '@/lib/utils'
 import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
@@ -65,7 +65,7 @@ export default function ChatDetailPage() {
       }
 
       // Fetch thread info to check if we need to generate a title
-      const thread = await getOrCreateChatThreadById(chatThreadId)
+      const thread = await getOrCreateChatThread(chatThreadId)
 
       // Save messages and update context size using DAL
       const dbChatMessages = await saveMessagesWithContextUpdate(chatThreadId, messages)

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -6,7 +6,7 @@ import { convertDbChatMessageToUIMessage } from '@/lib/utils'
 import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { eq } from 'drizzle-orm'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import Chat from './chat'
 import { getChatMessagesByThreadId } from '@/lib/dal'
 import { v7 as uuidv7 } from 'uuid'
@@ -56,6 +56,8 @@ export default function ChatDetailPage() {
     enabled: !!chatThreadId,
   })
 
+  const navigate = useNavigate()
+
   const addMessagesMutation = useMutation({
     mutationFn: async (messages: ThunderboltUIMessage[]) => {
       if (!chatThreadId) {
@@ -64,6 +66,10 @@ export default function ChatDetailPage() {
 
       // Fetch thread info to check if we need to generate a title
       const thread = await getOrCreateChatThreadById(chatThreadId)
+
+      if (params.chatThreadId === 'new') {
+        navigate(`/chats/${chatThreadId}`, { relative: 'path' })
+      }
 
       // Save messages and update context size using DAL
       const dbChatMessages = await saveMessagesWithContextUpdate(chatThreadId, messages)

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -166,6 +166,8 @@ export default function ChatUI({
   const isStreaming = chatHelpers.status === 'streaming'
 
   const handleSubmit = async () => {
+    navigate(`/chats/${chatThreadId}`, { relative: 'path' })
+
     // Prevent submitting while streaming or if input is empty
     const textToSend = input.trim()
     if (isStreaming || !textToSend) return

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -2,7 +2,6 @@ import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { useContextTracking } from '@/hooks/use-context-tracking'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { trackEvent } from '@/lib/analytics'
-import { getOrCreateChatThread } from '@/lib/dal'
 import { cn } from '@/lib/utils'
 import type { AutomationRun, Model, ThunderboltUIMessage } from '@/types'
 import type { UseChatHelpers } from '@ai-sdk/react'
@@ -208,8 +207,7 @@ export default function ChatUI({
   }
 
   const handleNewChat = async () => {
-    const chatThreadId = await getOrCreateChatThread()
-    await navigate(`/chats/${chatThreadId}`)
+    await navigate('/chats/new')
   }
 
   return (

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -166,8 +166,6 @@ export default function ChatUI({
   const isStreaming = chatHelpers.status === 'streaming'
 
   const handleSubmit = async () => {
-    navigate(`/chats/${chatThreadId}`, { relative: 'path' })
-
     // Prevent submitting while streaming or if input is empty
     const textToSend = input.trim()
     if (isStreaming || !textToSend) return

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -20,7 +20,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { chatThreadsTable } from '@/db/tables'
 import { DatabaseSingleton } from '@/db/singleton'
 import { useIsMobile } from '@/hooks/use-mobile'
-import { getAllChatThreads, getOrCreateChatThread } from '@/lib/dal'
+import { getAllChatThreads } from '@/lib/dal'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { eq } from 'drizzle-orm'
 import {
@@ -105,25 +105,20 @@ export default function ChatSidebar() {
   const deleteAllChatsMutation = useMutation({
     mutationFn: async () => {
       await db.delete(chatThreadsTable)
-      // Create a new thread immediately after deletion
-      const chatThreadId = await getOrCreateChatThread()
-      return chatThreadId
     },
-    onSuccess: async (chatThreadId) => {
+    onSuccess: async () => {
       trackEvent('chat_clear_all')
       deleteAllChatsDialogRef.current?.close()
       // Invalidate queries after the new thread is created
       await queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
-      navigate(`/chats/${chatThreadId}`)
+      navigate('/chats/new')
     },
   })
 
   const createNewChat = async (closeAfter: boolean = true) => {
     try {
       trackEvent('chat_new_clicked')
-      const chatThreadId = await getOrCreateChatThread()
-      queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
-      navigate(`/chats/${chatThreadId}`)
+      navigate(`/chats/new`)
       // Close mobile sidebar after navigation
       if (closeAfter && isMobile) {
         setOpenMobile(false)

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -5,10 +5,13 @@ import { afterEach, beforeAll, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import {
+  createChatThread,
   createSetting,
   deleteSetting,
   getAllSettings,
   getBooleanSetting,
+  getChatThread,
+  getOrCreateChatThread,
   getDefaultModelForThread,
   getModelById,
   getSelectedModel,
@@ -511,53 +514,171 @@ describe('Chat Threads DAL', () => {
     await db.delete(chatThreadsTable)
   })
 
-  describe('getOrCreateChatThread', () => {
-    it('should create a new thread when none exist', async () => {
-      const threadId = await import('./dal').then((m) => m.getOrCreateChatThread())
-      expect(threadId).toBeDefined()
-      expect(typeof threadId).toBe('string')
+  describe('createChatThread', () => {
+    it('should create a new chat thread with the provided ID', async () => {
+      const threadId = uuidv7()
+
+      await createChatThread(threadId)
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
-      expect(threads.length).toBeGreaterThan(0)
+      expect(threads).toHaveLength(1)
+      expect(threads[0]?.id).toBe(threadId)
+      expect(threads[0]?.title).toBe('New Chat')
+    })
+
+    it('should create multiple threads with different IDs', async () => {
+      const threadId1 = uuidv7()
+      const threadId2 = uuidv7()
+
+      await createChatThread(threadId1)
+      await createChatThread(threadId2)
+
+      const db = DatabaseSingleton.instance.db
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(2)
+      expect(threads.map((t) => t.id)).toContain(threadId1)
+      expect(threads.map((t) => t.id)).toContain(threadId2)
+    })
+
+    it('should throw when creating thread with same ID twice', async () => {
+      const threadId = uuidv7()
+
+      await createChatThread(threadId)
+
+      // Should throw due to UNIQUE constraint
+      await expect(createChatThread(threadId)).rejects.toThrow()
+
+      const db = DatabaseSingleton.instance.db
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(1)
+      expect(threads[0]?.id).toBe(threadId)
+    })
+  })
+
+  describe('getChatThread', () => {
+    it('should return undefined values when thread does not exist', async () => {
+      const nonExistentId = uuidv7()
+      const thread = await getChatThread(nonExistentId)
+      expect(thread?.id).toBeUndefined()
+      expect(thread?.title).toBeUndefined()
+    })
+
+    it('should return the thread when it exists', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create a thread manually
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      const thread = await getChatThread(threadId)
+      expect(thread).not.toBeNull()
+      expect(thread?.id).toBe(threadId)
+      expect(thread?.title).toBe('Test Thread')
+    })
+
+    it('should return the correct thread when multiple threads exist', async () => {
+      const threadId1 = uuidv7()
+      const threadId2 = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create two threads
+      await db.insert(chatThreadsTable).values({
+        id: threadId1,
+        title: 'First Thread',
+        isEncrypted: 0,
+      })
+      await db.insert(chatThreadsTable).values({
+        id: threadId2,
+        title: 'Second Thread',
+        isEncrypted: 0,
+      })
+
+      const thread1 = await getChatThread(threadId1)
+      const thread2 = await getChatThread(threadId2)
+
+      expect(thread1?.id).toBe(threadId1)
+      expect(thread1?.title).toBe('First Thread')
+      expect(thread2?.id).toBe(threadId2)
+      expect(thread2?.title).toBe('Second Thread')
+    })
+  })
+
+  describe('getOrCreateChatThread', () => {
+    it('should return existing thread when it exists', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create a thread manually
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Existing Thread',
+        isEncrypted: 0,
+      })
+
+      const thread = await getOrCreateChatThread(threadId)
+      expect(thread).not.toBeNull()
+      expect(thread?.id).toBe(threadId)
+      expect(thread?.title).toBe('Existing Thread')
+
+      // Verify no new thread was created
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(1)
+    })
+
+    it('should create and return new thread when it does not exist', async () => {
+      const threadId = uuidv7()
+
+      const thread = await getOrCreateChatThread(threadId)
+      expect(thread).not.toBeNull()
+      expect(thread?.id).toBe(threadId)
+      expect(thread?.title).toBe('New Chat')
+
+      // Verify thread was created in database
+      const db = DatabaseSingleton.instance.db
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(1)
       expect(threads[0]?.id).toBe(threadId)
     })
 
-    it('should reuse empty thread when one exists', async () => {
+    it('should handle multiple calls with same ID consistently', async () => {
+      const threadId = uuidv7()
+
+      const thread1 = await getOrCreateChatThread(threadId)
+      const thread2 = await getOrCreateChatThread(threadId)
+
+      expect(thread1?.id).toBe(threadId)
+      expect(thread2?.id).toBe(threadId)
+      expect(thread1?.title).toBe('New Chat')
+      expect(thread2?.title).toBe('New Chat')
+
+      // Verify only one thread exists
       const db = DatabaseSingleton.instance.db
-
-      // Create an empty thread
-      const emptyThreadId = uuidv7()
-      await db.insert(chatThreadsTable).values({
-        id: emptyThreadId,
-        title: 'Empty Thread',
-        isEncrypted: 0,
-      })
-
-      const threadId = await import('./dal').then((m) => m.getOrCreateChatThread())
-      expect(threadId).toBe(emptyThreadId)
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(1)
     })
 
-    it('should create new thread when all existing threads have messages', async () => {
+    it('should work correctly with different thread IDs', async () => {
+      const threadId1 = uuidv7()
+      const threadId2 = uuidv7()
+
+      const thread1 = await getOrCreateChatThread(threadId1)
+      const thread2 = await getOrCreateChatThread(threadId2)
+
+      expect(thread1?.id).toBe(threadId1)
+      expect(thread2?.id).toBe(threadId2)
+      expect(thread1?.id).not.toBe(thread2?.id)
+
+      // Verify both threads exist
       const db = DatabaseSingleton.instance.db
-
-      // Create a thread with a message
-      const existingThreadId = uuidv7()
-      await db.insert(chatThreadsTable).values({
-        id: existingThreadId,
-        title: 'Thread with message',
-        isEncrypted: 0,
-      })
-
-      await db.insert(chatMessagesTable).values({
-        id: uuidv7(),
-        chatThreadId: existingThreadId,
-        role: 'user',
-        content: 'Hello',
-      })
-
-      const newThreadId = await import('./dal').then((m) => m.getOrCreateChatThread())
-      expect(newThreadId).not.toBe(existingThreadId)
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(2)
+      expect(threads.map((t) => t.id)).toContain(threadId1)
+      expect(threads.map((t) => t.id)).toContain(threadId2)
     })
   })
 })

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1,5 +1,4 @@
-import { and, asc, desc, eq, like, notExists, sql } from 'drizzle-orm'
-import { v7 as uuidv7 } from 'uuid'
+import { and, asc, desc, eq, like, sql } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
 import {
   accountsTable,

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -278,6 +278,23 @@ export const getChatThreadById = async (id: string) => {
 }
 
 /**
+ * Gets a specific chat thread by ID or create a new one with the provided ID
+ */
+export const getOrCreateChatThreadById = async (id: string) => {
+  const db = DatabaseSingleton.instance.db
+
+  const thread = await getChatThreadById(id)
+
+  if (thread?.id) {
+    return thread
+  }
+
+  await db.insert(chatThreadsTable).values({ id, title: 'New Chat' })
+
+  return await getChatThreadById(id)
+}
+
+/**
  * Gets an existing empty chat thread or creates a new one
  */
 export const getOrCreateChatThread = async (isEncrypted: boolean = false): Promise<string> => {

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -272,61 +272,32 @@ export const getAllChatThreads = async () => {
 /**
  * Gets a specific chat thread by ID
  */
-export const getChatThreadById = async (id: string) => {
+export const getChatThread = async (id: string) => {
   const db = DatabaseSingleton.instance.db
   return await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, id)).get()
 }
 
 /**
+ * Create a new chat thread
+ */
+export const createChatThread = async (id: string) => {
+  const db = DatabaseSingleton.instance.db
+  await db.insert(chatThreadsTable).values({ id, title: 'New Chat' })
+}
+
+/**
  * Gets a specific chat thread by ID or create a new one with the provided ID
  */
-export const getOrCreateChatThreadById = async (id: string) => {
-  const db = DatabaseSingleton.instance.db
-
-  const thread = await getChatThreadById(id)
+export const getOrCreateChatThread = async (id: string) => {
+  const thread = await getChatThread(id)
 
   if (thread?.id) {
     return thread
   }
 
-  await db.insert(chatThreadsTable).values({ id, title: 'New Chat' })
+  await createChatThread(id)
 
-  return await getChatThreadById(id)
-}
-
-/**
- * Gets an existing empty chat thread or creates a new one
- */
-export const getOrCreateChatThread = async (isEncrypted: boolean = false): Promise<string> => {
-  const db = DatabaseSingleton.instance.db
-  // First check if any threads exist
-  const threads = await db.select().from(chatThreadsTable).orderBy(desc(chatThreadsTable.id))
-
-  if (threads.length === 0) {
-    // No threads exist, create a new one
-    const chatThreadId = uuidv7()
-    await db.insert(chatThreadsTable).values({ id: chatThreadId, title: 'New Chat', isEncrypted: isEncrypted ? 1 : 0 })
-    return chatThreadId
-  }
-
-  // Check for empty threads first
-  const emptyThreads = await db
-    .select({ id: chatThreadsTable.id })
-    .from(chatThreadsTable)
-    .where(
-      notExists(db.select().from(chatMessagesTable).where(eq(chatMessagesTable.chatThreadId, chatThreadsTable.id))),
-    )
-    .limit(1)
-
-  if (emptyThreads.length > 0) {
-    // Use the empty thread
-    return emptyThreads[0].id
-  }
-
-  // No empty threads, create a new one
-  const chatThreadId = uuidv7()
-  await db.insert(chatThreadsTable).values({ id: chatThreadId, title: 'New Chat', isEncrypted: isEncrypted ? 1 : 0 })
-  return chatThreadId
+  return await getChatThread(id)
 }
 
 // ============================================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,6 @@ export type InitData = {
   window: Window | undefined
   sideviewType: SideviewType | null
   sideviewId: string | null
-  initialThreadId: string
 }
 
 export type ThunderboltUIMessage = UIMessage<UIMessageMetadata, UIDataTypes, UITools>


### PR DESCRIPTION
## Description
Previously, when a user clicked “New Chat”, the app would immediately create a new chat record in the database, retrieve its id, and then navigate directly to /chats/:id.

## New Approach
With this update, we refactored the flow to use a dedicated /chats/new route, improving both UX and architecture.
Now, when the user opens a new chat:

- They are first taken to /chats/new (a temporary in-memory state).
- Once they start typing or send the first message, the chat record is created in the database.
- The app then navigates to /chats/:id using useNavigate with the relative option to prevent reloads.

The `relative: 'path'` option tells React Router to resolve the new path relative to the current route instead of reloading the full page. This ensures state preservation, faster navigation, and no redundant re-renders between /chats/new and /chats/:id.

## Preview

https://github.com/user-attachments/assets/652130c0-0c41-4c08-8e1f-ea9e7619712b


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors chat creation to route to /chats/new and create the thread on first message, updating DAL APIs, routing, and tests accordingly.
> 
> - **Frontend/Routing**:
>   - Default index now redirects to `/chats/new` (removes dependency on `initData.initialThreadId`).
>   - `ChatDetailPage` handles `chats/new` by generating a UUID client-side and navigating to `chats/:id` on first message; updates query keys and navigation.
>   - `ChatUI` "New Chat" navigates to `/chats/new` (no pre-create).
>   - Sidebar "New Chat" and "Clear all chats" navigate to `/chats/new` and stop pre-creating threads.
>   - Minor: adjust `AppRoutes` param usage.
> - **DAL**:
>   - Add `createChatThread(id)` and `getChatThread(id)`; replace `getChatThreadById`.
>   - Change `getOrCreateChatThread(id)` to get-or-create by provided ID; remove internal UUID generation and empty-thread reuse logic.
> - **Tests**:
>   - Rewrite chat thread tests to cover `createChatThread`, `getChatThread`, and new `getOrCreateChatThread(id)` semantics; remove old empty-thread reuse tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42b63a049cfec84f991f32882e96a046a51d240d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->