### PR TITLE
feat: adding config files for app/universal links

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,12 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "BUMSKVQ3D9.net.thunderbird.thunderbolt",
+        "paths": ["/oauth/callback"]
+      }
+    ]
+  }
+}
+

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "net.thunderbird.thunderbolt",
+      "sha256_cert_fingerprints": [
+        "D1CC035D74C72F973E7BAE97C4B1D14ACEBA9F3B9F8F071652AD1023651EE236",
+        "D68EC4CD93FAC771490F3DF212CFF7721AF5D2CC81E52AE5C184C8983A1190C7"
+      ]
+    }
+  }
+]
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,9 +51,17 @@ export default defineConfig({
     {
       name: 'configure-response-headers',
       configureServer: (server) => {
-        server.middlewares.use((_req, res, next) => {
+        server.middlewares.use((req, res, next) => {
           res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
           res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+
+          // Set correct Content-Type for .well-known files (required for Universal Links / App Links)
+          if (req.url === '/.well-known/apple-app-site-association') {
+            res.setHeader('Content-Type', 'application/json')
+          } else if (req.url === '/.well-known/assetlinks.json') {
+            res.setHeader('Content-Type', 'application/json')
+          }
+
           next()
         })
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,9 +56,11 @@ export default defineConfig({
           res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
 
           // Set correct Content-Type for .well-known files (required for Universal Links / App Links)
-          if (req.url === '/.well-known/apple-app-site-association') {
+          // Parse pathname to ignore query parameters
+          const pathname = req.url?.split('?')[0]
+          if (pathname === '/.well-known/apple-app-site-association') {
             res.setHeader('Content-Type', 'application/json')
-          } else if (req.url === '/.well-known/assetlinks.json') {
+          } else if (pathname === '/.well-known/assetlinks.json') {
             res.setHeader('Content-Type', 'application/json')
           }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Apple AASA and Android Asset Links files and updates Vite dev middleware to serve them as application/json.
> 
> - **Links configuration**:
>   - Add `public/.well-known/apple-app-site-association` for iOS Universal Links (`appID` and `/oauth/callback`).
>   - Add `public/.well-known/assetlinks.json` for Android App Links (package and SHA-256 fingerprints).
> - **Dev server (Vite) middleware**:
>   - Set `Content-Type: application/json` for `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json` (parses pathname to ignore query).
>   - Retains `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e73345ac902aadf285efc013f55d13c002f75a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->