### PR TITLE
dal.ts refactor

### DIFF
--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -8,7 +8,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { eq } from 'drizzle-orm'
 import { useNavigate, useParams } from 'react-router'
 import Chat from './chat'
-import { getChatMessagesByThreadId } from '@/lib/dal'
+import { getChatMessages } from '@/lib/dal'
 import { v7 as uuidv7 } from 'uuid'
 import { useMemo } from 'react'
 
@@ -50,7 +50,7 @@ export default function ChatDetailPage() {
   } = useQuery<ThunderboltUIMessage[], Error>({
     queryKey: ['chatMessages', chatThreadId],
     queryFn: async () => {
-      const chatMessages = await getChatMessagesByThreadId(chatThreadId!)
+      const chatMessages = await getChatMessages(chatThreadId!)
       return chatMessages.map(convertDbChatMessageToUIMessage) as ThunderboltUIMessage[]
     },
     enabled: !!chatThreadId,

--- a/src/components/chat/message-preview.tsx
+++ b/src/components/chat/message-preview.tsx
@@ -1,5 +1,5 @@
 import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { getEmailMessageById, getEmailMessageByImapId } from '@/lib/dal'
+import { getEmailMessage, getEmailMessageByImapId } from '@/lib/dal'
 import { formatDate } from '@/lib/utils'
 import { useSideview } from '@/sideview/provider'
 import type { EmailMessageWithAddresses } from '@/types'
@@ -20,7 +20,7 @@ export function ChatMessagePreview({ messageId, imapId }: ChatMessagePreviewProp
     queryKey: ['messages', messageId, imapId],
     queryFn: async () => {
       if (messageId) {
-        return await getEmailMessageById(messageId)
+        return await getEmailMessage(messageId)
       } else if (imapId) {
         return await getEmailMessageByImapId(imapId)
       }

--- a/src/db/sqlocal-database.ts
+++ b/src/db/sqlocal-database.ts
@@ -42,7 +42,7 @@ export class SQLocalDatabase implements DatabaseInterface {
     // instead of: undefined
     //
     // Impact: This breaks optional chaining and truthy checks throughout the app.
-    // For example, getModelById() was returning malformed models, causing the chat screen
+    // For example, getModel() was returning malformed models, causing the chat screen
     // to render blank when a model reference was missing from the database.
     //
     // Expected behavior: .get() should return undefined when no results are found,

--- a/src/hooks/use-setting.ts
+++ b/src/hooks/use-setting.ts
@@ -24,15 +24,10 @@ import {
  * setCloudUrl('https://new-url.com')
  * ```
  */
-export const useSetting = <T = string>(
+export const useSetting = <T = string, V = T | null>(
   key: string,
-  defaultValue: T | null = null,
-): [
-  T | null,
-  (newValue: T | null) => void,
-  UseQueryResult<T | null, Error>,
-  UseMutationResult<void, Error, T | null, unknown>,
-] => {
+  defaultValue: V = null as V,
+): [V, (newValue: V) => void, UseQueryResult<V, Error>, UseMutationResult<void, Error, V, unknown>] => {
   const queryClient = useQueryClient()
 
   const query = useQuery({
@@ -41,13 +36,13 @@ export const useSetting = <T = string>(
   })
 
   const mutation = useMutation({
-    mutationFn: (newValue: T | null) => updateSetting(key, newValue ? newValue.toString() : null),
+    mutationFn: (newValue: V) => updateSetting(key, newValue ? newValue.toString() : null),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['settings', key] })
     },
   })
 
-  const setValue = (newValue: T | null) => {
+  const setValue = (newValue: V) => {
     mutation.mutate(newValue)
   }
 

--- a/src/layout/sideview.tsx
+++ b/src/layout/sideview.tsx
@@ -1,5 +1,5 @@
 import {
-  getEmailThreadByIdWithMessages,
+  getEmailThreadWithMessages,
   getEmailThreadByMessageIdWithMessages,
   getEmailThreadByMessageImapIdWithMessages,
 } from '@/lib/dal'
@@ -23,7 +23,7 @@ export function Sideview() {
         case 'imap':
           return await getEmailThreadByMessageImapIdWithMessages(sideviewId)
         case 'thread':
-          return await getEmailThreadByIdWithMessages(sideviewId)
+          return await getEmailThreadWithMessages(sideviewId)
         default:
           return null
       }

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -133,12 +133,12 @@ describe('Settings DAL', () => {
       expect(value).toBe(false)
     })
 
-    it.skip('should return custom default when setting does not exist', async () => {
+    it('should return custom default when setting does not exist', async () => {
       const value = await getBooleanSetting('nonexistent_key', true)
       expect(value).toBe(true)
     })
 
-    it.skip('should return true when value is "true"', async () => {
+    it('should return true when value is "true"', async () => {
       await createSetting('bool_key', 'true')
       const value = await getBooleanSetting('bool_key')
       expect(value).toBe(true)
@@ -215,7 +215,7 @@ describe('Settings DAL', () => {
   })
 
   describe('updateBooleanSetting', () => {
-    it.skip('should create a boolean setting with true value', async () => {
+    it('should create a boolean setting with true value', async () => {
       await updateBooleanSetting('bool_key', true)
       const value = await getBooleanSetting('bool_key')
       expect(value).toBe(true)
@@ -227,7 +227,7 @@ describe('Settings DAL', () => {
       expect(value).toBe(false)
     })
 
-    it.skip('should update existing boolean setting', async () => {
+    it('should update existing boolean setting', async () => {
       await updateBooleanSetting('bool_key', false)
       await updateBooleanSetting('bool_key', true)
       const value = await getBooleanSetting('bool_key')

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -1,21 +1,46 @@
 import { migrate } from '@/src/db/migrate'
 import { DatabaseSingleton } from '@/src/db/singleton'
-import { chatMessagesTable, chatThreadsTable, modelsTable, settingsTable } from '@/src/db/tables'
-import { afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import {
+  accountsTable,
+  chatMessagesTable,
+  chatThreadsTable,
+  mcpServersTable,
+  modelsTable,
+  promptsTable,
+  settingsTable,
+  tasksTable,
+} from '@/src/db/tables'
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import {
   createChatThread,
   createSetting,
   deleteSetting,
+  getAllAccounts,
+  getAllChatThreads,
+  getAllMcpServers,
+  getAllModels,
+  getAllPrompts,
   getAllSettings,
+  getAvailableModels,
   getBooleanSetting,
+  getBridgeSettings,
+  getChatMessages,
   getChatThread,
+  getHttpMcpServers,
+  getIncompleteTasks,
+  getIncompleteTasksCount,
+  getLastMessage,
   getOrCreateChatThread,
   getDefaultModelForThread,
   getModel,
+  getPreferencesSettings,
   getSelectedModel,
   getSetting,
+  getSystemModel,
+  getThemeSetting,
+  getTriggerPromptForThread,
   hasSetting,
   updateBooleanSetting,
   updateSetting,
@@ -260,6 +285,104 @@ describe('Settings DAL', () => {
       expect(settings.map((s) => s.key)).toContain('key3')
     })
   })
+
+  describe('getPreferencesSettings', () => {
+    it('should return default values when no settings exist', async () => {
+      const preferences = await getPreferencesSettings()
+      expect(preferences).toEqual({
+        locationName: '',
+        locationLat: '',
+        locationLng: '',
+        preferredName: '',
+        dataCollection: true,
+        experimentalFeatureTasks: false,
+      })
+    })
+
+    it('should return stored values when settings exist', async () => {
+      await updateSetting('location_name', 'New York')
+      await updateSetting('location_lat', '40.7128')
+      await updateSetting('location_lng', '-74.0060')
+      await updateSetting('preferred_name', 'John Doe')
+      await updateBooleanSetting('data_collection', false)
+      await updateBooleanSetting('experimental_feature_tasks', true)
+
+      const preferences = await getPreferencesSettings()
+      expect(preferences).toEqual({
+        locationName: 'New York',
+        locationLat: '40.7128',
+        locationLng: '-74.0060',
+        preferredName: 'John Doe',
+        dataCollection: false,
+        experimentalFeatureTasks: true,
+      })
+    })
+
+    it('should handle mixed default and custom values', async () => {
+      await updateSetting('location_name', 'San Francisco')
+      await updateBooleanSetting('experimental_feature_tasks', true)
+
+      const preferences = await getPreferencesSettings()
+      expect(preferences).toEqual({
+        locationName: 'San Francisco',
+        locationLat: '',
+        locationLng: '',
+        preferredName: '',
+        dataCollection: true,
+        experimentalFeatureTasks: true,
+      })
+    })
+  })
+
+  describe('getThemeSetting', () => {
+    it('should return default theme when setting does not exist', async () => {
+      const theme = await getThemeSetting('theme', 'light')
+      expect(theme).toBe('light')
+    })
+
+    it('should return stored theme when setting exists', async () => {
+      await updateSetting('theme', 'dark')
+      const theme = await getThemeSetting('theme', 'light')
+      expect(theme).toBe('dark')
+    })
+
+    it('should work with different storage keys', async () => {
+      await updateSetting('appearance_theme', 'auto')
+      const theme = await getThemeSetting('appearance_theme', 'light')
+      expect(theme).toBe('auto')
+    })
+
+    it('should return empty string when stored as empty', async () => {
+      await updateSetting('theme', '')
+      const theme = await getThemeSetting('theme', 'light')
+      expect(theme).toBe('')
+    })
+  })
+
+  describe('getBridgeSettings', () => {
+    it('should return default values when no settings exist', async () => {
+      const bridgeSettings = await getBridgeSettings()
+      expect(bridgeSettings).toEqual({
+        enabled: false,
+      })
+    })
+
+    it('should return stored values when settings exist', async () => {
+      await updateBooleanSetting('bridge_enabled', true)
+      const bridgeSettings = await getBridgeSettings()
+      expect(bridgeSettings).toEqual({
+        enabled: true,
+      })
+    })
+
+    it('should return false when bridge is explicitly disabled', async () => {
+      await updateBooleanSetting('bridge_enabled', false)
+      const bridgeSettings = await getBridgeSettings()
+      expect(bridgeSettings).toEqual({
+        enabled: false,
+      })
+    })
+  })
 })
 
 // ============================================================================
@@ -369,6 +492,195 @@ describe('Models DAL', () => {
       const model = await getSelectedModel()
       expect(model.id).toBe(selectedModelId)
       expect(model.name).toBe('Selected Model')
+    })
+  })
+
+  describe('getAllModels', () => {
+    it('should return empty array when no models exist', async () => {
+      const models = await getAllModels()
+      expect(models).toEqual([])
+    })
+
+    it('should return all models including disabled ones', async () => {
+      const db = DatabaseSingleton.instance.db
+      const modelId1 = uuidv7()
+      const modelId2 = uuidv7()
+
+      await db.insert(modelsTable).values({
+        id: modelId1,
+        provider: 'openai',
+        name: 'Enabled Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      await db.insert(modelsTable).values({
+        id: modelId2,
+        provider: 'openai',
+        name: 'Disabled Model',
+        model: 'gpt-3.5',
+        isSystem: 0,
+        enabled: 0,
+      })
+
+      const models = await getAllModels()
+      expect(models).toHaveLength(2)
+      expect(models.map((m) => m.id)).toContain(modelId1)
+      expect(models.map((m) => m.id)).toContain(modelId2)
+    })
+
+    it('should map model fields correctly', async () => {
+      const db = DatabaseSingleton.instance.db
+      const modelId = uuidv7()
+
+      await db.insert(modelsTable).values({
+        id: modelId,
+        provider: 'openai',
+        name: 'Test Model',
+        model: 'gpt-4',
+        isSystem: 1,
+        enabled: 1,
+        apiKey: 'test-key',
+      })
+
+      const models = await getAllModels()
+      const model = models.find((m) => m.id === modelId)
+      expect(model).toBeDefined()
+      expect(model?.name).toBe('Test Model')
+      expect(model?.isSystem).toBe(1)
+      expect(model?.apiKey).toBe('test-key')
+    })
+  })
+
+  describe('getAvailableModels', () => {
+    it('should return empty array when no enabled models exist', async () => {
+      const db = DatabaseSingleton.instance.db
+      await db.insert(modelsTable).values({
+        id: uuidv7(),
+        provider: 'openai',
+        name: 'Disabled Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 0,
+      })
+
+      const models = await getAvailableModels()
+      expect(models).toEqual([])
+    })
+
+    it('should return only enabled models', async () => {
+      const db = DatabaseSingleton.instance.db
+      const enabledModelId = uuidv7()
+      const disabledModelId = uuidv7()
+
+      await db.insert(modelsTable).values({
+        id: enabledModelId,
+        provider: 'openai',
+        name: 'Enabled Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      await db.insert(modelsTable).values({
+        id: disabledModelId,
+        provider: 'openai',
+        name: 'Disabled Model',
+        model: 'gpt-3.5',
+        isSystem: 0,
+        enabled: 0,
+      })
+
+      const models = await getAvailableModels()
+      expect(models).toHaveLength(1)
+      expect(models[0]?.id).toBe(enabledModelId)
+      expect(models[0]?.name).toBe('Enabled Model')
+    })
+
+    it('should include system models when enabled', async () => {
+      const db = DatabaseSingleton.instance.db
+      const systemModelId = uuidv7()
+
+      await db.insert(modelsTable).values({
+        id: systemModelId,
+        provider: 'flower',
+        name: 'System Model',
+        model: 'system/model',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      const models = await getAvailableModels()
+      expect(models).toHaveLength(1)
+      expect(models[0]?.id).toBe(systemModelId)
+      expect(models[0]?.isSystem).toBe(1)
+    })
+  })
+
+  describe('getSystemModel', () => {
+    it('should return null when no system model exists', async () => {
+      const db = DatabaseSingleton.instance.db
+      await db.insert(modelsTable).values({
+        id: uuidv7(),
+        provider: 'openai',
+        name: 'Non-System Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      const systemModel = await getSystemModel()
+      expect(systemModel).toBe(null)
+    })
+
+    it('should return the system model when it exists', async () => {
+      const db = DatabaseSingleton.instance.db
+      const systemModelId = uuidv7()
+
+      await db.insert(modelsTable).values({
+        id: systemModelId,
+        provider: 'flower',
+        name: 'System Model',
+        model: 'system/model',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      const systemModel = await getSystemModel()
+      expect(systemModel).not.toBe(null)
+      expect(systemModel?.id).toBe(systemModelId)
+      expect(systemModel?.name).toBe('System Model')
+      expect(systemModel?.isSystem).toBe(1)
+    })
+
+    it('should return the first system model when multiple exist', async () => {
+      const db = DatabaseSingleton.instance.db
+      const systemModelId1 = uuidv7()
+      const systemModelId2 = uuidv7()
+
+      await db.insert(modelsTable).values({
+        id: systemModelId1,
+        provider: 'flower',
+        name: 'First System Model',
+        model: 'system/model1',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      await db.insert(modelsTable).values({
+        id: systemModelId2,
+        provider: 'flower',
+        name: 'Second System Model',
+        model: 'system/model2',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      const systemModel = await getSystemModel()
+      expect(systemModel).not.toBe(null)
+      expect(systemModel?.id).toBe(systemModelId1)
+      expect(systemModel?.name).toBe('First System Model')
     })
   })
 
@@ -679,6 +991,915 @@ describe('Chat Threads DAL', () => {
       expect(threads).toHaveLength(2)
       expect(threads.map((t) => t.id)).toContain(threadId1)
       expect(threads.map((t) => t.id)).toContain(threadId2)
+    })
+  })
+
+  describe('getAllChatThreads', () => {
+    it('should return empty array when no threads exist', async () => {
+      const threads = await getAllChatThreads()
+      expect(threads).toEqual([])
+    })
+
+    it('should return all threads ordered by creation date (newest first)', async () => {
+      const db = DatabaseSingleton.instance.db
+      const threadId1 = uuidv7()
+      const threadId2 = uuidv7()
+      const threadId3 = uuidv7()
+
+      // Create threads with slight delays to ensure different timestamps
+      await db.insert(chatThreadsTable).values({
+        id: threadId1,
+        title: 'First Thread',
+        isEncrypted: 0,
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 10)) // Small delay
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId2,
+        title: 'Second Thread',
+        isEncrypted: 0,
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 10)) // Small delay
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId3,
+        title: 'Third Thread',
+        isEncrypted: 0,
+      })
+
+      const threads = await getAllChatThreads()
+      expect(threads).toHaveLength(3)
+      // Should be ordered by ID descending (newest first)
+      expect(threads[0]?.id).toBe(threadId3)
+      expect(threads[1]?.id).toBe(threadId2)
+      expect(threads[2]?.id).toBe(threadId1)
+    })
+
+    it('should return threads with all properties', async () => {
+      const db = DatabaseSingleton.instance.db
+      const threadId = uuidv7()
+      const promptId = uuidv7()
+
+      // Create a model first to satisfy foreign key constraint
+      const modelId = uuidv7()
+      await db.insert(modelsTable).values({
+        id: modelId,
+        provider: 'openai',
+        name: 'Test Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      // Create a prompt first to satisfy foreign key constraint
+      await db.insert(promptsTable).values({
+        id: promptId,
+        prompt: 'Test prompt',
+        title: 'Test Prompt',
+        modelId: modelId,
+      })
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 1,
+        wasTriggeredByAutomation: 1,
+        triggeredBy: promptId,
+      })
+
+      const threads = await getAllChatThreads()
+      expect(threads).toHaveLength(1)
+      expect(threads[0]?.id).toBe(threadId)
+      expect(threads[0]?.title).toBe('Test Thread')
+      expect(threads[0]?.isEncrypted).toBe(1)
+      expect(threads[0]?.wasTriggeredByAutomation).toBe(1)
+      expect(threads[0]?.triggeredBy).toBe(promptId)
+    })
+  })
+
+  describe('getChatMessages', () => {
+    afterEach(async () => {
+      // Clean up chat data after each test
+      const db = DatabaseSingleton.instance.db
+      await db.delete(chatMessagesTable)
+      await db.delete(chatThreadsTable)
+    })
+
+    it('should return empty array when thread has no messages', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create thread without messages
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Empty Thread',
+        isEncrypted: 0,
+      })
+
+      const messages = await getChatMessages(threadId)
+      expect(messages).toEqual([])
+    })
+
+    it('should return all messages for a thread ordered by ID', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create thread
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      // Create messages
+      const messageId1 = uuidv7()
+      const messageId2 = uuidv7()
+      const messageId3 = uuidv7()
+
+      await db.insert(chatMessagesTable).values({
+        id: messageId1,
+        chatThreadId: threadId,
+        role: 'user',
+        content: 'First message',
+      })
+
+      await db.insert(chatMessagesTable).values({
+        id: messageId2,
+        chatThreadId: threadId,
+        role: 'assistant',
+        content: 'Second message',
+      })
+
+      await db.insert(chatMessagesTable).values({
+        id: messageId3,
+        chatThreadId: threadId,
+        role: 'user',
+        content: 'Third message',
+      })
+
+      const messages = await getChatMessages(threadId)
+      expect(messages).toHaveLength(3)
+      expect(messages[0]?.id).toBe(messageId1)
+      expect(messages[1]?.id).toBe(messageId2)
+      expect(messages[2]?.id).toBe(messageId3)
+    })
+
+    it('should only return messages for the specified thread', async () => {
+      const threadId1 = uuidv7()
+      const threadId2 = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create two threads
+      await db.insert(chatThreadsTable).values({
+        id: threadId1,
+        title: 'Thread 1',
+        isEncrypted: 0,
+      })
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId2,
+        title: 'Thread 2',
+        isEncrypted: 0,
+      })
+
+      // Create messages for both threads
+      await db.insert(chatMessagesTable).values({
+        id: uuidv7(),
+        chatThreadId: threadId1,
+        role: 'user',
+        content: 'Thread 1 message',
+      })
+
+      await db.insert(chatMessagesTable).values({
+        id: uuidv7(),
+        chatThreadId: threadId2,
+        role: 'user',
+        content: 'Thread 2 message',
+      })
+
+      const messages1 = await getChatMessages(threadId1)
+      const messages2 = await getChatMessages(threadId2)
+
+      expect(messages1).toHaveLength(1)
+      expect(messages1[0]?.content).toBe('Thread 1 message')
+      expect(messages2).toHaveLength(1)
+      expect(messages2[0]?.content).toBe('Thread 2 message')
+    })
+  })
+
+  describe('getLastMessage', () => {
+    afterEach(async () => {
+      // Clean up chat data after each test
+      const db = DatabaseSingleton.instance.db
+      await db.delete(chatMessagesTable)
+      await db.delete(chatThreadsTable)
+    })
+
+    it('should return undefined when thread has no messages', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create thread without messages
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Empty Thread',
+        isEncrypted: 0,
+      })
+
+      const lastMessage = await getLastMessage(threadId)
+      expect(lastMessage).toBeUndefined()
+    })
+
+    it('should return the last message when thread has messages', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create thread
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      // Create messages
+      const messageId1 = uuidv7()
+      const messageId2 = uuidv7()
+      const messageId3 = uuidv7()
+
+      await db.insert(chatMessagesTable).values({
+        id: messageId1,
+        chatThreadId: threadId,
+        role: 'user',
+        content: 'First message',
+      })
+
+      await db.insert(chatMessagesTable).values({
+        id: messageId2,
+        chatThreadId: threadId,
+        role: 'assistant',
+        content: 'Second message',
+      })
+
+      await db.insert(chatMessagesTable).values({
+        id: messageId3,
+        chatThreadId: threadId,
+        role: 'user',
+        content: 'Third message',
+      })
+
+      const lastMessage = await getLastMessage(threadId)
+      expect(lastMessage).toBeDefined()
+      expect(lastMessage?.id).toBe(messageId3)
+      expect(lastMessage?.chatThreadId).toBe(threadId)
+    })
+
+    it('should return only id, chatThreadId, and modelId fields', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create a model first to satisfy foreign key constraint
+      const modelId = uuidv7()
+      await db.insert(modelsTable).values({
+        id: modelId,
+        provider: 'openai',
+        name: 'Test Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      // Create thread
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      // Create message with modelId
+      const messageId = uuidv7()
+
+      await db.insert(chatMessagesTable).values({
+        id: messageId,
+        chatThreadId: threadId,
+        role: 'assistant',
+        content: 'Test message',
+        modelId: modelId,
+      })
+
+      const lastMessage = await getLastMessage(threadId)
+      expect(lastMessage).toBeDefined()
+      expect(lastMessage?.id).toBe(messageId)
+      expect(lastMessage?.chatThreadId).toBe(threadId)
+      expect(lastMessage?.modelId).toBe(modelId)
+      // Should not have other fields like content, role, etc.
+      expect(lastMessage).not.toHaveProperty('content')
+      expect(lastMessage).not.toHaveProperty('role')
+    })
+  })
+})
+
+// ============================================================================
+// TASKS TESTS
+// ============================================================================
+
+describe('Tasks DAL', () => {
+  afterEach(async () => {
+    // Clean up tasks table after each test
+    const db = DatabaseSingleton.instance.db
+    await db.delete(tasksTable)
+  })
+
+  describe('getIncompleteTasks', () => {
+    it('should return empty array when no tasks exist', async () => {
+      const tasks = await getIncompleteTasks()
+      expect(tasks).toEqual([])
+    })
+
+    it('should return only incomplete tasks', async () => {
+      const db = DatabaseSingleton.instance.db
+      const taskId1 = uuidv7()
+      const taskId2 = uuidv7()
+      const taskId3 = uuidv7()
+
+      await db.insert(tasksTable).values({
+        id: taskId1,
+        item: 'Incomplete task 1',
+        isComplete: 0,
+        order: 1,
+      })
+
+      await db.insert(tasksTable).values({
+        id: taskId2,
+        item: 'Complete task',
+        isComplete: 1,
+        order: 2,
+      })
+
+      await db.insert(tasksTable).values({
+        id: taskId3,
+        item: 'Incomplete task 2',
+        isComplete: 0,
+        order: 3,
+      })
+
+      const tasks = await getIncompleteTasks()
+      expect(tasks).toHaveLength(2)
+      expect(tasks.map((t) => t.id)).toContain(taskId1)
+      expect(tasks.map((t) => t.id)).toContain(taskId3)
+      expect(tasks.map((t) => t.id)).not.toContain(taskId2)
+    })
+
+    it('should filter by search query when provided', async () => {
+      const db = DatabaseSingleton.instance.db
+      const taskId1 = uuidv7()
+      const taskId2 = uuidv7()
+      const taskId3 = uuidv7()
+
+      await db.insert(tasksTable).values({
+        id: taskId1,
+        item: 'Buy groceries',
+        isComplete: 0,
+        order: 1,
+      })
+
+      await db.insert(tasksTable).values({
+        id: taskId2,
+        item: 'Call doctor',
+        isComplete: 0,
+        order: 2,
+      })
+
+      await db.insert(tasksTable).values({
+        id: taskId3,
+        item: 'Buy milk',
+        isComplete: 0,
+        order: 3,
+      })
+
+      const tasks = await getIncompleteTasks('buy')
+      expect(tasks).toHaveLength(2)
+      expect(tasks.map((t) => t.item)).toContain('Buy groceries')
+      expect(tasks.map((t) => t.item)).toContain('Buy milk')
+      expect(tasks.map((t) => t.item)).not.toContain('Call doctor')
+    })
+
+    it('should limit results to 50 tasks', async () => {
+      const db = DatabaseSingleton.instance.db
+
+      // Create 60 incomplete tasks
+      for (let i = 0; i < 60; i++) {
+        await db.insert(tasksTable).values({
+          id: uuidv7(),
+          item: `Task ${i}`,
+          isComplete: 0,
+          order: i,
+        })
+      }
+
+      const tasks = await getIncompleteTasks()
+      expect(tasks).toHaveLength(50)
+    })
+
+    it('should filter out empty or whitespace-only tasks', async () => {
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(tasksTable).values({
+        id: uuidv7(),
+        item: 'Valid task',
+        isComplete: 0,
+        order: 1,
+      })
+
+      await db.insert(tasksTable).values({
+        id: uuidv7(),
+        item: '',
+        isComplete: 0,
+        order: 2,
+      })
+
+      await db.insert(tasksTable).values({
+        id: uuidv7(),
+        item: '   ',
+        isComplete: 0,
+        order: 3,
+      })
+
+      const tasks = await getIncompleteTasks()
+      expect(tasks).toHaveLength(1)
+      expect(tasks[0]?.item).toBe('Valid task')
+    })
+  })
+
+  describe('getIncompleteTasksCount', () => {
+    it('should return 0 when no incomplete tasks exist', async () => {
+      const count = await getIncompleteTasksCount()
+      expect(count).toBe(0)
+    })
+
+    it('should return correct count of incomplete tasks', async () => {
+      const db = DatabaseSingleton.instance.db
+
+      // Create some incomplete tasks
+      for (let i = 0; i < 3; i++) {
+        await db.insert(tasksTable).values({
+          id: uuidv7(),
+          item: `Incomplete task ${i}`,
+          isComplete: 0,
+          order: i,
+        })
+      }
+
+      // Create some complete tasks
+      for (let i = 0; i < 2; i++) {
+        await db.insert(tasksTable).values({
+          id: uuidv7(),
+          item: `Complete task ${i}`,
+          isComplete: 1,
+          order: i + 3,
+        })
+      }
+
+      const count = await getIncompleteTasksCount()
+      expect(count).toBe(3)
+    })
+
+    it('should return 0 when only complete tasks exist', async () => {
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(tasksTable).values({
+        id: uuidv7(),
+        item: 'Complete task',
+        isComplete: 1,
+        order: 1,
+      })
+
+      const count = await getIncompleteTasksCount()
+      expect(count).toBe(0)
+    })
+  })
+})
+
+// ============================================================================
+// ACCOUNTS TESTS
+// ============================================================================
+
+describe('Accounts DAL', () => {
+  afterEach(async () => {
+    // Clean up accounts table after each test
+    const db = DatabaseSingleton.instance.db
+    await db.delete(accountsTable)
+  })
+
+  describe('getAllAccounts', () => {
+    it('should return empty array when no accounts exist', async () => {
+      const accounts = await getAllAccounts()
+      expect(accounts).toEqual([])
+    })
+
+    it('should return all accounts', async () => {
+      const db = DatabaseSingleton.instance.db
+      const accountId1 = uuidv7()
+      const accountId2 = uuidv7()
+
+      await db.insert(accountsTable).values({
+        id: accountId1,
+        type: 'imap',
+        imapHostname: 'imap.example.com',
+        imapPort: 993,
+        imapUsername: 'test1@example.com',
+        imapPassword: 'password1',
+      })
+
+      await db.insert(accountsTable).values({
+        id: accountId2,
+        type: 'imap',
+        imapHostname: 'imap.example.com',
+        imapPort: 993,
+        imapUsername: 'test2@example.com',
+        imapPassword: 'password2',
+      })
+
+      const accounts = await getAllAccounts()
+      expect(accounts).toHaveLength(2)
+      expect(accounts.map((a) => a.id)).toContain(accountId1)
+      expect(accounts.map((a) => a.id)).toContain(accountId2)
+    })
+  })
+})
+
+// ============================================================================
+// MCP SERVERS TESTS
+// ============================================================================
+
+describe('MCP Servers DAL', () => {
+  afterEach(async () => {
+    // Clean up MCP servers table after each test
+    const db = DatabaseSingleton.instance.db
+    await db.delete(mcpServersTable)
+  })
+
+  describe('getAllMcpServers', () => {
+    it('should return empty array when no servers exist', async () => {
+      const servers = await getAllMcpServers()
+      expect(servers).toEqual([])
+    })
+
+    it('should return all MCP servers', async () => {
+      const db = DatabaseSingleton.instance.db
+      const serverId1 = uuidv7()
+      const serverId2 = uuidv7()
+
+      await db.insert(mcpServersTable).values({
+        id: serverId1,
+        name: 'Test Server 1',
+        type: 'http',
+        url: 'https://example.com',
+        enabled: 1,
+      })
+
+      await db.insert(mcpServersTable).values({
+        id: serverId2,
+        name: 'Test Server 2',
+        type: 'stdio',
+        url: null,
+        enabled: 0,
+      })
+
+      const servers = await getAllMcpServers()
+      expect(servers).toHaveLength(2)
+      expect(servers.map((s) => s.id)).toContain(serverId1)
+      expect(servers.map((s) => s.id)).toContain(serverId2)
+    })
+  })
+
+  describe('getHttpMcpServers', () => {
+    it('should return empty array when no HTTP servers exist', async () => {
+      const db = DatabaseSingleton.instance.db
+      await db.insert(mcpServersTable).values({
+        id: uuidv7(),
+        name: 'STDIO Server',
+        type: 'stdio',
+        url: null,
+        enabled: 1,
+      })
+
+      const servers = await getHttpMcpServers()
+      expect(servers).toEqual([])
+    })
+
+    it('should return only HTTP servers with non-null URLs', async () => {
+      const db = DatabaseSingleton.instance.db
+      const httpServerId = uuidv7()
+      const stdioServerId = uuidv7()
+
+      await db.insert(mcpServersTable).values({
+        id: httpServerId,
+        name: 'HTTP Server',
+        type: 'http',
+        url: 'https://example.com',
+        enabled: 1,
+      })
+
+      await db.insert(mcpServersTable).values({
+        id: stdioServerId,
+        name: 'STDIO Server',
+        type: 'stdio',
+        url: null,
+        enabled: 1,
+      })
+
+      const servers = await getHttpMcpServers()
+      expect(servers).toHaveLength(1)
+      expect(servers[0]?.id).toBe(httpServerId)
+      expect(servers[0]?.name).toBe('HTTP Server')
+      expect(servers[0]?.url).toBe('https://example.com')
+    })
+
+    it('should exclude HTTP servers with null URLs', async () => {
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(mcpServersTable).values({
+        id: uuidv7(),
+        name: 'HTTP Server with null URL',
+        type: 'http',
+        url: null,
+        enabled: 1,
+      })
+
+      const servers = await getHttpMcpServers()
+      expect(servers).toEqual([])
+    })
+
+    it('should return servers with correct structure', async () => {
+      const db = DatabaseSingleton.instance.db
+      const serverId = uuidv7()
+
+      await db.insert(mcpServersTable).values({
+        id: serverId,
+        name: 'Test HTTP Server',
+        type: 'http',
+        url: 'https://api.example.com',
+        enabled: 1,
+      })
+
+      const servers = await getHttpMcpServers()
+      expect(servers).toHaveLength(1)
+      const server = servers[0]
+      expect(server).toHaveProperty('id')
+      expect(server).toHaveProperty('name')
+      expect(server).toHaveProperty('url')
+      expect(server).toHaveProperty('enabled')
+      expect(server).toHaveProperty('createdAt')
+      expect(server).toHaveProperty('updatedAt')
+      expect(server?.id).toBe(serverId)
+      expect(server?.name).toBe('Test HTTP Server')
+      expect(server?.url).toBe('https://api.example.com')
+      expect(server?.enabled).toBe(1)
+    })
+  })
+})
+
+// ============================================================================
+// PROMPTS TESTS
+// ============================================================================
+
+describe('Prompts DAL', () => {
+  beforeEach(async () => {
+    // Clean up prompts and chat tables before each test
+    const db = DatabaseSingleton.instance.db
+    await db.delete(chatMessagesTable)
+    await db.delete(chatThreadsTable)
+    await db.delete(promptsTable)
+    await db.delete(modelsTable)
+  })
+
+  afterEach(async () => {
+    // Clean up prompts and chat tables after each test
+    const db = DatabaseSingleton.instance.db
+    await db.delete(chatMessagesTable)
+    await db.delete(chatThreadsTable)
+    await db.delete(promptsTable)
+    await db.delete(modelsTable)
+  })
+
+  describe('getAllPrompts', () => {
+    it('should return empty array when no prompts exist', async () => {
+      const prompts = await getAllPrompts()
+      expect(prompts).toEqual([])
+    })
+
+    it('should return all prompts when no search query provided', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId1 = uuidv7()
+      const promptId2 = uuidv7()
+      const modelId = uuidv7()
+
+      // Create a model first to satisfy foreign key constraint
+      await db.insert(modelsTable).values({
+        id: modelId,
+        provider: 'openai',
+        name: 'Test Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      await db.insert(promptsTable).values({
+        id: promptId1,
+        prompt: 'First prompt',
+        title: 'Prompt 1',
+        modelId: modelId,
+      })
+
+      await db.insert(promptsTable).values({
+        id: promptId2,
+        prompt: 'Second prompt',
+        title: 'Prompt 2',
+        modelId: modelId,
+      })
+
+      const prompts = await getAllPrompts()
+      expect(prompts).toHaveLength(2)
+      expect(prompts.map((p) => p.id)).toContain(promptId1)
+      expect(prompts.map((p) => p.id)).toContain(promptId2)
+    })
+
+    it('should filter by search query when provided', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId1 = uuidv7()
+      const promptId2 = uuidv7()
+      const modelId = uuidv7()
+
+      // Create a model first to satisfy foreign key constraint
+      await db.insert(modelsTable).values({
+        id: modelId,
+        provider: 'openai',
+        name: 'Test Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      await db.insert(promptsTable).values({
+        id: promptId1,
+        prompt: 'Hello world prompt',
+        title: 'Greeting',
+        modelId: modelId,
+      })
+
+      await db.insert(promptsTable).values({
+        id: promptId2,
+        prompt: 'Goodbye world prompt',
+        title: 'Farewell',
+        modelId: modelId,
+      })
+
+      const prompts = await getAllPrompts('hello')
+      expect(prompts).toHaveLength(1)
+      expect(prompts[0]?.id).toBe(promptId1)
+      expect(prompts[0]?.prompt).toBe('Hello world prompt')
+    })
+
+    it('should limit results to 50 prompts', async () => {
+      const db = DatabaseSingleton.instance.db
+      const modelId = uuidv7()
+
+      // Create a model first to satisfy foreign key constraint
+      await db.insert(modelsTable).values({
+        id: modelId,
+        provider: 'openai',
+        name: 'Test Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      // Create 60 prompts
+      for (let i = 0; i < 60; i++) {
+        await db.insert(promptsTable).values({
+          id: uuidv7(),
+          prompt: `Prompt ${i}`,
+          title: `Name ${i}`,
+          modelId: modelId,
+        })
+      }
+
+      const prompts = await getAllPrompts()
+      expect(prompts).toHaveLength(50)
+    })
+  })
+
+  describe('getTriggerPromptForThread', () => {
+    it('should return null when thread does not exist', async () => {
+      const threadId = uuidv7()
+      const result = await getTriggerPromptForThread(threadId)
+      expect(result).toBe(null)
+    })
+
+    it('should return null when thread was not triggered by automation', async () => {
+      const db = DatabaseSingleton.instance.db
+      const threadId = uuidv7()
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Regular Thread',
+        isEncrypted: 0,
+        wasTriggeredByAutomation: 0,
+        triggeredBy: null,
+      })
+
+      const result = await getTriggerPromptForThread(threadId)
+      expect(result).not.toBe(null)
+      expect(result?.wasTriggeredByAutomation).toBe(false)
+      expect(result?.isAutomationDeleted).toBe(false)
+      expect(result?.prompt).toBe(null)
+    })
+
+    it('should return automation info when thread was triggered by automation', async () => {
+      const db = DatabaseSingleton.instance.db
+      const threadId = uuidv7()
+      const promptId = uuidv7()
+      const modelId = uuidv7()
+
+      // Create a model first to satisfy foreign key constraint
+      await db.insert(modelsTable).values({
+        id: modelId,
+        provider: 'openai',
+        name: 'Test Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      // Create a prompt
+      await db.insert(promptsTable).values({
+        id: promptId,
+        prompt: 'Test automation prompt',
+        title: 'Test Automation',
+        modelId: modelId,
+      })
+
+      // Create a thread triggered by automation
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Automated Thread',
+        isEncrypted: 0,
+        wasTriggeredByAutomation: 1,
+        triggeredBy: promptId,
+      })
+
+      const result = await getTriggerPromptForThread(threadId)
+      expect(result).not.toBe(null)
+      expect(result?.wasTriggeredByAutomation).toBe(true)
+      expect(result?.isAutomationDeleted).toBe(false)
+      expect(result?.prompt).toBeDefined()
+      expect(result?.prompt?.id).toBe(promptId)
+      expect(result?.prompt?.title).toBe('Test Automation')
+    })
+
+    it('should indicate deleted automation when prompt no longer exists', async () => {
+      const db = DatabaseSingleton.instance.db
+      const threadId = uuidv7()
+      const promptId = uuidv7()
+      const modelId = uuidv7()
+
+      // Create a model first to satisfy foreign key constraint
+      await db.insert(modelsTable).values({
+        id: modelId,
+        provider: 'openai',
+        name: 'Test Model',
+        model: 'gpt-4',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      // Create a prompt first, then delete it to simulate deleted automation
+      await db.insert(promptsTable).values({
+        id: promptId,
+        prompt: 'Test automation prompt',
+        title: 'Test Automation',
+        modelId: modelId,
+      })
+
+      // Create a thread triggered by automation
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Automated Thread',
+        isEncrypted: 0,
+        wasTriggeredByAutomation: 1,
+        triggeredBy: promptId,
+      })
+
+      // Delete the prompt to simulate deleted automation
+      await db.delete(promptsTable).where(eq(promptsTable.id, promptId))
+
+      const result = await getTriggerPromptForThread(threadId)
+      expect(result).not.toBe(null)
+      expect(result?.wasTriggeredByAutomation).toBe(true)
+      expect(result?.isAutomationDeleted).toBe(true)
+      expect(result?.prompt).toBe(null)
     })
   })
 })

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -13,7 +13,7 @@ import {
   getChatThread,
   getOrCreateChatThread,
   getDefaultModelForThread,
-  getModelById,
+  getModel,
   getSelectedModel,
   getSetting,
   hasSetting,
@@ -274,14 +274,14 @@ describe('Models DAL', () => {
     await db.delete(settingsTable)
   })
 
-  describe('getModelById', () => {
+  describe('getModel', () => {
     it('should return null when model does not exist', async () => {
-      const model = await getModelById('nonexistent-model-id')
+      const model = await getModel('nonexistent-model-id')
       expect(model).toBe(null)
     })
 
     it('should return null when model ID is empty string', async () => {
-      const model = await getModelById('')
+      const model = await getModel('')
       expect(model).toBe(null)
     })
 
@@ -298,7 +298,7 @@ describe('Models DAL', () => {
         enabled: 1,
       })
 
-      const model = await getModelById(modelId)
+      const model = await getModel(modelId)
       expect(model).not.toBe(null)
       expect(model?.id).toBe(modelId)
       expect(model?.name).toBe('Test Model')

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -55,10 +55,30 @@ beforeAll(async () => {
   await migrate(db)
 })
 
-afterEach(async () => {
-  // Clean up settings table after each test
+beforeEach(async () => {
+  // Ensure clean state before each test
   const db = DatabaseSingleton.instance.db
   await db.delete(settingsTable)
+  await db.delete(modelsTable)
+  await db.delete(chatMessagesTable)
+  await db.delete(chatThreadsTable)
+  await db.delete(tasksTable)
+  await db.delete(accountsTable)
+  await db.delete(mcpServersTable)
+  await db.delete(promptsTable)
+})
+
+afterEach(async () => {
+  // Clean up all tables after each test to ensure proper isolation
+  const db = DatabaseSingleton.instance.db
+  await db.delete(settingsTable)
+  await db.delete(modelsTable)
+  await db.delete(chatMessagesTable)
+  await db.delete(chatThreadsTable)
+  await db.delete(tasksTable)
+  await db.delete(accountsTable)
+  await db.delete(mcpServersTable)
+  await db.delete(promptsTable)
 })
 
 // ============================================================================

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -57,7 +57,7 @@ export const getAvailableModels = async (): Promise<Model[]> => {
 /**
  * Gets a specific model by ID
  */
-export const getModelById = async (id: string): Promise<Model | null> => {
+export const getModel = async (id: string): Promise<Model | null> => {
   const db = DatabaseSingleton.instance.db
   const model = await db.select().from(modelsTable).where(eq(modelsTable.id, id)).get()
   return model ? mapModel(model) : null
@@ -111,7 +111,7 @@ export const getDefaultModelForThread = async (threadId: string, fallbackModelId
     .get()
 
   if (lastMessage?.modelId) {
-    const model = await getModelById(lastMessage.modelId)
+    const model = await getModel(lastMessage.modelId)
 
     if (model) {
       return model
@@ -119,7 +119,7 @@ export const getDefaultModelForThread = async (threadId: string, fallbackModelId
   }
 
   if (fallbackModelId) {
-    const model = await getModelById(fallbackModelId)
+    const model = await getModel(fallbackModelId)
 
     if (model) {
       return model

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -190,10 +190,10 @@ export const hasSetting = async (key: string): Promise<boolean> => {
 /**
  * Get a setting value from the settings table
  */
-export const getSetting = async <T = string>(key: string, defaultValue: T | null = null): Promise<T | null> => {
+export const getSetting = async <T = string, V = T | null>(key: string, defaultValue: V = null as V): Promise<V> => {
   const db = DatabaseSingleton.instance.db
   const setting = await db.select().from(settingsTable).where(eq(settingsTable.key, key)).get()
-  return (setting?.value as T) ?? defaultValue
+  return (setting?.value as V) ?? defaultValue
 }
 
 /**

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -449,7 +449,7 @@ export const getTriggerPromptForThread = async (threadId: string): Promise<Autom
 // EMAIL THREADS
 // ============================================================================
 
-export const getEmailThreadByIdWithMessages = async (
+export const getEmailThreadWithMessages = async (
   emailThreadId: string,
 ): Promise<EmailThreadWithMessagesAndAddresses | null> => {
   const db = DatabaseSingleton.instance.db

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -535,7 +535,7 @@ export const getEmailThreadByMessageIdWithMessages = async (
 /**
  * Gets an email message by ID with sender and recipients
  */
-export const getEmailMessageById = async (messageId: string) => {
+export const getEmailMessage = async (messageId: string) => {
   const db = DatabaseSingleton.instance.db
   const message = await db.query.emailMessagesTable.findFirst({
     where: eq(emailMessagesTable.id, messageId),

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -154,19 +154,17 @@ export const getPreferencesSettings = async () => {
  * Gets theme setting with proper typing
  */
 export const getThemeSetting = async (storageKey: string, defaultTheme: string): Promise<string> => {
-  const db = DatabaseSingleton.instance.db
-  const result = await db.select().from(settingsTable).where(eq(settingsTable.key, storageKey))
-  return (result[0]?.value as string) || defaultTheme
+  const result = await getSetting(storageKey, defaultTheme)
+  return result
 }
 
 /**
  * Gets bridge settings with specific structure
  */
 export const getBridgeSettings = async () => {
-  const db = DatabaseSingleton.instance.db
-  const enabledData = await db.select().from(settingsTable).where(eq(settingsTable.key, 'bridge_enabled'))
+  const enabled = await getBooleanSetting('bridge_enabled', false)
   return {
-    enabled: enabledData[0]?.value === 'true',
+    enabled,
   }
 }
 

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -133,24 +133,20 @@ export const getAllSettings = async () => {
  * Gets preferences settings with specific structure
  */
 export const getPreferencesSettings = async () => {
-  const db = DatabaseSingleton.instance.db
-  const nameData = await db.select().from(settingsTable).where(eq(settingsTable.key, 'location_name'))
-  const latData = await db.select().from(settingsTable).where(eq(settingsTable.key, 'location_lat'))
-  const lngData = await db.select().from(settingsTable).where(eq(settingsTable.key, 'location_lng'))
-  const preferredNameData = await db.select().from(settingsTable).where(eq(settingsTable.key, 'preferred_name'))
-  const dataCollection = await db.select().from(settingsTable).where(eq(settingsTable.key, 'data_collection'))
-  const experimentalFeatureTasks = await db
-    .select()
-    .from(settingsTable)
-    .where(eq(settingsTable.key, 'experimental_feature_tasks'))
+  const locationName = await getSetting('location_name', '')
+  const locationLat = await getSetting('location_lat', '')
+  const locationLng = await getSetting('location_lng', '')
+  const preferredName = await getSetting('preferred_name', '')
+  const dataCollection = await getBooleanSetting('data_collection', true)
+  const experimentalFeatureTasks = await getBooleanSetting('experimental_feature_tasks', false)
 
   return {
-    locationName: nameData[0]?.value || '',
-    locationLat: latData[0]?.value || '',
-    locationLng: lngData[0]?.value || '',
-    preferredName: preferredNameData[0]?.value || '',
-    dataCollection: dataCollection[0]?.value === 'false' ? false : true,
-    experimentalFeatureTasks: experimentalFeatureTasks[0]?.value === 'true' ? true : false,
+    locationName,
+    locationLat,
+    locationLng,
+    preferredName,
+    dataCollection,
+    experimentalFeatureTasks,
   }
 }
 

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -288,7 +288,7 @@ export const getOrCreateChatThread = async (id: string) => {
 /**
  * Gets all chat messages for a specific thread
  */
-export const getChatMessagesByThreadId = async (threadId: string) => {
+export const getChatMessages = async (threadId: string) => {
   const db = DatabaseSingleton.instance.db
   const chatMessages = await db
     .select()

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, like, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, isNotNull, like, sql } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
 import {
   accountsTable,
@@ -379,17 +379,19 @@ export const getAllMcpServers = async () => {
  */
 export const getHttpMcpServers = async () => {
   const db = DatabaseSingleton.instance.db
-  const allServers = await db.select().from(mcpServersTable)
-  return allServers
-    .filter((server) => server.type === 'http' && server.url !== null)
-    .map((server) => ({
-      id: server.id,
-      name: server.name,
-      url: server.url as string,
-      enabled: server.enabled,
-      createdAt: server.createdAt,
-      updatedAt: server.updatedAt,
-    }))
+  const allServers = await db
+    .select()
+    .from(mcpServersTable)
+    .where(and(eq(mcpServersTable.type, 'http'), isNotNull(mcpServersTable.url)))
+
+  return allServers.map((server) => ({
+    id: server.id,
+    name: server.name,
+    url: server.url as string,
+    enabled: server.enabled,
+    createdAt: server.createdAt,
+    updatedAt: server.updatedAt,
+  }))
 }
 
 // ============================================================================

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -63,33 +63,33 @@ export const getModel = async (id: string): Promise<Model | null> => {
   return model ? mapModel(model) : null
 }
 
+export const getSystemModel = async () => {
+  const db = DatabaseSingleton.instance.db
+  const systemModel = await db.select().from(modelsTable).where(eq(modelsTable.isSystem, 1)).get()
+  return systemModel ? mapModel(systemModel) : null
+}
+
 /**
  * Gets the currently selected model or falls back to the system default model
  */
 export const getSelectedModel = async (): Promise<Model> => {
-  const db = DatabaseSingleton.instance.db
-  const model = await db
-    .select()
-    .from(modelsTable)
-    .where(
-      eq(
-        modelsTable.id,
-        db.select({ value: settingsTable.value }).from(settingsTable).where(eq(settingsTable.key, 'selected_model')),
-      ),
-    )
-    .get()
+  const selectedModelId = await getSetting('selected_model')
 
-  if (model?.id) {
-    return mapModel(model)
+  if (selectedModelId) {
+    const model = await getModel(selectedModelId)
+
+    if (model?.id) {
+      return model
+    }
   }
 
-  const systemModel = await db.select().from(modelsTable).where(eq(modelsTable.isSystem, 1)).get()
+  const systemModel = await getSystemModel()
 
   if (!systemModel) {
     throw new Error('No system model found')
   }
 
-  return mapModel(systemModel)
+  return systemModel
 }
 
 /**

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -96,19 +96,7 @@ export const getSelectedModel = async (): Promise<Model> => {
  * Gets the default model for a chat thread based on the last message in the thread, falling back to the selected_model setting.
  */
 export const getDefaultModelForThread = async (threadId: string, fallbackModelId?: string): Promise<Model> => {
-  const db = DatabaseSingleton.instance.db
-
-  const lastMessage = await db
-    .select({
-      id: chatMessagesTable.id,
-      chatThreadId: chatMessagesTable.chatThreadId,
-      modelId: chatMessagesTable.modelId,
-    })
-    .from(chatMessagesTable)
-    .where(eq(chatMessagesTable.chatThreadId, threadId))
-    .orderBy(desc(chatMessagesTable.id))
-    .limit(1)
-    .get()
+  const lastMessage = await getLastMessage(threadId)
 
   if (lastMessage?.modelId) {
     const model = await getModel(lastMessage.modelId)
@@ -314,6 +302,22 @@ export const getChatMessagesByThreadId = async (threadId: string) => {
     .where(eq(chatMessagesTable.chatThreadId, threadId))
     .orderBy(chatMessagesTable.id)
   return chatMessages
+}
+
+export const getLastMessage = async (threadId: string) => {
+  const db = DatabaseSingleton.instance.db
+
+  return await db
+    .select({
+      id: chatMessagesTable.id,
+      chatThreadId: chatMessagesTable.chatThreadId,
+      modelId: chatMessagesTable.modelId,
+    })
+    .from(chatMessagesTable)
+    .where(eq(chatMessagesTable.chatThreadId, threadId))
+    .orderBy(desc(chatMessagesTable.id))
+    .limit(1)
+    .get()
 }
 
 // ============================================================================

--- a/src/settings/models/detail.tsx
+++ b/src/settings/models/detail.tsx
@@ -24,7 +24,7 @@ import { modelsTable } from '@/db/tables'
 import { DatabaseSingleton } from '@/db/singleton'
 import type { Model } from '@/types'
 import { Trash2 } from 'lucide-react'
-import { getModelById } from '@/lib/dal'
+import { getModel } from '@/lib/dal'
 
 const formSchema = z
   .object({
@@ -71,7 +71,7 @@ export default function ModelDetailPage() {
 
   const { data: model, isLoading } = useQuery({
     queryKey: ['models', modelId],
-    queryFn: () => getModelById(modelId!),
+    queryFn: () => getModel(modelId!),
     enabled: !!modelId,
   })
 

--- a/src/sideview/thread.tsx
+++ b/src/sideview/thread.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
-import { getEmailThreadByIdWithMessages, getEmailThreadByMessageIdWithMessages } from '@/lib/dal'
+import { getEmailThreadWithMessages, getEmailThreadByMessageIdWithMessages } from '@/lib/dal'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowRightToLine, ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
 import { useState } from 'react'
@@ -17,7 +17,7 @@ export function EmailThreadView() {
       if (!sideviewId) return null
 
       if (sideviewType === 'thread') {
-        return await getEmailThreadByIdWithMessages(sideviewId)
+        return await getEmailThreadWithMessages(sideviewId)
       }
 
       if (sideviewType === 'message') {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors DAL APIs (renames and new helpers), improves settings/types and queries, updates UI/hooks to new names, and adds extensive test coverage.
> 
> - **DAL**:
>   - API renames: `getModelById` → `getModel`, `getChatMessagesByThreadId` → `getChatMessages`, `getEmailThreadByIdWithMessages` → `getEmailThreadWithMessages`, `getEmailMessageById` → `getEmailMessage`.
>   - New helpers: `getSystemModel`, `getLastMessage`.
>   - `getSelectedModel` now reads `selected_model` via `getSetting`, falls back to `getSystemModel`.
>   - Settings utilities simplified: `getPreferencesSettings`, `getThemeSetting`, `getBridgeSettings` now reuse `getSetting`/`getBooleanSetting`.
>   - `getHttpMcpServers` now filters in SQL using `and(...)` and `isNotNull(...)`.
>   - Typing: `getSetting` made generic with default type param.
> - **Hooks**:
>   - `useSetting` made more generic (`<T, V>`), updated types and mutation signatures.
> - **UI Callers**:
>   - Update imports/usages to new DAL names in `src/chats/detail.tsx`, `src/components/chat/message-preview.tsx`, `src/layout/sideview.tsx`, `src/sideview/thread.tsx`, and `src/settings/models/detail.tsx`.
> - **DB Driver**:
>   - Minor comment tweak referencing `getModel` in `sqlocal-database`.
> - **Tests**:
>   - Major expansion of `dal.test.ts`: covers models (incl. `getSystemModel`, availability), settings/theme/preferences/bridge, chat threads/messages (`getChatMessages`, `getLastMessage`, listings), tasks (incomplete + count), accounts, MCP servers (incl. HTTP filter), prompts (listing + trigger info); unskips several boolean-setting tests; adds setup/cleanup for all related tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 236f85644965072da352353bdd54a4142a9587ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->