### PR TITLE
THU-164: raivieiraadriano92/thu-164-dont-show-the-scroll-bar-in-the-reasoning-area-or-chat-area

### DIFF
--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -51,7 +51,7 @@ export default function ChatUI() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="flex-1 p-4 overflow-y-auto space-y-4 max-w-dvw hide-scrollbar"
+              className="flex-1 p-4 space-y-4 max-w-dvw hide-scrollbar"
             >
               <ChatMessages />
               <div ref={scrollTargetRef} />

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -51,7 +51,7 @@ export default function ChatUI() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="flex-1 p-4 overflow-y-auto space-y-4 max-w-dvw"
+              className="flex-1 p-4 overflow-y-auto space-y-4 max-w-dvw hide-scrollbar"
             >
               <ChatMessages />
               <div ref={scrollTargetRef} />

--- a/src/components/chat/reasoning-display.tsx
+++ b/src/components/chat/reasoning-display.tsx
@@ -100,7 +100,7 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
           }}
         >
           <div className="absolute top-0 w-full h-6 bg-gradient-to-b from-background to-transparent" />
-          <div className="max-h-[200px] overflow-y-auto px-4 hide-scrollbar py-3">
+          <div className="max-h-[200px] px-4 hide-scrollbar py-3">
             {displayText}
             <div ref={scrollTargetRef} />
           </div>

--- a/src/components/chat/reasoning-display.tsx
+++ b/src/components/chat/reasoning-display.tsx
@@ -100,7 +100,7 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
           }}
         >
           <div className="absolute top-0 w-full h-6 bg-gradient-to-b from-background to-transparent" />
-          <div className="max-h-[200px] overflow-y-auto px-4  py-3">
+          <div className="max-h-[200px] overflow-y-auto px-4 hide-scrollbar py-3">
             {displayText}
             <div ref={scrollTargetRef} />
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -199,7 +199,7 @@ body {
 .hide-scrollbar {
   -ms-overflow-style: none; /* For Internet Explorer and Edge */
   scrollbar-width: none; /* For Firefox */
-  overflow-y: scroll; /* or overflow: auto; to only show scrollbar when needed */
+  overflow-y: auto; /* or overflow: auto; to only show scrollbar when needed */
 }
 
 /* For Chrome, Safari, and Opera */

--- a/src/index.css
+++ b/src/index.css
@@ -195,3 +195,14 @@ body {
     transform: translateX(100%); /* Move across to the right */
   }
 }
+
+.hide-scrollbar {
+  -ms-overflow-style: none; /* For Internet Explorer and Edge */
+  scrollbar-width: none; /* For Firefox */
+  overflow-y: scroll; /* or overflow: auto; to only show scrollbar when needed */
+}
+
+/* For Chrome, Safari, and Opera */
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Hides scrollbars in chat and reasoning areas while retaining scroll behavior via a new `hide-scrollbar` utility.
> 
> - **UI**:
>   - `src/components/chat/chat-ui.tsx`: Replace `overflow-y-auto` with `hide-scrollbar` on the scrollable chat container.
>   - `src/components/chat/reasoning-display.tsx`: Apply `hide-scrollbar` to the reasoning content container.
> - **CSS**:
>   - `src/index.css`: Add cross-browser `hide-scrollbar` utility and WebKit scrollbar rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8e0923727ac57b54a2a0e58ccf2faba0e0a7050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->