### PR TITLE
THU-87: Fix bug where shortcut buttons on new chat screen animate in twice

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -20,7 +20,7 @@ import { usePageTracking } from '@/hooks/use-analytics'
 import { useKeyboardInset } from '@/hooks/use-keyboard-inset'
 import { useMcpSync } from '@/hooks/use-mcp-sync'
 import ChatLayout from '@/layout/main-layout'
-import { PostHogProvider } from '@/lib/analytics'
+import { initPosthog, PostHogProvider } from '@/lib/analytics'
 import { seedModels, seedPrompts, seedSettings, seedTasks } from '@/lib/seed'
 import { ThemeProvider } from '@/lib/theme-provider'
 import DevSettingsPage from '@/settings/dev-settings'
@@ -129,9 +129,12 @@ const init = async (): Promise<InitData> => {
     }
   }
 
+  const posthogClient = await initPosthog()
+
   return {
     sideviewType,
     sideviewId,
+    posthogClient,
     ...tray,
   }
 }
@@ -204,7 +207,7 @@ export const App = () => {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <PostHogProvider>
+      <PostHogProvider client={initData.posthogClient}>
         <ThemeProvider defaultTheme="system" storageKey="ui_theme">
           <TrayProvider tray={initData.tray} window={initData.window}>
             <MCPProvider>

--- a/src/lib/analytics.tsx
+++ b/src/lib/analytics.tsx
@@ -4,7 +4,7 @@ import ky from 'ky'
 import type { PostHog } from 'posthog-js'
 import posthog from 'posthog-js'
 import { PostHogProvider as PostHogReactProvider } from 'posthog-js/react'
-import { useEffect, useState, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 
 let posthogClient: PostHog | null = null
 
@@ -86,16 +86,8 @@ export const initPosthog = async (): Promise<PostHog | null> => {
 /**
  * PostHog Provider component for React
  */
-export const PostHogProvider = ({ children }: { children: ReactNode }) => {
-  const [client, setClient] = useState<PostHog | null>(null)
-
-  useEffect(() => {
-    initPosthog().then(setClient)
-  }, [])
-
-  if (!client) return <>{children}</>
-
-  return <PostHogReactProvider client={client}>{children}</PostHogReactProvider>
+export const PostHogProvider = ({ children, client }: { children: ReactNode; client: PostHog | null }) => {
+  return client ? <PostHogReactProvider client={client}>{children}</PostHogReactProvider> : children
 }
 
 export type EventType =

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,12 +14,14 @@ import type {
   tasksTable,
   triggersTable,
 } from './db/tables'
+import { type PostHog } from 'posthog-js'
 
 export type InitData = {
   tray: TrayIcon | undefined
   window: Window | undefined
   sideviewType: SideviewType | null
   sideviewId: string | null
+  posthogClient: PostHog | null
 }
 
 export type ThunderboltUIMessage = UIMessage<UIMessageMetadata, UIDataTypes, UITools>


### PR DESCRIPTION
## Summary

Previously, the PostHogProvider component was initializing the PostHog client asynchronously after mount, which caused the React tree to change structure once the client became available.
This resulted in the children being unmounted and remounted, as the rendered tree switched from:

```tsx
<>{children}</>
```

to

```tsx
<PostHogReactProvider client={client}>{children}</PostHogReactProvider>
```

Because React considers these different element types, it discarded the previous subtree and recreated it — leading to unnecessary re-renders, lost local state, and flickering in parts of the app.

## Solution

Moved the PostHog client initialization to the app startup (during app initialization), and passed the resolved client (or null) as a prop to PostHogProvider.
This ensures that by the time the provider mounts, we already know whether a PostHog client is available — allowing React to render a stable tree from the start.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize PostHog during app init and pass the client to PostHogProvider, refactoring provider to be stateless and extending InitData.
> 
> - **Analytics**:
>   - Initialize PostHog in `init()` via `initPosthog()` and include `posthogClient` in `InitData`.
>   - Update app root to use `<PostHogProvider client={initData.posthogClient}>`.
>   - Refactor `PostHogProvider` to accept a `client` prop and remove internal async initialization and effects; returns children when no client.
> - **Types**:
>   - Extend `InitData` with `posthogClient: PostHog | null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 553e9f05bdd49d958840d7cb4e2010f6eadd40f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->