### PR TITLE
Fix lint, commit and push

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,6 +77,7 @@ export default [
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       'prefer-const': 'error',
       'no-async-promise-executor': 'off',
+      'no-undef': 'off', // TypeScript handles this
       // Prevent importing React as default
       'no-restricted-imports': [
         'error',


### PR DESCRIPTION
Disable ESLint's `no-undef` rule because TypeScript's compiler handles these checks natively.

The `no-undef` rule was causing false positives for built-in TypeScript DOM types (`EventListenerOrEventListenerObject`, `AddEventListenerOptions`). Disabling it aligns with standard TypeScript + ESLint practices where the TypeScript compiler is responsible for type checking.

---
<a href="https://cursor.com/background-agent?bcId=bc-faa2a38b-7e57-45f5-a101-d3d5900a91f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-faa2a38b-7e57-45f5-a101-d3d5900a91f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

