### PR TITLE
THU-163: Change "Used x tools in y s" to "Completed x steps in y s" (and include each reasoning as a step in the count)

### DIFF
--- a/src/components/chat/reasoning-group-title.tsx
+++ b/src/components/chat/reasoning-group-title.tsx
@@ -66,7 +66,7 @@ export const ReasoningGroupTitle = ({ totalDuration, isThinking, tools }: Reason
             className="w-full"
           >
             {tools.length > 0
-              ? `Used ${tools.length} tools in ${formatDuration(totalDuration)}`
+              ? `Completed ${tools.length} steps in ${formatDuration(totalDuration)}`
               : `Thought for ${formatDuration(totalDuration)}`}
           </motion.div>
         )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the final summary text to "Completed N steps in {duration}" in ReasoningGroupTitle.
> 
> - **UI copy**:
>   - Update `src/components/chat/reasoning-group-title.tsx` to show `Completed {tools.length} steps in {formatDuration(totalDuration)}` instead of `Used {tools.length} tools in ...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec979922e93b4b9fb43c0b0adc2b069971a5c123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->