### PR TITLE
THU-152: Server should tell us why it doesn't start

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -141,13 +141,12 @@ const startServer = async () => {
     const errorMessage = error instanceof Error ? error.message : String(error)
     const errorStack = error instanceof Error ? error.stack : undefined
 
-    console.error('\n❌ Server startup failed:')
-    console.error(errorMessage)
-    if (errorStack && process.env.NODE_ENV !== 'production') {
-      console.error('\nStack trace:')
-      console.error(errorStack)
+    const output = ['\n❌ Server startup failed:', errorMessage]
+    if (errorStack) {
+      output.push('\nStack trace:', errorStack)
     }
 
+    console.error(output.join('\n'))
     process.exit(1)
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -94,8 +94,8 @@ const startServer = async () => {
 
     await withServerListen(
       () =>
-        new Promise<void>((resolve) => {
-          app.listen(
+        new Promise<void>((resolve, reject) => {
+          const server = app.listen(
             {
               hostname,
               port: settings.port,
@@ -122,6 +122,10 @@ const startServer = async () => {
               resolve()
             },
           )
+
+          server.on('error', (error) => {
+            reject(error)
+          })
         }),
       settings.port,
       hostname,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import { createHttpLoggingMiddleware } from '@/middleware/http-logging'
 import { createOpenAIRoutes } from '@/openai/routes'
 import { createPostHogRoutes } from '@/posthog/routes'
 import { createProToolsRoutes } from '@/pro/routes'
+import { withAppCreation, withServerListen, withSettingsValidation } from '@/utils/startup-errors'
 import { cors } from '@elysiajs/cors'
 import { Elysia } from 'elysia'
 
@@ -67,7 +68,7 @@ const createApp = async (fetchFn: typeof fetch = globalThis.fetch) => {
  * Start the server
  */
 const startServer = async () => {
-  const settings = getSettings()
+  const settings = withSettingsValidation(() => getSettings())
   const log = createStandaloneLogger(settings)
 
   // Set up logging
@@ -83,7 +84,7 @@ const startServer = async () => {
   )
 
   try {
-    const app = await createApp()
+    const app = await withAppCreation(() => createApp())
 
     const hostname = process.env.HOST
       ? process.env.HOST
@@ -91,31 +92,39 @@ const startServer = async () => {
         ? '0.0.0.0'
         : 'localhost'
 
-    app.listen(
-      {
-        hostname,
-        port: settings.port,
-        reusePort: process.env.NODE_ENV === 'production',
-      },
-      () => {
-        log.info(
-          {
-            hostname,
-            port: settings.port,
-            url: `http://localhost:${settings.port}/v1`,
-          },
-          '🦊 Elysia server started',
-        )
-
-        if (process.env.NODE_ENV !== 'production') {
-          log.info(
+    await withServerListen(
+      () =>
+        new Promise<void>((resolve) => {
+          app.listen(
             {
-              swaggerUrl: `http://localhost:${settings.port}/v1/swagger`,
+              hostname,
+              port: settings.port,
+              reusePort: process.env.NODE_ENV === 'production',
             },
-            '📚 Swagger documentation available',
+            () => {
+              log.info(
+                {
+                  hostname,
+                  port: settings.port,
+                  url: `http://localhost:${settings.port}/v1`,
+                },
+                '🦊 Elysia server started',
+              )
+
+              if (process.env.NODE_ENV !== 'production') {
+                log.info(
+                  {
+                    swaggerUrl: `http://localhost:${settings.port}/v1/swagger`,
+                  },
+                  '📚 Swagger documentation available',
+                )
+              }
+              resolve()
+            },
           )
-        }
-      },
+        }),
+      settings.port,
+      hostname,
     )
 
     // Graceful shutdown
@@ -129,7 +138,16 @@ const startServer = async () => {
       process.exit(0)
     })
   } catch (error) {
-    log.error({ error }, 'Failed to start server')
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorStack = error instanceof Error ? error.stack : undefined
+
+    console.error('\n❌ Server startup failed:')
+    console.error(errorMessage)
+    if (errorStack && process.env.NODE_ENV !== 'production') {
+      console.error('\nStack trace:')
+      console.error(errorStack)
+    }
+
     process.exit(1)
   }
 }

--- a/backend/src/utils/startup-errors.ts
+++ b/backend/src/utils/startup-errors.ts
@@ -1,0 +1,95 @@
+import { ZodError } from 'zod'
+
+/**
+ * Enhanced error type for startup failures
+ */
+class StartupError extends Error {
+  constructor(
+    message: string,
+    public readonly context: string,
+    public readonly originalError?: unknown,
+  ) {
+    super(message)
+    this.name = 'StartupError'
+  }
+}
+
+/**
+ * Format Zod validation errors into readable messages
+ */
+const formatZodError = (error: ZodError): string => {
+  const issues = error.issues.map((issue) => {
+    const path = issue.path.join('.')
+    return `  - ${path}: ${issue.message}`
+  })
+  return `\n${issues.join('\n')}`
+}
+
+/**
+ * Wraps settings validation with enhanced error context
+ */
+export const withSettingsValidation = <T>(fn: () => T): T => {
+  try {
+    return fn()
+  } catch (error) {
+    if (error instanceof ZodError) {
+      throw new StartupError(`Failed to validate server settings${formatZodError(error)}`, 'settings_validation', error)
+    }
+
+    throw new StartupError(
+      `Failed to load server settings: ${error instanceof Error ? error.message : String(error)}`,
+      'settings_validation',
+      error,
+    )
+  }
+}
+
+/**
+ * Wraps app creation with enhanced error context
+ */
+export const withAppCreation = async <T>(fn: () => Promise<T>): Promise<T> => {
+  try {
+    return await fn()
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    throw new StartupError(`Failed to initialize application: ${errorMessage}`, 'app_creation', error)
+  }
+}
+
+/**
+ * Generate a helpful error message for server listen failures
+ */
+const getServerListenErrorMessage = (error: unknown, hostname: string, port: number): string => {
+  if (!(error instanceof Error)) {
+    return `Failed to start server on ${hostname}:${port}: ${String(error)}`
+  }
+
+  const baseMessage = `Failed to start server on ${hostname}:${port}`
+  const errorMsg = error.message.toLowerCase()
+
+  if (errorMsg.includes('eaddrinuse') || errorMsg.includes('address already in use')) {
+    return `${baseMessage}: Port ${port} is already in use. Check if another instance is running or change the PORT environment variable.`
+  }
+
+  if (errorMsg.includes('eacces') || errorMsg.includes('permission denied')) {
+    return `${baseMessage}: Permission denied. Try using a port number above 1024 or run with appropriate permissions.`
+  }
+
+  if (errorMsg.includes('eaddrnotavail')) {
+    return `${baseMessage}: Address not available. Check if the hostname '${hostname}' is valid.`
+  }
+
+  return `${baseMessage}: ${error.message}`
+}
+
+/**
+ * Wraps server listen with enhanced error context
+ */
+export const withServerListen = async <T>(fn: () => Promise<T>, port: number, hostname: string): Promise<T> => {
+  try {
+    return await fn()
+  } catch (error) {
+    const message = getServerListenErrorMessage(error, hostname, port)
+    throw new StartupError(message, 'server_listen', error)
+  }
+}

--- a/backend/src/utils/startup-errors.ts
+++ b/backend/src/utils/startup-errors.ts
@@ -6,12 +6,18 @@ import { ZodError } from 'zod'
 class StartupError extends Error {
   constructor(
     message: string,
-    public readonly context: string,
     public readonly originalError?: unknown,
   ) {
     super(message)
     this.name = 'StartupError'
   }
+}
+
+/**
+ * Extract error message from unknown error type
+ */
+const getErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.message : String(error)
 }
 
 /**
@@ -33,14 +39,10 @@ export const withSettingsValidation = <T>(fn: () => T): T => {
     return fn()
   } catch (error) {
     if (error instanceof ZodError) {
-      throw new StartupError(`Failed to validate server settings${formatZodError(error)}`, 'settings_validation', error)
+      throw new StartupError(`Failed to validate server settings${formatZodError(error)}`, error)
     }
 
-    throw new StartupError(
-      `Failed to load server settings: ${error instanceof Error ? error.message : String(error)}`,
-      'settings_validation',
-      error,
-    )
+    throw new StartupError(`Failed to load server settings: ${getErrorMessage(error)}`, error)
   }
 }
 
@@ -51,8 +53,7 @@ export const withAppCreation = async <T>(fn: () => Promise<T>): Promise<T> => {
   try {
     return await fn()
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    throw new StartupError(`Failed to initialize application: ${errorMessage}`, 'app_creation', error)
+    throw new StartupError(`Failed to initialize application: ${getErrorMessage(error)}`, error)
   }
 }
 
@@ -89,7 +90,6 @@ export const withServerListen = async <T>(fn: () => Promise<T>, port: number, ho
   try {
     return await fn()
   } catch (error) {
-    const message = getServerListenErrorMessage(error, hostname, port)
-    throw new StartupError(message, 'server_listen', error)
+    throw new StartupError(getServerListenErrorMessage(error, hostname, port), error)
   }
 }


### PR DESCRIPTION
Added robust layer to catch possible errors during initialization and make them human-readable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces centralized startup error wrappers and detailed messaging, and integrates them into server settings, app creation, and listen flow.
> 
> - **Server startup reliability**:
>   - **New utilities** in `backend/src/utils/startup-errors.ts`:
>     - `StartupError` class; `withSettingsValidation`, `withAppCreation`, `withServerListen` wrappers.
>     - Formats `ZodError` issues and maps common listen errors (e.g., `EADDRINUSE`, `EACCES`, `EADDRNOTAVAIL`) to actionable messages.
>   - **Integration** in `backend/src/index.ts`:
>     - Wrap `getSettings`, `createApp`, and server `listen` with the new helpers.
>     - Convert `listen` to a Promise with explicit error handling via `server.on('error')`.
>     - On failure, print concise message plus optional stack and exit with non-zero code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1cc2027f668e97ed54a0044985b226be05dcce4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->