### PR TITLE
fix(THU-135): fix backend CORS regex

### DIFF
--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -27,7 +27,9 @@ const settingsSchema = z.object({
 
   // CORS settings
   corsOrigins: z.string().default('http://localhost:1420'),
-  corsOriginRegex: z.string().default('^(tauri:\/\/localhost|http:\/\/localhost:\d+)$'),
+  corsOriginRegex: z
+    .string()
+    .default('^(tauri://localhost|http://tauri\\.localhost|http://localhost:\\d+|null|file://.*)$'),
   corsAllowCredentials: z.boolean().default(true),
   corsAllowMethods: z.string().default('GET,POST,PUT,DELETE,PATCH,OPTIONS'),
   corsAllowHeaders: z
@@ -57,7 +59,9 @@ const parseSettings = (): Settings => {
     posthogHost: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
     posthogApiKey: process.env.POSTHOG_API_KEY || '',
     corsOrigins: process.env.CORS_ORIGINS || 'http://localhost:1420',
-    corsOriginRegex: process.env.CORS_ORIGIN_REGEX || '',
+    corsOriginRegex:
+      process.env.CORS_ORIGIN_REGEX ||
+      '^(tauri://localhost|http://tauri\\.localhost|http://localhost:\\d+|null|file://.*)$',
     corsAllowCredentials: process.env.CORS_ALLOW_CREDENTIALS !== 'false',
     corsAllowMethods: process.env.CORS_ALLOW_METHODS || 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -41,7 +41,6 @@ const createApp = async (fetchFn: typeof fetch = globalThis.fetch) => {
 
   return (
     configuredApp
-      .use(createLoggerMiddleware(settings))
       .use(
         cors({
           origin: settings.corsOriginRegex ? new RegExp(settings.corsOriginRegex) : getCorsOriginsList(settings),
@@ -51,6 +50,7 @@ const createApp = async (fetchFn: typeof fetch = globalThis.fetch) => {
           exposeHeaders: settings.corsExposeHeaders,
         }),
       )
+      .use(createLoggerMiddleware(settings))
       .use(createHttpLoggingMiddleware())
       .use(createErrorHandlingMiddleware())
       // Mount route groups

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -41,6 +41,7 @@ const createApp = async (fetchFn: typeof fetch = globalThis.fetch) => {
 
   return (
     configuredApp
+      .use(createLoggerMiddleware(settings))
       .use(
         cors({
           origin: settings.corsOriginRegex ? new RegExp(settings.corsOriginRegex) : getCorsOriginsList(settings),
@@ -50,7 +51,6 @@ const createApp = async (fetchFn: typeof fetch = globalThis.fetch) => {
           exposeHeaders: settings.corsExposeHeaders,
         }),
       )
-      .use(createLoggerMiddleware(settings))
       .use(createHttpLoggingMiddleware())
       .use(createErrorHandlingMiddleware())
       // Mount route groups


### PR DESCRIPTION
Requests were blocked by CORS on Android mobile WebViews, causing "Access-Control-Allow-Origin" errors.

## Root Cause

- Backend server only listened on localhost (not accessible from mobile devices) - I had to force the server in my local to 0.0.0.0.
- CORS regex didn't include mobile Tauri origins (http://tauri.localhost)

## Solution

- Configure server to listen on 0.0.0.0 to accept mobile device connections (for local development only)
- Update CORS regex to include mobile Tauri origins: tauri://localhost, http://tauri.localhost, null, and file:// schemes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand default CORS origin regex and its env fallback to include Tauri, file, and null origins.
> 
> - **Backend config (`backend/src/config/settings.ts`)**:
>   - Expand default `corsOriginRegex` to allow `tauri://localhost`, `http://tauri.localhost`, `http://localhost:\d+`, `null`, and `file://.*`.
>   - Align env fallback for `CORS_ORIGIN_REGEX` with the new default pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2070f2e33d23ea06982152324a9633257a35dd8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->