### PR TITLE
Fix: Handle client disconnections gracefully in OpenAI streaming

### DIFF
--- a/backend/src/utils/streaming.test.ts
+++ b/backend/src/utils/streaming.test.ts
@@ -214,5 +214,32 @@ describe('Utils - Streaming', () => {
       }
       expect(chunks[chunks.length - 1]).toBe('data: [DONE]\n\n')
     })
+
+    it('should handle client disconnection gracefully', async () => {
+      const mockAbort = jest.fn()
+      const mockChunks = [
+        { id: 'chunk1', choices: [{ delta: { content: 'First' } }] },
+        { id: 'chunk2', choices: [{ delta: { content: 'Second' } }] },
+        { id: 'chunk3', choices: [{ delta: { content: 'Third' } }] },
+      ]
+
+      const mockCompletion = {
+        ...createMockCompletion(mockChunks),
+        controller: { abort: mockAbort },
+      }
+
+      const stream = createSSEStreamFromCompletion(mockCompletion as any, 'test-model')
+      const reader = stream.getReader()
+
+      // Read first chunk
+      await reader.read()
+
+      // Cancel the stream (simulating client disconnect)
+      await reader.cancel()
+
+      // Verify abort was called on the OpenAI stream
+      expect(mockAbort).toHaveBeenCalled()
+      expect(mockConsoleError).not.toHaveBeenCalled()
+    })
   })
 })

--- a/backend/src/utils/streaming.ts
+++ b/backend/src/utils/streaming.ts
@@ -62,7 +62,9 @@ export const createSSEStreamFromCompletion = (
           // })
         }
 
-        controller.close()
+        if (controller.desiredSize !== null) {
+          controller.close()
+        }
       } catch (error) {
         if (!isCancelled) {
           console.error('OpenAI streaming error:', error)

--- a/backend/src/utils/streaming.ts
+++ b/backend/src/utils/streaming.ts
@@ -17,11 +17,17 @@ export const createSSEStreamFromCompletion = (
 ): ReadableStream<Uint8Array> => {
   const encoder = new TextEncoder()
   let lastUsage: any = null
+  let isCancelled = false
 
   return new ReadableStream<Uint8Array>({
     async start(controller) {
       try {
         for await (const chunk of completion) {
+          // Stop processing if client disconnected
+          if (isCancelled) {
+            break
+          }
+
           // Track usage data if present
           if (chunk.usage) {
             lastUsage = chunk.usage
@@ -29,11 +35,23 @@ export const createSSEStreamFromCompletion = (
 
           // Convert chunk back to SSE format for client compatibility
           const sseChunk = `data: ${JSON.stringify(chunk)}\n\n`
-          controller.enqueue(encoder.encode(sseChunk))
+
+          try {
+            controller.enqueue(encoder.encode(sseChunk))
+          } catch (enqueueError) {
+            // Controller already closed (client disconnected)
+            break
+          }
         }
 
-        // Send [DONE] message
-        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        // Send [DONE] message if not cancelled
+        if (!isCancelled) {
+          try {
+            controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+          } catch {
+            // Ignore if controller is closed
+          }
+        }
 
         // Log usage if captured (PostHog will also capture this automatically)
         if (lastUsage) {
@@ -46,9 +64,17 @@ export const createSSEStreamFromCompletion = (
 
         controller.close()
       } catch (error) {
-        console.error('OpenAI streaming error:', error)
-        controller.error(error)
+        if (!isCancelled) {
+          console.error('OpenAI streaming error:', error)
+          controller.error(error)
+        }
       }
+    },
+    cancel() {
+      // Mark as cancelled to stop processing chunks
+      isCancelled = true
+      // Abort the OpenAI stream
+      completion.controller.abort()
     },
   })
 }

--- a/backend/src/utils/streaming.ts
+++ b/backend/src/utils/streaming.ts
@@ -74,7 +74,7 @@ export const createSSEStreamFromCompletion = (
       // Mark as cancelled to stop processing chunks
       isCancelled = true
       // Abort the OpenAI stream
-      completion.controller.abort()
+      completion.controller?.abort()
     },
   })
 }


### PR DESCRIPTION
This fixes a bug where client disconnections during streaming chat completions would cause "Invalid state: Controller is already closed" errors to be logged. The issue occurred when a client disconnected (browser closed, network issue, etc.) while the server was still processing chunks from the OpenAI/Fireworks stream. The code would attempt to write to an already-closed stream controller, causing noisy error logs. The fix adds proper cancellation handling by: (1) tracking cancellation state to stop processing chunks when the client disconnects, (2) wrapping enqueue calls in try-catch to handle already-closed controllers gracefully, and (3) implementing a cancel handler that aborts the upstream OpenAI stream immediately, preventing unnecessary API usage. This ensures clean disconnections with no error logs and reduces wasted API calls when clients disconnect mid-stream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cancellation handling to SSE streaming to stop on client disconnects, abort the upstream stream, and avoid closed-controller errors, with a test covering the behavior.
> 
> - **Backend**:
>   - `backend/src/utils/streaming.ts` (`createSSEStreamFromCompletion`):
>     - Add cancellation state and `cancel()` to abort `completion.controller`.
>     - Stop processing when cancelled; wrap `enqueue` and `[DONE]` sends in try/catch.
>     - Suppress error/close operations if cancelled; conditionally `close()` controller.
> - **Tests**:
>   - `backend/src/utils/streaming.test.ts`: add test ensuring client cancel triggers abort and no console errors; maintain SSE format expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb35a3018826d416d0cc26f25655a086f143cbcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->