### PR TITLE
fix: set mobile sidebar overlay background

### DIFF
--- a/src/components/ui/mobile-sidebar.tsx
+++ b/src/components/ui/mobile-sidebar.tsx
@@ -111,7 +111,7 @@ export const MobileSidebar = ({
       <DialogPrimitive.Portal>
         {/* Animated overlay */}
         <motion.div
-          className="fixed inset-0 z-50 bg-black"
+          className="fixed inset-0 z-50 bg-sidebar"
           style={{
             opacity: overlayOpacity,
             // willChange hints to browser this property will animate, enabling GPU acceleration


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Change overlay class from `bg-black` to `bg-sidebar` in `src/components/ui/mobile-sidebar.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0411d0114867b7af0f13c70f6f0dc9b1d81ed8c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->