### PR TITLE
THU-119: Thinking Popover UI Experiment

### DIFF
--- a/src/components/chat/assistant-message.test.tsx
+++ b/src/components/chat/assistant-message.test.tsx
@@ -24,11 +24,11 @@ const createToolPart = (state: ToolUIPart['state'], toolName = 'search'): ToolUI
     output: state === 'output-available' ? { result: 'data' } : undefined,
   }) as unknown as ToolUIPart
 
-const createToolGroupPart = (tools: ToolUIPart[]): ToolGroupUIPart =>
-  ({
-    type: 'group_tools',
-    tools,
-  }) as ToolGroupUIPart
+const createToolGroupPart = (tools: ToolUIPart[], reasoning: ReasoningUIPart[] = []): ToolGroupUIPart => ({
+  type: 'group_tools',
+  tools,
+  parts: [...reasoning, ...tools],
+})
 
 describe('mountMessageParts', () => {
   describe('empty parts', () => {
@@ -42,8 +42,9 @@ describe('mountMessageParts', () => {
   })
 
   describe('reasoning parts', () => {
-    it('renders reasoning part', () => {
-      const parts: GroupedUIPart[] = [createReasoningPart('Let me think about this...')]
+    it('renders reasoning part in tool group', () => {
+      const reasoningPart = createReasoningPart('Let me think about this...')
+      const parts: GroupedUIPart[] = [createToolGroupPart([], [reasoningPart])]
       const result = mountMessageParts(parts, false)
 
       expect(result).toHaveLength(1)
@@ -137,35 +138,35 @@ describe('mountMessageParts', () => {
 
   describe('mixed part types', () => {
     it('renders multiple different part types in order', () => {
+      const reasoningPart = createReasoningPart('Thinking...')
       const parts: GroupedUIPart[] = [
-        createReasoningPart('Thinking...'),
-        createToolGroupPart([createToolPart('output-available')]),
+        createToolGroupPart([createToolPart('output-available')], [reasoningPart]),
         createTextPart('Here is the result'),
       ]
       const result = mountMessageParts(parts, false)
 
-      expect(result).toHaveLength(3)
+      expect(result).toHaveLength(2)
       expect(result[0]).toBeDefined()
       expect(result[1]).toBeDefined()
-      expect(result[2]).toBeDefined()
     })
 
     it('handles complex message with reasoning, tools, and text', () => {
+      const reasoningPart = createReasoningPart('Let me search for that')
       const parts: GroupedUIPart[] = [
-        createReasoningPart('Let me search for that'),
-        createToolGroupPart([
-          createToolPart('output-available', 'search'),
-          createToolPart('output-available', 'fetch_content'),
-        ]),
+        createToolGroupPart(
+          [createToolPart('output-available', 'search'), createToolPart('output-available', 'fetch_content')],
+          [reasoningPart],
+        ),
         createTextPart('Based on the search results, I found...'),
       ]
       const result = mountMessageParts(parts, true)
 
-      expect(result).toHaveLength(3)
+      expect(result).toHaveLength(2)
     })
 
     it('handles message with only reasoning and text (no tools)', () => {
-      const parts: GroupedUIPart[] = [createReasoningPart('Thinking...'), createTextPart('Direct answer')]
+      const reasoningPart = createReasoningPart('Thinking...')
+      const parts: GroupedUIPart[] = [createToolGroupPart([], [reasoningPart]), createTextPart('Direct answer')]
       const result = mountMessageParts(parts, false)
 
       expect(result).toHaveLength(2)
@@ -214,7 +215,8 @@ describe('mountMessageParts', () => {
     })
 
     it('handles message with only reasoning', () => {
-      const parts: GroupedUIPart[] = [createReasoningPart('Just thinking out loud...')]
+      const reasoningPart = createReasoningPart('Just thinking out loud...')
+      const parts: GroupedUIPart[] = [createToolGroupPart([], [reasoningPart])]
       const result = mountMessageParts(parts, false)
 
       expect(result).toHaveLength(1)

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -6,10 +6,9 @@ import {
   type ToolGroupUIPart,
 } from '@/lib/assistant-message'
 import { splitPartType } from '@/lib/utils'
-import type { ReasoningUIPart, TextUIPart, ToolUIPart, UIMessage } from 'ai'
+import type { TextUIPart, ToolUIPart, UIMessage } from 'ai'
 import { memo, type ReactNode } from 'react'
 import { DisplayToolHandler } from './display-tool-handler'
-import { ReasoningPart } from './reasoning-part'
 import { SyntheticLoadingPart } from './synthetic-loading-part'
 import { TextPart } from './text-part'
 import { ToolGroup } from './tool-group'
@@ -45,14 +44,12 @@ export const mountMessageParts = (groupedParts: GroupedUIPart[], isStreaming: bo
     const isLastPart = index === groupedParts.length - 1
 
     switch (partType) {
-      case 'reasoning':
-        partElements.push(<ReasoningPart part={part as ReasoningUIPart} />)
-        break
       case 'group_tools': {
         const toolGroup = part as ToolGroupUIPart
         partElements.push(
           <ToolGroup
             tools={toolGroup.tools}
+            parts={toolGroup.parts}
             isStreaming={isStreaming}
             isLastPartInMessage={isLastPart}
             hasTextInMessage={hasTextPart}

--- a/src/components/chat/object-sidebar.tsx
+++ b/src/components/chat/object-sidebar.tsx
@@ -1,33 +1,20 @@
 import { Sidebar, SidebarContent, SidebarHeader, SidebarRail, useSidebar } from '@/components/ui/sidebar'
-import { SidebarCloseButton } from '@/components/ui/sidebar-close-button'
-import { getToolMetadataSync } from '@/lib/tool-metadata'
-import { splitPartType } from '@/lib/utils'
-import { type ComponentProps } from 'react'
 import { useObjectView } from './object-view-provider'
-
-const getOutput = (part: any) => {
-  if (typeof part?.output === 'string') {
-    return part?.output
-  } else {
-    return JSON.stringify(part?.output, null, 2)
-  }
-}
+import { SidebarCloseButton } from '@/components/ui/sidebar-close-button'
+import { type ComponentProps } from 'react'
 
 export function ObjectSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
   const { objectContent, closeObjectSidebar } = useObjectView()
   const { open } = useSidebar()
 
-  const [, toolName] = splitPartType(objectContent?.type ?? '')
-  const metadata = getToolMetadataSync(toolName, objectContent?.input)
-
   return (
     <Sidebar side="right" variant="sidebar" {...props}>
       <SidebarHeader className="flex-row justify-between items-center flex bg-card">
-        <h2 className="text-lg font-semibold truncate">{metadata.displayName}</h2>
+        <h2 className="text-lg font-semibold truncate">{objectContent?.title}</h2>
         <SidebarCloseButton onClick={closeObjectSidebar} />
       </SidebarHeader>
       <SidebarContent className="p-4 overflow-x-hidden">
-        <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{getOutput(objectContent)}</p>
+        <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{objectContent?.content}</p>
       </SidebarContent>
       {open && <SidebarRail enableDrag direction="left" maxResizeWidth="52rem" />}
     </Sidebar>

--- a/src/components/chat/object-view-provider.tsx
+++ b/src/components/chat/object-view-provider.tsx
@@ -2,9 +2,14 @@ import { createContext, useContext, useState } from 'react'
 import { SidebarInset, useSidebar } from '../ui/sidebar'
 import { ObjectSidebar } from './object-sidebar'
 
+type ObjectContent = {
+  title: string
+  content: string
+}
+
 interface ObjectViewContextType {
-  objectContent: any
-  openObjectSidebar: (content: any) => void
+  objectContent: ObjectContent | null
+  openObjectSidebar: (content: ObjectContent) => void
   closeObjectSidebar: () => void
 }
 
@@ -15,10 +20,10 @@ interface ObjectViewProviderProps {
 }
 
 export function ObjectViewProvider({ children }: ObjectViewProviderProps) {
-  const [objectContent, setObjectContent] = useState<any>()
+  const [objectContent, setObjectContent] = useState<ObjectContent | null>(null)
   const { isMobile, setOpenMobile, setOpen } = useSidebar()
 
-  const openObjectSidebar = (content: any) => {
+  const openObjectSidebar = (content: ObjectContent) => {
     setObjectContent(content)
     isMobile ? setOpenMobile(true) : setOpen(true)
   }

--- a/src/components/chat/tool-group.stories.tsx
+++ b/src/components/chat/tool-group.stories.tsx
@@ -2,7 +2,7 @@ import { ObjectViewProvider } from '@/components/chat/object-view-provider'
 import { ToolGroup } from '@/components/chat/tool-group'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import type { ToolUIPart } from 'ai'
+import type { ReasoningUIPart, ToolUIPart } from 'ai'
 
 const meta = {
   title: 'components/chat/tool-group',
@@ -46,9 +46,16 @@ const createMockTool = (
     input: {},
   }) as ToolUIPart
 
+const createMockReasoning = (text: string): ReasoningUIPart =>
+  ({
+    type: 'reasoning',
+    text,
+  }) as ReasoningUIPart
+
 export const SingleToolLoading: Story = {
   args: {
     tools: [createMockTool('input-streaming', undefined, 'tool-1')],
+    parts: [createMockTool('input-streaming', undefined, 'tool-1')],
     isStreaming: true,
     isLastPartInMessage: true,
     hasTextInMessage: false,
@@ -65,6 +72,7 @@ export const SingleToolLoading: Story = {
 export const SingleToolComplete: Story = {
   args: {
     tools: [createMockTool('output-available', { result: 'success' }, 'tool-1')],
+    parts: [createMockTool('output-available', { result: 'success' }, 'tool-1')],
     isStreaming: false,
     isLastPartInMessage: true,
     hasTextInMessage: false,
@@ -81,6 +89,11 @@ export const SingleToolComplete: Story = {
 export const MultipleToolsLoading: Story = {
   args: {
     tools: [
+      createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
+      createMockTool('input-streaming', undefined, 'tool-2', 'tool:fetch_content'),
+      createMockTool('input-available', undefined, 'tool-3', 'tool:get_weather'),
+    ],
+    parts: [
       createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
       createMockTool('input-streaming', undefined, 'tool-2', 'tool:fetch_content'),
       createMockTool('input-available', undefined, 'tool-3', 'tool:get_weather'),
@@ -105,6 +118,11 @@ export const MultipleToolsCompleteWithNextAction: Story = {
       createMockTool('output-available', { result: 'data' }, 'tool-2', 'tool:fetch_content'),
       createMockTool('output-available', { result: 'info' }, 'tool-3', 'tool:get_weather'),
     ],
+    parts: [
+      createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
+      createMockTool('output-available', { result: 'data' }, 'tool-2', 'tool:fetch_content'),
+      createMockTool('output-available', { result: 'info' }, 'tool-3', 'tool:get_weather'),
+    ],
     isStreaming: true,
     isLastPartInMessage: true,
     hasTextInMessage: false,
@@ -125,6 +143,10 @@ export const MultipleToolsWithText: Story = {
       createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
       createMockTool('output-available', { result: 'data' }, 'tool-2', 'tool:fetch_content'),
     ],
+    parts: [
+      createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
+      createMockTool('output-available', { result: 'data' }, 'tool-2', 'tool:fetch_content'),
+    ],
     isStreaming: true,
     isLastPartInMessage: false,
     hasTextInMessage: true,
@@ -141,6 +163,11 @@ export const MultipleToolsWithText: Story = {
 export const ToolsWithError: Story = {
   args: {
     tools: [
+      createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
+      createMockTool('output-error', undefined, 'tool-2', 'tool:fetch_content'),
+      createMockTool('output-available', { result: 'info' }, 'tool-3', 'tool:get_weather'),
+    ],
+    parts: [
       createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
       createMockTool('output-error', undefined, 'tool-2', 'tool:fetch_content'),
       createMockTool('output-available', { result: 'info' }, 'tool-3', 'tool:get_weather'),
@@ -169,6 +196,14 @@ export const ManyTools: Story = {
       createMockTool('output-available', { result: '5' }, 'tool-5', 'tool:get_email'),
       createMockTool('output-available', { result: '6' }, 'tool-6', 'tool:search'),
     ],
+    parts: [
+      createMockTool('output-available', { result: '1' }, 'tool-1', 'tool:search'),
+      createMockTool('output-available', { result: '2' }, 'tool-2', 'tool:fetch_content'),
+      createMockTool('output-available', { result: '3' }, 'tool-3', 'tool:get_weather'),
+      createMockTool('output-available', { result: '4' }, 'tool-4', 'tool:search'),
+      createMockTool('output-available', { result: '5' }, 'tool-5', 'tool:get_email'),
+      createMockTool('output-available', { result: '6' }, 'tool-6', 'tool:search'),
+    ],
     isStreaming: false,
     isLastPartInMessage: true,
     hasTextInMessage: false,
@@ -177,6 +212,31 @@ export const ManyTools: Story = {
     docs: {
       description: {
         story: 'Many tools showing the wrap behavior of the tool group layout.',
+      },
+    },
+  },
+}
+
+export const WithReasoning: Story = {
+  args: {
+    tools: [
+      createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
+      createMockTool('output-available', { result: 'data' }, 'tool-2', 'tool:fetch_content'),
+    ],
+    parts: [
+      createMockReasoning('Let me search for that information'),
+      createMockTool('output-available', { result: 'success' }, 'tool-1', 'tool:search'),
+      createMockReasoning('Now let me fetch the content'),
+      createMockTool('output-available', { result: 'data' }, 'tool-2', 'tool:fetch_content'),
+    ],
+    isStreaming: false,
+    isLastPartInMessage: true,
+    hasTextInMessage: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Tools with reasoning parts showing the mixed order of thinking and actions.',
       },
     },
   },

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -2,6 +2,7 @@ import type { ReasoningUIPart, ToolUIPart } from 'ai'
 import { Brain } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
+import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { useObjectView } from './object-view-provider'
 import { ToolIcon } from './tool-icon'
 import { ToolItem } from './tool-item'
@@ -14,6 +15,57 @@ type UseToolGroupStateParams = {
   isStreaming: boolean
   isLastPartInMessage: boolean
   hasTextInMessage: boolean
+}
+
+type ReasoningPartProps = {
+  part: ReasoningUIPart
+  index: number
+  onOpenDetails: () => void
+}
+
+const ReasoningPart = ({ part, index, onOpenDetails }: ReasoningPartProps) => {
+  const isOpen = part.state === 'streaming'
+  const isStreaming = part.state === 'streaming'
+
+  const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
+    dependencies: [part.text],
+    isStreaming,
+    smooth: false, // Use instant scrolling for better UX during streaming
+  })
+
+  return (
+    <Popover key={`reasoning-${index}`} open={isOpen}>
+      <PopoverTrigger asChild>
+        <motion.div
+          className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"
+          initial={{ scale: 0 }}
+          animate={{
+            scale: 1,
+          }}
+        >
+          <ToolIcon
+            toolName="reasoning"
+            toolOutput=""
+            Icon={Brain}
+            initials=""
+            isLoading={false}
+            isError={false}
+            tooltipKey={`reasoning-${index}`}
+            onClick={onOpenDetails}
+          />
+        </motion.div>
+      </PopoverTrigger>
+      <PopoverContent
+        className="PopoverContent max-w-lg max-h-40 overflow-scroll"
+        ref={scrollContainerRef}
+        {...scrollHandlers}
+      >
+        <p className="font-medium">Thinking</p>
+        <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{part.text}</p>
+        <div ref={scrollTargetRef} />
+      </PopoverContent>
+    </Popover>
+  )
 }
 
 /**
@@ -56,40 +108,18 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
     <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
       {parts.map((part, index) => {
         if (part.type === 'reasoning') {
-          const isOpen = part.state === 'streaming'
-
           return (
-            <Popover key={`reasoning-${index}`} open={isOpen}>
-              <PopoverTrigger asChild>
-                <motion.div
-                  className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"
-                  initial={{ scale: 0 }}
-                  animate={{
-                    scale: 1,
-                  }}
-                >
-                  <ToolIcon
-                    toolName="reasoning"
-                    toolOutput=""
-                    Icon={Brain}
-                    initials=""
-                    isLoading={false}
-                    isError={false}
-                    tooltipKey={`reasoning-${index}`}
-                    onClick={() =>
-                      openObjectSidebar({
-                        content: part.text,
-                        title: 'Thinking',
-                      })
-                    }
-                  />
-                </motion.div>
-              </PopoverTrigger>
-              <PopoverContent className="PopoverContent max-w-lg max-h-40 overflow-scroll">
-                <p className="font-medium">Thinking</p>
-                <p className="font-medium">{part.text}</p>
-              </PopoverContent>
-            </Popover>
+            <ReasoningPart
+              key={`reasoning-${index}`}
+              part={part}
+              index={index}
+              onOpenDetails={() =>
+                openObjectSidebar({
+                  content: part.text,
+                  title: 'Thinking',
+                })
+              }
+            />
           )
         } else {
           const tool = part as ToolUIPart

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -5,6 +5,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { useObjectView } from './object-view-provider'
 import { ToolIcon } from './tool-icon'
 import { ToolItem } from './tool-item'
+import { getMessagePartOutput, splitPartType } from '@/lib/utils'
+import { getToolMetadataSync } from '@/lib/tool-metadata'
 
 type UseToolGroupStateParams = {
   tools: ToolUIPart[]
@@ -71,7 +73,12 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
                     isLoading={false}
                     isError={false}
                     tooltipKey={`reasoning-${index}`}
-                    onClick={() => {}}
+                    onClick={() =>
+                      openObjectSidebar({
+                        content: part.text,
+                        title: 'Thinking',
+                      })
+                    }
                   />
                 </motion.div>
               </TooltipTrigger>
@@ -82,12 +89,21 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
           )
         } else {
           const tool = part as ToolUIPart
+
+          const [, toolName] = splitPartType(tool.type)
+          const metadata = getToolMetadataSync(toolName, tool.input)
+
           return (
             <ToolItem
               key={tool.toolCallId ?? `${tool.type}-${index}`}
               tool={tool}
               index={index}
-              onOpenDetails={openObjectSidebar}
+              onOpenDetails={() =>
+                openObjectSidebar({
+                  content: getMessagePartOutput(tool),
+                  title: metadata.displayName,
+                })
+              }
             />
           )
         }

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -4,14 +4,12 @@ import { motion } from 'framer-motion'
 import { useObjectView } from './object-view-provider'
 import { ToolIcon } from './tool-icon'
 import { ToolItem } from './tool-item'
-import { cn, getMessagePartOutput, splitPartType } from '@/lib/utils'
+import { getMessagePartOutput, splitPartType } from '@/lib/utils'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
-
-import { useMemo } from 'react'
 import { Popover, PopoverAnchor, PopoverContent } from '../ui/popover'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
-import { useIsMobile } from '@/hooks/use-mobile'
+import { useThinkingPopover } from '@/hooks/use-thinking-popover'
 
 type UseToolGroupStateParams = {
   tools: ToolUIPart[]
@@ -93,35 +91,19 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
     hasTextInMessage,
   })
 
-  // Memoize the streaming reasoning part to prevent unnecessary re-renders
-  const streamingReasoningData = useMemo(() => {
-    const index = parts.findIndex((part) => part.type === 'reasoning' && part.state === 'streaming')
-    return {
-      index,
-      part: index !== -1 ? (parts[index] as ReasoningUIPart) : undefined,
-    }
-  }, [parts])
-
-  const { index: streamingReasoningIndex, part: streamingReasoningPart } = streamingReasoningData
-
-  const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
-    dependencies: [streamingReasoningPart?.text],
-    isStreaming: !!streamingReasoningPart,
-    smooth: false, // Disable smooth scrolling during streaming to reduce lag
+  const { isPopoverOpen, displayReasoningPart, popoverStyle } = useThinkingPopover({
+    parts,
+    minimumDisplayTime: 3000,
   })
 
-  const isMobile = useIsMobile()
-
-  // Memoize the left position calculation to prevent style recalculations
-  const popoverStyle = useMemo(
-    () => ({
-      marginLeft: isMobile ? '0' : `calc(${streamingReasoningIndex * 32}px + 4px)`,
-    }),
-    [streamingReasoningIndex, isMobile],
-  )
+  const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
+    dependencies: [displayReasoningPart?.text],
+    isStreaming: displayReasoningPart?.state === 'streaming',
+    smooth: false,
+  })
 
   return (
-    <Popover open={streamingReasoningIndex >= 0}>
+    <Popover open={isPopoverOpen}>
       <PopoverAnchor>
         <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
           {parts.map((part, index) => {
@@ -188,10 +170,17 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
           )}
         </div>
       </PopoverAnchor>
-      <PopoverContent align="start" side="bottom" className={cn('PopoverContent max-w-md')} style={popoverStyle}>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        className="PopoverContent max-w-md transition-[margin] duration-300 ease-in-out"
+        style={popoverStyle}
+      >
         <div className="max-h-40 overflow-scroll" ref={scrollContainerRef} {...scrollHandlers}>
           <p className="font-medium">Thinking</p>
-          <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{streamingReasoningPart?.text}</p>
+          <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">
+            {displayReasoningPart?.text || ''}
+          </p>
           <div ref={scrollTargetRef} />
         </div>
       </PopoverContent>

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -24,17 +24,16 @@ type ReasoningPartProps = {
 }
 
 const ReasoningPart = ({ part, index, onOpenDetails }: ReasoningPartProps) => {
-  const isOpen = part.state === 'streaming'
   const isStreaming = part.state === 'streaming'
 
   const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
     dependencies: [part.text],
     isStreaming,
-    smooth: false, // Use instant scrolling for better UX during streaming
+    smooth: true,
   })
 
   return (
-    <Popover key={`reasoning-${index}`} open={isOpen}>
+    <Popover key={`reasoning-${index}`} open={isStreaming}>
       <PopoverTrigger asChild>
         <motion.div
           className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -55,13 +55,16 @@ const ReasoningPart = ({ part, index, onOpenDetails }: ReasoningPartProps) => {
         </motion.div>
       </PopoverTrigger>
       <PopoverContent
-        className="PopoverContent max-w-lg max-h-40 overflow-scroll"
+        align="start"
+        className="PopoverContent max-w-lg py-4"
         ref={scrollContainerRef}
         {...scrollHandlers}
       >
-        <p className="font-medium">Thinking</p>
-        <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{part.text}</p>
-        <div ref={scrollTargetRef} />
+        <div className="max-h-40 overflow-scroll">
+          <p className="font-medium">Thinking</p>
+          <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{part.text}</p>
+          <div ref={scrollTargetRef} />
+        </div>
       </PopoverContent>
     </Popover>
   )

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -1,12 +1,13 @@
 import type { ReasoningUIPart, ToolUIPart } from 'ai'
 import { Brain } from 'lucide-react'
 import { motion } from 'framer-motion'
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { useObjectView } from './object-view-provider'
 import { ToolIcon } from './tool-icon'
 import { ToolItem } from './tool-item'
 import { getMessagePartOutput, splitPartType } from '@/lib/utils'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 
 type UseToolGroupStateParams = {
   tools: ToolUIPart[]
@@ -55,9 +56,11 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
     <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
       {parts.map((part, index) => {
         if (part.type === 'reasoning') {
+          const isOpen = part.state === 'streaming'
+
           return (
-            <Tooltip key={`reasoning-${index}`}>
-              <TooltipTrigger asChild>
+            <Popover key={`reasoning-${index}`} open={isOpen}>
+              <PopoverTrigger asChild>
                 <motion.div
                   className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"
                   initial={{ scale: 0 }}
@@ -81,11 +84,12 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
                     }
                   />
                 </motion.div>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">
+              </PopoverTrigger>
+              <PopoverContent className="PopoverContent max-w-lg max-h-40 overflow-scroll">
                 <p className="font-medium">Thinking</p>
-              </TooltipContent>
-            </Tooltip>
+                <p className="font-medium">{part.text}</p>
+              </PopoverContent>
+            </Popover>
           )
         } else {
           const tool = part as ToolUIPart

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -1,7 +1,6 @@
 import type { ReasoningUIPart, ToolUIPart } from 'ai'
 import { Brain } from 'lucide-react'
-import { motion } from 'framer-motion'
-import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
+import { AnimatePresence, motion } from 'framer-motion'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { useObjectView } from './object-view-provider'
 import { ToolIcon } from './tool-icon'
@@ -9,6 +8,8 @@ import { ToolItem } from './tool-item'
 import { getMessagePartOutput, splitPartType } from '@/lib/utils'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { cn } from '@/lib/utils'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 type UseToolGroupStateParams = {
   tools: ToolUIPart[]
@@ -23,50 +24,27 @@ type ReasoningPartProps = {
   onOpenDetails: () => void
 }
 
-const ReasoningPart = ({ part, index, onOpenDetails }: ReasoningPartProps) => {
-  const isStreaming = part.state === 'streaming'
-
-  const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
-    dependencies: [part.text],
-    isStreaming,
-    smooth: true,
-  })
-
+const ReasoningPart = ({ part: _part, index, onOpenDetails }: ReasoningPartProps) => {
   return (
-    <Popover key={`reasoning-${index}`} open={isStreaming}>
-      <PopoverTrigger asChild>
-        <motion.div
-          className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"
-          initial={{ scale: 0 }}
-          animate={{
-            scale: 1,
-          }}
-        >
-          <ToolIcon
-            toolName="reasoning"
-            toolOutput=""
-            Icon={Brain}
-            initials=""
-            isLoading={false}
-            isError={false}
-            tooltipKey={`reasoning-${index}`}
-            onClick={onOpenDetails}
-          />
-        </motion.div>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="PopoverContent max-w-lg py-4"
-        ref={scrollContainerRef}
-        {...scrollHandlers}
-      >
-        <div className="max-h-40 overflow-scroll">
-          <p className="font-medium">Thinking</p>
-          <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{part.text}</p>
-          <div ref={scrollTargetRef} />
-        </div>
-      </PopoverContent>
-    </Popover>
+    <motion.div
+      key={`reasoning-${index}`}
+      className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"
+      initial={{ scale: 0 }}
+      animate={{
+        scale: 1,
+      }}
+    >
+      <ToolIcon
+        toolName="reasoning"
+        toolOutput=""
+        Icon={Brain}
+        initials=""
+        isLoading={false}
+        isError={false}
+        tooltipKey={`reasoning-${index}`}
+        onClick={onOpenDetails}
+      />
+    </motion.div>
   )
 }
 
@@ -106,70 +84,116 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
     hasTextInMessage,
   })
 
+  // Find the first streaming reasoning part and its index
+  const streamingReasoningIndex = parts.findIndex((part) => part.type === 'reasoning' && part.state === 'streaming')
+  const streamingReasoningPart =
+    streamingReasoningIndex !== -1 ? (parts[streamingReasoningIndex] as ReasoningUIPart) : undefined
+
+  const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
+    dependencies: [streamingReasoningPart?.text],
+    isStreaming: !!streamingReasoningPart,
+    smooth: true,
+  })
+
+  const isMobile = useIsMobile()
+
   return (
-    <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
-      {parts.map((part, index) => {
-        if (part.type === 'reasoning') {
-          return (
-            <ReasoningPart
-              key={`reasoning-${index}`}
-              part={part}
-              index={index}
-              onOpenDetails={() =>
-                openObjectSidebar({
-                  content: part.text,
-                  title: 'Thinking',
-                })
-              }
-            />
-          )
-        } else {
-          const tool = part as ToolUIPart
+    <AnimatePresence>
+      <div className="relative">
+        <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
+          {parts.map((part, index) => {
+            if (part.type === 'reasoning') {
+              return (
+                <ReasoningPart
+                  key={`reasoning-${index}`}
+                  part={part}
+                  index={index}
+                  onOpenDetails={() =>
+                    openObjectSidebar({
+                      content: part.text,
+                      title: 'Thinking',
+                    })
+                  }
+                />
+              )
+            } else {
+              const tool = part as ToolUIPart
 
-          const [, toolName] = splitPartType(tool.type)
-          const metadata = getToolMetadataSync(toolName, tool.input)
+              const [, toolName] = splitPartType(tool.type)
+              const metadata = getToolMetadataSync(toolName, tool.input)
 
-          return (
-            <ToolItem
-              key={tool.toolCallId ?? `${tool.type}-${index}`}
-              tool={tool}
-              index={index}
-              onOpenDetails={() =>
-                openObjectSidebar({
-                  content: getMessagePartOutput(tool),
-                  title: metadata.displayName,
-                })
-              }
-            />
-          )
-        }
-      })}
-      {showLoadingNext && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <motion.div
-              initial={{ scale: 0 }}
-              animate={{
-                scale: 1,
-              }}
-            >
-              <ToolIcon
-                toolName="processing"
-                toolOutput={undefined}
-                Icon={null}
-                initials="..."
-                isLoading={true}
-                isError={false}
-                tooltipKey="next-action-loading"
-                onClick={() => {}}
-              />
-            </motion.div>
-          </TooltipTrigger>
-          <TooltipContent className="max-w-xs">
-            <p className="font-medium">Thinking...</p>
-          </TooltipContent>
-        </Tooltip>
-      )}
-    </div>
+              return (
+                <ToolItem
+                  key={tool.toolCallId ?? `${tool.type}-${index}`}
+                  tool={tool}
+                  index={index}
+                  onOpenDetails={() =>
+                    openObjectSidebar({
+                      content: getMessagePartOutput(tool),
+                      title: metadata.displayName,
+                    })
+                  }
+                />
+              )
+            }
+          })}
+          {showLoadingNext && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <motion.div
+                  initial={{ scale: 0 }}
+                  animate={{
+                    scale: 1,
+                  }}
+                >
+                  <ToolIcon
+                    toolName="processing"
+                    toolOutput={undefined}
+                    Icon={null}
+                    initials="..."
+                    isLoading={true}
+                    isError={false}
+                    tooltipKey="next-action-loading"
+                    onClick={() => {}}
+                  />
+                </motion.div>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p className="font-medium">Thinking...</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+
+        {/* Custom popover for reasoning parts */}
+        {streamingReasoningPart && (
+          <motion.div
+            key={`popover-${streamingReasoningIndex}`}
+            initial={{ opacity: 0, scale: 0 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0 }}
+            className={cn(
+              '-mt-4 absolute z-50 max-w-lg rounded-md border bg-popover p-4 text-popover-foreground shadow-md',
+            )}
+            style={{
+              // Calculate left position based on the index of the streaming reasoning part
+              // Each tool icon is approximately 40px wide with -8px spacing (space-x-2 = -8px)
+              // So each subsequent item is offset by 32px (40px - 8px)
+              left: isMobile ? '0' : `calc(${streamingReasoningIndex * 32}px + 4px)`, // 4px for the p-1 padding
+            }}
+            ref={scrollContainerRef}
+            {...scrollHandlers}
+          >
+            <div className="max-h-40 overflow-scroll">
+              <p className="font-medium">Thinking</p>
+              <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">
+                {streamingReasoningPart.text}
+              </p>
+              <div ref={scrollTargetRef} />
+            </div>
+          </motion.div>
+        )}
+      </div>
+    </AnimatePresence>
   )
 }

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -1,4 +1,5 @@
-import type { ToolUIPart } from 'ai'
+import type { ReasoningUIPart, ToolUIPart } from 'ai'
+import { Brain } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { useObjectView } from './object-view-provider'
@@ -32,12 +33,13 @@ export const useToolGroupState = ({
 
 type ToolGroupProps = {
   tools: ToolUIPart[]
+  parts: (ToolUIPart | ReasoningUIPart)[]
   isStreaming: boolean
   isLastPartInMessage: boolean
   hasTextInMessage: boolean
 }
 
-export const ToolGroup = ({ tools, isStreaming, isLastPartInMessage, hasTextInMessage }: ToolGroupProps) => {
+export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasTextInMessage }: ToolGroupProps) => {
   const { openObjectSidebar } = useObjectView()
 
   const { showLoadingNext } = useToolGroupState({
@@ -49,14 +51,47 @@ export const ToolGroup = ({ tools, isStreaming, isLastPartInMessage, hasTextInMe
 
   return (
     <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
-      {tools.map((tool, index) => (
-        <ToolItem
-          key={tool.toolCallId ?? `${tool.type}-${index}`}
-          tool={tool}
-          index={index}
-          onOpenDetails={openObjectSidebar}
-        />
-      ))}
+      {parts.map((part, index) => {
+        if (part.type === 'reasoning') {
+          return (
+            <Tooltip key={`reasoning-${index}`}>
+              <TooltipTrigger asChild>
+                <motion.div
+                  className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"
+                  initial={{ scale: 0 }}
+                  animate={{
+                    scale: 1,
+                  }}
+                >
+                  <ToolIcon
+                    toolName="reasoning"
+                    toolOutput=""
+                    Icon={Brain}
+                    initials=""
+                    isLoading={false}
+                    isError={false}
+                    tooltipKey={`reasoning-${index}`}
+                    onClick={() => {}}
+                  />
+                </motion.div>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p className="font-medium">Thinking</p>
+              </TooltipContent>
+            </Tooltip>
+          )
+        } else {
+          const tool = part as ToolUIPart
+          return (
+            <ToolItem
+              key={tool.toolCallId ?? `${tool.type}-${index}`}
+              tool={tool}
+              index={index}
+              onOpenDetails={openObjectSidebar}
+            />
+          )
+        }
+      })}
       {showLoadingNext && (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -10,6 +10,7 @@ import { getToolMetadataSync } from '@/lib/tool-metadata'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { cn } from '@/lib/utils'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useMemo, memo } from 'react'
 
 type UseToolGroupStateParams = {
   tools: ToolUIPart[]
@@ -48,6 +49,61 @@ const ReasoningPart = ({ part: _part, index, onOpenDetails }: ReasoningPartProps
   )
 }
 
+type ReasoningPopoverProps = {
+  streamingReasoningPart: ReasoningUIPart | undefined
+  streamingReasoningIndex: number
+  popoverStyle: React.CSSProperties
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
+  scrollTargetRef: React.RefObject<HTMLDivElement | null>
+  scrollHandlers: {
+    onScroll: () => void
+    onWheel: (e: React.WheelEvent) => void
+  }
+}
+
+const ReasoningPopover = memo(
+  ({
+    streamingReasoningPart,
+    streamingReasoningIndex,
+    popoverStyle,
+    scrollContainerRef,
+    scrollTargetRef,
+    scrollHandlers,
+  }: ReasoningPopoverProps) => {
+    return (
+      <AnimatePresence mode="wait">
+        {streamingReasoningPart && (
+          <motion.div
+            key={`popover-${streamingReasoningIndex}`}
+            initial={{ opacity: 0, y: -10, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -10, scale: 0.95 }}
+            transition={{
+              duration: 0.2,
+              ease: 'easeOut',
+            }}
+            className={cn(
+              '-mt-4 absolute z-50 max-w-lg rounded-md border bg-popover p-4 text-popover-foreground shadow-md',
+              'will-change-transform', // Hint browser for GPU acceleration
+            )}
+            style={popoverStyle}
+            ref={scrollContainerRef}
+            {...scrollHandlers}
+          >
+            <div className="max-h-40 overflow-scroll">
+              <p className="font-medium">Thinking</p>
+              <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">
+                {streamingReasoningPart.text}
+              </p>
+              <div ref={scrollTargetRef} />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    )
+  },
+)
+
 /**
  * Computes the display state for a tool group, including completion status
  * and whether to show a loading indicator for the next action.
@@ -84,116 +140,109 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
     hasTextInMessage,
   })
 
-  // Find the first streaming reasoning part and its index
-  const streamingReasoningIndex = parts.findIndex((part) => part.type === 'reasoning' && part.state === 'streaming')
-  const streamingReasoningPart =
-    streamingReasoningIndex !== -1 ? (parts[streamingReasoningIndex] as ReasoningUIPart) : undefined
+  // Memoize the streaming reasoning part to prevent unnecessary re-renders
+  const streamingReasoningData = useMemo(() => {
+    const index = parts.findIndex((part) => part.type === 'reasoning' && part.state === 'streaming')
+    return {
+      index,
+      part: index !== -1 ? (parts[index] as ReasoningUIPart) : undefined,
+    }
+  }, [parts])
+
+  const { index: streamingReasoningIndex, part: streamingReasoningPart } = streamingReasoningData
 
   const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
     dependencies: [streamingReasoningPart?.text],
     isStreaming: !!streamingReasoningPart,
-    smooth: true,
+    smooth: false, // Disable smooth scrolling during streaming to reduce lag
   })
 
   const isMobile = useIsMobile()
 
+  // Memoize the left position calculation to prevent style recalculations
+  const popoverStyle = useMemo(
+    () => ({
+      left: isMobile ? '0' : `calc(${streamingReasoningIndex * 32}px + 4px)`,
+    }),
+    [streamingReasoningIndex, isMobile],
+  )
+
   return (
-    <AnimatePresence>
-      <div className="relative">
-        <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
-          {parts.map((part, index) => {
-            if (part.type === 'reasoning') {
-              return (
-                <ReasoningPart
-                  key={`reasoning-${index}`}
-                  part={part}
-                  index={index}
-                  onOpenDetails={() =>
-                    openObjectSidebar({
-                      content: part.text,
-                      title: 'Thinking',
-                    })
-                  }
+    <div className="relative">
+      <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
+        {parts.map((part, index) => {
+          if (part.type === 'reasoning') {
+            return (
+              <ReasoningPart
+                key={`reasoning-${index}`}
+                part={part}
+                index={index}
+                onOpenDetails={() =>
+                  openObjectSidebar({
+                    content: part.text,
+                    title: 'Thinking',
+                  })
+                }
+              />
+            )
+          } else {
+            const tool = part as ToolUIPart
+
+            const [, toolName] = splitPartType(tool.type)
+            const metadata = getToolMetadataSync(toolName, tool.input)
+
+            return (
+              <ToolItem
+                key={tool.toolCallId ?? `${tool.type}-${index}`}
+                tool={tool}
+                index={index}
+                onOpenDetails={() =>
+                  openObjectSidebar({
+                    content: getMessagePartOutput(tool),
+                    title: metadata.displayName,
+                  })
+                }
+              />
+            )
+          }
+        })}
+        {showLoadingNext && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <motion.div
+                initial={{ scale: 0 }}
+                animate={{
+                  scale: 1,
+                }}
+              >
+                <ToolIcon
+                  toolName="processing"
+                  toolOutput={undefined}
+                  Icon={null}
+                  initials="..."
+                  isLoading={true}
+                  isError={false}
+                  tooltipKey="next-action-loading"
+                  onClick={() => {}}
                 />
-              )
-            } else {
-              const tool = part as ToolUIPart
-
-              const [, toolName] = splitPartType(tool.type)
-              const metadata = getToolMetadataSync(toolName, tool.input)
-
-              return (
-                <ToolItem
-                  key={tool.toolCallId ?? `${tool.type}-${index}`}
-                  tool={tool}
-                  index={index}
-                  onOpenDetails={() =>
-                    openObjectSidebar({
-                      content: getMessagePartOutput(tool),
-                      title: metadata.displayName,
-                    })
-                  }
-                />
-              )
-            }
-          })}
-          {showLoadingNext && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <motion.div
-                  initial={{ scale: 0 }}
-                  animate={{
-                    scale: 1,
-                  }}
-                >
-                  <ToolIcon
-                    toolName="processing"
-                    toolOutput={undefined}
-                    Icon={null}
-                    initials="..."
-                    isLoading={true}
-                    isError={false}
-                    tooltipKey="next-action-loading"
-                    onClick={() => {}}
-                  />
-                </motion.div>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">
-                <p className="font-medium">Thinking...</p>
-              </TooltipContent>
-            </Tooltip>
-          )}
-        </div>
-
-        {/* Custom popover for reasoning parts */}
-        {streamingReasoningPart && (
-          <motion.div
-            key={`popover-${streamingReasoningIndex}`}
-            initial={{ opacity: 0, scale: 0 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0 }}
-            className={cn(
-              '-mt-4 absolute z-50 max-w-lg rounded-md border bg-popover p-4 text-popover-foreground shadow-md',
-            )}
-            style={{
-              // Calculate left position based on the index of the streaming reasoning part
-              // Each tool icon is approximately 40px wide with -8px spacing (space-x-2 = -8px)
-              // So each subsequent item is offset by 32px (40px - 8px)
-              left: isMobile ? '0' : `calc(${streamingReasoningIndex * 32}px + 4px)`, // 4px for the p-1 padding
-            }}
-            ref={scrollContainerRef}
-            {...scrollHandlers}
-          >
-            <div className="max-h-40 overflow-scroll">
-              <p className="font-medium">Thinking</p>
-              <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">
-                {streamingReasoningPart.text}
-              </p>
-              <div ref={scrollTargetRef} />
-            </div>
-          </motion.div>
+              </motion.div>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              <p className="font-medium">Thinking...</p>
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
-    </AnimatePresence>
+
+      {/* Custom popover for reasoning parts */}
+      <ReasoningPopover
+        streamingReasoningPart={streamingReasoningPart}
+        streamingReasoningIndex={streamingReasoningIndex}
+        popoverStyle={popoverStyle}
+        scrollContainerRef={scrollContainerRef}
+        scrollTargetRef={scrollTargetRef}
+        scrollHandlers={scrollHandlers}
+      />
+    </div>
   )
 }

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -93,7 +93,6 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
 
   const { isPopoverOpen, displayReasoningPart, popoverStyle } = useThinkingPopover({
     parts,
-    minimumDisplayTime: 3000,
   })
 
   const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({

--- a/src/components/chat/tool-group.tsx
+++ b/src/components/chat/tool-group.tsx
@@ -1,16 +1,17 @@
 import type { ReasoningUIPart, ToolUIPart } from 'ai'
 import { Brain } from 'lucide-react'
-import { AnimatePresence, motion } from 'framer-motion'
-import { useAutoScroll } from '@/hooks/use-auto-scroll'
+import { motion } from 'framer-motion'
 import { useObjectView } from './object-view-provider'
 import { ToolIcon } from './tool-icon'
 import { ToolItem } from './tool-item'
-import { getMessagePartOutput, splitPartType } from '@/lib/utils'
+import { cn, getMessagePartOutput, splitPartType } from '@/lib/utils'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
-import { cn } from '@/lib/utils'
+
+import { useMemo } from 'react'
+import { Popover, PopoverAnchor, PopoverContent } from '../ui/popover'
+import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { useIsMobile } from '@/hooks/use-mobile'
-import { useMemo, memo } from 'react'
 
 type UseToolGroupStateParams = {
   tools: ToolUIPart[]
@@ -27,82 +28,34 @@ type ReasoningPartProps = {
 
 const ReasoningPart = ({ part: _part, index, onOpenDetails }: ReasoningPartProps) => {
   return (
-    <motion.div
-      key={`reasoning-${index}`}
-      className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"
-      initial={{ scale: 0 }}
-      animate={{
-        scale: 1,
-      }}
-    >
-      <ToolIcon
-        toolName="reasoning"
-        toolOutput=""
-        Icon={Brain}
-        initials=""
-        isLoading={false}
-        isError={false}
-        tooltipKey={`reasoning-${index}`}
-        onClick={onOpenDetails}
-      />
-    </motion.div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <motion.div
+          key={`reasoning-${index}`}
+          className="data-[slot=avatar]:ring-background data-[slot=avatar]:ring-2 data-[slot=avatar]:grayscale"
+          initial={{ scale: 0 }}
+          animate={{
+            scale: 1,
+          }}
+        >
+          <ToolIcon
+            toolName="reasoning"
+            toolOutput=""
+            Icon={Brain}
+            initials=""
+            isLoading={false}
+            isError={false}
+            tooltipKey={`reasoning-${index}`}
+            onClick={onOpenDetails}
+          />
+        </motion.div>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">
+        <p className="font-medium">Thinking</p>
+      </TooltipContent>
+    </Tooltip>
   )
 }
-
-type ReasoningPopoverProps = {
-  streamingReasoningPart: ReasoningUIPart | undefined
-  streamingReasoningIndex: number
-  popoverStyle: React.CSSProperties
-  scrollContainerRef: React.RefObject<HTMLDivElement | null>
-  scrollTargetRef: React.RefObject<HTMLDivElement | null>
-  scrollHandlers: {
-    onScroll: () => void
-    onWheel: (e: React.WheelEvent) => void
-  }
-}
-
-const ReasoningPopover = memo(
-  ({
-    streamingReasoningPart,
-    streamingReasoningIndex,
-    popoverStyle,
-    scrollContainerRef,
-    scrollTargetRef,
-    scrollHandlers,
-  }: ReasoningPopoverProps) => {
-    return (
-      <AnimatePresence mode="wait">
-        {streamingReasoningPart && (
-          <motion.div
-            key={`popover-${streamingReasoningIndex}`}
-            initial={{ opacity: 0, y: -10, scale: 0.95 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -10, scale: 0.95 }}
-            transition={{
-              duration: 0.2,
-              ease: 'easeOut',
-            }}
-            className={cn(
-              '-mt-4 absolute z-50 max-w-lg rounded-md border bg-popover p-4 text-popover-foreground shadow-md',
-              'will-change-transform', // Hint browser for GPU acceleration
-            )}
-            style={popoverStyle}
-            ref={scrollContainerRef}
-            {...scrollHandlers}
-          >
-            <div className="max-h-40 overflow-scroll">
-              <p className="font-medium">Thinking</p>
-              <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">
-                {streamingReasoningPart.text}
-              </p>
-              <div ref={scrollTargetRef} />
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    )
-  },
-)
 
 /**
  * Computes the display state for a tool group, including completion status
@@ -162,87 +115,86 @@ export const ToolGroup = ({ tools, parts, isStreaming, isLastPartInMessage, hasT
   // Memoize the left position calculation to prevent style recalculations
   const popoverStyle = useMemo(
     () => ({
-      left: isMobile ? '0' : `calc(${streamingReasoningIndex * 32}px + 4px)`,
+      marginLeft: isMobile ? '0' : `calc(${streamingReasoningIndex * 32}px + 4px)`,
     }),
     [streamingReasoningIndex, isMobile],
   )
 
   return (
-    <div className="relative">
-      <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
-        {parts.map((part, index) => {
-          if (part.type === 'reasoning') {
-            return (
-              <ReasoningPart
-                key={`reasoning-${index}`}
-                part={part}
-                index={index}
-                onOpenDetails={() =>
-                  openObjectSidebar({
-                    content: part.text,
-                    title: 'Thinking',
-                  })
-                }
-              />
-            )
-          } else {
-            const tool = part as ToolUIPart
-
-            const [, toolName] = splitPartType(tool.type)
-            const metadata = getToolMetadataSync(toolName, tool.input)
-
-            return (
-              <ToolItem
-                key={tool.toolCallId ?? `${tool.type}-${index}`}
-                tool={tool}
-                index={index}
-                onOpenDetails={() =>
-                  openObjectSidebar({
-                    content: getMessagePartOutput(tool),
-                    title: metadata.displayName,
-                  })
-                }
-              />
-            )
-          }
-        })}
-        {showLoadingNext && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <motion.div
-                initial={{ scale: 0 }}
-                animate={{
-                  scale: 1,
-                }}
-              >
-                <ToolIcon
-                  toolName="processing"
-                  toolOutput={undefined}
-                  Icon={null}
-                  initials="..."
-                  isLoading={true}
-                  isError={false}
-                  tooltipKey="next-action-loading"
-                  onClick={() => {}}
+    <Popover open={streamingReasoningIndex >= 0}>
+      <PopoverAnchor>
+        <div className="*:data-[slot=avatar]:ring-background flex -space-x-2 -space-y-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale p-1 mt-6 mb-4 flex-wrap">
+          {parts.map((part, index) => {
+            if (part.type === 'reasoning') {
+              return (
+                <ReasoningPart
+                  key={`reasoning-${index}`}
+                  part={part}
+                  index={index}
+                  onOpenDetails={() =>
+                    openObjectSidebar({
+                      content: part.text,
+                      title: 'Thinking',
+                    })
+                  }
                 />
-              </motion.div>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs">
-              <p className="font-medium">Thinking...</p>
-            </TooltipContent>
-          </Tooltip>
-        )}
-      </div>
+              )
+            } else {
+              const tool = part as ToolUIPart
 
-      {/* Custom popover for reasoning parts */}
-      <ReasoningPopover
-        streamingReasoningPart={streamingReasoningPart}
-        streamingReasoningIndex={streamingReasoningIndex}
-        popoverStyle={popoverStyle}
-        scrollContainerRef={scrollContainerRef}
-        scrollTargetRef={scrollTargetRef}
-        scrollHandlers={scrollHandlers}
-      />
-    </div>
+              const [, toolName] = splitPartType(tool.type)
+              const metadata = getToolMetadataSync(toolName, tool.input)
+
+              return (
+                <ToolItem
+                  key={tool.toolCallId ?? `${tool.type}-${index}`}
+                  tool={tool}
+                  index={index}
+                  onOpenDetails={() =>
+                    openObjectSidebar({
+                      content: getMessagePartOutput(tool),
+                      title: metadata.displayName,
+                    })
+                  }
+                />
+              )
+            }
+          })}
+          {showLoadingNext && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <motion.div
+                  initial={{ scale: 0 }}
+                  animate={{
+                    scale: 1,
+                  }}
+                >
+                  <ToolIcon
+                    toolName="processing"
+                    toolOutput={undefined}
+                    Icon={null}
+                    initials="..."
+                    isLoading={true}
+                    isError={false}
+                    tooltipKey="next-action-loading"
+                    onClick={() => {}}
+                  />
+                </motion.div>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p className="font-medium">Thinking...</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      </PopoverAnchor>
+      <PopoverContent align="start" side="bottom" className={cn('PopoverContent max-w-md')} style={popoverStyle}>
+        <div className="max-h-40 overflow-scroll" ref={scrollContainerRef} {...scrollHandlers}>
+          <p className="font-medium">Thinking</p>
+          <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{streamingReasoningPart?.text}</p>
+          <div ref={scrollTargetRef} />
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/src/components/chat/tool-part.tsx
+++ b/src/components/chat/tool-part.tsx
@@ -1,5 +1,5 @@
 import { getToolMetadata, getToolMetadataSync } from '@/lib/tool-metadata'
-import { splitPartType } from '@/lib/utils'
+import { getMessagePartOutput, splitPartType } from '@/lib/utils'
 import { useQuery } from '@tanstack/react-query'
 import type { ToolUIPart } from 'ai'
 import { Check, Loader2, X } from 'lucide-react'
@@ -21,14 +21,6 @@ const getToolIcon = (state: ToolUIPart['state']) => {
       return <Check className={`${baseClass} text-green-600 dark:text-green-400`} />
     case 'output-error':
       return <X className={`${baseClass} text-red-600 dark:text-red-400`} />
-  }
-}
-
-const getOutput = (part: ToolUIPart) => {
-  if (typeof part.output === 'string') {
-    return part.output
-  } else {
-    return JSON.stringify(part.output, null, 2)
   }
 }
 
@@ -70,7 +62,7 @@ export const ToolPart = ({ part }: ToolPartProps) => {
     >
       <div className="tool-result w-full">
         <div className="rounded-md">
-          <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{getOutput(part)}</p>
+          <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{getMessagePartOutput(part)}</p>
         </div>
       </div>
     </Expandable>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps } from 'react'
+import { Fragment, type ComponentProps } from 'react'
 import * as PopoverPrimitive from '@radix-ui/react-popover'
 
 import { cn } from '@/lib/utils'
@@ -12,13 +12,16 @@ function PopoverTrigger({ ...props }: ComponentProps<typeof PopoverPrimitive.Tri
 }
 
 function PopoverContent({
+  disablePortal = false,
   className,
   align = 'center',
   sideOffset = 4,
   ...props
-}: ComponentProps<typeof PopoverPrimitive.Content>) {
+}: ComponentProps<typeof PopoverPrimitive.Content> & { disablePortal?: boolean }) {
+  const Container = disablePortal ? Fragment : PopoverPrimitive.Portal
+
   return (
-    <PopoverPrimitive.Portal>
+    <Container>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}
@@ -29,7 +32,7 @@ function PopoverContent({
         )}
         {...props}
       />
-    </PopoverPrimitive.Portal>
+    </Container>
   )
 }
 

--- a/src/hooks/use-thinking-popover.ts
+++ b/src/hooks/use-thinking-popover.ts
@@ -10,32 +10,54 @@ type UseThinkingPopoverParams = {
 /**
  * Hook to manage thinking popover state with minimum display time.
  * Ensures the popover stays open for a minimum duration even when streaming stops,
- * and caches content to prevent empty popovers during the display period.
+ * and provides smooth animation for popover positioning.
  */
 export const useThinkingPopover = ({ parts, minimumDisplayTime = 3000 }: UseThinkingPopoverParams) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const [cachedReasoningIndex, setCachedReasoningIndex] = useState(-1)
+  const [animatedIndex, setAnimatedIndex] = useState(-1)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const rafRef = useRef<number | null>(null)
 
   const isMobile = useIsMobile()
 
-  // Memoize the streaming reasoning part to prevent unnecessary re-renders
+  // Find the currently streaming reasoning part
   const streamingReasoningIndex = useMemo(
     () => parts.findIndex((part) => part.type === 'reasoning' && part.state === 'streaming'),
     [parts],
   )
 
-  const popoverStyle = useMemo(
-    () => ({
-      marginLeft: isMobile ? '0' : `calc(${cachedReasoningIndex * 32}px + 4px)`,
-    }),
-    [cachedReasoningIndex, isMobile],
-  )
-
   // Get the reasoning content to display (either streaming or cached)
   const displayReasoningPart = cachedReasoningIndex >= 0 ? (parts[cachedReasoningIndex] as ReasoningUIPart) : null
 
-  // Handle popover state with minimum display time
+  // Smooth animation for popover positioning
+  const animateToIndex = (targetIndex: number) => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current)
+    }
+
+    const startIndex = animatedIndex
+    const startTime = performance.now()
+    const duration = 200
+
+    const animate = (currentTime: number) => {
+      const elapsed = currentTime - startTime
+      const progress = Math.min(elapsed / duration, 1)
+
+      const easeOutCubic = 1 - Math.pow(1 - progress, 3)
+      const currentIndex = startIndex + (targetIndex - startIndex) * easeOutCubic
+
+      setAnimatedIndex(currentIndex)
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(animate)
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(animate)
+  }
+
+  // Handle popover state and animation
   useEffect(() => {
     // Clear any existing timeout
     if (timeoutRef.current) {
@@ -44,27 +66,43 @@ export const useThinkingPopover = ({ parts, minimumDisplayTime = 3000 }: UseThin
     }
 
     if (streamingReasoningIndex >= 0) {
-      // New thinking task started - open popover immediately and cache index
+      // New thinking task started
       setIsPopoverOpen(true)
       setCachedReasoningIndex(streamingReasoningIndex)
+      animateToIndex(streamingReasoningIndex)
     } else {
       // No streaming reasoning - start minimum display time countdown
       if (isPopoverOpen) {
         timeoutRef.current = setTimeout(() => {
           setIsPopoverOpen(false)
           setCachedReasoningIndex(-1)
+          setAnimatedIndex(-1)
         }, minimumDisplayTime)
       }
     }
 
-    // Cleanup timeout on unmount
+    // Cleanup on unmount
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
+      }
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
       }
     }
   }, [streamingReasoningIndex, isPopoverOpen, minimumDisplayTime])
 
-  return { displayReasoningPart, popoverStyle, isPopoverOpen }
+  // Calculate popover position
+  const popoverStyle = useMemo(
+    () => ({
+      marginLeft: isMobile ? '0' : `calc(${Math.round(animatedIndex * 32)}px + 4px)`,
+    }),
+    [animatedIndex, isMobile],
+  )
+
+  return {
+    displayReasoningPart,
+    popoverStyle,
+    isPopoverOpen,
+  }
 }

--- a/src/hooks/use-thinking-popover.ts
+++ b/src/hooks/use-thinking-popover.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useIsMobile } from './use-mobile'
 import type { ReasoningUIPart, ToolUIPart } from 'ai'
 
@@ -31,31 +31,44 @@ export const useThinkingPopover = ({ parts, minimumDisplayTime = 3000 }: UseThin
   const displayReasoningPart = cachedReasoningIndex >= 0 ? (parts[cachedReasoningIndex] as ReasoningUIPart) : null
 
   // Smooth animation for popover positioning
-  const animateToIndex = (targetIndex: number) => {
-    if (rafRef.current) {
-      cancelAnimationFrame(rafRef.current)
-    }
-
-    const startIndex = animatedIndex
-    const startTime = performance.now()
-    const duration = 200
-
-    const animate = (currentTime: number) => {
-      const elapsed = currentTime - startTime
-      const progress = Math.min(elapsed / duration, 1)
-
-      const easeOutCubic = 1 - Math.pow(1 - progress, 3)
-      const currentIndex = startIndex + (targetIndex - startIndex) * easeOutCubic
-
-      setAnimatedIndex(currentIndex)
-
-      if (progress < 1) {
-        rafRef.current = requestAnimationFrame(animate)
+  const animateToIndex = useCallback(
+    (targetIndex: number) => {
+      // Skip animation if already at target or very close
+      if (Math.abs(animatedIndex - targetIndex) < 0.1) {
+        setAnimatedIndex(targetIndex)
+        return
       }
-    }
 
-    rafRef.current = requestAnimationFrame(animate)
-  }
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+      }
+
+      const startIndex = animatedIndex
+      const startTime = performance.now()
+      const duration = 150 // Reduced from 200ms
+
+      const animate = (currentTime: number) => {
+        const elapsed = currentTime - startTime
+        const progress = Math.min(elapsed / duration, 1)
+
+        // Use simpler easing to reduce computation
+        const easeOutQuad = 1 - (1 - progress) * (1 - progress)
+        const currentIndex = startIndex + (targetIndex - startIndex) * easeOutQuad
+
+        setAnimatedIndex(currentIndex)
+
+        if (progress < 1) {
+          rafRef.current = requestAnimationFrame(animate)
+        } else {
+          // Ensure we end exactly at target
+          setAnimatedIndex(targetIndex)
+        }
+      }
+
+      rafRef.current = requestAnimationFrame(animate)
+    },
+    [animatedIndex],
+  )
 
   // Handle popover state and animation
   useEffect(() => {
@@ -81,7 +94,6 @@ export const useThinkingPopover = ({ parts, minimumDisplayTime = 3000 }: UseThin
       }
     }
 
-    // Cleanup on unmount
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)

--- a/src/hooks/use-thinking-popover.ts
+++ b/src/hooks/use-thinking-popover.ts
@@ -1,0 +1,70 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+import { useIsMobile } from './use-mobile'
+import type { ReasoningUIPart, ToolUIPart } from 'ai'
+
+type UseThinkingPopoverParams = {
+  minimumDisplayTime?: number
+  parts: (ToolUIPart | ReasoningUIPart)[]
+}
+
+/**
+ * Hook to manage thinking popover state with minimum display time.
+ * Ensures the popover stays open for a minimum duration even when streaming stops,
+ * and caches content to prevent empty popovers during the display period.
+ */
+export const useThinkingPopover = ({ parts, minimumDisplayTime = 3000 }: UseThinkingPopoverParams) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+  const [cachedReasoningIndex, setCachedReasoningIndex] = useState(-1)
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  const isMobile = useIsMobile()
+
+  // Memoize the streaming reasoning part to prevent unnecessary re-renders
+  const streamingReasoningIndex = useMemo(
+    () => parts.findIndex((part) => part.type === 'reasoning' && part.state === 'streaming'),
+    [parts],
+  )
+
+  const popoverStyle = useMemo(
+    () => ({
+      marginLeft: isMobile ? '0' : `calc(${cachedReasoningIndex * 32}px + 4px)`,
+    }),
+    [cachedReasoningIndex, isMobile],
+  )
+
+  // Get the reasoning content to display (either streaming or cached)
+  const displayReasoningPart = cachedReasoningIndex >= 0 ? (parts[cachedReasoningIndex] as ReasoningUIPart) : null
+
+  // Handle popover state with minimum display time
+  useEffect(() => {
+    // Clear any existing timeout
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+
+    if (streamingReasoningIndex >= 0) {
+      // New thinking task started - open popover immediately and cache index
+      setIsPopoverOpen(true)
+      setCachedReasoningIndex(streamingReasoningIndex)
+    } else {
+      // No streaming reasoning - start minimum display time countdown
+      if (isPopoverOpen) {
+        timeoutRef.current = setTimeout(() => {
+          setIsPopoverOpen(false)
+          setCachedReasoningIndex(-1)
+        }, minimumDisplayTime)
+      }
+    }
+
+    // Cleanup timeout on unmount
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
+    }
+  }, [streamingReasoningIndex, isPopoverOpen, minimumDisplayTime])
+
+  return { displayReasoningPart, popoverStyle, isPopoverOpen }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -96,17 +96,6 @@
   }
 }
 
-@keyframes scaleIn {
-  from {
-    opacity: 0;
-    transform: scale(0);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
 @utility animate-accordion-down {
   animation: accordion-down 0.2s ease-out;
 }
@@ -159,4 +148,9 @@ body {
 
 .prose-sm tr:last-child td {
   @apply border-b-0;
+}
+
+.PopoverContent {
+  width: var(--radix-popover-trigger-width);
+  max-height: var(--radix-popover-content-available-height);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -96,6 +96,17 @@
   }
 }
 
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 @utility animate-accordion-down {
   animation: accordion-down 0.2s ease-out;
 }
@@ -148,4 +159,11 @@ body {
 
 .prose-sm tr:last-child td {
   @apply border-b-0;
+}
+
+.PopoverContent {
+  width: var(--radix-popover-content-available-width);
+  /* max-height: var(--radix-popover-content-available-height); */
+  transform-origin: var(--radix-popover-content-transform-origin);
+  animation: scaleIn 0.5s ease-out;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -96,6 +96,17 @@
   }
 }
 
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 @utility animate-accordion-down {
   animation: accordion-down 0.2s ease-out;
 }
@@ -153,4 +164,5 @@ body {
 .PopoverContent {
   width: var(--radix-popover-trigger-width);
   max-height: var(--radix-popover-content-available-height);
+  animation: scaleIn 0.5s ease-out;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -160,10 +160,3 @@ body {
 .prose-sm tr:last-child td {
   @apply border-b-0;
 }
-
-.PopoverContent {
-  width: var(--radix-popover-content-available-width);
-  /* max-height: var(--radix-popover-content-available-height); */
-  transform-origin: var(--radix-popover-content-transform-origin);
-  animation: scaleIn 0.5s ease-out;
-}

--- a/src/lib/assistant-message.test.ts
+++ b/src/lib/assistant-message.test.ts
@@ -26,6 +26,7 @@ describe('assistant-message utilities', () => {
       expect(grouped[0]).toEqual({
         type: 'group_tools',
         tools: [toolAlpha, toolBeta],
+        parts: [toolAlpha, toolBeta],
       })
       expect(grouped[1]).toBe(textPart)
     })
@@ -38,17 +39,52 @@ describe('assistant-message utilities', () => {
 
       const grouped = groupToolParts([displayTool, regularTool, reasoningPart, trailingTool])
 
-      expect(grouped).toHaveLength(4)
+      expect(grouped).toHaveLength(2)
       expect(grouped[0]).toBe(displayTool)
       expect(grouped[1]).toEqual({
         type: 'group_tools',
-        tools: [regularTool],
+        tools: [regularTool, trailingTool],
+        parts: [regularTool, reasoningPart, trailingTool],
       })
-      expect(grouped[2]).toBe(reasoningPart)
-      expect(grouped[3]).toEqual({
+    })
+
+    it('groups reasoning and tools together in the same group', () => {
+      const reasoningPart1: ReasoningUIPart = { type: 'reasoning', text: 'thinking first' }
+      const toolAlpha = createToolPart('alpha')
+      const reasoningPart2: ReasoningUIPart = { type: 'reasoning', text: 'thinking second' }
+      const toolBeta = createToolPart('beta')
+      const toolGamma = createToolPart('gamma')
+      const textPart: TextUIPart = { type: 'text', text: 'response' }
+
+      const parts = [reasoningPart1, toolAlpha, reasoningPart2, toolBeta, toolGamma, textPart]
+
+      const grouped = groupToolParts(parts)
+
+      expect(grouped).toHaveLength(2)
+      expect(grouped[0]).toEqual({
         type: 'group_tools',
-        tools: [trailingTool],
+        tools: [toolAlpha, toolBeta, toolGamma],
+        parts: [reasoningPart1, toolAlpha, reasoningPart2, toolBeta, toolGamma],
       })
+      expect(grouped[1]).toBe(textPart)
+    })
+
+    it('handles reasoning parts without tools', () => {
+      const reasoningPart1: ReasoningUIPart = { type: 'reasoning', text: 'thinking first' }
+      const reasoningPart2: ReasoningUIPart = { type: 'reasoning', text: 'thinking second' }
+      const textPart: TextUIPart = { type: 'text', text: 'response' }
+
+      const parts = [reasoningPart1, reasoningPart2, textPart]
+
+      const grouped = groupToolParts(parts)
+
+      expect(grouped).toHaveLength(2)
+      expect(grouped[0]).toEqual({
+        type: 'group_tools',
+        tools: [],
+        parts: [reasoningPart1, reasoningPart2],
+      })
+      expect(grouped[1]).toBe(textPart)
     })
   })
 

--- a/src/lib/assistant-message.ts
+++ b/src/lib/assistant-message.ts
@@ -6,6 +6,7 @@ export type GroupableUIPart = ReasoningUIPart | TextUIPart | ToolUIPart
 export type ToolGroupUIPart = {
   type: 'group_tools'
   tools: ToolUIPart[]
+  parts: (ToolUIPart | ReasoningUIPart)[]
 }
 
 export type GroupedUIPart = GroupableUIPart | ToolGroupUIPart
@@ -14,28 +15,32 @@ const supportedPartTypes = ['reasoning', 'tool', 'text']
 
 export const groupToolParts = (parts: GroupableUIPart[]): GroupedUIPart[] => {
   const grouped: GroupedUIPart[] = []
-  let currentGroup: ToolUIPart[] = []
+  let currentGroup: (ToolUIPart | ReasoningUIPart)[] = []
 
-  // Collects the currently buffered tool parts into a single group node so they render via ToolGroup.
+  // Collects the currently buffered tool parts and reasoning into a single group node so they render via ToolGroup.
   const flushGroup = () => {
     if (currentGroup.length === 0) {
       return
     }
 
+    // Extract only tools for the tools array (for backward compatibility)
+    const tools: ToolUIPart[] = currentGroup.filter((part) => part.type !== 'reasoning') as ToolUIPart[]
+
     grouped.push({
       type: 'group_tools',
-      tools: [...currentGroup],
+      tools,
+      parts: [...currentGroup], // Keep original order for rendering
     })
 
     currentGroup = []
   }
 
-  // Walk through the incoming parts and buffer every consecutive non-display tool call.
+  // Walk through the incoming parts and buffer every consecutive non-display tool call and reasoning.
   parts.forEach((part) => {
     const [partType, toolName] = splitPartType(part.type)
 
-    if (partType === 'tool' && !toolName.startsWith('display-')) {
-      currentGroup.push(part as ToolUIPart)
+    if ((partType === 'tool' && !toolName.startsWith('display-')) || partType === 'reasoning') {
+      currentGroup.push(part as ToolUIPart | ReasoningUIPart)
       return
     }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -211,3 +211,11 @@ export const hashValues = (values: (string | number | null | undefined)[]): stri
   }
   return hash.toString(36)
 }
+
+export const getMessagePartOutput = (part: any) => {
+  if (typeof part?.output === 'string') {
+    return part?.output
+  } else {
+    return JSON.stringify(part?.output, null, 2)
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies reasoning and tool parts into `ToolGroup` with a new “Thinking” popover, updates sidebar/content plumbing, and adjusts utils, tests, stories, and styles.
> 
> - **Chat UI**:
>   - `ToolGroup` now accepts `parts` (tools + reasoning), renders reasoning as icons, and shows a "Thinking" popover with auto-scroll.
>   - `assistant-message` mounts reasoning inside `group_tools` and passes `parts` to `ToolGroup`; removes standalone reasoning rendering.
>   - Adds hook `use-thinking-popover` and enhances `Popover` to support non-portal rendering and anchored content.
> - **Data/Types & Utils**:
>   - `groupToolParts` groups reasoning with tools and adds `parts` to `ToolGroupUIPart`.
>   - `ObjectViewProvider` introduces typed `ObjectContent { title, content }`.
>   - Adds `getMessagePartOutput` and uses it in `tool-part` and object sidebar.
> - **Sidebar**:
>   - `ObjectSidebar` now displays `objectContent.title` and `objectContent.content` (removes tool metadata coupling).
> - **Stories/Tests**:
>   - Storybook: `ToolGroup` stories updated to pass `parts` and new "WithReasoning" example.
>   - Tests updated to reflect grouping changes and new lengths/structures.
> - **Styles**:
>   - Adds `scaleIn` animation and `.PopoverContent` sizing/animation rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e40843948b5ff08b53f7af3553d4850b5c374617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->