### PR TITLE
THU-47: Enforce encryption state per thread

### DIFF
--- a/src/automations/automation-form-modal.tsx
+++ b/src/automations/automation-form-modal.tsx
@@ -305,6 +305,7 @@ export default function AutomationFormModal({
               {/* Main Content - Prompt Input */}
               <CardHeader className="px-6 pb-0 pt-2">
                 <PromptInput
+                  chatThread={null}
                   value={promptText}
                   onChange={handlePromptChange}
                   placeholder="Enter your prompt here..."

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -1,4 +1,4 @@
-import { getModel, getChatMessages, getOrCreateChatThread, saveMessagesWithContextUpdate } from '@/dal'
+import { getChatMessages, getOrCreateChatThread, saveMessagesWithContextUpdate } from '@/dal'
 import { generateTitle } from '@/lib/title-generator'
 import { convertDbChatMessageToUIMessage } from '@/lib/utils'
 import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -48,29 +48,14 @@ export default function ChatDetailPage() {
 
   const addMessagesMutation = useMutation({
     mutationFn: async (messages: ThunderboltUIMessage[]) => {
-      const isNewChat = params.chatThreadId === 'new'
-      let isEncrypted = false
-
       if (!chatThreadId) {
         throw new Error('No chat thread ID')
       }
 
-      if (isNewChat) {
-        const modelId = messages[0]?.metadata?.modelId
-        if (!modelId) {
-          throw new Error('No model ID')
-        }
-
-        const model = await getModel(modelId)
-        if (!model) {
-          throw new Error('No model found')
-        }
-
-        isEncrypted = model.isConfidential === 1
-      }
+      const modelId = messages[0]?.metadata?.modelId
 
       // Fetch thread info to check if we need to generate a title
-      const thread = await getOrCreateChatThread(chatThreadId, isEncrypted)
+      const thread = await getOrCreateChatThread(chatThreadId, modelId)
 
       // Save messages and update context size using DAL
       const dbChatMessages = await saveMessagesWithContextUpdate(chatThreadId, messages)
@@ -80,7 +65,7 @@ export default function ChatDetailPage() {
         updateThreadTitle(messages, chatThreadId)
       }
 
-      if (isNewChat) {
+      if (params.chatThreadId === 'new') {
         navigate(`/chats/${chatThreadId}`, { relative: 'path' })
       }
 

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -55,7 +55,7 @@ export default function ChatDetailPage() {
       const modelId = messages[0]?.metadata?.modelId
 
       // Fetch thread info to check if we need to generate a title
-      const thread = await getOrCreateChatThread(chatThreadId, modelId)
+      const thread = await getOrCreateChatThread(chatThreadId, modelId ?? '')
 
       // Save messages and update context size using DAL
       const dbChatMessages = await saveMessagesWithContextUpdate(chatThreadId, messages)

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -1,4 +1,4 @@
-import { getChatMessages, getOrCreateChatThread, saveMessagesWithContextUpdate } from '@/dal'
+import { getModel, getChatMessages, getOrCreateChatThread, saveMessagesWithContextUpdate } from '@/dal'
 import { DatabaseSingleton } from '@/db/singleton'
 import { chatThreadsTable } from '@/db/tables'
 import { generateTitle } from '@/lib/title-generator'
@@ -51,12 +51,29 @@ export default function ChatDetailPage() {
 
   const addMessagesMutation = useMutation({
     mutationFn: async (messages: ThunderboltUIMessage[]) => {
+      const isNewChat = params.chatThreadId === 'new'
+      let isEncrypted = false
+
       if (!chatThreadId) {
         throw new Error('No chat thread ID')
       }
 
+      if (isNewChat) {
+        const modelId = messages[0]?.metadata?.modelId
+        if (!modelId) {
+          throw new Error('No model ID')
+        }
+
+        const model = await getModel(modelId)
+        if (!model) {
+          throw new Error('No model found')
+        }
+
+        isEncrypted = model.isConfidential === 1
+      }
+
       // Fetch thread info to check if we need to generate a title
-      const thread = await getOrCreateChatThread(chatThreadId)
+      const thread = await getOrCreateChatThread(chatThreadId, isEncrypted)
 
       // Save messages and update context size using DAL
       const dbChatMessages = await saveMessagesWithContextUpdate(chatThreadId, messages)
@@ -66,7 +83,7 @@ export default function ChatDetailPage() {
         updateThreadTitle(messages, chatThreadId)
       }
 
-      if (params.chatThreadId === 'new') {
+      if (isNewChat) {
         navigate(`/chats/${chatThreadId}`, { relative: 'path' })
       }
 

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -1,15 +1,13 @@
 import { getModel, getChatMessages, getOrCreateChatThread, saveMessagesWithContextUpdate } from '@/dal'
-import { DatabaseSingleton } from '@/db/singleton'
-import { chatThreadsTable } from '@/db/tables'
 import { generateTitle } from '@/lib/title-generator'
 import { convertDbChatMessageToUIMessage } from '@/lib/utils'
 import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { eq } from 'drizzle-orm'
 import { useCallback, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { v7 as uuidv7 } from 'uuid'
 import Chat from './chat'
+import { updateChatThread } from '@/dal/chat-threads'
 
 export default function ChatDetailPage() {
   const params = useParams()
@@ -19,7 +17,6 @@ export default function ChatDetailPage() {
     [params.chatThreadId],
   )
 
-  const db = DatabaseSingleton.instance.db
   const queryClient = useQueryClient()
 
   const updateThreadTitle = async (messages: ThunderboltUIMessage[], threadId: string) => {
@@ -34,7 +31,7 @@ export default function ChatDetailPage() {
     if (!textContent) return
 
     const title = await generateTitle(textContent)
-    await db.update(chatThreadsTable).set({ title }).where(eq(chatThreadsTable.id, threadId))
+    await updateChatThread(threadId, { title })
     queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
   }
 

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -179,6 +179,13 @@ export default function ChatUI({
     const textToSend = input.trim()
     if (isStreaming || !textToSend) return
 
+    // Validate encryption state
+    if (chatThread && chatThread.isEncrypted !== selectedModel?.isConfidential) {
+      throw new Error(
+        `This model is not available for ${chatThread.isEncrypted === 1 ? 'encrypted' : 'unencrypted'} conversations.`,
+      )
+    }
+
     if (isOverflowing) {
       setShowOverflowModal(true)
       trackEvent('chat_send_prompt_overflow', {

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -325,6 +325,7 @@ export default function ChatUI({
           >
             <PromptInput
               ref={formRef}
+              chatThread={chatThread}
               value={input}
               onChange={(value: string) => setInput(value)}
               placeholder="Say something..."

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -15,6 +15,10 @@ import { PromptInput } from '../ui/prompt-input'
 import { AssistantMessage } from './assistant-message'
 import { TriggerMessage } from './trigger-message'
 import { UserMessage } from './user-message'
+import { Lock } from 'lucide-react'
+import TimelineMessage from './timeline-message'
+import { useQuery } from '@tanstack/react-query'
+import { getChatThread } from '@/dal'
 
 interface ChatUIProps {
   chatHelpers: UseChatHelpers<ThunderboltUIMessage>
@@ -88,6 +92,11 @@ export default function ChatUI({
     chatThreadId,
     currentInput: input,
     onOverflow: () => setShowOverflowModal(true),
+  })
+
+  const { data: chatThread } = useQuery({
+    queryKey: ['chatThreads', chatThreadId],
+    queryFn: async () => (await getChatThread(chatThreadId ?? '')) ?? null,
   })
 
   // Extract prompt from the first message (automation prompt) for trigger display
@@ -227,6 +236,14 @@ export default function ChatUI({
             exit={{ opacity: 0 }}
             className="flex-1 p-4 overflow-y-auto space-y-4"
           >
+            {chatThread?.isEncrypted === 1 && (
+              <TimelineMessage>
+                <div className="flex flex-row items-center gap-2">
+                  <Lock className="size-4 text-blue-600 dark:text-blue-400" />
+                  <p className="text-blue-700 dark:text-blue-300">This conversation is encrypted</p>
+                </div>
+              </TimelineMessage>
+            )}
             {/* Automation trigger banner */}
             {triggerAutomation?.wasTriggeredByAutomation && (
               <TriggerMessage

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -26,7 +26,7 @@ interface ChatUIProps {
   selectedModelId?: string
   onModelChange: (model: string | null) => void
   triggerAutomation?: AutomationRun | null
-  chatThreadId?: string
+  chatThreadId: string
 }
 
 interface SuggestionButtonProps {
@@ -94,9 +94,9 @@ export default function ChatUI({
     onOverflow: () => setShowOverflowModal(true),
   })
 
-  const { data: chatThread } = useQuery({
+  const { data: chatThread = null } = useQuery({
     queryKey: ['chatThreads', chatThreadId],
-    queryFn: async () => (await getChatThread(chatThreadId ?? '')) ?? null,
+    queryFn: () => getChatThread(chatThreadId),
   })
 
   // Extract prompt from the first message (automation prompt) for trigger display

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -189,7 +189,7 @@ export default function ChatUI({
     // Clear the input immediately for responsive UX
     setInput('')
 
-    await chatHelpers.sendMessage({ text: textToSend })
+    await chatHelpers.sendMessage({ text: textToSend, metadata: { modelId: selectedModelId } })
 
     // Reset user scroll state and scroll to bottom when submitting a new message
     resetUserScroll()

--- a/src/components/chat/timeline-message.tsx
+++ b/src/components/chat/timeline-message.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils'
+import { type PropsWithChildren } from 'react'
+
+type TimelineMessageProps = PropsWithChildren<{
+  className?: string
+}>
+
+export const TimelineMessage = ({ children, className }: TimelineMessageProps) => (
+  <div className={cn('flex flex-col items-center select-none', className)}>
+    {/* Timeline bullet */}
+    <span className="w-3 h-3 rounded-full bg-secondary" />
+    {/* Vertical line above the text */}
+    <span className="h-6 w-px bg-secondary mb-2" />
+    {/* Label */}
+    <div className="text-xs text-muted-foreground uppercase tracking-wide mb-2">{children}</div>
+    {/* Vertical line that runs directly into the accordion */}
+    <span className="h-6 w-px bg-secondary" />
+  </div>
+)
+
+export default TimelineMessage

--- a/src/components/chat/trigger-message.tsx
+++ b/src/components/chat/trigger-message.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils'
 import { Zap } from 'lucide-react'
 import { Expandable } from '../ui/expandable'
 import { StreamingMarkdown } from './streaming-markdown'
+import TimelineMessage from './timeline-message'
 
 interface TriggerMessageProps {
   /** The title of the automation that triggered the chat */
@@ -21,21 +22,7 @@ interface TriggerMessageProps {
  */
 export const TriggerMessage = ({ title, prompt, isDeleted = false, className }: TriggerMessageProps) => (
   <div className={cn('flex flex-col items-center w-full', className)}>
-    {/* Timeline marker and label */}
-    <div className="flex flex-col items-center select-none">
-      {/* Timeline bullet */}
-      <span className="w-3 h-3 rounded-full bg-secondary" />
-
-      {/* Vertical line above the text */}
-      <span className="h-6 w-px bg-secondary mb-2" />
-
-      {/* Label */}
-      <div className="text-xs text-muted-foreground uppercase tracking-wide mb-2">Triggered by automation</div>
-
-      {/* Vertical line that runs directly into the accordion */}
-      <span className="h-6 w-px bg-secondary" />
-    </div>
-
+    <TimelineMessage>Triggered by automation</TimelineMessage>
     {/* Automation title & prompt */}
     {prompt ? (
       <Expandable

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -4,8 +4,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import type { Model } from '@/types'
 import { ArrowUp, Lock, Square } from 'lucide-react'
 import { forwardRef, type ReactNode, type ChangeEvent, type KeyboardEvent } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip'
+import { type ChatThread } from '@/layout/sidebar/types'
 
 interface PromptInputProps {
+  chatThread?: ChatThread | null
   value: string
   onChange: (value: string) => void
   placeholder?: string
@@ -31,6 +34,7 @@ interface PromptInputProps {
 export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
   (
     {
+      chatThread,
       value = '',
       onChange,
       placeholder = 'Say something...',
@@ -89,14 +93,27 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
                 <SelectValue placeholder="Select a model" />
               </SelectTrigger>
               <SelectContent>
-                {models.map((model) => (
-                  <SelectItem key={model.id} value={model.id}>
-                    <div className="flex items-center gap-2">
-                      {model.isConfidential ? <Lock className="size-3.5" /> : null}
-                      <p className="text-left">{model.name}</p>
-                    </div>
-                  </SelectItem>
-                ))}
+                {models.map((model) => {
+                  const isDisabled = chatThread ? chatThread.isEncrypted !== model.isConfidential : false
+
+                  return (
+                    <Tooltip key={model.id}>
+                      <TooltipTrigger asChild>
+                        <SelectItem disabled={isDisabled} value={model.id} style={{ pointerEvents: 'auto' }}>
+                          <div className="flex items-center gap-2">
+                            {model.isConfidential ? <Lock className="size-3.5" /> : null}
+                            <p className="text-left">{model.name}</p>
+                          </div>
+                        </SelectItem>
+                      </TooltipTrigger>
+                      {chatThread && isDisabled && (
+                        <TooltipContent side="left">
+                          <p>{`This model is not available for ${chatThread.isEncrypted === 1 ? 'encrypted' : 'unencrypted'} conversations.`}</p>
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  )
+                })}
               </SelectContent>
             </Select>
 

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -8,7 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip'
 import { type ChatThread } from '@/layout/sidebar/types'
 
 interface PromptInputProps {
-  chatThread?: ChatThread | null
+  chatThread: ChatThread | null
   value: string
   onChange: (value: string) => void
   placeholder?: string

--- a/src/dal/chat-messages.test.ts
+++ b/src/dal/chat-messages.test.ts
@@ -106,7 +106,7 @@ describe('Chat Messages DAL', () => {
   })
 
   describe('getLastMessage', () => {
-    it('should return undefined when thread has no messages', async () => {
+    it('should return null when thread has no messages', async () => {
       const threadId = uuidv7()
       const db = DatabaseSingleton.instance.db
 
@@ -117,7 +117,7 @@ describe('Chat Messages DAL', () => {
       })
 
       const lastMessage = await getLastMessage(threadId)
-      expect(lastMessage).toBeUndefined()
+      expect(lastMessage).toBeNull()
     })
 
     it('should return the last message for a thread', async () => {

--- a/src/dal/chat-messages.ts
+++ b/src/dal/chat-messages.ts
@@ -3,6 +3,7 @@ import { DatabaseSingleton } from '../db/singleton'
 import { chatMessagesTable, chatThreadsTable } from '../db/tables'
 import { convertUIMessageToDbChatMessage } from '../lib/utils'
 import type { ChatMessage, ThunderboltUIMessage, UIMessageMetadata } from '../types'
+import { getChatThread } from './chat-threads'
 
 /**
  * Gets a single chat message by ID
@@ -57,7 +58,7 @@ export const saveMessagesWithContextUpdate = async (
   const db = DatabaseSingleton.instance.db
 
   // Verify thread exists
-  const thread = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, threadId)).get()
+  const thread = await getChatThread(threadId)
   if (!thread) {
     throw new Error('Thread not found')
   }

--- a/src/dal/chat-messages.ts
+++ b/src/dal/chat-messages.ts
@@ -1,9 +1,9 @@
 import { desc, eq, sql } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
-import { chatMessagesTable, chatThreadsTable } from '../db/tables'
-import { convertUIMessageToDbChatMessage } from '../lib/utils'
+import { chatMessagesTable } from '../db/tables'
 import type { ChatMessage, ThunderboltUIMessage, UIMessageMetadata } from '../types'
-import { getChatThread } from './chat-threads'
+import { convertUIMessageToDbChatMessage } from '../lib/utils'
+import { getChatThread, updateChatThread } from './chat-threads'
 
 /**
  * Gets a single chat message by ID
@@ -90,10 +90,7 @@ export const saveMessagesWithContextUpdate = async (
   const metadata = latestMessage?.metadata as UIMessageMetadata | undefined
 
   if (metadata?.usage?.totalTokens) {
-    await db
-      .update(chatThreadsTable)
-      .set({ contextSize: metadata.usage.totalTokens })
-      .where(eq(chatThreadsTable.id, threadId))
+    await updateChatThread(threadId, { contextSize: metadata.usage.totalTokens })
   }
 
   return dbChatMessages

--- a/src/dal/chat-messages.ts
+++ b/src/dal/chat-messages.ts
@@ -26,22 +26,18 @@ export const getChatMessages = async (threadId: string): Promise<ChatMessage[]> 
   return chatMessages
 }
 
-export const getLastMessage = async (
-  threadId: string,
-): Promise<Pick<ChatMessage, 'id' | 'chatThreadId' | 'modelId'> | undefined> => {
+export const getLastMessage = async (threadId: string): Promise<ChatMessage | null> => {
   const db = DatabaseSingleton.instance.db
 
-  return await db
-    .select({
-      id: chatMessagesTable.id,
-      chatThreadId: chatMessagesTable.chatThreadId,
-      modelId: chatMessagesTable.modelId,
-    })
+  const lastMessage = await db
+    .select()
     .from(chatMessagesTable)
     .where(eq(chatMessagesTable.chatThreadId, threadId))
     .orderBy(desc(chatMessagesTable.id))
     .limit(1)
     .get()
+
+  return lastMessage ?? null
 }
 
 /**

--- a/src/dal/chat-threads.test.ts
+++ b/src/dal/chat-threads.test.ts
@@ -10,6 +10,7 @@ import {
   getChatThread,
   getContextSizeForThread,
   getOrCreateChatThread,
+  updateChatThread,
 } from './chat-threads'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 
@@ -342,6 +343,244 @@ describe('Chat Threads DAL', () => {
       expect(threadsBefore).toHaveLength(0)
 
       await expect(deleteAllChatThreads()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('updateChatThread', () => {
+    it('should update thread title', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create initial thread
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Original Title',
+        isEncrypted: 0,
+      })
+
+      // Update title
+      await updateChatThread(threadId, { title: 'Updated Title' })
+
+      // Verify update
+      const updatedThread = await getChatThread(threadId)
+      expect(updatedThread?.title).toBe('Updated Title')
+      expect(updatedThread?.id).toBe(threadId)
+      expect(updatedThread?.isEncrypted).toBe(0) // Should remain unchanged
+    })
+
+    it('should update context size', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create initial thread
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      // Update context size
+      await updateChatThread(threadId, { contextSize: 2000 })
+
+      // Verify update
+      const updatedThread = await getChatThread(threadId)
+      expect(updatedThread?.contextSize).toBe(2000)
+      expect(updatedThread?.title).toBe('Test Thread') // Should remain unchanged
+    })
+
+    it('should update triggeredBy field', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create initial thread
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+      })
+
+      // Update triggeredBy to null (since we don't have a valid prompt ID)
+      await updateChatThread(threadId, { triggeredBy: null })
+
+      // Verify update
+      const updatedThread = await getChatThread(threadId)
+      expect(updatedThread?.triggeredBy).toBeNull()
+    })
+
+    it('should update wasTriggeredByAutomation field', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create initial thread
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+        wasTriggeredByAutomation: 0,
+      })
+
+      // Update wasTriggeredByAutomation
+      await updateChatThread(threadId, { wasTriggeredByAutomation: 1 })
+
+      // Verify update
+      const updatedThread = await getChatThread(threadId)
+      expect(updatedThread?.wasTriggeredByAutomation).toBe(1)
+    })
+
+    it('should update multiple fields at once', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create initial thread
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Original Title',
+        isEncrypted: 0,
+        contextSize: 1000,
+        wasTriggeredByAutomation: 0,
+      })
+
+      // Update multiple fields
+      await updateChatThread(threadId, {
+        title: 'Updated Title',
+        contextSize: 3000,
+        triggeredBy: null,
+        wasTriggeredByAutomation: 1,
+      })
+
+      // Verify all updates
+      const updatedThread = await getChatThread(threadId)
+      expect(updatedThread?.title).toBe('Updated Title')
+      expect(updatedThread?.contextSize).toBe(3000)
+      expect(updatedThread?.triggeredBy).toBeNull()
+      expect(updatedThread?.wasTriggeredByAutomation).toBe(1)
+      expect(updatedThread?.id).toBe(threadId) // Should remain unchanged
+      expect(updatedThread?.isEncrypted).toBe(0) // Should remain unchanged
+    })
+
+    it('should update only specified fields (partial update)', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create initial thread with all fields
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Original Title',
+        isEncrypted: 0,
+        contextSize: 1000,
+        wasTriggeredByAutomation: 0,
+      })
+
+      // Update only title
+      await updateChatThread(threadId, { title: 'Updated Title' })
+
+      // Verify only title changed
+      const updatedThread = await getChatThread(threadId)
+      expect(updatedThread?.title).toBe('Updated Title')
+      expect(updatedThread?.contextSize).toBe(1000) // Should remain unchanged
+      expect(updatedThread?.wasTriggeredByAutomation).toBe(0) // Should remain unchanged
+    })
+
+    it('should not throw when updating non-existent thread', async () => {
+      const nonExistentId = uuidv7()
+
+      // Should not throw
+      await expect(updateChatThread(nonExistentId, { title: 'New Title' })).resolves.toBeUndefined()
+    })
+
+    it('should update specific thread when multiple threads exist', async () => {
+      const threadId1 = uuidv7()
+      const threadId2 = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create two threads
+      await db.insert(chatThreadsTable).values([
+        {
+          id: threadId1,
+          title: 'First Thread',
+          isEncrypted: 0,
+          contextSize: 1000,
+        },
+        {
+          id: threadId2,
+          title: 'Second Thread',
+          isEncrypted: 0,
+          contextSize: 2000,
+        },
+      ])
+
+      // Update only the first thread
+      await updateChatThread(threadId1, { title: 'Updated First Thread', contextSize: 1500 })
+
+      // Verify only first thread was updated
+      const firstThread = await getChatThread(threadId1)
+      const secondThread = await getChatThread(threadId2)
+
+      expect(firstThread?.title).toBe('Updated First Thread')
+      expect(firstThread?.contextSize).toBe(1500)
+      expect(secondThread?.title).toBe('Second Thread')
+      expect(secondThread?.contextSize).toBe(2000)
+    })
+
+    it('should handle null values correctly', async () => {
+      const threadId = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create thread with values
+      await db.insert(chatThreadsTable).values({
+        id: threadId,
+        title: 'Test Thread',
+        isEncrypted: 0,
+        contextSize: 1000,
+        triggeredBy: null, // Start with null to avoid foreign key constraint
+      })
+
+      // Update with null values
+      await updateChatThread(threadId, {
+        contextSize: null,
+        triggeredBy: null,
+      })
+
+      // Verify null values were set
+      const updatedThread = await getChatThread(threadId)
+      expect(updatedThread?.contextSize).toBeNull()
+      expect(updatedThread?.triggeredBy).toBeNull()
+      expect(updatedThread?.title).toBe('Test Thread') // Should remain unchanged
+    })
+
+    it('should not affect other threads when updating one', async () => {
+      const threadId1 = uuidv7()
+      const threadId2 = uuidv7()
+      const threadId3 = uuidv7()
+      const db = DatabaseSingleton.instance.db
+
+      // Create three threads
+      await db.insert(chatThreadsTable).values([
+        { id: threadId1, title: 'Thread 1', isEncrypted: 0, contextSize: 1000 },
+        { id: threadId2, title: 'Thread 2', isEncrypted: 0, contextSize: 2000 },
+        { id: threadId3, title: 'Thread 3', isEncrypted: 0, contextSize: 3000 },
+      ])
+
+      // Update only the second thread
+      await updateChatThread(threadId2, {
+        title: 'Updated Thread 2',
+        contextSize: 2500,
+      })
+
+      // Verify all threads
+      const allThreads = await getAllChatThreads()
+      expect(allThreads).toHaveLength(3)
+
+      const thread1 = allThreads.find((t) => t.id === threadId1)
+      const thread2 = allThreads.find((t) => t.id === threadId2)
+      const thread3 = allThreads.find((t) => t.id === threadId3)
+
+      expect(thread1?.title).toBe('Thread 1')
+      expect(thread1?.contextSize).toBe(1000)
+      expect(thread2?.title).toBe('Updated Thread 2')
+      expect(thread2?.contextSize).toBe(2500)
+      expect(thread3?.title).toBe('Thread 3')
+      expect(thread3?.contextSize).toBe(3000)
     })
   })
 })

--- a/src/dal/chat-threads.test.ts
+++ b/src/dal/chat-threads.test.ts
@@ -59,7 +59,10 @@ describe('Chat Threads DAL', () => {
       const threadId = uuidv7()
       const modelId = await createTestModel()
 
-      await createChatThread({ id: threadId, title: 'New Chat' }, modelId)
+      await createChatThread(
+        { id: threadId, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
+        modelId,
+      )
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
@@ -73,8 +76,14 @@ describe('Chat Threads DAL', () => {
       const threadId2 = uuidv7()
       const modelId = await createTestModel()
 
-      await createChatThread({ id: threadId1, title: 'New Chat' }, modelId)
-      await createChatThread({ id: threadId2, title: 'New Chat' }, modelId)
+      await createChatThread(
+        { id: threadId1, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
+        modelId,
+      )
+      await createChatThread(
+        { id: threadId2, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
+        modelId,
+      )
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
@@ -87,10 +96,18 @@ describe('Chat Threads DAL', () => {
       const threadId = uuidv7()
       const modelId = await createTestModel()
 
-      await createChatThread({ id: threadId, title: 'New Chat' }, modelId)
+      await createChatThread(
+        { id: threadId, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
+        modelId,
+      )
 
       // Should throw due to UNIQUE constraint
-      await expect(createChatThread({ id: threadId, title: 'New Chat' }, modelId)).rejects.toThrow()
+      await expect(
+        createChatThread(
+          { id: threadId, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
+          modelId,
+        ),
+      ).rejects.toThrow()
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)

--- a/src/dal/chat-threads.test.ts
+++ b/src/dal/chat-threads.test.ts
@@ -30,7 +30,7 @@ describe('Chat Threads DAL', () => {
     it('should create a new chat thread with the provided ID', async () => {
       const threadId = uuidv7()
 
-      await createChatThread(threadId)
+      await createChatThread({ id: threadId, title: 'New Chat', isEncrypted: 0 })
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
@@ -43,8 +43,8 @@ describe('Chat Threads DAL', () => {
       const threadId1 = uuidv7()
       const threadId2 = uuidv7()
 
-      await createChatThread(threadId1)
-      await createChatThread(threadId2)
+      await createChatThread({ id: threadId1, title: 'New Chat', isEncrypted: 0 })
+      await createChatThread({ id: threadId2, title: 'New Chat', isEncrypted: 0 })
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
@@ -56,10 +56,10 @@ describe('Chat Threads DAL', () => {
     it('should throw when creating thread with same ID twice', async () => {
       const threadId = uuidv7()
 
-      await createChatThread(threadId)
+      await createChatThread({ id: threadId, title: 'New Chat', isEncrypted: 0 })
 
       // Should throw due to UNIQUE constraint
-      await expect(createChatThread(threadId)).rejects.toThrow()
+      await expect(createChatThread({ id: threadId, title: 'New Chat', isEncrypted: 0 })).rejects.toThrow()
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
@@ -132,7 +132,7 @@ describe('Chat Threads DAL', () => {
         isEncrypted: 0,
       })
 
-      const thread = await getOrCreateChatThread(threadId)
+      const thread = await getOrCreateChatThread(threadId, false)
       expect(thread).not.toBeNull()
       expect(thread?.id).toBe(threadId)
       expect(thread?.title).toBe('Existing Thread')
@@ -145,7 +145,7 @@ describe('Chat Threads DAL', () => {
     it('should create and return new thread when it does not exist', async () => {
       const threadId = uuidv7()
 
-      const thread = await getOrCreateChatThread(threadId)
+      const thread = await getOrCreateChatThread(threadId, false)
       expect(thread).not.toBeNull()
       expect(thread?.id).toBe(threadId)
       expect(thread?.title).toBe('New Chat')
@@ -160,8 +160,8 @@ describe('Chat Threads DAL', () => {
     it('should handle multiple calls with same ID consistently', async () => {
       const threadId = uuidv7()
 
-      const thread1 = await getOrCreateChatThread(threadId)
-      const thread2 = await getOrCreateChatThread(threadId)
+      const thread1 = await getOrCreateChatThread(threadId, false)
+      const thread2 = await getOrCreateChatThread(threadId, false)
 
       expect(thread1?.id).toBe(threadId)
       expect(thread2?.id).toBe(threadId)
@@ -178,8 +178,8 @@ describe('Chat Threads DAL', () => {
       const threadId1 = uuidv7()
       const threadId2 = uuidv7()
 
-      const thread1 = await getOrCreateChatThread(threadId1)
-      const thread2 = await getOrCreateChatThread(threadId2)
+      const thread1 = await getOrCreateChatThread(threadId1, false)
+      const thread2 = await getOrCreateChatThread(threadId2, false)
 
       expect(thread1?.id).toBe(threadId1)
       expect(thread2?.id).toBe(threadId2)

--- a/src/dal/chat-threads.test.ts
+++ b/src/dal/chat-threads.test.ts
@@ -1,5 +1,5 @@
 import { DatabaseSingleton } from '@/db/singleton'
-import { chatThreadsTable } from '@/db/tables'
+import { chatThreadsTable, modelsTable } from '@/db/tables'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
 import { v7 as uuidv7 } from 'uuid'
 import {
@@ -22,6 +22,33 @@ afterAll(async () => {
   await teardownTestDatabase()
 })
 
+/**
+ * Helper function to create a test model
+ */
+const createTestModel = async () => {
+  const db = DatabaseSingleton.instance.db
+  const modelId = uuidv7()
+
+  await db.insert(modelsTable).values({
+    id: modelId,
+    provider: 'thunderbolt',
+    name: 'Test Model',
+    model: 'gpt-oss-120b',
+    isSystem: 0,
+    enabled: 1,
+    isConfidential: 0,
+    contextWindow: 131072,
+    toolUsage: 1,
+    startWithReasoning: 0,
+    deletedAt: null,
+    apiKey: null,
+    url: null,
+    defaultHash: null,
+  })
+
+  return modelId
+}
+
 describe('Chat Threads DAL', () => {
   afterEach(async () => {
     await resetTestDatabase()
@@ -30,8 +57,9 @@ describe('Chat Threads DAL', () => {
   describe('createChatThread', () => {
     it('should create a new chat thread with the provided ID', async () => {
       const threadId = uuidv7()
+      const modelId = await createTestModel()
 
-      await createChatThread({ id: threadId, title: 'New Chat', isEncrypted: 0 })
+      await createChatThread({ id: threadId, title: 'New Chat' }, modelId)
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
@@ -43,9 +71,10 @@ describe('Chat Threads DAL', () => {
     it('should create multiple threads with different IDs', async () => {
       const threadId1 = uuidv7()
       const threadId2 = uuidv7()
+      const modelId = await createTestModel()
 
-      await createChatThread({ id: threadId1, title: 'New Chat', isEncrypted: 0 })
-      await createChatThread({ id: threadId2, title: 'New Chat', isEncrypted: 0 })
+      await createChatThread({ id: threadId1, title: 'New Chat' }, modelId)
+      await createChatThread({ id: threadId2, title: 'New Chat' }, modelId)
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
@@ -56,11 +85,12 @@ describe('Chat Threads DAL', () => {
 
     it('should throw when creating thread with same ID twice', async () => {
       const threadId = uuidv7()
+      const modelId = await createTestModel()
 
-      await createChatThread({ id: threadId, title: 'New Chat', isEncrypted: 0 })
+      await createChatThread({ id: threadId, title: 'New Chat' }, modelId)
 
       // Should throw due to UNIQUE constraint
-      await expect(createChatThread({ id: threadId, title: 'New Chat', isEncrypted: 0 })).rejects.toThrow()
+      await expect(createChatThread({ id: threadId, title: 'New Chat' }, modelId)).rejects.toThrow()
 
       const db = DatabaseSingleton.instance.db
       const threads = await db.select().from(chatThreadsTable)
@@ -133,7 +163,8 @@ describe('Chat Threads DAL', () => {
         isEncrypted: 0,
       })
 
-      const thread = await getOrCreateChatThread(threadId, false)
+      const modelId = await createTestModel()
+      const thread = await getOrCreateChatThread(threadId, modelId)
       expect(thread).not.toBeNull()
       expect(thread?.id).toBe(threadId)
       expect(thread?.title).toBe('Existing Thread')
@@ -145,8 +176,9 @@ describe('Chat Threads DAL', () => {
 
     it('should create and return new thread when it does not exist', async () => {
       const threadId = uuidv7()
+      const modelId = await createTestModel()
 
-      const thread = await getOrCreateChatThread(threadId, false)
+      const thread = await getOrCreateChatThread(threadId, modelId)
       expect(thread).not.toBeNull()
       expect(thread?.id).toBe(threadId)
       expect(thread?.title).toBe('New Chat')
@@ -160,9 +192,10 @@ describe('Chat Threads DAL', () => {
 
     it('should handle multiple calls with same ID consistently', async () => {
       const threadId = uuidv7()
+      const modelId = await createTestModel()
 
-      const thread1 = await getOrCreateChatThread(threadId, false)
-      const thread2 = await getOrCreateChatThread(threadId, false)
+      const thread1 = await getOrCreateChatThread(threadId, modelId)
+      const thread2 = await getOrCreateChatThread(threadId, modelId)
 
       expect(thread1?.id).toBe(threadId)
       expect(thread2?.id).toBe(threadId)
@@ -178,9 +211,10 @@ describe('Chat Threads DAL', () => {
     it('should work correctly with different thread IDs', async () => {
       const threadId1 = uuidv7()
       const threadId2 = uuidv7()
+      const modelId = await createTestModel()
 
-      const thread1 = await getOrCreateChatThread(threadId1, false)
-      const thread2 = await getOrCreateChatThread(threadId2, false)
+      const thread1 = await getOrCreateChatThread(threadId1, modelId)
+      const thread2 = await getOrCreateChatThread(threadId2, modelId)
 
       expect(thread1?.id).toBe(threadId1)
       expect(thread2?.id).toBe(threadId2)

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -6,7 +6,7 @@ import { type ChatThread } from '@/types'
 /**
  * Gets all chat threads ordered by creation date
  */
-export const getAllChatThreads = async () => {
+export const getAllChatThreads = async (): Promise<ChatThread[]> => {
   const db = DatabaseSingleton.instance.db
   return await db.select().from(chatThreadsTable).orderBy(desc(chatThreadsTable.id))
 }
@@ -14,15 +14,16 @@ export const getAllChatThreads = async () => {
 /**
  * Gets a specific chat thread by ID
  */
-export const getChatThread = async (id: string) => {
+export const getChatThread = async (id: string): Promise<ChatThread | null> => {
   const db = DatabaseSingleton.instance.db
-  return await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, id)).get()
+  const thread = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, id)).get()
+  return thread ?? null
 }
 
 /**
  * Create a new chat thread
  */
-export const createChatThread = async (data: Partial<ChatThread> & Required<Pick<ChatThread, 'id'>>) => {
+export const createChatThread = async (data: Partial<ChatThread> & Required<Pick<ChatThread, 'id'>>): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   await db.insert(chatThreadsTable).values(data)
 }
@@ -30,7 +31,7 @@ export const createChatThread = async (data: Partial<ChatThread> & Required<Pick
 /**
  * Gets a specific chat thread by ID or create a new one with the provided ID
  */
-export const getOrCreateChatThread = async (id: string, isEncrypted: boolean) => {
+export const getOrCreateChatThread = async (id: string, isEncrypted: boolean): Promise<ChatThread> => {
   const thread = await getChatThread(id)
 
   if (thread?.id) {
@@ -43,7 +44,7 @@ export const getOrCreateChatThread = async (id: string, isEncrypted: boolean) =>
     isEncrypted: isEncrypted ? 1 : 0,
   })
 
-  return await getChatThread(id)
+  return (await getChatThread(id))! // We know the thread exists because we just created it
 }
 
 /**
@@ -65,7 +66,7 @@ export const getContextSizeForThread = async (threadId: string): Promise<number 
 /**
  * Deletes a specific chat thread by ID
  */
-export const deleteChatThread = async (id: string) => {
+export const deleteChatThread = async (id: string): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   await db.delete(chatThreadsTable).where(eq(chatThreadsTable.id, id))
 }
@@ -73,7 +74,7 @@ export const deleteChatThread = async (id: string) => {
 /**
  * Deletes all chat threads
  */
-export const deleteAllChatThreads = async () => {
+export const deleteAllChatThreads = async (): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   await db.delete(chatThreadsTable)
 }

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -2,6 +2,7 @@ import { desc, eq } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
 import { chatThreadsTable } from '../db/tables'
 import { type ChatThread } from '@/types'
+import { getModel } from './models'
 
 /**
  * Gets all chat threads ordered by creation date
@@ -23,9 +24,19 @@ export const getChatThread = async (id: string): Promise<ChatThread | null> => {
 /**
  * Create a new chat thread
  */
-export const createChatThread = async (data: Partial<ChatThread> & Required<Pick<ChatThread, 'id'>>): Promise<void> => {
+export const createChatThread = async (
+  data: Partial<Omit<ChatThread, 'isEncrypted'>> & Required<Pick<ChatThread, 'id'>>,
+  modelId: string,
+): Promise<void> => {
   const db = DatabaseSingleton.instance.db
-  await db.insert(chatThreadsTable).values(data)
+
+  const model = await getModel(modelId)
+
+  if (!model) {
+    throw new Error('No model found')
+  }
+
+  await db.insert(chatThreadsTable).values({ ...data, isEncrypted: model.isConfidential })
 }
 
 export const updateChatThread = async (
@@ -39,18 +50,20 @@ export const updateChatThread = async (
 /**
  * Gets a specific chat thread by ID or create a new one with the provided ID
  */
-export const getOrCreateChatThread = async (id: string, isEncrypted: boolean): Promise<ChatThread> => {
+export const getOrCreateChatThread = async (id: string, modelId?: string): Promise<ChatThread> => {
   const thread = await getChatThread(id)
 
   if (thread?.id) {
     return thread
   }
 
-  await createChatThread({
-    id,
-    title: 'New Chat',
-    isEncrypted: isEncrypted ? 1 : 0,
-  })
+  await createChatThread(
+    {
+      id,
+      title: 'New Chat',
+    },
+    modelId!,
+  )
 
   return (await getChatThread(id))! // We know the thread exists because we just created it
 }

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -25,7 +25,8 @@ export const getChatThread = async (id: string): Promise<ChatThread | null> => {
  * Create a new chat thread
  */
 export const createChatThread = async (
-  data: Partial<Omit<ChatThread, 'isEncrypted'>> & Required<Pick<ChatThread, 'id'>>,
+  data: Partial<Pick<ChatThread, 'contextSize' | 'title' | 'triggeredBy' | 'wasTriggeredByAutomation'>> &
+    Required<Pick<ChatThread, 'id'>>,
   modelId: string,
 ): Promise<void> => {
   const db = DatabaseSingleton.instance.db
@@ -41,7 +42,7 @@ export const createChatThread = async (
 
 export const updateChatThread = async (
   id: string,
-  data: Partial<Omit<ChatThread, 'id' | 'isEncrypted'>>,
+  data: Partial<Pick<ChatThread, 'contextSize' | 'title' | 'triggeredBy' | 'wasTriggeredByAutomation'>>,
 ): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   await db.update(chatThreadsTable).set(data).where(eq(chatThreadsTable.id, id))

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -1,6 +1,7 @@
 import { desc, eq } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
 import { chatThreadsTable } from '../db/tables'
+import { type ChatThread } from '@/types'
 
 /**
  * Gets all chat threads ordered by creation date
@@ -21,22 +22,26 @@ export const getChatThread = async (id: string) => {
 /**
  * Create a new chat thread
  */
-export const createChatThread = async (id: string) => {
+export const createChatThread = async (data: Partial<ChatThread> & Required<Pick<ChatThread, 'id'>>) => {
   const db = DatabaseSingleton.instance.db
-  await db.insert(chatThreadsTable).values({ id, title: 'New Chat' })
+  await db.insert(chatThreadsTable).values(data)
 }
 
 /**
  * Gets a specific chat thread by ID or create a new one with the provided ID
  */
-export const getOrCreateChatThread = async (id: string) => {
+export const getOrCreateChatThread = async (id: string, isEncrypted: boolean) => {
   const thread = await getChatThread(id)
 
   if (thread?.id) {
     return thread
   }
 
-  await createChatThread(id)
+  await createChatThread({
+    id,
+    title: 'New Chat',
+    isEncrypted: isEncrypted ? 1 : 0,
+  })
 
   return await getChatThread(id)
 }

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -28,6 +28,14 @@ export const createChatThread = async (data: Partial<ChatThread> & Required<Pick
   await db.insert(chatThreadsTable).values(data)
 }
 
+export const updateChatThread = async (
+  id: string,
+  data: Partial<Omit<ChatThread, 'id' | 'isEncrypted'>>,
+): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.update(chatThreadsTable).set(data).where(eq(chatThreadsTable.id, id))
+}
+
 /**
  * Gets a specific chat thread by ID or create a new one with the provided ID
  */

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -51,7 +51,7 @@ export const updateChatThread = async (
 /**
  * Gets a specific chat thread by ID or create a new one with the provided ID
  */
-export const getOrCreateChatThread = async (id: string, modelId?: string): Promise<ChatThread> => {
+export const getOrCreateChatThread = async (id: string, modelId: string): Promise<ChatThread> => {
   const thread = await getChatThread(id)
 
   if (thread?.id) {
@@ -63,7 +63,7 @@ export const getOrCreateChatThread = async (id: string, modelId?: string): Promi
       id,
       title: 'New Chat',
     },
-    modelId!,
+    modelId,
   )
 
   return (await getChatThread(id))! // We know the thread exists because we just created it

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -25,8 +25,7 @@ export const getChatThread = async (id: string): Promise<ChatThread | null> => {
  * Create a new chat thread
  */
 export const createChatThread = async (
-  data: Partial<Pick<ChatThread, 'contextSize' | 'title' | 'triggeredBy' | 'wasTriggeredByAutomation'>> &
-    Required<Pick<ChatThread, 'id'>>,
+  data: Pick<ChatThread, 'contextSize' | 'id' | 'title' | 'triggeredBy' | 'wasTriggeredByAutomation'>,
   modelId: string,
 ): Promise<void> => {
   const db = DatabaseSingleton.instance.db
@@ -62,6 +61,9 @@ export const getOrCreateChatThread = async (id: string, modelId: string): Promis
     {
       id,
       title: 'New Chat',
+      contextSize: null,
+      triggeredBy: null,
+      wasTriggeredByAutomation: 0,
     },
     modelId,
   )

--- a/src/dal/mcp-servers.ts
+++ b/src/dal/mcp-servers.ts
@@ -1,11 +1,12 @@
 import { and, eq, isNotNull } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
 import { mcpServersTable } from '../db/tables'
+import { type McpServer } from '@/types'
 
 /**
  * Gets all MCP servers from the database
  */
-export const getAllMcpServers = async () => {
+export const getAllMcpServers = async (): Promise<McpServer[]> => {
   const db = DatabaseSingleton.instance.db
   return await db.select().from(mcpServersTable)
 }
@@ -13,19 +14,10 @@ export const getAllMcpServers = async () => {
 /**
  * Gets all HTTP MCP servers with non-null URLs from the database
  */
-export const getHttpMcpServers = async () => {
+export const getHttpMcpServers = async (): Promise<McpServer[]> => {
   const db = DatabaseSingleton.instance.db
-  const allServers = await db
+  return await db
     .select()
     .from(mcpServersTable)
     .where(and(eq(mcpServersTable.type, 'http'), isNotNull(mcpServersTable.url)))
-
-  return allServers.map((server) => ({
-    id: server.id,
-    name: server.name,
-    url: server.url as string,
-    enabled: server.enabled,
-    createdAt: server.createdAt,
-    updatedAt: server.updatedAt,
-  }))
 }

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -53,7 +53,7 @@ export const getModel = async (id: string): Promise<Model | null> => {
   return model ? mapModel(model) : null
 }
 
-export const getSystemModel = async () => {
+export const getSystemModel = async (): Promise<Model | null> => {
   const db = DatabaseSingleton.instance.db
   const systemModel = await db
     .select()
@@ -124,7 +124,7 @@ export const getDefaultModelForThread = async (threadId: string, fallbackModelId
 /**
  * Update a model (preserves defaultHash for modification tracking)
  */
-export const updateModel = async (id: string, updates: Partial<Model>) => {
+export const updateModel = async (id: string, updates: Partial<Model>): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   // Don't allow updating defaultHash - it must be preserved for modification tracking
   const { defaultHash, ...updateFields } = updates as Partial<Model> & { defaultHash?: string }
@@ -134,7 +134,7 @@ export const updateModel = async (id: string, updates: Partial<Model>) => {
 /**
  * Reset a model to its default state
  */
-export const resetModelToDefault = async (id: string, defaultModel: Model) => {
+export const resetModelToDefault = async (id: string, defaultModel: Model): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   const { defaultHash, ...defaultFields } = defaultModel
   await db.update(modelsTable).set(defaultFields).where(eq(modelsTable.id, id))

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -114,13 +114,15 @@ export const runAutomation = async (promptId: string): Promise<string> => {
 
   const threadId = uuidv7()
 
-  await createChatThread({
-    id: threadId,
-    title: prompt.title ?? 'Automation',
-    isEncrypted: model.isConfidential,
-    triggeredBy: prompt.id,
-    wasTriggeredByAutomation: 1,
-  })
+  await createChatThread(
+    {
+      id: threadId,
+      title: prompt.title ?? 'Automation',
+      triggeredBy: prompt.id,
+      wasTriggeredByAutomation: 1,
+    },
+    model.id,
+  )
 
   const userMessage = {
     id: uuidv7(),

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -57,7 +57,7 @@ export const getTriggerPromptForThread = async (threadId: string): Promise<Autom
 /**
  * Update an automation/prompt (preserves defaultHash for modification tracking)
  */
-export const updateAutomation = async (id: string, updates: Partial<Prompt>) => {
+export const updateAutomation = async (id: string, updates: Partial<Prompt>): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   // Don't allow updating defaultHash - it must be preserved for modification tracking
   const { defaultHash, ...updateFields } = updates as Partial<Prompt> & { defaultHash?: string }
@@ -67,7 +67,7 @@ export const updateAutomation = async (id: string, updates: Partial<Prompt>) => 
 /**
  * Reset an automation to its default state
  */
-export const resetAutomationToDefault = async (id: string, defaultAutomation: Prompt) => {
+export const resetAutomationToDefault = async (id: string, defaultAutomation: Prompt): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   const { defaultHash, ...defaultFields } = defaultAutomation
   await db.update(promptsTable).set(defaultFields).where(eq(promptsTable.id, id))
@@ -76,7 +76,7 @@ export const resetAutomationToDefault = async (id: string, defaultAutomation: Pr
 /**
  * Delete an automation (soft delete) and its associated triggers
  */
-export const deleteAutomation = async (id: string) => {
+export const deleteAutomation = async (id: string): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   // Import locally to avoid circular dependency
   const { triggersTable } = await import('../db/tables')

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -1,9 +1,11 @@
 import { and, asc, eq, isNull, like } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import { DatabaseSingleton } from '../db/singleton'
-import { chatMessagesTable, chatThreadsTable, modelsTable, promptsTable } from '../db/tables'
+import { chatMessagesTable, chatThreadsTable, promptsTable } from '../db/tables'
 import type { AutomationRun, Prompt } from '../types'
 import { convertUIMessageToDbChatMessage } from '../lib/utils'
+import { getModel } from './models'
+import { createChatThread } from './chat-threads'
 
 /**
  * Gets all prompts, optionally filtered by search query
@@ -84,6 +86,17 @@ export const deleteAutomation = async (id: string) => {
   await db.update(promptsTable).set({ deletedAt: Date.now() }).where(eq(promptsTable.id, id))
 }
 
+export const getPrompt = async (id: string): Promise<Prompt | null> => {
+  const db = DatabaseSingleton.instance.db
+  const prompt = await db
+    .select()
+    .from(promptsTable)
+    .where(and(eq(promptsTable.id, id), isNull(promptsTable.deletedAt)))
+    .get()
+
+  return prompt ?? null
+}
+
 /**
  * Runs an automation by creating a new chat thread and seeding it with the prompt
  * @returns The threadId of the newly created chat thread
@@ -91,25 +104,20 @@ export const deleteAutomation = async (id: string) => {
 export const runAutomation = async (promptId: string): Promise<string> => {
   const db = DatabaseSingleton.instance.db
 
-  const prompt = await db
-    .select()
-    .from(promptsTable)
-    .where(and(eq(promptsTable.id, promptId), isNull(promptsTable.deletedAt)))
-    .get()
+  const prompt = await getPrompt(promptId)
+
   if (!prompt) throw new Error('Prompt not found')
 
-  const model = await db
-    .select()
-    .from(modelsTable)
-    .where(and(eq(modelsTable.id, prompt.modelId), isNull(modelsTable.deletedAt)))
-    .get()
+  const model = await getModel(prompt.modelId)
+
   if (!model) throw new Error('Model not found')
 
   const threadId = uuidv7()
 
-  await db.insert(chatThreadsTable).values({
+  await createChatThread({
     id: threadId,
     title: prompt.title ?? 'Automation',
+    isEncrypted: model.isConfidential,
     triggeredBy: prompt.id,
     wasTriggeredByAutomation: 1,
   })

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -120,6 +120,7 @@ export const runAutomation = async (promptId: string): Promise<string> => {
       title: prompt.title ?? 'Automation',
       triggeredBy: prompt.id,
       wasTriggeredByAutomation: 1,
+      contextSize: null,
     },
     model.id,
   )

--- a/src/dal/settings.ts
+++ b/src/dal/settings.ts
@@ -9,7 +9,7 @@ import { camelCased, hashValues } from '../lib/utils'
 /**
  * Gets all settings from the database
  */
-export const getAllSettings = async () => {
+export const getAllSettings = async (): Promise<Setting[]> => {
   const db = DatabaseSingleton.instance.db
   return await db.select().from(settingsTable)
 }
@@ -281,7 +281,7 @@ export const deleteSetting = async (key: string): Promise<void> => {
 /**
  * Reset a setting to its default state
  */
-export const resetSettingToDefault = async (key: string, defaultSetting: Setting) => {
+export const resetSettingToDefault = async (key: string, defaultSetting: Setting): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   // Compute the hash for the default setting so it shows as unmodified after reset
   const computedHash = hashSetting(defaultSetting)

--- a/src/dal/tasks.ts
+++ b/src/dal/tasks.ts
@@ -38,7 +38,7 @@ export const getIncompleteTasksCount = async (): Promise<number> => {
 /**
  * Update a task (preserves defaultHash for modification tracking)
  */
-export const updateTask = async (id: string, updates: Partial<Task>) => {
+export const updateTask = async (id: string, updates: Partial<Task>): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   // Don't allow updating defaultHash - it must be preserved for modification tracking
   const { defaultHash, ...updateFields } = updates as Partial<Task> & { defaultHash?: string }

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -24,15 +24,7 @@ import { Check, Copy, Globe, Plus, Trash2, X } from 'lucide-react'
 import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
 import { v7 as uuidv7 } from 'uuid'
 import { getHttpMcpServers } from '@/dal'
-
-interface McpServer {
-  id: string
-  name: string
-  url: string
-  enabled: number
-  createdAt: number | null
-  updatedAt: number | null
-}
+import { type McpServer } from '@/types'
 
 interface ServerTools {
   [serverId: string]: string[]
@@ -419,7 +411,7 @@ export default function McpServersPage() {
                               }}
                               className="text-lg font-medium cursor-pointer"
                             >
-                              {formatServerTitle(server.url, server.id)}
+                              {formatServerTitle(server.url ?? '', server.id)}
                             </CardTitle>
                           </PopoverTrigger>
                           <PopoverContent className="w-auto p-2" side="bottom" align="start">
@@ -431,7 +423,7 @@ export default function McpServersPage() {
                                 className="h-6 w-6 p-0 hover:bg-muted"
                                 onClick={(e) => {
                                   e.stopPropagation()
-                                  handleCopyUrl(server.url)
+                                  handleCopyUrl(server.url ?? '')
                                 }}
                                 disabled={copiedUrl === server.url}
                               >


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Binds chat threads to model confidentiality, disables incompatible model choices and message sends, and refactors DAL to support thread encryption with new helpers and tests.
> 
> - **Chat UI/UX**:
>   - Enforce per-thread encryption: block send when `chatThread.isEncrypted !== selectedModel.isConfidential`; pass `modelId` in message metadata.
>   - Fetch thread via `getChatThread` and pass `chatThread` into `PromptInput`; require `chatThreadId` prop.
>   - Disable incompatible models in selector with tooltip; show encrypted-conversation banner using new `TimelineMessage` (lock icon).
>   - Replace inline trigger timeline markup with reusable `TimelineMessage`.
> - **Prompt Input**:
>   - New `chatThread` prop to gate model selection; tooltips explain disabled states.
> - **DAL (Threads/Messages/Prompts)**:
>   - `createChatThread(id, modelId)` → store `isEncrypted` from model; add `updateChatThread`; `getOrCreateChatThread(id, modelId)` required.
>   - `getChatThread`/`getAllChatThreads` typed; return `null` when not found.
>   - `getLastMessage` now returns full message or `null`; `saveMessagesWithContextUpdate` uses `getChatThread` and `updateChatThread` for `contextSize`.
>   - `runAutomation` uses `createChatThread` and model lookup; add `getPrompt` helper.
>   - Misc DAL APIs add explicit return types; `getHttpMcpServers` returns rows directly.
> - **Chat Detail**:
>   - Use `updateChatThread` to set title; pass modelId to `getOrCreateChatThread`; include model metadata on send.
> - **Settings (MCP Servers)**:
>   - Use shared `McpServer` type; handle nullable URLs in UI.
> - **Tests**:
>   - Update for new signatures (`modelId` required); expect `null` for missing last message; add comprehensive `updateChatThread` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9075c3f36f212020547dfc1d0eaf9ae1f2aa47ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->