### PR TITLE
Refactor: improve backend types + injectable fetch

### DIFF
--- a/backend/src/api/routes.test.ts
+++ b/backend/src/api/routes.test.ts
@@ -1,11 +1,27 @@
+import type { Settings } from '@/config/settings'
 import * as settingsModule from '@/config/settings'
 import { afterAll, beforeAll, describe, expect, it, spyOn } from 'bun:test'
 import { createApp } from '../index'
 
 describe('Main Routes', () => {
   let app: Awaited<ReturnType<typeof createApp>>
-  let fetchSpy: ReturnType<typeof spyOn>
   let getSettingsSpy: ReturnType<typeof spyOn>
+
+  const mockFetch = async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+    const url = input instanceof Request ? input.url : input.toString()
+    if (url.startsWith('https://geocoding-api.open-meteo.com')) {
+      return new Response(
+        JSON.stringify({
+          results: [{ name: 'London', admin1: 'England', country: 'UK', latitude: 51.5, longitude: -0.12 }],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+  }
 
   beforeAll(async () => {
     // Mock console methods to reduce test noise
@@ -13,23 +29,6 @@ describe('Main Routes', () => {
     spyOn(console, 'info').mockImplementation(() => {})
     spyOn(console, 'error').mockImplementation(() => {})
     spyOn(console, 'warn').mockImplementation(() => {})
-
-    // Mock fetch for geocoding API
-    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL, _init?: RequestInit) => {
-      const url = input instanceof Request ? input.url : input.toString()
-      if (url.startsWith('https://geocoding-api.open-meteo.com')) {
-        return new Response(
-          JSON.stringify({
-            results: [{ name: 'London', admin1: 'England', country: 'UK', latitude: 51.5, longitude: -0.12 }],
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        )
-      }
-      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
-    }) as unknown as typeof fetch)
 
     // Mock settings for analytics route
     getSettingsSpy = spyOn(settingsModule, 'getSettings').mockReturnValue({
@@ -51,14 +50,13 @@ describe('Main Routes', () => {
       corsAllowHeaders:
         'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With',
       corsExposeHeaders: 'mcp-session-id',
-    } as any)
+    } satisfies Settings)
 
-    app = await createApp()
+    // Inject mock fetch into app
+    app = await createApp(mockFetch as typeof fetch)
   })
 
   afterAll(async () => {
-    // Cleanup if needed
-    fetchSpy?.mockRestore()
     getSettingsSpy?.mockRestore()
   })
 

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -14,7 +14,7 @@ export interface LocationResult {
 /**
  * Create main API routes
  */
-export const createMainRoutes = () => {
+export const createMainRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
   return new Elysia()
     .get('/health', () => ({
       status: 'ok',
@@ -74,7 +74,7 @@ export const createMainRoutes = () => {
           url.searchParams.set('language', 'en')
           url.searchParams.set('format', 'json')
 
-          const response = await fetch(url.toString())
+          const response = await fetchFn(url.toString())
 
           if (!response.ok) {
             if (response.status === 400) {

--- a/backend/src/auth/google.ts
+++ b/backend/src/auth/google.ts
@@ -7,7 +7,7 @@ const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 /**
  * Create Google OAuth router
  */
-export const createGoogleAuthRoutes = () => {
+export const createGoogleAuthRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
   return new Elysia({ prefix: '/auth/google' })
     .get('/config', async () => {
       const settings = getSettings()
@@ -41,7 +41,7 @@ export const createGoogleAuthRoutes = () => {
         })
 
         try {
-          const response = await fetch(GOOGLE_TOKEN_URL, {
+          const response = await fetchFn(GOOGLE_TOKEN_URL, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded',
@@ -111,7 +111,7 @@ export const createGoogleAuthRoutes = () => {
         })
 
         try {
-          const response = await fetch(GOOGLE_TOKEN_URL, {
+          const response = await fetchFn(GOOGLE_TOKEN_URL, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded',

--- a/backend/src/auth/microsoft.ts
+++ b/backend/src/auth/microsoft.ts
@@ -9,7 +9,7 @@ const SCOPES = 'https://graph.microsoft.com/mail.read User.Read offline_access'
 /**
  * Create Microsoft OAuth router
  */
-export const createMicrosoftAuthRoutes = () => {
+export const createMicrosoftAuthRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
   return new Elysia({ prefix: '/auth/microsoft' })
     .get('/config', async () => {
       const settings = getSettings()
@@ -45,7 +45,7 @@ export const createMicrosoftAuthRoutes = () => {
         })
 
         try {
-          const response = await fetch(MICROSOFT_TOKEN_URL, {
+          const response = await fetchFn(MICROSOFT_TOKEN_URL, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded',
@@ -116,7 +116,7 @@ export const createMicrosoftAuthRoutes = () => {
         })
 
         try {
-          const response = await fetch(MICROSOFT_TOKEN_URL, {
+          const response = await fetchFn(MICROSOFT_TOKEN_URL, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded',

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -1,10 +1,17 @@
-import { afterAll, beforeAll, describe, expect, it, spyOn } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it, mock, spyOn } from 'bun:test'
 import { Elysia } from 'elysia'
 import { createGoogleAuthRoutes } from './google'
 import { createMicrosoftAuthRoutes } from './microsoft'
 
 describe('Authentication Routes', () => {
   let app: Elysia
+  let mockFetch: ReturnType<typeof mock>
+
+  const createMockOAuthResponse = (status = 200, body: any = {}) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
 
   beforeAll(async () => {
     // Mock console methods to reduce test noise
@@ -13,7 +20,13 @@ describe('Authentication Routes', () => {
     spyOn(console, 'error').mockImplementation(() => {})
     spyOn(console, 'warn').mockImplementation(() => {})
 
-    app = new Elysia().use(createGoogleAuthRoutes()).use(createMicrosoftAuthRoutes())
+    // Create mock fetch
+    mockFetch = mock(() => Promise.resolve(createMockOAuthResponse()))
+
+    // Inject mock fetch into routes
+    app = new Elysia()
+      .use(createGoogleAuthRoutes(mockFetch as unknown as typeof fetch))
+      .use(createMicrosoftAuthRoutes(mockFetch as unknown as typeof fetch))
   })
 
   afterAll(async () => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -55,11 +55,11 @@ const createApp = async (fetchFn: typeof fetch = globalThis.fetch) => {
       .use(createErrorHandlingMiddleware())
       // Mount route groups
       .use(createMainRoutes(fetchFn))
-      .use(createGoogleAuthRoutes())
-      .use(createMicrosoftAuthRoutes())
-      .use(createProToolsRoutes())
+      .use(createGoogleAuthRoutes(fetchFn))
+      .use(createMicrosoftAuthRoutes(fetchFn))
+      .use(createProToolsRoutes(fetchFn))
       .use(createOpenAIRoutes())
-      .use(createPostHogRoutes())
+      .use(createPostHogRoutes(fetchFn))
   )
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,7 +15,7 @@ import { Elysia } from 'elysia'
 /**
  * Create the main Elysia application
  */
-const createApp = async () => {
+const createApp = async (fetchFn: typeof fetch = globalThis.fetch) => {
   const settings = getSettings()
 
   const app = new Elysia({
@@ -54,7 +54,7 @@ const createApp = async () => {
       .use(createHttpLoggingMiddleware())
       .use(createErrorHandlingMiddleware())
       // Mount route groups
-      .use(createMainRoutes())
+      .use(createMainRoutes(fetchFn))
       .use(createGoogleAuthRoutes())
       .use(createMicrosoftAuthRoutes())
       .use(createProToolsRoutes())

--- a/backend/src/posthog/routes.ts
+++ b/backend/src/posthog/routes.ts
@@ -6,7 +6,7 @@ import { Elysia } from 'elysia'
 /**
  * PostHog analytics proxy routes
  */
-export const createPostHogRoutes = () => {
+export const createPostHogRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
   const settings = getSettings()
 
   return new Elysia({
@@ -35,7 +35,7 @@ export const createPostHogRoutes = () => {
         const queryString = buildQueryString(ctx.query)
         const url = `${baseUrl}${queryString}`
 
-        const response = await fetch(url, {
+        const response = await fetchFn(url, {
           method: ctx.request.method,
           headers,
           body: ctx.request.body as BodyInit,

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -5,7 +5,6 @@ import type { LinkPreviewResponse } from './types'
 
 describe('Link Preview Routes', () => {
   let app: Elysia
-  let fetchSpy: ReturnType<typeof spyOn>
   let consoleSpy: ReturnType<typeof spyOn>
   let mockFetch: ReturnType<typeof mock>
 
@@ -25,15 +24,14 @@ describe('Link Preview Routes', () => {
     // Suppress console output during tests
     consoleSpy = spyOn(console, 'error').mockImplementation(() => {})
 
-    // Mock global fetch
+    // Create mock fetch - no global mocking needed
     mockFetch = mock(() => Promise.resolve(createMockHtmlResponse('<html></html>')))
-    fetchSpy = spyOn(global, 'fetch').mockImplementation(mockFetch as any)
 
-    app = new Elysia().use(createLinkPreviewRoutes())
+    // Inject mock fetch into routes
+    app = new Elysia().use(createLinkPreviewRoutes(mockFetch as unknown as typeof fetch))
   })
 
   afterAll(() => {
-    fetchSpy?.mockRestore()
     consoleSpy?.mockRestore()
   })
 

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -24,7 +24,7 @@ describe('Link Preview Routes', () => {
     // Suppress console output during tests
     consoleSpy = spyOn(console, 'error').mockImplementation(() => {})
 
-    // Create mock fetch - no global mocking needed
+    // Create mock fetch
     mockFetch = mock(() => Promise.resolve(createMockHtmlResponse('<html></html>')))
 
     // Inject mock fetch into routes

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -56,7 +56,7 @@ const extractMetadata = (html: string, url: string) => {
  * Link preview routes
  * Fetches and parses Open Graph metadata from URLs
  */
-export const createLinkPreviewRoutes = () => {
+export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
   const settings = getSettings()
 
   return new Elysia({
@@ -110,7 +110,7 @@ export const createLinkPreviewRoutes = () => {
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), 2_000)
 
-        const response = await fetch(targetUrl, {
+        const response = await fetchFn(targetUrl, {
           method: 'GET',
           headers: {
             // Use a realistic user agent to avoid Forbidden errors

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -25,7 +25,7 @@ describe('Proxy Routes', () => {
     // Suppress console output during tests
     consoleSpy = spyOn(console, 'error').mockImplementation(() => {})
 
-    // Create mock fetch - no global mocking needed
+    // Create mock fetch
     mockFetch = mock(() => Promise.resolve(createMockResponse('test content')))
 
     // Inject mock fetch into routes

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -4,7 +4,6 @@ import { createProxyRoutes } from './proxy'
 
 describe('Proxy Routes', () => {
   let app: Elysia
-  let fetchSpy: ReturnType<typeof spyOn>
   let consoleSpy: ReturnType<typeof spyOn>
   let mockFetch: ReturnType<typeof mock>
 
@@ -26,15 +25,14 @@ describe('Proxy Routes', () => {
     // Suppress console output during tests
     consoleSpy = spyOn(console, 'error').mockImplementation(() => {})
 
-    // Mock global fetch
+    // Create mock fetch - no global mocking needed
     mockFetch = mock(() => Promise.resolve(createMockResponse('test content')))
-    fetchSpy = spyOn(global, 'fetch').mockImplementation(mockFetch as any)
 
-    app = new Elysia().use(createProxyRoutes())
+    // Inject mock fetch into routes
+    app = new Elysia().use(createProxyRoutes(mockFetch as unknown as typeof fetch))
   })
 
   afterAll(() => {
-    fetchSpy?.mockRestore()
     consoleSpy?.mockRestore()
   })
 

--- a/backend/src/pro/proxy.ts
+++ b/backend/src/pro/proxy.ts
@@ -6,7 +6,7 @@ import { Elysia } from 'elysia'
  * General-purpose proxy routes
  * Proxies GET requests to external URLs with CORS headers
  */
-export const createProxyRoutes = () => {
+export const createProxyRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
   const settings = getSettings()
 
   return new Elysia({
@@ -61,7 +61,7 @@ export const createProxyRoutes = () => {
 
       try {
         // Make the proxied request
-        const response = await fetch(targetUrl, {
+        const response = await fetchFn(targetUrl, {
           method: 'GET',
           headers: {
             'User-Agent': 'Mozilla/5.0 (compatible; ThunderboltBot/1.0)',

--- a/backend/src/pro/routes.test.ts
+++ b/backend/src/pro/routes.test.ts
@@ -1,8 +1,15 @@
-import { afterAll, beforeAll, describe, expect, it, spyOn } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it, mock, spyOn } from 'bun:test'
 import { createProToolsRoutes } from './routes'
 
 describe('Pro Tools Routes', () => {
   let app: ReturnType<typeof createProToolsRoutes>
+  let mockFetch: ReturnType<typeof mock>
+
+  const createMockWeatherResponse = (body: any = {}) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
 
   beforeAll(async () => {
     // Mock console methods to reduce test noise
@@ -11,7 +18,44 @@ describe('Pro Tools Routes', () => {
     spyOn(console, 'error').mockImplementation(() => {})
     spyOn(console, 'warn').mockImplementation(() => {})
 
-    app = createProToolsRoutes()
+    // Create mock fetch for weather API calls
+    mockFetch = mock((url: string) => {
+      if (url.includes('geocoding-api.open-meteo.com')) {
+        return Promise.resolve(
+          createMockWeatherResponse({
+            results: [
+              {
+                name: 'London',
+                latitude: 51.5074,
+                longitude: -0.1278,
+                admin1: 'England',
+                country: 'United Kingdom',
+                elevation: 11,
+              },
+            ],
+          }),
+        )
+      }
+      if (url.includes('api.open-meteo.com')) {
+        return Promise.resolve(
+          createMockWeatherResponse({
+            current: {
+              temperature_2m: 15,
+              wind_speed_10m: 10,
+              relative_humidity_2m: 70,
+            },
+            daily: {
+              time: ['2025-10-24', '2025-10-25', '2025-10-26'],
+              temperature_2m_max: [18, 19, 17],
+              temperature_2m_min: [12, 13, 11],
+            },
+          }),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+
+    app = createProToolsRoutes(mockFetch as unknown as typeof fetch)
   })
 
   afterAll(async () => {

--- a/backend/src/pro/routes.test.ts
+++ b/backend/src/pro/routes.test.ts
@@ -19,7 +19,8 @@ describe('Pro Tools Routes', () => {
     spyOn(console, 'warn').mockImplementation(() => {})
 
     // Create mock fetch for weather API calls
-    mockFetch = mock((url: string) => {
+    mockFetch = mock((input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : input.toString()
       if (url.includes('geocoding-api.open-meteo.com')) {
         return Promise.resolve(
           createMockWeatherResponse({
@@ -41,13 +42,39 @@ describe('Pro Tools Routes', () => {
           createMockWeatherResponse({
             current: {
               temperature_2m: 15,
-              wind_speed_10m: 10,
               relative_humidity_2m: 70,
+              apparent_temperature: 14,
+              weather_code: 0,
+              wind_speed_10m: 10,
+              wind_direction_10m: 180,
+              time: '2025-10-24T12:00',
+            },
+            current_units: {
+              temperature_2m: '°C',
+              relative_humidity_2m: '%',
+              apparent_temperature: '°C',
+              wind_speed_10m: 'km/h',
+              wind_direction_10m: '°',
             },
             daily: {
               time: ['2025-10-24', '2025-10-25', '2025-10-26'],
+              weather_code: [0, 1, 2],
               temperature_2m_max: [18, 19, 17],
               temperature_2m_min: [12, 13, 11],
+              apparent_temperature_max: [17, 18, 16],
+              apparent_temperature_min: [11, 12, 10],
+              precipitation_sum: [0, 2.5, 5.0],
+              precipitation_probability_max: [10, 60, 80],
+              wind_speed_10m_max: [15, 20, 25],
+            },
+            daily_units: {
+              temperature_2m_max: '°C',
+              temperature_2m_min: '°C',
+              apparent_temperature_max: '°C',
+              apparent_temperature_min: '°C',
+              precipitation_sum: 'mm',
+              precipitation_probability_max: '%',
+              wind_speed_10m_max: 'km/h',
             },
           }),
         )

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -21,13 +21,13 @@ type WeatherPreferences = {
   temperatureUnit?: 'c' | 'f'
 }
 
-// Initialize the tool clients
-const weatherClient = new OpenMeteoWeather()
-
 /**
  * Create pro tools routes
  */
-export const createProToolsRoutes = () => {
+export const createProToolsRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
+  // Initialize the tool clients with injected fetch
+  const weatherClient = new OpenMeteoWeather(fetchFn)
+
   return new Elysia({ prefix: '/pro' })
     .onError(({ code, error, set }) => {
       set.status = code === 'VALIDATION' ? 400 : 500
@@ -38,8 +38,8 @@ export const createProToolsRoutes = () => {
       }
     })
     .use(exaPlugin)
-    .use(createProxyRoutes())
-    .use(createLinkPreviewRoutes())
+    .use(createProxyRoutes(fetchFn))
+    .use(createLinkPreviewRoutes(fetchFn))
 
     .post(
       '/weather/current',

--- a/backend/src/pro/weather.test.ts
+++ b/backend/src/pro/weather.test.ts
@@ -6,7 +6,7 @@ describe('Pro - OpenMeteoWeather', () => {
   let mockFetch: ReturnType<typeof mock>
 
   beforeEach(() => {
-    // Create mock fetch - no global mocking needed
+    // Create mock fetch
     mockFetch = mock(() => Promise.resolve(new Response()))
     weather = new OpenMeteoWeather(mockFetch as unknown as typeof fetch)
   })

--- a/backend/src/pro/weather.test.ts
+++ b/backend/src/pro/weather.test.ts
@@ -1,15 +1,14 @@
-import { beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import { OpenMeteoWeather } from './weather'
-
-// Mock fetch globally
-const mockFetch = spyOn(globalThis, 'fetch')
 
 describe('Pro - OpenMeteoWeather', () => {
   let weather: OpenMeteoWeather
+  let mockFetch: ReturnType<typeof mock>
 
   beforeEach(() => {
-    weather = new OpenMeteoWeather()
-    mockFetch.mockReset()
+    // Create mock fetch - no global mocking needed
+    mockFetch = mock(() => Promise.resolve(new Response()))
+    weather = new OpenMeteoWeather(mockFetch as unknown as typeof fetch)
   })
 
   describe('searchLocations', () => {

--- a/backend/src/pro/weather.ts
+++ b/backend/src/pro/weather.ts
@@ -33,6 +33,11 @@ interface Location {
 export class OpenMeteoWeather {
   private readonly geocodingUrl = 'https://geocoding-api.open-meteo.com/v1/search'
   private readonly weatherUrl = 'https://api.open-meteo.com/v1/forecast'
+  private readonly fetchFn: typeof fetch
+
+  constructor(fetchFn: typeof fetch = globalThis.fetch) {
+    this.fetchFn = fetchFn
+  }
 
   /**
    * Convert user preferences to Open-Meteo API parameters
@@ -110,7 +115,7 @@ export class OpenMeteoWeather {
     url.searchParams.set('language', 'en')
     url.searchParams.set('format', 'json')
 
-    const response = await fetch(url.toString())
+    const response = await this.fetchFn(url.toString())
 
     if (!response.ok) {
       throw new Error(`Geocoding API error: ${response.status}`)
@@ -153,7 +158,7 @@ export class OpenMeteoWeather {
     const localizationParams = this.getUserLocalizationParams(userPreferences)
     this.applyLocalizationParams(url, localizationParams)
 
-    const response = await fetch(url.toString())
+    const response = await this.fetchFn(url.toString())
 
     if (!response.ok) {
       throw new Error(`Weather API error: ${response.status}`)
@@ -229,7 +234,7 @@ export class OpenMeteoWeather {
       // Determine temperature unit based on what was requested
       const temperatureUnit: 'c' | 'f' = localizationParams.temperatureUnit === 'fahrenheit' ? 'f' : 'c'
 
-      const response = await fetch(url.toString())
+      const response = await this.fetchFn(url.toString())
 
       if (!response.ok) {
         throw new Error(`Weather API error: ${response.status}`)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Injects a configurable fetch into backend routes/services and updates tests to use injected mocks for deterministic network behavior.
> 
> - **Core**
>   - `createApp` accepts optional `fetchFn` and propagates to route factories (`main`, `auth`, `pro`, `posthog`).
> - **API**
>   - `createMainRoutes(fetchFn)` uses injected `fetchFn` for `/locations` geocoding.
> - **Auth**
>   - `createGoogleAuthRoutes(fetchFn)` and `createMicrosoftAuthRoutes(fetchFn)` use injected `fetchFn` for token exchanges/refresh.
> - **Pro Tools**
>   - `createProToolsRoutes(fetchFn)` passes `fetchFn` to sub-routes and initializes `OpenMeteoWeather(fetchFn)`.
>   - `createProxyRoutes(fetchFn)` and `createLinkPreviewRoutes(fetchFn)` use injected `fetchFn`.
>   - `OpenMeteoWeather` class now accepts `fetchFn` and uses it for geocoding/forecast calls.
> - **PostHog**
>   - `createPostHogRoutes(fetchFn)` proxies via injected `fetchFn`.
> - **Tests**
>   - Switch from spying on global `fetch` to using Bun `mock` and passing injected `fetchFn` into apps/routes.
>   - Add targeted mock responses for OAuth, weather, geocoding, proxy, and link-preview.
>   - Minor typing improvement: use `satisfies Settings` in settings mock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03c62b9fcfa3a0c4d3627044b95304b1e14b1a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->