### PR TITLE
THU-140: Add Content-Type headers for .well-known files

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,12 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "BUMSKVQ3D9.net.thunderbird.thunderbolt",
+        "paths": ["/oauth/callback"]
+      }
+    ]
+  }
+}
+

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "net.thunderbird.thunderbolt",
+      "sha256_cert_fingerprints": [
+        "D1CC035D74C72F973E7BAE97C4B1D14ACEBA9F3B9F8F071652AD1023651EE236",
+        "D68EC4CD93FAC771490F3DF212CFF7721AF5D2CC81E52AE5C184C8983A1190C7"
+      ]
+    }
+  }
+]
+

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,6 @@
+/.well-known/apple-app-site-association
+  Content-Type: application/json
+
+/.well-known/assetlinks.json
+  Content-Type: application/json
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,16 +54,6 @@ export default defineConfig({
         server.middlewares.use((req, res, next) => {
           res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
           res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
-
-          // Set correct Content-Type for .well-known files (required for Universal Links / App Links)
-          // Parse pathname to ignore query parameters
-          const pathname = req.url?.split('?')[0]
-          if (pathname === '/.well-known/apple-app-site-association') {
-            res.setHeader('Content-Type', 'application/json')
-          } else if (pathname === '/.well-known/assetlinks.json') {
-            res.setHeader('Content-Type', 'application/json')
-          }
-
           next()
         })
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,9 +51,17 @@ export default defineConfig({
     {
       name: 'configure-response-headers',
       configureServer: (server) => {
-        server.middlewares.use((_req, res, next) => {
+        server.middlewares.use((req, res, next) => {
           res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
           res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+
+          // Set correct Content-Type for .well-known files (required for Universal Links / App Links)
+          if (req.url === '/.well-known/apple-app-site-association') {
+            res.setHeader('Content-Type', 'application/json')
+          } else if (req.url === '/.well-known/assetlinks.json') {
+            res.setHeader('Content-Type', 'application/json')
+          }
+
           next()
         })
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,9 +56,11 @@ export default defineConfig({
           res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
 
           // Set correct Content-Type for .well-known files (required for Universal Links / App Links)
-          if (req.url === '/.well-known/apple-app-site-association') {
+          // Parse pathname to ignore query parameters
+          const pathname = req.url?.split('?')[0]
+          if (pathname === '/.well-known/apple-app-site-association') {
             res.setHeader('Content-Type', 'application/json')
-          } else if (req.url === '/.well-known/assetlinks.json') {
+          } else if (pathname === '/.well-known/assetlinks.json') {
             res.setHeader('Content-Type', 'application/json')
           }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `.well-known` Apple/Android app-linking files and set JSON Content-Type headers; minor dev-server middleware tweak.
> 
> - **Public assets / app linking**:
>   - Add `public/.well-known/apple-app-site-association` with `applinks` for `net.thunderbird.thunderbolt` (`/oauth/callback`).
>   - Add `public/.well-known/assetlinks.json` for Android app `net.thunderbird.thunderbolt` with SHA-256 fingerprints.
>   - Configure `public/_headers` to serve both files with `Content-Type: application/json`.
> - **Dev server**:
>   - Update Vite middleware to accept `req` parameter in `vite.config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de40b918badf92cd27576b613ff1ddeef8a68858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->