### PR TITLE
THU-137: Prevent migration file misery

### DIFF
--- a/src/db/bundle-migrations.ts
+++ b/src/db/bundle-migrations.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs'
 import { dirname, join } from 'path'
+import prettier from 'prettier'
 
 interface Migration {
   hash: string
@@ -90,8 +91,20 @@ export const migrations: Migration[] = [
 ];
 `
 
-  // Write the output file
-  writeFileSync(OUTPUT_FILE, fileContent)
+  try {
+    // Load Prettier config if available
+    const prettierConfig = (await prettier.resolveConfig(OUTPUT_FILE)) ?? {}
+    const formatted = await prettier.format(fileContent, {
+      ...prettierConfig,
+      filepath: OUTPUT_FILE, // ensures correct parser detection
+    })
+
+    writeFileSync(OUTPUT_FILE, formatted)
+  } catch (err) {
+    // Fallback: write unformatted content if Prettier fails
+    writeFileSync(OUTPUT_FILE, fileContent)
+    console.warn('⚠️ Failed to format _migrations.ts with Prettier:', err)
+  }
 
   if (!silent) {
     console.log(`Generated ${OUTPUT_FILE} with ${migrations.length} migrations`)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Formats the generated migrations TypeScript file with Prettier, with a safe fallback if formatting fails.
> 
> - **Build tooling**:
>   - Format generated `src/drizzle/_migrations.ts` via Prettier in `src/db/bundle-migrations.ts`, resolving project config and writing the formatted output.
>   - Add fallback to write unformatted content on Prettier errors with a console warning.
>   - Import `prettier` and update write logic accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b581528149dacddd84cab1b4e6c3763d8664655f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->