### PR TITLE
THU-102: Fix excessive modal scrolling on mobile

### DIFF
--- a/src/components/ui/responsive-modal.tsx
+++ b/src/components/ui/responsive-modal.tsx
@@ -78,7 +78,7 @@ const ResponsiveModalContent = forwardRef<ElementRef<typeof DialogPrimitive.Cont
             // Keep the sheet inside the visible viewport when raised.
             maxHeight: 'calc(80dvh - var(--kb, 0px))',
             // Ensure content isn’t hidden behind the iOS home indicator notch.
-            paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + var(--kb, 0px))',
+            paddingBottom: 'env(safe-area-inset-bottom, 0px)',
           }
         : undefined
 


### PR DESCRIPTION
## Preview

https://github.com/user-attachments/assets/6e1641eb-503e-4a35-bdae-908bd9178fb9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `ResponsiveModalContent` bottom-sheet `paddingBottom` to use only `env(safe-area-inset-bottom)` (removes `var(--kb)` offset).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1087a81bb018689a68df02d028652619b1348652. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->