### PR TITLE
THU-109: Track parent message ID when creating new messages

### DIFF
--- a/src/automations/runner.ts
+++ b/src/automations/runner.ts
@@ -36,7 +36,8 @@ export const runAutomation = async (promptId: string, navigate?: Navigate) => {
     parts: [{ type: 'text', text: prompt.prompt }],
   }
 
-  await db.insert(chatMessagesTable).values(convertUIMessageToDbChatMessage(userMessage, threadId))
+  // First message in the thread, so no parent
+  await db.insert(chatMessagesTable).values(convertUIMessageToDbChatMessage(userMessage, threadId, null))
 
   navigate?.(`/chats/${threadId}`)
 }

--- a/src/db/relations.ts
+++ b/src/db/relations.ts
@@ -5,7 +5,7 @@ export const chatThreadsRelations = relations(chatThreadsTable, ({ many }) => ({
   messages: many(chatMessagesTable),
 }))
 
-export const chatMessagesRelations = relations(chatMessagesTable, ({ one }) => ({
+export const chatMessagesRelations = relations(chatMessagesTable, ({ one, many }) => ({
   thread: one(chatThreadsTable, {
     fields: [chatMessagesTable.chatThreadId],
     references: [chatThreadsTable.id],
@@ -13,6 +13,14 @@ export const chatMessagesRelations = relations(chatMessagesTable, ({ one }) => (
   model: one(modelsTable, {
     fields: [chatMessagesTable.modelId],
     references: [modelsTable.id],
+  }),
+  parent: one(chatMessagesTable, {
+    fields: [chatMessagesTable.parentId],
+    references: [chatMessagesTable.id],
+    relationName: 'messageThread',
+  }),
+  children: many(chatMessagesTable, {
+    relationName: 'messageThread',
   }),
 }))
 

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -43,6 +43,7 @@ export const chatMessagesTable = sqliteTable('chat_messages', {
     .notNull()
     .references(() => chatThreadsTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
   modelId: text('model_id').references(() => modelsTable.id),
+  parentId: text('parent_id').references((): any => chatMessagesTable.id, { onDelete: 'cascade' }),
 })
 
 export const tasksTable = sqliteTable('tasks', {

--- a/src/drizzle/0007_mighty_hannibal_king.sql
+++ b/src/drizzle/0007_mighty_hannibal_king.sql
@@ -1,0 +1,13 @@
+ALTER TABLE `chat_messages` ADD `parent_id` text REFERENCES chat_messages(id) ON DELETE CASCADE;--> statement-breakpoint
+
+-- Set parent_id for existing messages based on chronological order within each thread
+-- This creates a linear chain of messages within each thread
+UPDATE chat_messages
+SET parent_id = (
+  SELECT id 
+  FROM chat_messages AS prev_msg
+  WHERE prev_msg.chat_thread_id = chat_messages.chat_thread_id
+    AND prev_msg.id < chat_messages.id
+  ORDER BY prev_msg.id DESC
+  LIMIT 1
+);

--- a/src/drizzle/_migrations.ts
+++ b/src/drizzle/_migrations.ts
@@ -44,4 +44,9 @@ export const migrations: Migration[] = [
     name: '0006_thick_donald_blake.sql',
     sql: 'PRAGMA foreign_keys=OFF;--> statement-breakpoint\nDROP TABLE `accounts`;--> statement-breakpoint\nDROP TABLE `contacts`;--> statement-breakpoint\nDROP TABLE `email_addresses`;--> statement-breakpoint\nDROP TABLE `email_messages`;--> statement-breakpoint\nDROP TABLE `email_messages_to_addresses`;--> statement-breakpoint\nDROP TABLE `email_threads`;--> statement-breakpoint\nDROP TABLE `embeddings`;--> statement-breakpoint\nCREATE TABLE `__new_tasks` (\n\t`id` text PRIMARY KEY NOT NULL,\n\t`item` text NOT NULL,\n\t`order` integer DEFAULT 0 NOT NULL,\n\t`is_complete` integer DEFAULT 0 NOT NULL\n);\n--> statement-breakpoint\nINSERT INTO `__new_tasks`("id", "item", "order", "is_complete") SELECT "id", "item", "order", "is_complete" FROM `tasks`;--> statement-breakpoint\nDROP TABLE `tasks`;--> statement-breakpoint\nALTER TABLE `__new_tasks` RENAME TO `tasks`;--> statement-breakpoint\nPRAGMA foreign_keys=ON;--> statement-breakpoint\nCREATE UNIQUE INDEX `tasks_id_unique` ON `tasks` (`id`);',
   },
+  {
+    hash: '0007_mighty_hannibal_king',
+    name: '0007_mighty_hannibal_king.sql',
+    sql: 'ALTER TABLE `chat_messages` ADD `parent_id` text REFERENCES chat_messages(id) ON DELETE CASCADE;--> statement-breakpoint\n\n-- Set parent_id for existing messages based on chronological order within each thread\n-- This creates a linear chain of messages within each thread\nUPDATE chat_messages\nSET parent_id = (\n  SELECT id \n  FROM chat_messages AS prev_msg\n  WHERE prev_msg.chat_thread_id = chat_messages.chat_thread_id\n    AND prev_msg.id < chat_messages.id\n  ORDER BY prev_msg.id DESC\n  LIMIT 1\n);',
+  },
 ]

--- a/src/drizzle/meta/0007_snapshot.json
+++ b/src/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,563 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c3c03e5e-91d1-4ed5-8bf7-f770f0b938b7",
+  "prevId": "c0432a27-3a4d-450f-8d8b-258aa99e6b29",
+  "tables": {
+    "chat_messages": {
+      "name": "chat_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_messages_id_unique": {
+          "name": "chat_messages_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": ["chat_thread_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "chat_messages_model_id_models_id_fk": {
+          "name": "chat_messages_model_id_models_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "models",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_messages_parent_id_chat_messages_id_fk": {
+          "name": "chat_messages_parent_id_chat_messages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_messages",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_threads": {
+      "name": "chat_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "was_triggered_by_automation": {
+          "name": "was_triggered_by_automation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_threads_id_unique": {
+          "name": "chat_threads_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_triggered_by_prompts_id_fk": {
+          "name": "chat_threads_triggered_by_prompts_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "prompts",
+          "columnsFrom": ["triggered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "mcp_servers_id_unique": {
+          "name": "mcp_servers_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "models": {
+      "name": "models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "tool_usage": {
+          "name": "tool_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_confidential": {
+          "name": "is_confidential",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "start_with_reasoning": {
+          "name": "start_with_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "models_id_unique": {
+          "name": "models_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompts_id_unique": {
+          "name": "prompts_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "prompts_model_id_models_id_fk": {
+          "name": "prompts_model_id_models_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "models",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "tasks_id_unique": {
+          "name": "tasks_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "triggers": {
+      "name": "triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_time": {
+          "name": "trigger_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "triggers_id_unique": {
+          "name": "triggers_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "triggers_prompt_id_prompts_id_fk": {
+          "name": "triggers_prompt_id_prompts_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "prompts",
+          "columnsFrom": ["prompt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1760467870850,
       "tag": "0006_thick_donald_blake",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1760542615522,
+      "tag": "0007_mighty_hannibal_king",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -9,6 +9,7 @@ import {
   settingsTable,
   tasksTable,
 } from '@/src/db/tables'
+import type { ThunderboltUIMessage } from '@/types'
 import { afterEach, beforeAll, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
@@ -40,6 +41,7 @@ import {
   getThemeSetting,
   getTriggerPromptForThread,
   hasSetting,
+  saveMessagesWithContextUpdate,
   updateBooleanSetting,
   updateSetting,
 } from './dal'
@@ -1038,6 +1040,305 @@ describe('Chat Messages DAL', () => {
       expect(lastMessage).not.toBeUndefined()
       expect(lastMessage?.id).toBe(messageId2)
       expect(lastMessage?.modelId).toBe(modelId)
+    })
+  })
+
+  describe('saveMessagesWithContextUpdate with parent_id', () => {
+    it('should set parent_id to null for first message in empty thread', async () => {
+      const threadId = uuidv7()
+      const messageId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      const messages: ThunderboltUIMessage[] = [
+        {
+          id: messageId,
+          role: 'user',
+          parts: [{ type: 'text', text: 'First message' }],
+        },
+      ]
+
+      await saveMessagesWithContextUpdate(threadId, messages)
+
+      const savedMessages = await db.select().from(chatMessagesTable).where(eq(chatMessagesTable.id, messageId))
+      expect(savedMessages).toHaveLength(1)
+      expect(savedMessages[0]?.parentId).toBe(null)
+    })
+
+    it('should set parent_id to last message when adding new message', async () => {
+      const threadId = uuidv7()
+      const messageId1 = uuidv7()
+      const messageId2 = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      await db.insert(chatMessagesTable).values({
+        id: messageId1,
+        chatThreadId: threadId,
+        role: 'user',
+        content: 'First message',
+        parentId: null,
+      })
+
+      const messages: ThunderboltUIMessage[] = [
+        {
+          id: messageId2,
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Second message' }],
+        },
+      ]
+
+      await saveMessagesWithContextUpdate(threadId, messages)
+
+      const savedMessages = await db.select().from(chatMessagesTable).where(eq(chatMessagesTable.id, messageId2))
+      expect(savedMessages).toHaveLength(1)
+      expect(savedMessages[0]?.parentId).toBe(messageId1)
+    })
+
+    it('should chain multiple messages in batch correctly', async () => {
+      const threadId = uuidv7()
+      const existingMessageId = uuidv7()
+      const messageId1 = uuidv7()
+      const messageId2 = uuidv7()
+      const messageId3 = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      // Insert existing message
+      await db.insert(chatMessagesTable).values({
+        id: existingMessageId,
+        chatThreadId: threadId,
+        role: 'user',
+        content: 'Existing message',
+        parentId: null,
+      })
+
+      const messages: ThunderboltUIMessage[] = [
+        {
+          id: messageId1,
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Message 1' }],
+        },
+        {
+          id: messageId2,
+          role: 'user',
+          parts: [{ type: 'text', text: 'Message 2' }],
+        },
+        {
+          id: messageId3,
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Message 3' }],
+        },
+      ]
+
+      await saveMessagesWithContextUpdate(threadId, messages)
+
+      const allMessages = await db
+        .select()
+        .from(chatMessagesTable)
+        .where(eq(chatMessagesTable.chatThreadId, threadId))
+        .orderBy(chatMessagesTable.id)
+
+      expect(allMessages).toHaveLength(4)
+
+      // First new message should point to existing message
+      const msg1 = allMessages.find((m) => m.id === messageId1)
+      expect(msg1?.parentId).toBe(existingMessageId)
+
+      // Second new message should point to first new message
+      const msg2 = allMessages.find((m) => m.id === messageId2)
+      expect(msg2?.parentId).toBe(messageId1)
+
+      // Third new message should point to second new message
+      const msg3 = allMessages.find((m) => m.id === messageId3)
+      expect(msg3?.parentId).toBe(messageId2)
+    })
+
+    it('should update context size from message metadata', async () => {
+      const threadId = uuidv7()
+      const messageId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      const messages: ThunderboltUIMessage[] = [
+        {
+          id: messageId,
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Response' }],
+          metadata: {
+            usage: {
+              inputTokens: 100,
+              outputTokens: 200,
+              totalTokens: 300,
+            },
+          },
+        },
+      ]
+
+      await saveMessagesWithContextUpdate(threadId, messages)
+
+      const thread = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, threadId)).get()
+      expect(thread?.contextSize).toBe(300)
+    })
+  })
+
+  describe('cascade delete with parent_id', () => {
+    it('should delete child messages when parent is deleted', async () => {
+      const threadId = uuidv7()
+      const parentMessageId = uuidv7()
+      const childMessageId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      await db.insert(chatMessagesTable).values([
+        {
+          id: parentMessageId,
+          chatThreadId: threadId,
+          role: 'user',
+          content: 'Parent message',
+          parentId: null,
+        },
+        {
+          id: childMessageId,
+          chatThreadId: threadId,
+          role: 'assistant',
+          content: 'Child message',
+          parentId: parentMessageId,
+        },
+      ])
+
+      // Delete parent message
+      await db.delete(chatMessagesTable).where(eq(chatMessagesTable.id, parentMessageId))
+
+      // Child should be deleted by cascade
+      const messages = await db.select().from(chatMessagesTable).where(eq(chatMessagesTable.chatThreadId, threadId))
+      expect(messages).toHaveLength(0)
+    })
+
+    it('should delete entire chain when root message is deleted', async () => {
+      const threadId = uuidv7()
+      const msg1Id = uuidv7()
+      const msg2Id = uuidv7()
+      const msg3Id = uuidv7()
+      const msg4Id = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      // Create a chain: msg1 -> msg2 -> msg3 -> msg4
+      await db.insert(chatMessagesTable).values([
+        {
+          id: msg1Id,
+          chatThreadId: threadId,
+          role: 'user',
+          content: 'Message 1',
+          parentId: null,
+        },
+        {
+          id: msg2Id,
+          chatThreadId: threadId,
+          role: 'assistant',
+          content: 'Message 2',
+          parentId: msg1Id,
+        },
+        {
+          id: msg3Id,
+          chatThreadId: threadId,
+          role: 'user',
+          content: 'Message 3',
+          parentId: msg2Id,
+        },
+        {
+          id: msg4Id,
+          chatThreadId: threadId,
+          role: 'assistant',
+          content: 'Message 4',
+          parentId: msg3Id,
+        },
+      ])
+
+      // Delete root message
+      await db.delete(chatMessagesTable).where(eq(chatMessagesTable.id, msg1Id))
+
+      // All messages should be deleted by cascade
+      const messages = await db.select().from(chatMessagesTable).where(eq(chatMessagesTable.chatThreadId, threadId))
+      expect(messages).toHaveLength(0)
+    })
+
+    it('should delete only descendant branch when deleting middle message', async () => {
+      const threadId = uuidv7()
+      const msg1Id = uuidv7()
+      const msg2Id = uuidv7()
+      const msg3Id = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      // Create chain: msg1 -> msg2 -> msg3
+      await db.insert(chatMessagesTable).values([
+        {
+          id: msg1Id,
+          chatThreadId: threadId,
+          role: 'user',
+          content: 'Message 1',
+          parentId: null,
+        },
+        {
+          id: msg2Id,
+          chatThreadId: threadId,
+          role: 'assistant',
+          content: 'Message 2',
+          parentId: msg1Id,
+        },
+        {
+          id: msg3Id,
+          chatThreadId: threadId,
+          role: 'user',
+          content: 'Message 3',
+          parentId: msg2Id,
+        },
+      ])
+
+      // Delete middle message
+      await db.delete(chatMessagesTable).where(eq(chatMessagesTable.id, msg2Id))
+
+      // msg1 should remain, msg2 and msg3 should be deleted
+      const messages = await db.select().from(chatMessagesTable).where(eq(chatMessagesTable.chatThreadId, threadId))
+      expect(messages).toHaveLength(1)
+      expect(messages[0]?.id).toBe(msg1Id)
     })
   })
 })

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -454,8 +454,17 @@ export const saveMessagesWithContextUpdate = async (threadId: string, messages: 
     throw new Error('Thread not found')
   }
 
-  // Convert UI messages to DB messages
-  const dbChatMessages = messages.map((message) => convertUIMessageToDbChatMessage(message, threadId))
+  // Get the last message in the thread to use as parent for new messages
+  const lastMessage = await getLastMessage(threadId)
+  const parentId = lastMessage?.id ?? null
+
+  // Convert UI messages to DB messages with parent relationship
+  const dbChatMessages = messages.map((message, index) => {
+    // For the first message in this batch, use the last message in the thread as parent
+    // For subsequent messages in the batch, use the previous message in the batch
+    const messageParentId = index === 0 ? parentId : messages[index - 1].id
+    return convertUIMessageToDbChatMessage(message, threadId, messageParentId)
+  })
 
   // Insert messages
   await db
@@ -467,6 +476,7 @@ export const saveMessagesWithContextUpdate = async (threadId: string, messages: 
         content: sql`excluded.content`,
         parts: sql`excluded.parts`,
         role: sql`excluded.role`,
+        parentId: sql`excluded.parent_id`,
       },
     })
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,7 @@
+import type { UIMessage } from 'ai'
 import { describe, expect, it } from 'bun:test'
-import { formatNumber } from './utils'
+import { v7 as uuidv7 } from 'uuid'
+import { convertUIMessageToDbChatMessage, formatNumber } from './utils'
 
 describe('utils', () => {
   describe('formatNumber', () => {
@@ -32,6 +34,81 @@ describe('utils', () => {
       expect(formatNumber(2000)).toBe('2K')
       expect(formatNumber(5000000)).toBe('5M')
       expect(formatNumber(3000000000)).toBe('3B')
+    })
+  })
+
+  describe('convertUIMessageToDbChatMessage', () => {
+    it('should convert UI message to DB message without parent', () => {
+      const threadId = uuidv7()
+      const messageId = uuidv7()
+
+      const uiMessage: UIMessage = {
+        id: messageId,
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello world' }],
+      }
+
+      const dbMessage = convertUIMessageToDbChatMessage(uiMessage, threadId)
+
+      expect(dbMessage.id).toBe(messageId)
+      expect(dbMessage.chatThreadId).toBe(threadId)
+      expect(dbMessage.role).toBe('user')
+      expect(dbMessage.content).toBe('Hello world')
+      expect(dbMessage.parentId).toBe(null)
+    })
+
+    it('should convert UI message to DB message with parent_id', () => {
+      const threadId = uuidv7()
+      const messageId = uuidv7()
+      const parentId = uuidv7()
+
+      const uiMessage: UIMessage = {
+        id: messageId,
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Response text' }],
+      }
+
+      const dbMessage = convertUIMessageToDbChatMessage(uiMessage, threadId, parentId)
+
+      expect(dbMessage.id).toBe(messageId)
+      expect(dbMessage.chatThreadId).toBe(threadId)
+      expect(dbMessage.role).toBe('assistant')
+      expect(dbMessage.content).toBe('Response text')
+      expect(dbMessage.parentId).toBe(parentId)
+    })
+
+    it('should set parentId to null when explicitly passed null', () => {
+      const threadId = uuidv7()
+      const messageId = uuidv7()
+
+      const uiMessage: UIMessage = {
+        id: messageId,
+        role: 'user',
+        parts: [{ type: 'text', text: 'First message' }],
+      }
+
+      const dbMessage = convertUIMessageToDbChatMessage(uiMessage, threadId, null)
+
+      expect(dbMessage.parentId).toBe(null)
+    })
+
+    it('should handle messages with model metadata', () => {
+      const threadId = uuidv7()
+      const messageId = uuidv7()
+      const parentId = uuidv7()
+      const modelId = uuidv7()
+
+      const uiMessage: UIMessage = {
+        id: messageId,
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Response' }],
+        metadata: { modelId },
+      }
+
+      const dbMessage = convertUIMessageToDbChatMessage(uiMessage, threadId, parentId)
+
+      expect(dbMessage.modelId).toBe(modelId)
+      expect(dbMessage.parentId).toBe(parentId)
     })
   })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,7 +27,11 @@ export function convertDbChatMessageToUIMessage(message: ChatMessage): UIMessage
   }
 }
 
-export function convertUIMessageToDbChatMessage(message: UIMessage, chatThreadId: string): ChatMessage {
+export function convertUIMessageToDbChatMessage(
+  message: UIMessage,
+  chatThreadId: string,
+  parentId?: string | null,
+): ChatMessage {
   const metadata = message.metadata as UIMessageMetadata | undefined
 
   return {
@@ -37,6 +41,7 @@ export function convertUIMessageToDbChatMessage(message: UIMessage, chatThreadId
     content: message.parts.map((part) => (part.type === 'text' ? part.text : '')).join(''),
     chatThreadId,
     modelId: metadata?.modelId ?? null,
+    parentId: parentId ?? null,
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `parent_id` on `chat_messages` with self-relations, migrate/backfill, and update saves to chain messages by parent; add tests and minor automation insert tweak.
> 
> - **Database**:
>   - Add `parent_id` to `chat_messages` (FK self-reference, cascade delete) and define `parent`/`children` relations in `relations`.
>   - Migration `0007_mighty_hannibal_king.sql`: add column and backfill linear parent chains per thread; update snapshots/journal.
> - **DAL**:
>   - Update `saveMessagesWithContextUpdate` to chain new messages by setting `parent_id` (uses `getLastMessage`; upsert sets `parent_id`).
> - **Utils**:
>   - Extend `convertUIMessageToDbChatMessage(message, threadId, parentId?)` to persist `parentId`.
> - **Automations**:
>   - Seed first user message with explicit `parent_id` null in `automations/runner`.
> - **Tests**:
>   - Add tests for chaining across batches, first-message null parent, context size update, and cascade delete of message chains.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6464445036b2e8ec4cc62ab91a1560838f9bbcea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->