### PR TITLE
THU-161: Change the tool title, loading spinner, and green check to all be gray

### DIFF
--- a/src/components/chat/reasoning-group-title.tsx
+++ b/src/components/chat/reasoning-group-title.tsx
@@ -45,7 +45,7 @@ export const ReasoningGroupTitle = ({ totalDuration, isThinking, tools }: Reason
                 }}
                 className={cn('w-full', !isActive && 'pointer-events-none absolute inset-0')}
               >
-                <span className="text-xs text-blue-600 dark:text-blue-400 italic animate-pulse truncate min-w-0">
+                <span className="text-xs text-muted-foreground italic animate-pulse truncate min-w-0">
                   {metadata.loadingMessage}
                 </span>
               </motion.div>

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -50,9 +50,9 @@ export const ReasoningGroup = ({ parts, isStreaming, isLastPartInMessage, hasTex
         className="shadow-none tool-invocation-card rounded-lg overflow-hidden transition-colors"
         icon={
           isThinking ? (
-            <Loader2 className={`h-4 w-4 animate-spin text-blue-600 dark:text-blue-400`} />
+            <Loader2 className={`h-4 w-4 animate-spin text-muted-foreground`} />
           ) : (
-            <CheckIcon className="h-4 w-4 text-green-600 dark:text-green-400" />
+            <CheckIcon className="h-4 w-4 text-muted-foreground" />
           )
         }
         defaultOpen={false}

--- a/src/components/chat/reasoning-item.tsx
+++ b/src/components/chat/reasoning-item.tsx
@@ -58,7 +58,7 @@ export const ReasoningItem = ({ part }: ReasoningItemProps) => {
     >
       <div className="flex gap-3 flex-row flex-1 items-center">
         {itemData.isLoading ? (
-          <Loader2 className={`h-4 w-4 animate-spin text-blue-600 dark:text-blue-400`} />
+          <Loader2 className={`h-4 w-4 animate-spin text-muted-foreground`} />
         ) : (
           !!Icon && <Icon className="h-4 w-4 text-muted-foreground" />
         )}

--- a/src/components/chat/reasoning-part.tsx
+++ b/src/components/chat/reasoning-part.tsx
@@ -15,9 +15,9 @@ export const ReasoningPart = ({ part }: ReasoningPartProps) => {
       className="shadow-none"
       icon={
         state === 'streaming' ? (
-          <Loader2 className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400" data-testid="reasoning-loading" />
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" data-testid="reasoning-loading" />
         ) : (
-          <Check className="h-4 w-4 text-green-600 dark:text-green-400" data-testid="reasoning-completed" />
+          <Check className="h-4 w-4 text-muted-foreground" data-testid="reasoning-completed" />
         )
       }
       defaultOpen={false}

--- a/src/components/chat/synthetic-loading-part.tsx
+++ b/src/components/chat/synthetic-loading-part.tsx
@@ -19,7 +19,7 @@ export const SyntheticLoadingPart = ({ message = '', isStreaming }: SyntheticLoa
     <Expandable
       title={titleNode}
       defaultOpen={false}
-      icon={<Loader2 className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400" />}
+      icon={<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
       className="shadow-none pointer-events-none mt-6" // Prevent clicking while loading
     >
       {null}


### PR DESCRIPTION
…e gray

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch loading spinners, check icons, and loading/title text in reasoning components to muted gray.
> 
> - **Chat Reasoning UI**
>   - Replace blue loading spinners and green check icons with `text-muted-foreground` in:
>     - `src/components/chat/reasoning-group.tsx` (group icon states)
>     - `src/components/chat/reasoning-item.tsx` (item loading icon)
>     - `src/components/chat/reasoning-part.tsx` (reasoning state icons)
>     - `src/components/chat/synthetic-loading-part.tsx` (synthetic loading icon)
>   - Adjust loading message color in `src/components/chat/reasoning-group-title.tsx` to `text-muted-foreground`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41607d729b842be6e2261a15722cfb41fa03f7a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->