### PR TITLE
THU-140: Fix Google/Microsoft login on mobile - Universal Link approach

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",
@@ -39,6 +38,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/react-query": "^5.85.5",
         "@tauri-apps/api": "^2.9.0",
+        "@tauri-apps/plugin-deep-link": "^2.4.5",
         "@tauri-apps/plugin-fs": "^2.4.4",
         "@tauri-apps/plugin-http": "^2.5.4",
         "@tauri-apps/plugin-opener": "^2.5.2",
@@ -631,6 +631,8 @@
     "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.9.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-fSATtJDc0fNjVB6ystyi8NbwhNFk8i8E05h6KrsC8Fio5eaJIJvPCbC9pdrPl6kkxN1X7fj25ErBbgfqgcK8Fg=="],
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.9.1", "", { "os": "win32", "cpu": "x64" }, "sha512-/JHlOzpUDhjBOO9w167bcYxfJbcMQv7ykS/Y07xjtcga8np0rzUzVGWYmLMH7orKcDMC7wjhheEW1x8cbGma/Q=="],
+
+    "@tauri-apps/plugin-deep-link": ["@tauri-apps/plugin-deep-link@2.4.5", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zf2RTj1D9IQQ45/jqW8XTKvql24HqlPjcpv0mV/O2jHQkNe11HOTZBVj6IK37qs+MWV7xZzcmazx/QVZnhAwaQ=="],
 
     "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.4.4", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-MTorXxIRmOnOPT1jZ3w96vjSuScER38ryXY88vl5F0uiKdnvTKKTtaEjTEo8uPbl4e3gnUtfsDVwC7h77GQLvQ=="],
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query": "^5.85.5",
     "@tauri-apps/api": "^2.9.0",
+    "@tauri-apps/plugin-deep-link": "^2.4.5",
     "@tauri-apps/plugin-fs": "^2.4.4",
     "@tauri-apps/plugin-http": "^2.5.4",
     "@tauri-apps/plugin-opener": "^2.5.2",

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -5,8 +5,8 @@
       "namespace": "android_app",
       "package_name": "net.thunderbird.thunderbolt",
       "sha256_cert_fingerprints": [
-        "D1CC035D74C72F973E7BAE97C4B1D14ACEBA9F3B9F8F071652AD1023651EE236",
-        "D68EC4CD93FAC771490F3DF212CFF7721AF5D2CC81E52AE5C184C8983A1190C7"
+        "D6:8E:C4:CD:93:FA:C7:71:49:0F:3D:F2:12:CF:F7:72:1A:F5:D2:CC:81:E5:2A:E5:C1:84:C8:98:3A:11:90:C7",
+        "D1:CC:03:5D:74:C7:2F:97:3E:7B:AE:97:C4:B1:D1:4A:CE:BA:9F:3B:9F:8F:07:16:52:AD:10:23:65:1E:E2:36"
       ]
     }
   }

--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,0 @@
-/.well-known/apple-app-site-association
-  Content-Type: application/json
-
-/.well-known/assetlinks.json
-  Content-Type: application/json
-

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -905,6 +905,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1416,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -4149,6 +4178,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5116,6 +5155,16 @@ dependencies = [
  "crossbeam-utils",
  "portable-atomic",
  "portable-atomic-util",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -6119,6 +6168,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e82759f7c7d51de3cbde51c04b3f2332de52436ed84541182cd8944b04e9e73"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.17",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-devtools"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6457,6 +6527,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-devtools",
  "tauri-plugin-fs",
  "tauri-plugin-http",
@@ -6619,6 +6690,15 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -81,6 +81,7 @@ thunderbolt-embeddings = { package = "thunderbolt-embeddings", path = "./thunder
 thunderbolt-bridge = { package = "thunderbolt-bridge", path = "./thunderbolt_bridge", optional = true }
 thunderbolt-libsql = { package = "thunderbolt-libsql", path = "./thunderbolt_libsql", optional = true }
 thunderbolt-email = { package = "thunderbolt-email", path = "./thunderbolt_email", optional = true }
+tauri-plugin-deep-link = "2"
 
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.

--- a/src-tauri/capabilities/auth.json
+++ b/src-tauri/capabilities/auth.json
@@ -2,7 +2,9 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "auth",
   "description": "Strict, no-IPC capability profile for OAuth authentication windows",
-  "windows": ["oauth-*"],
+  "windows": [
+    "oauth-*"
+  ],
   "permissions": [
     "core:default",
     {
@@ -15,6 +17,7 @@
           "url": "https://www.googleapis.com"
         }
       ]
-    }
+    },
+    "deep-link:default"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "opener:default",
     "os:default",
+    "deep-link:default",
+    "core:event:default",
     "core:window:allow-hide",
     "core:window:allow-show",
     "core:window:allow-set-focus",

--- a/src-tauri/gen/apple/thunderbolt_iOS/thunderbolt_iOS.entitlements
+++ b/src-tauri/gen/apple/thunderbolt_iOS/thunderbolt_iOS.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:thunderbolt.io</string>
+	</array>
+</dict>
 </plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use tokio::sync::Mutex;
 
 // Shared app builder function
 pub fn create_app() -> tauri::Builder<tauri::Wry> {
-    let mut builder = tauri::Builder::default().plugin(tauri_plugin_deep_link::init());
+    let mut builder = tauri::Builder::default();
 
     // Conditionally include the HTTP plugin when the `native_fetch` feature is enabled
     #[cfg(feature = "native_fetch")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use tokio::sync::Mutex;
 
 // Shared app builder function
 pub fn create_app() -> tauri::Builder<tauri::Wry> {
-    let mut builder = tauri::Builder::default();
+    let mut builder = tauri::Builder::default().plugin(tauri_plugin_deep_link::init());
 
     // Conditionally include the HTTP plugin when the `native_fetch` feature is enabled
     #[cfg(feature = "native_fetch")]
@@ -35,6 +35,7 @@ pub fn create_app() -> tauri::Builder<tauri::Wry> {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_m3::init())
+        .plugin(tauri_plugin_deep_link::init())
         .setup(|_app| {
             #[cfg(feature = "bridge")]
             _app.manage(Mutex::new(AppState::default()));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,5 +52,17 @@
     "android": {
       "versionCode": 1018
     }
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        {
+          "scheme": ["https"],
+          "host": "thunderbolt.io",
+          "pathPrefix": ["/oauth/callback"],
+          "appLink": true
+        }
+      ]
+    }
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import OAuthCallback from '@/components/oauth-callback'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { HttpClientProvider } from '@/contexts'
 import { usePageTracking } from '@/hooks/use-analytics'
+import { useDeepLinkListener } from '@/hooks/use-deep-link-listener'
 import { useKeyboardInset } from '@/hooks/use-keyboard-inset'
 import { useMcpSync } from '@/hooks/use-mcp-sync'
 import ChatLayout from '@/layout/main-layout'
@@ -52,6 +53,7 @@ function AppContent({ initData }: { initData: InitData }) {
 
 function AppRoutes(_: { initData: InitData }) {
   usePageTracking()
+  useDeepLinkListener()
 
   const { experimentalFeatureTasks } = useSettings({
     experimental_feature_tasks: Boolean,

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -1,4 +1,4 @@
-import { updateSetting } from '@/dal'
+import { updateSettings } from '@/dal'
 import { type MCPClient } from '@/lib/mcp-provider'
 import { trackEvent } from '@/lib/posthog'
 import type { AutomationRun, ChatThread, Model, ThunderboltUIMessage } from '@/types'
@@ -83,7 +83,7 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
 
     set({ selectedModel: model })
 
-    updateSetting('selected_model', model.id)
+    updateSettings({ selected_model: model.id })
 
     trackEvent('model_select', { model: model.id })
   },

--- a/src/components/onboarding/onboarding-auth-step.tsx
+++ b/src/components/onboarding/onboarding-auth-step.tsx
@@ -1,7 +1,7 @@
 import { ConnectProviderButton } from '@/components/connect-provider-button'
 import { GoogleLogo } from '@/components/ui/google-logo'
 import { MicrosoftLogo } from '@/components/ui/microsoft-logo'
-import { updateSetting } from '@/dal'
+import { updateSettings } from '@/dal'
 import { useOAuthConnect } from '@/hooks/use-oauth-connect'
 import type { UseOAuthConnectResult } from '@/hooks/use-oauth-connect'
 import { type OAuthProvider } from '@/lib/auth'
@@ -69,8 +69,10 @@ export const OnboardingAuthStep = ({
 
   const handleDisconnect = async () => {
     try {
-      await updateSetting(`integrations_${provider}_credentials`, '')
-      await updateSetting(`integrations_${provider}_is_enabled`, 'false')
+      await updateSettings({
+        [`integrations_${provider}_credentials`]: '',
+        [`integrations_${provider}_is_enabled`]: 'false',
+      })
       onConnectionChange(false)
     } catch (error) {
       console.error('Failed to disconnect:', error)

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -20,7 +20,7 @@ export {
   getThemeSetting,
   hasSetting,
   resetSettingToDefault,
-  updateSetting,
+  updateSettings,
 } from './settings'
 
 // Chat Threads

--- a/src/dal/models.test.ts
+++ b/src/dal/models.test.ts
@@ -11,7 +11,7 @@ import {
   getSelectedModel,
   getSystemModel,
 } from './models'
-import { updateSetting } from './settings'
+import { updateSettings } from './settings'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 
 beforeAll(async () => {
@@ -118,7 +118,7 @@ describe('Models DAL', () => {
       })
 
       // Set the selected model
-      await updateSetting('selected_model', selectedModelId)
+      await updateSettings({ selected_model: selectedModelId })
 
       const model = await getSelectedModel()
       expect(model.id).toBe(selectedModelId)
@@ -151,7 +151,7 @@ describe('Models DAL', () => {
       })
 
       // Set the disabled model as selected
-      await updateSetting('selected_model', disabledModelId)
+      await updateSettings({ selected_model: disabledModelId })
 
       // Should fall back to system model since selected model is disabled
       const model = await getSelectedModel()

--- a/src/dal/settings.test.ts
+++ b/src/dal/settings.test.ts
@@ -9,11 +9,13 @@ import {
   deleteSetting,
   getAllSettings,
   getSettings,
+  getSettingsRecords,
   getThemeSetting,
   hasSetting,
   resetSettingToDefault,
-  updateSetting,
+  updateSettings,
 } from './settings'
+import { hashValues } from '../lib/utils'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 
 beforeAll(async () => {
@@ -114,67 +116,133 @@ describe('Settings DAL', () => {
     })
   })
 
-  describe('updateSetting', () => {
-    it('should create a new setting if it does not exist', async () => {
-      await updateSetting('new_key', 'new_value')
-      const settings = await getSettings({ new_key: String })
-      expect(settings.newKey).toBe('new_value')
+  describe('updateSettings', () => {
+    it('should create multiple new settings at once', async () => {
+      await updateSettings({
+        batch_key_one: 'value1',
+        batch_key_two: 'value2',
+        batch_key_three: 'value3',
+      })
+
+      const settings = await getSettings({
+        batch_key_one: String,
+        batch_key_two: String,
+        batch_key_three: String,
+      })
+
+      expect(settings.batchKeyOne).toBe('value1')
+      expect(settings.batchKeyTwo).toBe('value2')
+      expect(settings.batchKeyThree).toBe('value3')
     })
 
-    it('should update existing setting', async () => {
-      await createSetting('update_key', 'old_value')
-      await updateSetting('update_key', 'new_value')
-      const settings = await getSettings({ update_key: String })
-      expect(settings.updateKey).toBe('new_value')
+    it('should update multiple existing settings at once', async () => {
+      await createSetting('existing_one', 'old1')
+      await createSetting('existing_two', 'old2')
+
+      await updateSettings({
+        existing_one: 'new1',
+        existing_two: 'new2',
+      })
+
+      const settings = await getSettings({
+        existing_one: String,
+        existing_two: String,
+      })
+
+      expect(settings.existingOne).toBe('new1')
+      expect(settings.existingTwo).toBe('new2')
     })
 
-    it('should update to null value', async () => {
-      await createSetting('nullable_key', 'original_value')
-      await updateSetting('nullable_key', null)
-      const settings = await getSettings({ nullable_key: 'default' })
-      expect(settings.nullableKey).toBe('default')
+    it('should handle mixed types (string, number, boolean)', async () => {
+      await updateSettings({
+        mixed_string: 'text',
+        mixed_number: 42,
+        mixed_boolean: true,
+      })
+
+      const settings = await getSettings({
+        mixed_string: String,
+        mixed_number: Number,
+        mixed_boolean: Boolean,
+      })
+
+      expect(settings.mixedString).toBe('text')
+      expect(settings.mixedNumber).toBe(42)
+      expect(settings.mixedBoolean).toBe(true)
     })
 
-    it('should update to empty string', async () => {
-      await createSetting('empty_key', 'original_value')
-      await updateSetting('empty_key', '')
-      const settings = await getSettings({ empty_key: 'default' })
-      expect(settings.emptyKey).toBe('')
+    it('should handle empty object gracefully', async () => {
+      await updateSettings({})
+      expect(true).toBe(true)
+    })
+
+    it('should support recomputeHash option for all settings', async () => {
+      await updateSettings(
+        {
+          hash_key_one: 'baseline1',
+          hash_key_two: 'baseline2',
+        },
+        { recomputeHash: true },
+      )
+
+      const records = await getSettingsRecords({
+        hash_key_one: String,
+        hash_key_two: String,
+      })
+
+      const expectedHash1 = hashValues(['hash_key_one', 'baseline1'])
+      const expectedHash2 = hashValues(['hash_key_two', 'baseline2'])
+
+      expect(records['hash_key_one'].defaultHash).toBe(expectedHash1)
+      expect(records['hash_key_two'].defaultHash).toBe(expectedHash2)
+    })
+
+    it('should handle deeply nested JSON structures', async () => {
+      // Test that the JsonValue type properly accepts complex nested structures
+      const complexCredentials = {
+        access_token: 'token123',
+        refresh_token: 'refresh456',
+        expires_at: 1234567890,
+        profile: {
+          email: 'user@example.com',
+          name: 'Test User',
+          metadata: {
+            created: '2024-01-01',
+            tags: ['premium', 'verified'],
+            settings: {
+              theme: 'dark',
+              notifications: true,
+            },
+          },
+        },
+      }
+
+      await updateSettings({
+        complex_nested_data: complexCredentials,
+        simple_array: [1, 2, 3, 4, 5],
+        nested_array: [
+          { id: 1, value: 'a' },
+          { id: 2, value: 'b' },
+        ],
+      })
+
+      // Verify it was stored correctly by reading back
+      const settings = await getSettings({
+        complex_nested_data: String, // Gets back as JSON string
+        simple_array: String,
+        nested_array: String,
+      })
+
+      expect(JSON.parse(settings.complexNestedData!)).toEqual(complexCredentials)
+      expect(JSON.parse(settings.simpleArray!)).toEqual([1, 2, 3, 4, 5])
+      expect(JSON.parse(settings.nestedArray!)).toEqual([
+        { id: 1, value: 'a' },
+        { id: 2, value: 'b' },
+      ])
     })
   })
 
-  describe('updateSetting with boolean values', () => {
-    it('should create a boolean setting with true value', async () => {
-      await updateSetting('bool_key', true)
-      const settings = await getSettings({ bool_key: false })
-      expect(settings.boolKey).toBe(true)
-    })
-
-    it('should create a boolean setting with false value', async () => {
-      await updateSetting('bool_key', false)
-      const settings = await getSettings({ bool_key: true })
-      expect(settings.boolKey).toBe(false)
-    })
-
-    it('should update existing boolean setting', async () => {
-      await updateSetting('bool_key', false)
-      await updateSetting('bool_key', true)
-      const settings = await getSettings({ bool_key: false })
-      expect(settings.boolKey).toBe(true)
-    })
-
-    it('should store as "true" and "false" strings', async () => {
-      await updateSetting('bool_key', true)
-      const trueSettings = await getSettings({ bool_key: String })
-      expect(trueSettings.boolKey).toBe('true')
-
-      await updateSetting('bool_key', false)
-      const falseSettings = await getSettings({ bool_key: String })
-      expect(falseSettings.boolKey).toBe('false')
-    })
-  })
-
-  describe('updateSetting with recomputeHash option', () => {
+  describe('updateSettings with recomputeHash option', () => {
     it('should not update defaultHash by default', async () => {
       const db = DatabaseSingleton.instance.db
 
@@ -187,7 +255,7 @@ describe('Settings DAL', () => {
       })
 
       // Update the value without recomputeHash
-      await updateSetting('test_key', 'modified')
+      await updateSettings({ test_key: 'modified' })
 
       const setting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'test_key')).get()
 
@@ -211,7 +279,7 @@ describe('Settings DAL', () => {
       })
 
       // Update the value with recomputeHash: true
-      await updateSetting('test_key', 'new_baseline', { recomputeHash: true })
+      await updateSettings({ test_key: 'new_baseline' }, { recomputeHash: true })
 
       const setting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'test_key')).get()
 
@@ -227,14 +295,14 @@ describe('Settings DAL', () => {
       const db = DatabaseSingleton.instance.db
 
       // Create a setting
-      await updateSetting('test_key', 'baseline', { recomputeHash: true })
+      await updateSettings({ test_key: 'baseline' }, { recomputeHash: true })
 
       // Verify it's not modified
       let setting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'test_key')).get()
       expect(isSettingModified(setting!)).toBe(false)
 
       // Now modify it again without recomputeHash
-      await updateSetting('test_key', 'different_value')
+      await updateSettings({ test_key: 'different_value' })
 
       // Should be detected as modified relative to the new baseline
       setting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'test_key')).get()
@@ -246,8 +314,7 @@ describe('Settings DAL', () => {
       const db = DatabaseSingleton.instance.db
 
       // Simulate initial auto-population from country data with recomputeHash
-      await updateSetting('distance_unit', 'metric', { recomputeHash: true })
-      await updateSetting('temperature_unit', 'c', { recomputeHash: true })
+      await updateSettings({ distance_unit: 'metric', temperature_unit: 'c' }, { recomputeHash: true })
 
       // Verify they're not marked as modified
       const distanceSetting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
@@ -257,7 +324,7 @@ describe('Settings DAL', () => {
       expect(isSettingModified(tempSetting!)).toBe(false)
 
       // User manually changes one setting
-      await updateSetting('temperature_unit', 'f')
+      await updateSettings({ temperature_unit: 'f' })
 
       // Only the manually changed setting should be modified
       const distanceAfter = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
@@ -267,8 +334,7 @@ describe('Settings DAL', () => {
       expect(isSettingModified(tempAfter!)).toBe(true)
 
       // User changes location, triggering new localization values with recomputeHash
-      await updateSetting('distance_unit', 'imperial', { recomputeHash: true })
-      await updateSetting('temperature_unit', 'f', { recomputeHash: true })
+      await updateSettings({ distance_unit: 'imperial', temperature_unit: 'f' }, { recomputeHash: true })
 
       // Both should now be unmodified relative to the new baseline
       const distanceFinal = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
@@ -279,12 +345,12 @@ describe('Settings DAL', () => {
     })
   })
 
-  describe('updateSetting with updateHashOnly option', () => {
+  describe('updateSettings with updateHashOnly option', () => {
     it('should only update hash without changing value', async () => {
       const db = DatabaseSingleton.instance.db
 
       // Create a setting with an initial value
-      await updateSetting('test_key', 'user_custom_value', { recomputeHash: true })
+      await updateSettings({ test_key: 'user_custom_value' }, { recomputeHash: true })
 
       // Verify initial state
       let setting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'test_key')).get()
@@ -292,7 +358,7 @@ describe('Settings DAL', () => {
       expect(isSettingModified(setting!)).toBe(false)
 
       // Update only the hash to a new baseline value without changing the actual value
-      await updateSetting('test_key', 'new_baseline', { updateHashOnly: true })
+      await updateSettings({ test_key: 'new_baseline' }, { updateHashOnly: true })
 
       // Value should remain unchanged, but hash should be updated
       setting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'test_key')).get()
@@ -307,10 +373,10 @@ describe('Settings DAL', () => {
       const db = DatabaseSingleton.instance.db
 
       // Scenario: User has location set to UK, gets 'metric' units
-      await updateSetting('distance_unit', 'metric', { recomputeHash: true })
+      await updateSettings({ distance_unit: 'metric' }, { recomputeHash: true })
 
       // User manually changes to imperial
-      await updateSetting('distance_unit', 'imperial')
+      await updateSettings({ distance_unit: 'imperial' })
 
       let setting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
       expect(setting?.value).toBe('imperial')
@@ -318,7 +384,7 @@ describe('Settings DAL', () => {
 
       // User changes location to US, which defaults to 'imperial'
       // We update the hash to 'imperial' without changing the value
-      await updateSetting('distance_unit', 'imperial', { updateHashOnly: true })
+      await updateSettings({ distance_unit: 'imperial' }, { updateHashOnly: true })
 
       // Value stays 'imperial' (user's choice), but now it's the baseline
       setting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
@@ -330,11 +396,10 @@ describe('Settings DAL', () => {
       const db = DatabaseSingleton.instance.db
 
       // Initial location (UK): metric and c
-      await updateSetting('distance_unit', 'metric', { recomputeHash: true })
-      await updateSetting('temperature_unit', 'c', { recomputeHash: true })
+      await updateSettings({ distance_unit: 'metric', temperature_unit: 'c' }, { recomputeHash: true })
 
       // User manually changes temperature to f
-      await updateSetting('temperature_unit', 'f')
+      await updateSettings({ temperature_unit: 'f' })
 
       // Verify state before location change
       let distanceSetting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
@@ -344,9 +409,9 @@ describe('Settings DAL', () => {
 
       // User changes location to US: imperial and f
       // For unmodified settings, update value and hash
-      await updateSetting('distance_unit', 'imperial', { recomputeHash: true })
+      await updateSettings({ distance_unit: 'imperial' }, { recomputeHash: true })
       // For modified settings, only update hash (preserve user's value)
-      await updateSetting('temperature_unit', 'f', { updateHashOnly: true })
+      await updateSettings({ temperature_unit: 'f' }, { updateHashOnly: true })
 
       // Check final state
       distanceSetting = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
@@ -409,7 +474,7 @@ describe('Settings DAL', () => {
     })
 
     it('should return stored theme when setting exists', async () => {
-      await updateSetting('theme', 'dark')
+      await updateSettings({ theme: 'dark' })
       const theme = await getThemeSetting('theme', 'light')
       expect(theme).toBe('dark')
     })
@@ -429,7 +494,7 @@ describe('Settings DAL', () => {
       })
 
       // User modifies it
-      await updateSetting(defaultSetting.key, 'user_modified_value')
+      await updateSettings({ [defaultSetting.key]: 'user_modified_value' })
 
       // Verify it's modified
       const modified = await db.select().from(settingsTable).where(eq(settingsTable.key, defaultSetting.key)).get()
@@ -456,7 +521,7 @@ describe('Settings DAL', () => {
         updatedAt: null,
         defaultHash: hashSetting(defaultSetting),
       })
-      await updateSetting(defaultSetting.key, 'modified')
+      await updateSettings({ [defaultSetting.key]: 'modified' })
 
       // Reset
       await resetSettingToDefault(defaultSetting.key, defaultSetting)
@@ -467,7 +532,7 @@ describe('Settings DAL', () => {
       expect(isSettingModified(setting!)).toBe(false)
 
       // Modify again
-      await updateSetting(defaultSetting.key, 'modified_again')
+      await updateSettings({ [defaultSetting.key]: 'modified_again' })
       const modifiedAgain = await db.select().from(settingsTable).where(eq(settingsTable.key, defaultSetting.key)).get()
 
       // Should be detected as modified

--- a/src/dal/settings.ts
+++ b/src/dal/settings.ts
@@ -231,41 +231,71 @@ export const createSetting = async (key: string, value: string | null): Promise<
 }
 
 /**
- * Update or create a setting in the settings table
- * @param key - The setting key
- * @param value - The value (can be string, null, boolean, number, or JSON-serializable object)
- * @param options - Optional configuration
- * @param options.recomputeHash - If true, updates the defaultHash to match the new value (makes it the new baseline for modification tracking)
- * @param options.updateHashOnly - If true, only updates the defaultHash using the provided value without changing the actual stored value (useful for updating the baseline without overwriting user customizations)
+ * Prepare a setting row for batch insert/update
  */
-export const updateSetting = async (
-  key: string,
-  value: any,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const prepareSettingRow = (key: string, value: any, recomputeHash: boolean) => {
+  const stringValue = serializeValue(value)
+  return {
+    key,
+    value: stringValue,
+    ...(recomputeHash && { defaultHash: hashValues([key, stringValue]) }),
+  }
+}
+
+/**
+ * Update or create multiple settings at once in a single database operation
+ *
+ * @param settings - Object mapping setting keys to values
+ * @param options - Optional configuration (applies to all settings)
+ * @param options.recomputeHash - If true, updates the defaultHash to match the new value for all settings
+ * @param options.updateHashOnly - If true, only updates the defaultHash without changing actual values
+ *
+ * @example
+ * ```ts
+ * await updateSettings({
+ *   oauth_state: 'abc123',
+ *   oauth_provider: 'google',
+ *   oauth_verifier: 'xyz789',
+ * })
+ * ```
+ */
+export const updateSettings = async (
+  settings: Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
   options: { recomputeHash?: boolean; updateHashOnly?: boolean } = {},
 ): Promise<void> => {
-  const db = DatabaseSingleton.instance.db
-  const stringValue = serializeValue(value)
+  const entries = Object.entries(settings)
+  if (entries.length === 0) return
 
+  const db = DatabaseSingleton.instance.db
+
+  // Handle updateHashOnly separately as it requires UPDATE statements
+  // Note: SQLite doesn't support batch UPDATE with different values per row,
+  // so we use parallel updates within a transaction for atomicity
   if (options.updateHashOnly) {
-    // Only update the hash, don't change the actual value
-    const newHash = hashValues([key, stringValue])
-    await db.update(settingsTable).set({ defaultHash: newHash }).where(eq(settingsTable.key, key))
+    await db.transaction(async (tx) => {
+      await Promise.all(
+        entries.map(([key, value]) => {
+          const stringValue = serializeValue(value)
+          const newHash = hashValues([key, stringValue])
+          return tx.update(settingsTable).set({ defaultHash: newHash }).where(eq(settingsTable.key, key))
+        }),
+      )
+    })
     return
   }
 
-  const updateFields: { value: string | null; defaultHash?: string | null } = { value: stringValue }
-
-  // If recomputeHash is true, update the defaultHash to match the new value
-  if (options.recomputeHash) {
-    updateFields.defaultHash = hashValues([key, stringValue])
-  }
+  // Single batch upsert for value updates
+  const values = entries.map(([key, value]) => prepareSettingRow(key, value, options.recomputeHash ?? false))
 
   await db
     .insert(settingsTable)
-    .values({ key, ...updateFields })
+    .values(values)
     .onConflictDoUpdate({
       target: settingsTable.key,
-      set: updateFields,
+      set: options.recomputeHash
+        ? { value: sql`excluded.value`, defaultHash: sql`excluded.default_hash` }
+        : { value: sql`excluded.value` },
     })
 }
 

--- a/src/hooks/use-deep-link-listener.test.ts
+++ b/src/hooks/use-deep-link-listener.test.ts
@@ -285,6 +285,139 @@ describe('useDeepLinkListener hook', () => {
     expect(customHandlerUrls).toEqual(mockUrls)
   })
 
+  it('does NOT call custom handler for OAuth callback URLs', async () => {
+    const mockUrls = ['https://thunderbolt.io/oauth/callback?code=abc123&state=xyz789']
+    let customHandlerCalled = false
+    let callback: ((urls: string[]) => void) | null = null
+
+    const getCurrent = () => Promise.resolve(null)
+    const onOpenUrl = (cb: (urls: string[]) => void): Promise<() => Promise<void>> => {
+      callback = cb
+      return Promise.resolve(async () => {})
+    }
+    const getSettings = () => Promise.resolve({ oauthReturnContext: '/chats/test' })
+
+    const customHandler = async (_urls: string[]) => {
+      customHandlerCalled = true
+    }
+
+    renderHook(
+      () =>
+        useDeepLinkListener(customHandler, {
+          isTauri: () => true,
+          getCurrent,
+          onOpenUrl,
+          getSettings,
+        }),
+      { wrapper },
+    )
+
+    // Wait for setup
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    // Trigger OAuth callback
+    expect(callback).not.toBeNull()
+    await act(async () => {
+      callback!(mockUrls)
+    })
+
+    // Handler should NOT have been called for OAuth URL
+    expect(customHandlerCalled).toBe(false)
+  })
+
+  it('calls custom handler only once with multiple non-OAuth URLs', async () => {
+    const mockUrls = ['https://thunderbolt.io/path1', 'https://thunderbolt.io/path2', 'https://thunderbolt.io/path3']
+    let customHandlerCallCount = 0
+    let receivedUrls: string[] = []
+    let callback: ((urls: string[]) => void) | null = null
+
+    const getCurrent = () => Promise.resolve(null)
+    const onOpenUrl = (cb: (urls: string[]) => void): Promise<() => Promise<void>> => {
+      callback = cb
+      return Promise.resolve(async () => {})
+    }
+    const getSettings = () => Promise.resolve({ oauthReturnContext: null })
+
+    const customHandler = async (urls: string[]) => {
+      customHandlerCallCount++
+      receivedUrls = urls
+    }
+
+    renderHook(
+      () =>
+        useDeepLinkListener(customHandler, {
+          isTauri: () => true,
+          getCurrent,
+          onOpenUrl,
+          getSettings,
+        }),
+      { wrapper },
+    )
+
+    // Wait for setup
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    // Trigger with multiple URLs
+    expect(callback).not.toBeNull()
+    await act(async () => {
+      callback!(mockUrls)
+    })
+
+    // Handler should be called exactly once with all URLs
+    expect(customHandlerCallCount).toBe(1)
+    expect(receivedUrls).toEqual(mockUrls)
+  })
+
+  it('filters out OAuth URLs and only passes non-OAuth URLs to handler', async () => {
+    const mockUrls = [
+      'https://thunderbolt.io/path1',
+      'https://thunderbolt.io/oauth/callback?code=abc123&state=xyz',
+      'https://thunderbolt.io/path2',
+    ]
+    let receivedUrls: string[] = []
+    let callback: ((urls: string[]) => void) | null = null
+
+    const getCurrent = () => Promise.resolve(null)
+    const onOpenUrl = (cb: (urls: string[]) => void): Promise<() => Promise<void>> => {
+      callback = cb
+      return Promise.resolve(async () => {})
+    }
+    const getSettings = () => Promise.resolve({ oauthReturnContext: '/chats/test' })
+
+    const customHandler = async (urls: string[]) => {
+      receivedUrls = urls
+    }
+
+    renderHook(
+      () =>
+        useDeepLinkListener(customHandler, {
+          isTauri: () => true,
+          getCurrent,
+          onOpenUrl,
+          getSettings,
+        }),
+      { wrapper },
+    )
+
+    // Wait for setup
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    // Trigger with mixed URLs
+    expect(callback).not.toBeNull()
+    await act(async () => {
+      callback!(mockUrls)
+    })
+
+    // Handler should only receive non-OAuth URLs
+    expect(receivedUrls).toEqual(['https://thunderbolt.io/path1', 'https://thunderbolt.io/path2'])
+  })
+
   it('handles invalid URLs gracefully', async () => {
     const mockUrls = ['not-a-valid-url']
 

--- a/src/hooks/use-deep-link-listener.test.ts
+++ b/src/hooks/use-deep-link-listener.test.ts
@@ -1,0 +1,352 @@
+import { act, renderHook } from '@testing-library/react'
+import { createElement } from 'react'
+import { BrowserRouter } from 'react-router'
+import { describe, expect, it } from 'bun:test'
+import { getClock } from '@/testing-library'
+import { determineNavigationTarget, parseOAuthCallback, useDeepLinkListener } from './use-deep-link-listener'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => createElement(BrowserRouter, null, children)
+
+describe('parseOAuthCallback', () => {
+  it('parses valid OAuth callback URL with code and state', () => {
+    const url = new URL('https://thunderbolt.io/oauth/callback?code=abc123&state=xyz789')
+    const result = parseOAuthCallback(url)
+
+    expect(result).toEqual({
+      code: 'abc123',
+      state: 'xyz789',
+      error: null,
+    })
+  })
+
+  it('parses OAuth callback URL with error parameter', () => {
+    const url = new URL('https://thunderbolt.io/oauth/callback?error=access_denied')
+    const result = parseOAuthCallback(url)
+
+    expect(result).toEqual({
+      code: null,
+      state: null,
+      error: 'access_denied',
+    })
+  })
+
+  it('prioritizes error_description over error parameter', () => {
+    const url = new URL('https://thunderbolt.io/oauth/callback?error=access_denied&error_description=User%20cancelled')
+    const result = parseOAuthCallback(url)
+
+    expect(result).toEqual({
+      code: null,
+      state: null,
+      error: 'User cancelled',
+    })
+  })
+
+  it('handles OAuth callback URL with missing parameters', () => {
+    const url = new URL('https://thunderbolt.io/oauth/callback')
+    const result = parseOAuthCallback(url)
+
+    expect(result).toEqual({
+      code: null,
+      state: null,
+      error: null,
+    })
+  })
+
+  it('handles OAuth callback URL with nested path', () => {
+    const url = new URL('https://thunderbolt.io/oauth/callback/extra?code=abc123&state=xyz789')
+    const result = parseOAuthCallback(url)
+
+    expect(result).toEqual({
+      code: 'abc123',
+      state: 'xyz789',
+      error: null,
+    })
+  })
+
+  it('returns null for wrong hostname', () => {
+    const url = new URL('https://evil.com/oauth/callback?code=abc123&state=xyz789')
+    const result = parseOAuthCallback(url)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for wrong path', () => {
+    const url = new URL('https://thunderbolt.io/different/path?code=abc123&state=xyz789')
+    const result = parseOAuthCallback(url)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for non-OAuth URL', () => {
+    const url = new URL('https://thunderbolt.io/')
+    const result = parseOAuthCallback(url)
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('determineNavigationTarget', () => {
+  const mockOAuthData = {
+    code: 'abc123',
+    state: 'xyz789',
+    error: null,
+  }
+
+  it('navigates to absolute path when returnContext starts with /', () => {
+    const result = determineNavigationTarget('/chats/123', mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/chats/123',
+      oauth: mockOAuthData,
+    })
+  })
+
+  it('navigates to chat detail page', () => {
+    const result = determineNavigationTarget('/chats/abc-def-ghi', mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/chats/abc-def-ghi',
+      oauth: mockOAuthData,
+    })
+  })
+
+  it('navigates to integrations page when returnContext is "integrations"', () => {
+    const result = determineNavigationTarget('integrations', mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/settings/integrations',
+      oauth: mockOAuthData,
+    })
+  })
+
+  it('defaults to integrations page when returnContext is null', () => {
+    const result = determineNavigationTarget(null, mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/settings/integrations',
+      oauth: mockOAuthData,
+    })
+  })
+
+  it('defaults to integrations page when returnContext is empty string', () => {
+    const result = determineNavigationTarget('', mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/settings/integrations',
+      oauth: mockOAuthData,
+    })
+  })
+
+  it('defaults to integrations page when returnContext is undefined', () => {
+    const result = determineNavigationTarget(undefined as unknown as string, mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/settings/integrations',
+      oauth: mockOAuthData,
+    })
+  })
+
+  it('navigates to settings pages', () => {
+    const result = determineNavigationTarget('/settings/preferences', mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/settings/preferences',
+      oauth: mockOAuthData,
+    })
+  })
+
+  it('preserves OAuth error in navigation target', () => {
+    const oauthWithError = {
+      code: null,
+      state: null,
+      error: 'access_denied',
+    }
+
+    const result = determineNavigationTarget('/chats/123', oauthWithError)
+
+    expect(result).toEqual({
+      path: '/chats/123',
+      oauth: oauthWithError,
+    })
+  })
+
+  it('handles relative-looking paths that do not start with /', () => {
+    const result = determineNavigationTarget('chats/123', mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/settings/integrations',
+      oauth: mockOAuthData,
+    })
+  })
+})
+
+describe('parseOAuthCallback + determineNavigationTarget integration', () => {
+  it('handles complete OAuth success flow', () => {
+    const url = new URL('https://thunderbolt.io/oauth/callback?code=abc123&state=xyz789')
+    const oauthData = parseOAuthCallback(url)
+
+    expect(oauthData).not.toBeNull()
+
+    const target = determineNavigationTarget('/chats/test-chat', oauthData!)
+
+    expect(target).toEqual({
+      path: '/chats/test-chat',
+      oauth: {
+        code: 'abc123',
+        state: 'xyz789',
+        error: null,
+      },
+    })
+  })
+
+  it('handles complete OAuth error flow', () => {
+    const url = new URL(
+      'https://thunderbolt.io/oauth/callback?error=access_denied&error_description=User%20cancelled%20authorization',
+    )
+    const oauthData = parseOAuthCallback(url)
+
+    expect(oauthData).not.toBeNull()
+
+    const target = determineNavigationTarget('integrations', oauthData!)
+
+    expect(target).toEqual({
+      path: '/settings/integrations',
+      oauth: {
+        code: null,
+        state: null,
+        error: 'User cancelled authorization',
+      },
+    })
+  })
+})
+
+describe('useDeepLinkListener hook', () => {
+  it('does not set up listeners when not running in Tauri', () => {
+    const getCurrent = () => Promise.resolve(null)
+    const onOpenUrl = () => Promise.resolve(() => {})
+    const getSettings = () => Promise.resolve({ oauthReturnContext: null })
+
+    renderHook(
+      () =>
+        useDeepLinkListener(undefined, {
+          isTauri: () => false,
+          getCurrent,
+          onOpenUrl,
+          getSettings,
+        }),
+      { wrapper },
+    )
+
+    // If the hook doesn't crash, it means it correctly skipped setup
+    expect(true).toBe(true)
+  })
+
+  it('handles custom handler for non-OAuth deep links', async () => {
+    const mockUrls = ['https://thunderbolt.io/some/other/path']
+    let customHandlerCalled = false
+    let customHandlerUrls: string[] = []
+    let callback: ((urls: string[]) => void) | null = null
+
+    const getCurrent = () => Promise.resolve(null)
+    const onOpenUrl = (cb: (urls: string[]) => void): Promise<() => Promise<void>> => {
+      callback = cb
+      return Promise.resolve(async () => {})
+    }
+    const getSettings = () => Promise.resolve({ oauthReturnContext: null })
+
+    const customHandler = async (urls: string[]) => {
+      customHandlerCalled = true
+      customHandlerUrls = urls
+    }
+
+    renderHook(
+      () =>
+        useDeepLinkListener(customHandler, {
+          isTauri: () => true,
+          getCurrent,
+          onOpenUrl,
+          getSettings,
+        }),
+      { wrapper },
+    )
+
+    // Wait for setup
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    // Now trigger the callback
+    expect(callback).not.toBeNull()
+    await act(async () => {
+      callback!(mockUrls)
+    })
+
+    expect(customHandlerCalled).toBe(true)
+    expect(customHandlerUrls).toEqual(mockUrls)
+  })
+
+  it('handles invalid URLs gracefully', async () => {
+    const mockUrls = ['not-a-valid-url']
+
+    const getCurrent = () => Promise.resolve(mockUrls)
+    const onOpenUrl = () => Promise.resolve(() => {})
+    const getSettings = () => Promise.resolve({ oauthReturnContext: null })
+
+    // Should not throw error
+    renderHook(
+      () =>
+        useDeepLinkListener(undefined, {
+          isTauri: () => true,
+          getCurrent,
+          onOpenUrl,
+          getSettings,
+        }),
+      { wrapper },
+    )
+
+    // Wait for async processing
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    // If we get here without error, the hook handled invalid URL gracefully
+    expect(true).toBe(true)
+  })
+
+  it('sets up listener for deep links while app is running', async () => {
+    let storedCallback: ((urls: string[]) => void) | null = null
+
+    const getCurrent = () => Promise.resolve(null)
+    const onOpenUrl = (callback: (urls: string[]) => void): Promise<() => Promise<void>> => {
+      storedCallback = callback
+      return Promise.resolve(async () => {})
+    }
+    const getSettings = () => Promise.resolve({ oauthReturnContext: '/chats/active' })
+
+    renderHook(
+      () =>
+        useDeepLinkListener(undefined, {
+          isTauri: () => true,
+          getCurrent,
+          onOpenUrl,
+          getSettings,
+        }),
+      { wrapper },
+    )
+
+    // Wait for setup
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    expect(storedCallback).not.toBeNull()
+
+    // Simulate a deep link event
+    expect(storedCallback).not.toBeNull()
+    await act(async () => {
+      storedCallback!(['https://thunderbolt.io/oauth/callback?code=test&state=test'])
+    })
+    // If no error thrown, the listener worked
+    expect(true).toBe(true)
+  })
+})

--- a/src/hooks/use-deep-link-listener.ts
+++ b/src/hooks/use-deep-link-listener.ts
@@ -6,28 +6,98 @@ import { useLocation, useNavigate } from 'react-router'
 
 type DeepLinkHandler = (urls: string[]) => void | Promise<void>
 
+type OAuthCallbackData = {
+  code: string | null
+  state: string | null
+  error: string | null
+}
+
+type NavigateTarget = {
+  path: string
+  oauth: OAuthCallbackData
+}
+
+/**
+ * Determines the navigation target based on OAuth return context
+ * Exported for testing
+ */
+export const determineNavigationTarget = (
+  oauthReturnContext: string | null,
+  oauth: OAuthCallbackData,
+): NavigateTarget => {
+  if (oauthReturnContext?.startsWith('/')) {
+    return { path: oauthReturnContext, oauth }
+  }
+
+  if (oauthReturnContext === 'integrations') {
+    return { path: '/settings/integrations', oauth }
+  }
+
+  // Default to integrations page
+  return { path: '/settings/integrations', oauth }
+}
+
+/**
+ * Parses OAuth callback parameters from a deep link URL
+ * Exported for testing
+ */
+export const parseOAuthCallback = (url: URL): OAuthCallbackData | null => {
+  if (url.hostname !== 'thunderbolt.io' || !url.pathname.startsWith('/oauth/callback')) {
+    return null
+  }
+
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state')
+  const error = url.searchParams.get('error')
+  const errorDescription = url.searchParams.get('error_description')
+
+  return {
+    code,
+    state,
+    error: errorDescription || error,
+  }
+}
+
+type DeepLinkDependencies = {
+  isTauri?: typeof isTauri
+  getCurrent?: typeof getCurrent
+  onOpenUrl?: typeof onOpenUrl
+  getSettings?: typeof getSettings
+}
+
 /**
  * Hook to listen for deep links (App Links / Universal Links)
  * Handles OAuth callbacks when the app is opened via https://thunderbolt.io/oauth/callback
+ *
+ * @param handler Optional custom handler for deep links
+ * @param dependencies Optional dependencies for testing (uses real implementations by default)
  */
-export const useDeepLinkListener = (handler?: DeepLinkHandler) => {
+export const useDeepLinkListener = (handler?: DeepLinkHandler, dependencies?: DeepLinkDependencies) => {
   const navigate = useNavigate()
   const location = useLocation()
 
+  // Use injected dependencies or fall back to real implementations
+  const {
+    isTauri: checkIsTauri = isTauri,
+    getCurrent: getCurrentUrls = getCurrent,
+    onOpenUrl: listenToOpenUrl = onOpenUrl,
+    getSettings: getSettingsData = getSettings,
+  } = dependencies || {}
+
   useEffect(() => {
-    if (!isTauri()) return
+    if (!checkIsTauri()) return
 
     let unlisten: (() => void) | null = null
 
     const setupListener = async () => {
       // Check if app was started via deep link
-      const startUrls = await getCurrent()
+      const startUrls = await getCurrentUrls()
       if (startUrls && startUrls.length > 0) {
         await handleDeepLinks(startUrls)
       }
 
       // Listen for deep links while app is running
-      unlisten = await onOpenUrl(async (urls) => {
+      unlisten = await listenToOpenUrl(async (urls) => {
         await handleDeepLinks(urls)
       })
     }
@@ -38,41 +108,16 @@ export const useDeepLinkListener = (handler?: DeepLinkHandler) => {
           const url = new URL(urlString)
 
           // Handle OAuth callback deep links
-          if (url.hostname === 'thunderbolt.io' && url.pathname.startsWith('/oauth/callback')) {
-            const code = url.searchParams.get('code')
-            const state = url.searchParams.get('state')
-            const error = url.searchParams.get('error')
-            const errorDescription = url.searchParams.get('error_description')
-
-            // Navigate to the appropriate route with OAuth data in state
+          const oauthData = parseOAuthCallback(url)
+          if (oauthData) {
             // Get the return context from SQLite settings (where mobile flow stores it)
-            const settings = await getSettings({ oauth_return_context: String })
-            const oauthReturnContext = settings.oauthReturnContext
+            const settings = await getSettingsData({ oauth_return_context: String })
+            const target = determineNavigationTarget(settings.oauthReturnContext, oauthData)
 
-            if (oauthReturnContext?.startsWith('/')) {
-              navigate(oauthReturnContext, {
-                state: {
-                  oauth: { code, state, error: errorDescription || error },
-                },
-                replace: true,
-              })
-            } else if (oauthReturnContext === 'integrations') {
-              // Explicit integrations context
-              navigate('/settings/integrations', {
-                state: {
-                  oauth: { code, state, error: errorDescription || error },
-                },
-                replace: true,
-              })
-            } else {
-              // Default to integrations page
-              navigate('/settings/integrations', {
-                state: {
-                  oauth: { code, state, error: errorDescription || error },
-                },
-                replace: true,
-              })
-            }
+            navigate(target.path, {
+              state: { oauth: target.oauth },
+              replace: true,
+            })
           }
 
           // Call custom handler if provided
@@ -92,5 +137,5 @@ export const useDeepLinkListener = (handler?: DeepLinkHandler) => {
         unlisten()
       }
     }
-  }, [handler, navigate, location.pathname])
+  }, [handler, navigate, location.pathname, checkIsTauri, getCurrentUrls, listenToOpenUrl, getSettingsData])
 }

--- a/src/hooks/use-deep-link-listener.ts
+++ b/src/hooks/use-deep-link-listener.ts
@@ -1,0 +1,86 @@
+import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link'
+import { isTauri } from '@/lib/platform'
+import { useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+
+type DeepLinkHandler = (urls: string[]) => void | Promise<void>
+
+/**
+ * Hook to listen for deep links (App Links / Universal Links)
+ * Handles OAuth callbacks when the app is opened via https://thunderbolt.io/oauth/callback
+ */
+export const useDeepLinkListener = (handler?: DeepLinkHandler) => {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  useEffect(() => {
+    if (!isTauri()) return
+
+    let unlisten: (() => void) | null = null
+
+    const setupListener = async () => {
+      // Check if app was started via deep link
+      const startUrls = await getCurrent()
+      if (startUrls && startUrls.length > 0) {
+        await handleDeepLinks(startUrls)
+      }
+
+      // Listen for deep links while app is running
+      unlisten = await onOpenUrl(async (urls) => {
+        await handleDeepLinks(urls)
+      })
+    }
+
+    const handleDeepLinks = async (urls: string[]) => {
+      for (const urlString of urls) {
+        try {
+          const url = new URL(urlString)
+
+          // Handle OAuth callback deep links
+          if (url.hostname === 'thunderbolt.io' && url.pathname.startsWith('/oauth/callback')) {
+            const code = url.searchParams.get('code')
+            const state = url.searchParams.get('state')
+            const error = url.searchParams.get('error')
+            const errorDescription = url.searchParams.get('error_description')
+
+            // Navigate to the appropriate route with OAuth data in state
+            // Check where we should return to
+            const oauthReturnContext = sessionStorage.getItem('oauth_return_context')
+
+            if (oauthReturnContext?.startsWith('/')) {
+              navigate(oauthReturnContext, {
+                state: {
+                  oauth: { code, state, error: errorDescription || error },
+                },
+                replace: true,
+              })
+            } else {
+              // Default to integrations page
+              navigate('/settings/integrations', {
+                state: {
+                  oauth: { code, state, error: errorDescription || error },
+                },
+                replace: true,
+              })
+            }
+          }
+
+          // Call custom handler if provided
+          if (handler) {
+            await handler(urls)
+          }
+        } catch (err) {
+          console.error('Failed to handle deep link:', urlString, err)
+        }
+      }
+    }
+
+    setupListener()
+
+    return () => {
+      if (unlisten) {
+        unlisten()
+      }
+    }
+  }, [handler, navigate, location.pathname])
+}

--- a/src/hooks/use-deep-link-listener.ts
+++ b/src/hooks/use-deep-link-listener.ts
@@ -103,6 +103,8 @@ export const useDeepLinkListener = (handler?: DeepLinkHandler, dependencies?: De
     }
 
     const handleDeepLinks = async (urls: string[]) => {
+      const nonOAuthUrls: string[] = []
+
       for (const urlString of urls) {
         try {
           const url = new URL(urlString)
@@ -118,15 +120,18 @@ export const useDeepLinkListener = (handler?: DeepLinkHandler, dependencies?: De
               state: { oauth: target.oauth },
               replace: true,
             })
-          }
-
-          // Call custom handler if provided
-          if (handler) {
-            await handler(urls)
+          } else {
+            // Collect non-OAuth URLs for custom handler
+            nonOAuthUrls.push(urlString)
           }
         } catch (err) {
           console.error('Failed to handle deep link:', urlString, err)
         }
+      }
+
+      // Call custom handler only for non-OAuth URLs, once
+      if (handler && nonOAuthUrls.length > 0) {
+        await handler(nonOAuthUrls)
       }
     }
 

--- a/src/hooks/use-deep-link-listener.ts
+++ b/src/hooks/use-deep-link-listener.ts
@@ -1,4 +1,5 @@
 import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link'
+import { getSettings } from '@/dal'
 import { isTauri } from '@/lib/platform'
 import { useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router'
@@ -44,11 +45,20 @@ export const useDeepLinkListener = (handler?: DeepLinkHandler) => {
             const errorDescription = url.searchParams.get('error_description')
 
             // Navigate to the appropriate route with OAuth data in state
-            // Check where we should return to
-            const oauthReturnContext = sessionStorage.getItem('oauth_return_context')
+            // Get the return context from SQLite settings (where mobile flow stores it)
+            const settings = await getSettings({ oauth_return_context: String })
+            const oauthReturnContext = settings.oauthReturnContext
 
             if (oauthReturnContext?.startsWith('/')) {
               navigate(oauthReturnContext, {
+                state: {
+                  oauth: { code, state, error: errorDescription || error },
+                },
+                replace: true,
+              })
+            } else if (oauthReturnContext === 'integrations') {
+              // Explicit integrations context
+              navigate('/settings/integrations', {
                 state: {
                   oauth: { code, state, error: errorDescription || error },
                 },

--- a/src/hooks/use-handle-integration-completion.test.ts
+++ b/src/hooks/use-handle-integration-completion.test.ts
@@ -8,7 +8,7 @@ import { DatabaseSingleton } from '@/db/singleton'
 import { chatThreadsTable } from '@/db/tables'
 import { v7 as uuidv7 } from 'uuid'
 import { saveMessagesWithContextUpdate, getMessage } from '@/dal/chat-messages'
-import { updateSetting } from '@/dal/settings'
+import { updateSettings } from '@/dal/settings'
 import type { ThunderboltUIMessage } from '@/types'
 import { getClock } from '@/testing-library'
 
@@ -164,8 +164,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: 'thread-1',
     })
 
-    await updateSetting('integrations_google_credentials', '')
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: '',
+      integrations_microsoft_credentials: '',
+    })
 
     renderHook(() => useHandleIntegrationCompletion({ saveMessages: mockSaveMessages }), {
       wrapper: createQueryTestWrapper(),
@@ -183,8 +185,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: 'thread-1',
     })
 
-    await updateSetting('integrations_google_credentials', '')
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: '',
+      integrations_microsoft_credentials: '',
+    })
 
     const { unmount } = renderHook(() => useHandleIntegrationCompletion({ saveMessages: mockSaveMessages }), {
       wrapper: createQueryTestWrapper(),
@@ -204,8 +208,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: 'thread-1',
     })
 
-    await updateSetting('integrations_google_credentials', '')
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: '',
+      integrations_microsoft_credentials: '',
+    })
 
     renderHook(() => useHandleIntegrationCompletion({ saveMessages: mockSaveMessages }), {
       wrapper: createQueryTestWrapper(),
@@ -233,8 +239,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: null,
     })
 
-    await updateSetting('integrations_google_credentials', '')
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: '',
+      integrations_microsoft_credentials: '',
+    })
 
     renderHook(() => useHandleIntegrationCompletion({ saveMessages: mockSaveMessages }), {
       wrapper: createQueryTestWrapper(),
@@ -285,8 +293,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: threadId,
     })
 
-    await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'test_token' }))
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: JSON.stringify({ access_token: 'test_token' }),
+      integrations_microsoft_credentials: '',
+    })
 
     renderHook(() => useHandleIntegrationCompletion({ saveMessages: mockSaveMessages }), {
       wrapper: createQueryTestWrapper({
@@ -364,8 +374,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: threadId,
     })
 
-    await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'test_token' }))
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: JSON.stringify({ access_token: 'test_token' }),
+      integrations_microsoft_credentials: '',
+    })
 
     renderHook(() => useHandleIntegrationCompletion({ saveMessages: mockSaveMessages }), {
       wrapper: createQueryTestWrapper({
@@ -432,8 +444,10 @@ describe('useHandleIntegrationCompletion', () => {
     })
 
     // Start with no credentials
-    await updateSetting('integrations_google_credentials', '')
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: '',
+      integrations_microsoft_credentials: '',
+    })
 
     renderHook(() => useHandleIntegrationCompletion({ saveMessages: mockSaveMessages }), {
       wrapper: createQueryTestWrapper({
@@ -460,7 +474,7 @@ describe('useHandleIntegrationCompletion', () => {
     expect(mockSaveMessages).not.toHaveBeenCalled()
 
     // Now add credentials to simulate connection
-    await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'test_token' }))
+    await updateSettings({ integrations_google_credentials: JSON.stringify({ access_token: 'test_token' }) })
 
     await act(async () => {
       await getClock().runAllAsync()
@@ -483,8 +497,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: threadId,
     })
 
-    await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'test_token' }))
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: JSON.stringify({ access_token: 'test_token' }),
+      integrations_microsoft_credentials: '',
+    })
 
     const originalWarn = console.warn
     const consoleWarnSpy = mock(() => {})
@@ -540,8 +556,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: threadId,
     })
 
-    await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'test_token' }))
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: JSON.stringify({ access_token: 'test_token' }),
+      integrations_microsoft_credentials: '',
+    })
 
     const originalWarn = console.warn
     const consoleWarnSpy = mock(() => {})
@@ -608,8 +626,10 @@ describe('useHandleIntegrationCompletion', () => {
       id: threadId,
     })
 
-    await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'test_token' }))
-    await updateSetting('integrations_microsoft_credentials', '')
+    await updateSettings({
+      integrations_google_credentials: JSON.stringify({ access_token: 'test_token' }),
+      integrations_microsoft_credentials: '',
+    })
 
     renderHook(() => useHandleIntegrationCompletion({ saveMessages: mockSaveMessages }), {
       wrapper: createQueryTestWrapper({

--- a/src/hooks/use-integration-status.test.ts
+++ b/src/hooks/use-integration-status.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, afterEach, describe, expect, it } from 'bun:test'
 import { setupTestDatabase, teardownTestDatabase, resetTestDatabase } from '@/dal/test-utils'
 import { createQueryTestWrapper } from '@/test-utils/react-query'
 import { useIntegrationStatus } from './use-integration-status'
-import { updateSetting } from '@/dal/settings'
+import { updateSettings } from '@/dal/settings'
 import { getClock } from '@/testing-library'
 
 describe('useIntegrationStatus', () => {
@@ -33,8 +33,10 @@ describe('useIntegrationStatus', () => {
 
   describe('No providers connected', () => {
     it('should return both providers as not connected when credentials are empty', async () => {
-      await updateSetting('integrations_google_credentials', '')
-      await updateSetting('integrations_microsoft_credentials', '')
+      await updateSettings({
+        integrations_google_credentials: '',
+        integrations_microsoft_credentials: '',
+      })
 
       const { result } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -58,8 +60,10 @@ describe('useIntegrationStatus', () => {
     })
 
     it('should return both providers as not connected when credentials are null', async () => {
-      await updateSetting('integrations_google_credentials', null)
-      await updateSetting('integrations_microsoft_credentials', null)
+      await updateSettings({
+        integrations_google_credentials: null,
+        integrations_microsoft_credentials: null,
+      })
 
       const { result } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -85,8 +89,10 @@ describe('useIntegrationStatus', () => {
 
   describe('Google provider connected', () => {
     it('should return Google as connected when credentials exist', async () => {
-      await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'test_token' }))
-      await updateSetting('integrations_microsoft_credentials', '')
+      await updateSettings({
+        integrations_google_credentials: JSON.stringify({ access_token: 'test_token' }),
+        integrations_microsoft_credentials: '',
+      })
 
       const { result } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -112,8 +118,10 @@ describe('useIntegrationStatus', () => {
 
   describe('Microsoft provider connected', () => {
     it('should return Microsoft as connected when credentials exist', async () => {
-      await updateSetting('integrations_google_credentials', '')
-      await updateSetting('integrations_microsoft_credentials', JSON.stringify({ access_token: 'test_token' }))
+      await updateSettings({
+        integrations_google_credentials: '',
+        integrations_microsoft_credentials: JSON.stringify({ access_token: 'test_token' }),
+      })
 
       const { result } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -139,8 +147,10 @@ describe('useIntegrationStatus', () => {
 
   describe('Both providers connected', () => {
     it('should return both providers as connected when both credentials exist', async () => {
-      await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'google_token' }))
-      await updateSetting('integrations_microsoft_credentials', JSON.stringify({ access_token: 'microsoft_token' }))
+      await updateSettings({
+        integrations_google_credentials: JSON.stringify({ access_token: 'google_token' }),
+        integrations_microsoft_credentials: JSON.stringify({ access_token: 'microsoft_token' }),
+      })
 
       const { result } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -166,8 +176,10 @@ describe('useIntegrationStatus', () => {
 
   describe('Edge cases', () => {
     it('should treat empty string as not connected', async () => {
-      await updateSetting('integrations_google_credentials', '')
-      await updateSetting('integrations_microsoft_credentials', '')
+      await updateSettings({
+        integrations_google_credentials: '',
+        integrations_microsoft_credentials: '',
+      })
 
       const { result } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -184,8 +196,10 @@ describe('useIntegrationStatus', () => {
     })
 
     it('should correctly identify connection status for different credential states', async () => {
-      await updateSetting('integrations_google_credentials', '')
-      await updateSetting('integrations_microsoft_credentials', '')
+      await updateSettings({
+        integrations_google_credentials: '',
+        integrations_microsoft_credentials: '',
+      })
 
       const { result: result1 } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -199,7 +213,7 @@ describe('useIntegrationStatus', () => {
       expect(result1.current.data?.googleConnected).toBe(false)
       expect(result1.current.data?.microsoftConnected).toBe(false)
 
-      await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'new_token' }))
+      await updateSettings({ integrations_google_credentials: JSON.stringify({ access_token: 'new_token' }) })
 
       const { result: result2 } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -215,8 +229,10 @@ describe('useIntegrationStatus', () => {
     })
 
     it('should return data structure with correct types', async () => {
-      await updateSetting('integrations_google_credentials', JSON.stringify({ access_token: 'test_token' }))
-      await updateSetting('integrations_microsoft_credentials', JSON.stringify({ access_token: 'test_token' }))
+      await updateSettings({
+        integrations_google_credentials: JSON.stringify({ access_token: 'test_token' }),
+        integrations_microsoft_credentials: JSON.stringify({ access_token: 'test_token' }),
+      })
 
       const { result } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper(),
@@ -247,8 +263,10 @@ describe('useIntegrationStatus', () => {
     })
 
     it('should handle query completion successfully', async () => {
-      await updateSetting('integrations_google_credentials', '')
-      await updateSetting('integrations_microsoft_credentials', '')
+      await updateSettings({
+        integrations_google_credentials: '',
+        integrations_microsoft_credentials: '',
+      })
 
       const { result } = renderHook(() => useIntegrationStatus(), {
         wrapper: createQueryTestWrapper({

--- a/src/hooks/use-oauth-connect.test.tsx
+++ b/src/hooks/use-oauth-connect.test.tsx
@@ -1,4 +1,4 @@
-import { getSettings, updateSetting } from '@/dal'
+import { getSettings, updateSettings } from '@/dal'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { cleanupSessionStorage, mockOAuthCallbackData, mockOAuthErrorCallbackData } from '@/test-utils/oauth'
 import { act, renderHook } from '@testing-library/react'
@@ -13,9 +13,11 @@ const createMockDependencies = (): OAuthDependencies => ({
   },
   redirectOAuthFlow: async (provider: string) => {
     // Simulate what the real redirectOAuthFlow does before redirecting
-    await updateSetting('oauth_state', 'mock_state_12345')
-    await updateSetting('oauth_provider', provider)
-    await updateSetting('oauth_verifier', 'mock_verifier_67890')
+    await updateSettings({
+      oauth_state: 'mock_state_12345',
+      oauth_provider: provider,
+      oauth_verifier: 'mock_verifier_67890',
+    })
     // Throw to simulate the redirect
     throw new Error('Redirecting for OAuth')
   },
@@ -170,9 +172,11 @@ describe('useOAuthConnect', () => {
     it('should handle successful OAuth callback', async () => {
       const callbackData = mockOAuthCallbackData()
       // Setup sqlite settings
-      await updateSetting('oauth_state', callbackData.state!)
-      await updateSetting('oauth_provider', 'google')
-      await updateSetting('oauth_verifier', 'mock_verifier_67890')
+      await updateSettings({
+        oauth_state: callbackData.state!,
+        oauth_provider: 'google',
+        oauth_verifier: 'mock_verifier_67890',
+      })
 
       const onSuccess = mock()
       const onError = mock()
@@ -200,9 +204,11 @@ describe('useOAuthConnect', () => {
     it('should handle state mismatch', async () => {
       const callbackData = mockOAuthCallbackData()
       // Setup sqlite settings with mismatched state
-      await updateSetting('oauth_state', 'different_state')
-      await updateSetting('oauth_provider', 'google')
-      await updateSetting('oauth_verifier', 'mock_verifier_67890')
+      await updateSettings({
+        oauth_state: 'different_state',
+        oauth_provider: 'google',
+        oauth_verifier: 'mock_verifier_67890',
+      })
 
       const onSuccess = mock()
       const onError = mock()

--- a/src/hooks/use-oauth-connect.ts
+++ b/src/hooks/use-oauth-connect.ts
@@ -1,4 +1,4 @@
-import { deleteSetting, getSettings, updateSetting } from '@/dal'
+import { deleteSetting, getSettings, updateSettings } from '@/dal'
 import { buildAuthUrl, exchangeCodeForTokens, getUserInfo, redirectOAuthFlow, type OAuthProvider } from '@/lib/auth'
 import { startOAuthFlowWebview } from '@/lib/oauth-webview'
 import { generateCodeChallenge, generateCodeVerifier } from '@/lib/pkce'
@@ -55,11 +55,13 @@ const saveOAuthCredentials = async (
     },
   }
 
-  await updateSetting(`integrations_${provider}_credentials`, JSON.stringify(credentials))
-  await updateSetting(`integrations_${provider}_is_enabled`, 'true')
+  await updateSettings({
+    [`integrations_${provider}_credentials`]: JSON.stringify(credentials),
+    [`integrations_${provider}_is_enabled`]: 'true',
+  })
 
   if (options.setPreferredName && userInfo.name) {
-    await updateSetting('preferred_name', userInfo.name)
+    await updateSettings({ preferred_name: userInfo.name })
   }
 }
 
@@ -96,10 +98,12 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
           const codeChallenge = await generateCodeChallenge(codeVerifier)
 
           // Store OAuth state for callback validation
-          await updateSetting('oauth_state', state)
-          await updateSetting('oauth_provider', provider)
-          await updateSetting('oauth_verifier', codeVerifier)
-          await updateSetting('oauth_return_context', returnContext)
+          await updateSettings({
+            oauth_state: state,
+            oauth_provider: provider,
+            oauth_verifier: codeVerifier,
+            oauth_return_context: returnContext,
+          })
 
           const authUrl = await buildAuthUrl(provider, state, codeChallenge)
 
@@ -121,7 +125,7 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
         }
       } else {
         // For web: Use redirect flow
-        await updateSetting('oauth_return_context', returnContext)
+        await updateSettings({ oauth_return_context: returnContext })
         await redirect(provider)
       }
     } catch (e: unknown) {

--- a/src/hooks/use-oauth-connect.ts
+++ b/src/hooks/use-oauth-connect.ts
@@ -84,16 +84,48 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
 
     try {
       if (isTauri()) {
-        const result = await startFlow(provider)
+        // Check if we're on mobile (iOS or Android)
+        const { platform } = await import('@tauri-apps/plugin-os')
+        const currentPlatform = await platform()
+        const isMobile = currentPlatform === 'ios' || currentPlatform === 'android'
 
-        if (!result) return
+        if (isMobile) {
+          // For mobile: Open OAuth in system browser with App Link / Universal Link redirect
+          // The deep link listener will handle the callback
+          const { buildAuthUrl } = await import('@/lib/auth')
+          const { v4: uuidv4 } = await import('uuid')
 
-        const { tokens, userInfo } = result
+          const state = uuidv4()
+          const codeVerifier = generateCodeVerifier()
+          const codeChallenge = await generateCodeChallenge(codeVerifier)
 
-        await saveOAuthCredentials(provider, tokens, userInfo, { setPreferredName })
+          // Store OAuth state for callback validation
+          await updateSetting('oauth_state', state)
+          await updateSetting('oauth_provider', provider)
+          await updateSetting('oauth_verifier', codeVerifier)
+          await updateSetting('oauth_return_context', returnContext)
 
-        onSuccess?.()
+          const authUrl = await buildAuthUrl(provider, state, codeChallenge)
+
+          // Open in system browser (not webview)
+          const { openUrl } = await import('@tauri-apps/plugin-opener')
+          await openUrl(authUrl)
+
+          // The callback will be handled by the deep link listener
+        } else {
+          // For desktop: Use webview flow
+          const result = await startFlow(provider)
+
+          if (!result) return
+
+          const { tokens, userInfo } = result
+
+          await saveOAuthCredentials(provider, tokens, userInfo, { setPreferredName })
+
+          onSuccess?.()
+        }
       } else {
+        // For web: Use redirect flow
         await updateSetting('oauth_return_context', returnContext)
         await redirect(provider)
       }
@@ -102,6 +134,25 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
       setError(message)
       onError?.(e instanceof Error ? e : new Error(message))
     }
+  }
+
+  const generateCodeVerifier = (): string => {
+    const array = new Uint8Array(32)
+    crypto.getRandomValues(array)
+    return btoa(String.fromCharCode(...array))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+  }
+
+  const generateCodeChallenge = async (verifier: string): Promise<string> => {
+    const encoder = new TextEncoder()
+    const data = encoder.encode(verifier)
+    const digest = await crypto.subtle.digest('SHA-256', data)
+    return btoa(String.fromCharCode(...new Uint8Array(digest)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
   }
 
   /**

--- a/src/hooks/use-oauth-connect.ts
+++ b/src/hooks/use-oauth-connect.ts
@@ -1,9 +1,11 @@
 import { deleteSetting, getSettings, updateSetting } from '@/dal'
-import { exchangeCodeForTokens, getUserInfo, redirectOAuthFlow, type OAuthProvider } from '@/lib/auth'
+import { buildAuthUrl, exchangeCodeForTokens, getUserInfo, redirectOAuthFlow, type OAuthProvider } from '@/lib/auth'
 import { startOAuthFlowWebview } from '@/lib/oauth-webview'
 import { generateCodeChallenge, generateCodeVerifier } from '@/lib/pkce'
-import { isTauri } from '@/lib/platform'
+import { isMobile, isTauri } from '@/lib/platform'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 
 type OAuthDependencies = {
   startOAuthFlowWebview?: typeof startOAuthFlowWebview
@@ -86,16 +88,9 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
     try {
       if (isTauri()) {
         // Check if we're on mobile (iOS or Android)
-        const { platform } = await import('@tauri-apps/plugin-os')
-        const currentPlatform = await platform()
-        const isMobile = currentPlatform === 'ios' || currentPlatform === 'android'
-
-        if (isMobile) {
+        if (isMobile()) {
           // For mobile: Open OAuth in system browser with App Link / Universal Link redirect
           // The deep link listener will handle the callback
-          const { buildAuthUrl } = await import('@/lib/auth')
-          const { v4: uuidv4 } = await import('uuid')
-
           const state = uuidv4()
           const codeVerifier = generateCodeVerifier()
           const codeChallenge = await generateCodeChallenge(codeVerifier)
@@ -109,7 +104,6 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
           const authUrl = await buildAuthUrl(provider, state, codeChallenge)
 
           // Open in system browser (not webview)
-          const { openUrl } = await import('@tauri-apps/plugin-opener')
           await openUrl(authUrl)
 
           // The callback will be handled by the deep link listener

--- a/src/hooks/use-oauth-connect.ts
+++ b/src/hooks/use-oauth-connect.ts
@@ -1,6 +1,7 @@
 import { deleteSetting, getSettings, updateSetting } from '@/dal'
 import { exchangeCodeForTokens, getUserInfo, redirectOAuthFlow, type OAuthProvider } from '@/lib/auth'
 import { startOAuthFlowWebview } from '@/lib/oauth-webview'
+import { generateCodeChallenge, generateCodeVerifier } from '@/lib/pkce'
 import { isTauri } from '@/lib/platform'
 import { useState } from 'react'
 
@@ -134,25 +135,6 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
       setError(message)
       onError?.(e instanceof Error ? e : new Error(message))
     }
-  }
-
-  const generateCodeVerifier = (): string => {
-    const array = new Uint8Array(32)
-    crypto.getRandomValues(array)
-    return btoa(String.fromCharCode(...array))
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/, '')
-  }
-
-  const generateCodeChallenge = async (verifier: string): Promise<string> => {
-    const encoder = new TextEncoder()
-    const data = encoder.encode(verifier)
-    const digest = await crypto.subtle.digest('SHA-256', data)
-    return btoa(String.fromCharCode(...new Uint8Array(digest)))
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/, '')
   }
 
   /**

--- a/src/hooks/use-oauth-connect.ts
+++ b/src/hooks/use-oauth-connect.ts
@@ -15,7 +15,7 @@ type UseOAuthConnectOptions = {
   onSuccess?: () => void
   onError?: (error: Error) => void
   setPreferredName?: boolean
-  returnContext?: 'onboarding' | 'integrations'
+  returnContext?: string
   dependencies?: OAuthDependencies
 }
 

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -1,6 +1,6 @@
 import { defaultSettings } from '@/defaults/settings'
 import { isSettingModified } from '@/defaults/utils'
-import { getSettingsRecords, resetSettingToDefault, updateSetting } from '@/dal'
+import { getSettingsRecords, resetSettingToDefault, updateSettings } from '@/dal'
 import { deserializeValue, inferTypeFromSchema } from '@/lib/serialization'
 import { camelCased } from '@/lib/utils'
 import type { Setting } from '@/types'
@@ -177,7 +177,7 @@ export function useSettings<T extends SettingSchema>(
       key: string
       value: any
       options?: { recomputeHash?: boolean; updateHashOnly?: boolean }
-    }) => updateSetting(key, value, options),
+    }) => updateSettings({ [key]: value }, options),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['settings', ...keys] })
     },

--- a/src/hooks/use-units-options.test.tsx
+++ b/src/hooks/use-units-options.test.tsx
@@ -1,4 +1,4 @@
-import { updateSetting } from '@/dal/settings'
+import { updateSettings } from '@/dal/settings'
 import { resetTestDatabase, setupTestDatabase } from '@/dal/test-utils'
 import '@testing-library/jest-dom'
 import { act, renderHook } from '@testing-library/react'
@@ -42,7 +42,7 @@ describe('useUnitsOptions', () => {
   beforeEach(async () => {
     await setupTestDatabase()
     // Set up the cloud_url setting in the database
-    await updateSetting('cloud_url', 'https://api.example.com')
+    await updateSettings({ cloud_url: 'https://api.example.com' })
   })
 
   afterEach(async () => {

--- a/src/integrations/google/auth.ts
+++ b/src/integrations/google/auth.ts
@@ -11,13 +11,37 @@ const fetchBackendConfig = memoize(async (): Promise<AuthProviderBackendConfig> 
   return await ky.get(`${cloudUrl}/auth/google/config`).json<AuthProviderBackendConfig>()
 })
 
+/**
+ * Get redirect URI for OAuth flow
+ * For mobile (iOS/Android), use App Link / Universal Link
+ * For desktop, use local webview callback
+ * For web, use the web callback route
+ */
+const getRedirectUri = async (): Promise<string> => {
+  if (!isTauri()) {
+    return window.location.origin + '/oauth/callback'
+  }
+
+  // Check if we're on mobile (iOS or Android)
+  const { platform } = await import('@tauri-apps/plugin-os')
+  const currentPlatform = await platform()
+
+  if (currentPlatform === 'ios' || currentPlatform === 'android') {
+    // Use App Link / Universal Link for mobile
+    return 'https://thunderbolt.io/oauth/callback'
+  }
+
+  // Use local webview callback for desktop
+  return window.location.origin + '/oauth-callback.html'
+}
+
 export const getOAuthConfig = async (): Promise<OAuthConfig> => {
   const { client_id } = await fetchBackendConfig()
+  const redirectUri = await getRedirectUri()
+
   return {
     clientId: client_id,
-    redirectUri: isTauri()
-      ? window.location.origin + '/oauth-callback.html'
-      : window.location.origin + '/oauth/callback',
+    redirectUri,
     scope: [
       'email',
       'profile',

--- a/src/integrations/google/auth.ts
+++ b/src/integrations/google/auth.ts
@@ -1,7 +1,7 @@
 import { getSettings } from '@/dal'
 import type { OAuthConfig, OAuthTokens } from '@/lib/auth'
 import { memoize } from '@/lib/memoize'
-import { isTauri } from '@/lib/platform'
+import { getOAuthRedirectUri } from '@/lib/oauth-redirect'
 import type { AuthProviderBackendConfig } from '@/types'
 import ky from 'ky'
 import type { GoogleUserInfo } from './types'
@@ -11,33 +11,9 @@ const fetchBackendConfig = memoize(async (): Promise<AuthProviderBackendConfig> 
   return await ky.get(`${cloudUrl}/auth/google/config`).json<AuthProviderBackendConfig>()
 })
 
-/**
- * Get redirect URI for OAuth flow
- * For mobile (iOS/Android), use App Link / Universal Link
- * For desktop, use local webview callback
- * For web, use the web callback route
- */
-const getRedirectUri = async (): Promise<string> => {
-  if (!isTauri()) {
-    return window.location.origin + '/oauth/callback'
-  }
-
-  // Check if we're on mobile (iOS or Android)
-  const { platform } = await import('@tauri-apps/plugin-os')
-  const currentPlatform = await platform()
-
-  if (currentPlatform === 'ios' || currentPlatform === 'android') {
-    // Use App Link / Universal Link for mobile
-    return 'https://thunderbolt.io/oauth/callback'
-  }
-
-  // Use local webview callback for desktop
-  return window.location.origin + '/oauth-callback.html'
-}
-
 export const getOAuthConfig = async (): Promise<OAuthConfig> => {
   const { client_id } = await fetchBackendConfig()
-  const redirectUri = await getRedirectUri()
+  const redirectUri = await getOAuthRedirectUri()
 
   return {
     clientId: client_id,

--- a/src/integrations/google/utils.ts
+++ b/src/integrations/google/utils.ts
@@ -1,5 +1,5 @@
 import { refreshAccessToken } from '@/lib/auth'
-import { getSettings, updateSetting } from '@/dal'
+import { getSettings, updateSettings } from '@/dal'
 import type { DraftEmailParams } from './tools'
 
 // =============================================================================
@@ -163,7 +163,7 @@ export const ensureValidGoogleToken = async (credentials: {
     expires_at: Date.now() + newTokens.expires_in * 1000,
   }
 
-  await updateSetting('integrations_google_credentials', JSON.stringify(updated))
+  await updateSettings({ integrations_google_credentials: JSON.stringify(updated) })
 
   return updated.access_token
 }

--- a/src/integrations/microsoft/auth.ts
+++ b/src/integrations/microsoft/auth.ts
@@ -1,43 +1,19 @@
 import { getSettings } from '@/dal'
-import type { GoogleUserInfo } from '@/integrations/google/types'
 import type { OAuthConfig, OAuthTokens } from '@/lib/auth'
 import { memoize } from '@/lib/memoize'
-import { isTauri } from '@/lib/platform'
+import { getOAuthRedirectUri } from '@/lib/oauth-redirect'
 import type { AuthProviderBackendConfig } from '@/types'
 import ky from 'ky'
+import type { MicrosoftUserInfo } from './types'
 
 const fetchBackendConfig = memoize(async (): Promise<AuthProviderBackendConfig> => {
   const { cloudUrl } = await getSettings({ cloud_url: 'http://localhost:8000/v1' })
   return await ky.get(`${cloudUrl}/auth/microsoft/config`).json<AuthProviderBackendConfig>()
 })
 
-/**
- * Get redirect URI for OAuth flow
- * For mobile (iOS/Android), use App Link / Universal Link
- * For desktop, use local webview callback
- * For web, use the web callback route
- */
-const getRedirectUri = async (): Promise<string> => {
-  if (!isTauri()) {
-    return window.location.origin + '/oauth/callback'
-  }
-
-  // Check if we're on mobile (iOS or Android)
-  const { platform } = await import('@tauri-apps/plugin-os')
-  const currentPlatform = await platform()
-
-  if (currentPlatform === 'ios' || currentPlatform === 'android') {
-    // Use App Link / Universal Link for mobile
-    return 'https://thunderbolt.io/oauth/callback'
-  }
-
-  // Use local webview callback for desktop
-  return window.location.origin + '/oauth-callback.html'
-}
-
 export const getOAuthConfig = async (): Promise<OAuthConfig> => {
   const { client_id } = await fetchBackendConfig()
-  const redirectUri = await getRedirectUri()
+  const redirectUri = await getOAuthRedirectUri()
 
   return {
     clientId: client_id,
@@ -70,7 +46,7 @@ export const exchangeCodeForTokens = async (code: string, codeVerifier: string):
     .json<OAuthTokens>()
 }
 
-export const getUserInfo = async (accessToken: string): Promise<GoogleUserInfo> => {
+export const getUserInfo = async (accessToken: string): Promise<MicrosoftUserInfo> => {
   const response = await fetch('https://graph.microsoft.com/v1.0/me', {
     headers: { Authorization: `Bearer ${accessToken}` },
   })

--- a/src/integrations/microsoft/auth.ts
+++ b/src/integrations/microsoft/auth.ts
@@ -11,13 +11,37 @@ const fetchBackendConfig = memoize(async (): Promise<AuthProviderBackendConfig> 
   return await ky.get(`${cloudUrl}/auth/microsoft/config`).json<AuthProviderBackendConfig>()
 })
 
+/**
+ * Get redirect URI for OAuth flow
+ * For mobile (iOS/Android), use App Link / Universal Link
+ * For desktop, use local webview callback
+ * For web, use the web callback route
+ */
+const getRedirectUri = async (): Promise<string> => {
+  if (!isTauri()) {
+    return window.location.origin + '/oauth/callback'
+  }
+
+  // Check if we're on mobile (iOS or Android)
+  const { platform } = await import('@tauri-apps/plugin-os')
+  const currentPlatform = await platform()
+
+  if (currentPlatform === 'ios' || currentPlatform === 'android') {
+    // Use App Link / Universal Link for mobile
+    return 'https://thunderbolt.io/oauth/callback'
+  }
+
+  // Use local webview callback for desktop
+  return window.location.origin + '/oauth-callback.html'
+}
+
 export const getOAuthConfig = async (): Promise<OAuthConfig> => {
   const { client_id } = await fetchBackendConfig()
+  const redirectUri = await getRedirectUri()
+
   return {
     clientId: client_id,
-    redirectUri: isTauri()
-      ? window.location.origin + '/oauth-callback.html'
-      : window.location.origin + '/oauth/callback',
+    redirectUri,
     scope: 'https://graph.microsoft.com/mail.read User.Read offline_access',
   }
 }

--- a/src/integrations/microsoft/tools.ts
+++ b/src/integrations/microsoft/tools.ts
@@ -1,6 +1,6 @@
 // New file with Microsoft Graph tools
 
-import { getSettings, updateSetting } from '@/dal'
+import { getSettings, updateSettings } from '@/dal'
 import type { ToolConfig } from '@/types'
 import ky, { type KyInstance } from 'ky'
 import { z } from 'zod'
@@ -79,7 +79,7 @@ const ensureValidToken = async (credentials: { access_token: string; refresh_tok
       expires_at: Date.now() + newTokens.expires_in * 1000,
     }
 
-    await updateSetting('integrations_microsoft_credentials', JSON.stringify(updated))
+    await updateSettings({ integrations_microsoft_credentials: JSON.stringify(updated) })
 
     return newTokens.access_token
   }

--- a/src/integrations/microsoft/types.ts
+++ b/src/integrations/microsoft/types.ts
@@ -1,0 +1,8 @@
+export type MicrosoftUserInfo = {
+  id: string
+  email: string
+  verified_email: boolean
+  name: string
+  given_name?: string
+  family_name?: string
+}

--- a/src/integrations/thunderbolt-pro/tools.test.ts
+++ b/src/integrations/thunderbolt-pro/tools.test.ts
@@ -1,4 +1,4 @@
-import { updateSetting } from '@/dal/settings'
+import { updateSettings } from '@/dal/settings'
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import type { WeatherForecastData } from '@/widgets/weather-forecast'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
@@ -67,9 +67,11 @@ const mockWeatherForecastData: WeatherForecastData = {
 describe('Thunderbolt Pro Tools', () => {
   beforeEach(async () => {
     // Set up test database with correct values
-    await updateSetting('cloud_url', 'http://localhost:8000/v1')
-    await updateSetting('temperature_unit', 'f')
-    await updateSetting('distance_unit', 'imperial')
+    await updateSettings({
+      cloud_url: 'http://localhost:8000/v1',
+      temperature_unit: 'f',
+      distance_unit: 'imperial',
+    })
   })
 
   describe('search', () => {

--- a/src/lib/oauth-redirect.test.ts
+++ b/src/lib/oauth-redirect.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test'
+import { getOAuthRedirectUri } from './oauth-redirect'
+
+describe('getOAuthRedirectUri', () => {
+  it('returns web callback for non-Tauri environment', async () => {
+    const originalLocation = window.location
+    // @ts-expect-error - mocking window.location
+    delete window.location
+    window.location = { origin: 'https://app.example.com' } as Location
+
+    const uri = await getOAuthRedirectUri()
+
+    expect(uri).toBe('https://app.example.com/oauth/callback')
+
+    // Restore
+    window.location = originalLocation
+  })
+
+  it('returns App Link for mobile platforms', async () => {
+    const uri = await getOAuthRedirectUri()
+
+    // In test environment (not Tauri), should return web callback
+    expect(uri).toContain('/oauth/callback')
+  })
+
+  it('returns valid URL format', async () => {
+    const originalLocation = window.location
+    // @ts-expect-error - mocking window.location
+    delete window.location
+    window.location = { origin: 'https://test.example.com' } as Location
+
+    const uri = await getOAuthRedirectUri()
+
+    // Should be a valid URL
+    expect(() => new URL(uri)).not.toThrow()
+
+    // Should end with /oauth/callback
+    expect(uri).toMatch(/\/oauth\/callback$/)
+
+    // Restore
+    window.location = originalLocation
+  })
+})

--- a/src/lib/oauth-redirect.test.ts
+++ b/src/lib/oauth-redirect.test.ts
@@ -4,16 +4,23 @@ import { getOAuthRedirectUri } from './oauth-redirect'
 describe('getOAuthRedirectUri', () => {
   it('returns web callback for non-Tauri environment', async () => {
     const originalLocation = window.location
-    // @ts-expect-error - mocking window.location
-    delete window.location
-    window.location = { origin: 'https://app.example.com' } as Location
+    const mockLocation = { origin: 'https://app.example.com' } as Location
+    Object.defineProperty(window, 'location', {
+      value: mockLocation,
+      writable: true,
+      configurable: true,
+    })
 
     const uri = await getOAuthRedirectUri()
 
     expect(uri).toBe('https://app.example.com/oauth/callback')
 
     // Restore
-    window.location = originalLocation
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
   })
 
   it('returns App Link for mobile platforms', async () => {
@@ -25,9 +32,12 @@ describe('getOAuthRedirectUri', () => {
 
   it('returns valid URL format', async () => {
     const originalLocation = window.location
-    // @ts-expect-error - mocking window.location
-    delete window.location
-    window.location = { origin: 'https://test.example.com' } as Location
+    const mockLocation = { origin: 'https://test.example.com' } as Location
+    Object.defineProperty(window, 'location', {
+      value: mockLocation,
+      writable: true,
+      configurable: true,
+    })
 
     const uri = await getOAuthRedirectUri()
 
@@ -38,6 +48,10 @@ describe('getOAuthRedirectUri', () => {
     expect(uri).toMatch(/\/oauth\/callback$/)
 
     // Restore
-    window.location = originalLocation
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
   })
 })

--- a/src/lib/oauth-redirect.ts
+++ b/src/lib/oauth-redirect.ts
@@ -1,0 +1,25 @@
+import { isTauri } from '@/lib/platform'
+
+/**
+ * Determines the correct OAuth redirect URI based on the platform
+ *
+ * - Web: Uses the web callback route at the current origin
+ * - Mobile (iOS/Android): Uses App Link / Universal Link (https://thunderbolt.io/oauth/callback)
+ * - Desktop (Tauri): Uses local webview callback
+ *
+ * @returns The appropriate redirect URI for the current platform
+ */
+export const getOAuthRedirectUri = async (): Promise<string> => {
+  if (!isTauri()) {
+    return window.location.origin + '/oauth/callback'
+  }
+
+  const { platform } = await import('@tauri-apps/plugin-os')
+  const currentPlatform = await platform()
+
+  if (currentPlatform === 'ios' || currentPlatform === 'android') {
+    return 'https://thunderbolt.io/oauth/callback'
+  }
+
+  return window.location.origin + '/oauth-callback.html'
+}

--- a/src/lib/oauth-state.ts
+++ b/src/lib/oauth-state.ts
@@ -1,4 +1,4 @@
-import { getSettings, updateSetting, deleteSetting } from '@/dal'
+import { getSettings, updateSettings, deleteSetting } from '@/dal'
 import type { OAuthProvider } from './auth'
 
 /**
@@ -34,22 +34,24 @@ export const getOAuthState = async (): Promise<OAuthState> => {
  * Sets OAuth state in sqlite settings
  */
 export const setOAuthState = async (state: Partial<OAuthState>): Promise<void> => {
-  const promises: Promise<void>[] = []
+  const settings: Record<string, string | null> = {}
 
   if (state.state !== undefined) {
-    promises.push(updateSetting('oauth_state', state.state))
+    settings.oauth_state = state.state
   }
   if (state.provider !== undefined) {
-    promises.push(updateSetting('oauth_provider', state.provider))
+    settings.oauth_provider = state.provider
   }
   if (state.verifier !== undefined) {
-    promises.push(updateSetting('oauth_verifier', state.verifier))
+    settings.oauth_verifier = state.verifier
   }
   if (state.returnContext !== undefined) {
-    promises.push(updateSetting('oauth_return_context', state.returnContext))
+    settings.oauth_return_context = state.returnContext
   }
 
-  await Promise.all(promises)
+  if (Object.keys(settings).length > 0) {
+    await updateSettings(settings)
+  }
 }
 
 /**

--- a/src/lib/pkce.test.ts
+++ b/src/lib/pkce.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test'
+import { generateCodeChallenge, generateCodeVerifier } from './pkce'
+
+describe('generateCodeVerifier', () => {
+  it('generates a valid code verifier', () => {
+    const verifier = generateCodeVerifier()
+
+    // Should be a non-empty string
+    expect(verifier).toBeTruthy()
+    expect(typeof verifier).toBe('string')
+
+    // Should be URL-safe (no +, /, or = characters)
+    expect(verifier).not.toMatch(/[+/=]/)
+
+    // Should be base64url encoded (43-128 characters as per RFC 7636)
+    expect(verifier.length).toBeGreaterThanOrEqual(43)
+    expect(verifier.length).toBeLessThanOrEqual(128)
+  })
+
+  it('generates unique verifiers on each call', () => {
+    const verifier1 = generateCodeVerifier()
+    const verifier2 = generateCodeVerifier()
+    const verifier3 = generateCodeVerifier()
+
+    expect(verifier1).not.toBe(verifier2)
+    expect(verifier2).not.toBe(verifier3)
+    expect(verifier1).not.toBe(verifier3)
+  })
+})
+
+describe('generateCodeChallenge', () => {
+  it('generates a valid code challenge from a verifier', async () => {
+    const verifier = generateCodeVerifier()
+    const challenge = await generateCodeChallenge(verifier)
+
+    // Should be a non-empty string
+    expect(challenge).toBeTruthy()
+    expect(typeof challenge).toBe('string')
+
+    // Should be URL-safe (no +, /, or = characters)
+    expect(challenge).not.toMatch(/[+/=]/)
+
+    // SHA-256 hash encoded as base64url should be 43 characters
+    expect(challenge.length).toBe(43)
+  })
+
+  it('generates the same challenge for the same verifier', async () => {
+    const verifier = 'test-verifier-12345'
+    const challenge1 = await generateCodeChallenge(verifier)
+    const challenge2 = await generateCodeChallenge(verifier)
+
+    expect(challenge1).toBe(challenge2)
+  })
+
+  it('generates different challenges for different verifiers', async () => {
+    const verifier1 = 'test-verifier-1'
+    const verifier2 = 'test-verifier-2'
+    const challenge1 = await generateCodeChallenge(verifier1)
+    const challenge2 = await generateCodeChallenge(verifier2)
+
+    expect(challenge1).not.toBe(challenge2)
+  })
+
+  it('handles empty string', async () => {
+    const challenge = await generateCodeChallenge('')
+
+    expect(challenge).toBeTruthy()
+    expect(typeof challenge).toBe('string')
+    expect(challenge.length).toBe(43)
+  })
+})
+
+describe('PKCE flow integration', () => {
+  it('verifier and challenge work together', async () => {
+    const verifier = generateCodeVerifier()
+    const challenge = await generateCodeChallenge(verifier)
+
+    // Both should be valid strings
+    expect(verifier).toBeTruthy()
+    expect(challenge).toBeTruthy()
+
+    // Challenge should be derived from verifier
+    const challengeAgain = await generateCodeChallenge(verifier)
+    expect(challenge).toBe(challengeAgain)
+  })
+})

--- a/src/lib/pkce.ts
+++ b/src/lib/pkce.ts
@@ -1,0 +1,27 @@
+/**
+ * Generates a cryptographically secure code verifier for PKCE (Proof Key for Code Exchange)
+ * @returns A URL-safe base64-encoded random string
+ */
+export const generateCodeVerifier = (): string => {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+/**
+ * Generates a code challenge from a code verifier using SHA-256 hashing
+ * @param verifier - The code verifier to hash
+ * @returns A URL-safe base64-encoded SHA-256 hash of the verifier
+ */
+export const generateCodeChallenge = async (verifier: string): Promise<string> => {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(verifier)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}

--- a/src/settings/integrations.tsx
+++ b/src/settings/integrations.tsx
@@ -10,7 +10,7 @@ import { configs as microsoftToolConfigs } from '@/integrations/microsoft/tools'
 import { configs as proToolConfigs } from '@/integrations/thunderbolt-pro/tools'
 import { getProStatus } from '@/integrations/thunderbolt-pro/utils'
 import { type OAuthProvider } from '@/lib/auth'
-import { getSettings, updateSetting } from '@/dal'
+import { getSettings, updateSettings } from '@/dal'
 import { useOAuthConnect } from '@/hooks/use-oauth-connect'
 import { useEffect, useState, type ReactNode } from 'react'
 import { useLocation, useNavigate } from 'react-router'
@@ -180,8 +180,10 @@ export default function IntegrationsPage() {
 
   const handleDisconnect = async (integration: Integration) => {
     try {
-      await updateSetting(`integrations_${integration.provider}_credentials`, '')
-      await updateSetting(`integrations_${integration.provider}_is_enabled`, 'false')
+      await updateSettings({
+        [`integrations_${integration.provider}_credentials`]: '',
+        [`integrations_${integration.provider}_is_enabled`]: 'false',
+      })
 
       console.log(`Disconnected from ${integration.name}`)
 
@@ -199,7 +201,7 @@ export default function IntegrationsPage() {
           ? 'integrations_pro_is_enabled'
           : `integrations_${integration.provider}_is_enabled`
 
-      await updateSetting(settingKey, enabled.toString())
+      await updateSettings({ [settingKey]: enabled.toString() })
 
       setIntegrations((prev) => prev.map((i) => (i.id === integration.id ? { ...i, isEnabled: enabled } : i)))
 

--- a/src/widgets/connect-integration/widget.tsx
+++ b/src/widgets/connect-integration/widget.tsx
@@ -108,7 +108,7 @@ export const ConnectIntegrationWidget = memo(
           )
         }, connectedStateDisplayDuration)
       },
-      returnContext: 'integrations',
+      returnContext: location.pathname,
     })
 
     const handleOAuthCallback = async (oauth: { code?: string; state?: string; error?: string }) => {


### PR DESCRIPTION
Implements verified HTTPS deep links (aka App Links (Android) or Universal Links (iOS)) (https://thunderbolt.io/oauth/callback) for seamless mobile OAuth with Google/Microsoft. Mobile devices now use system browser with PKCE flow. Includes deep link listener hook, comprehensive tests (33 passing), and refactored utilities for better code reuse.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds verified HTTPS deep links for mobile OAuth (with PKCE) and a deep-link listener, refactors settings to batch `updateSettings`, and updates Google/Microsoft auth plus new Microsoft tools.
> 
> - **Mobile Deep Linking & Tauri**:
>   - Add `@tauri-apps/plugin-deep-link`, initialize in `src-tauri/src/lib.rs`, and configure in `src-tauri/tauri.conf.json` with `https://thunderbolt.io/oauth/callback`.
>   - iOS entitlements (`associated-domains`) and Android `public/.well-known/assetlinks.json` updated.
>   - Capabilities grant `deep-link:default` in `capabilities/*.json`.
> - **OAuth Flow (PKCE + Redirects)**:
>   - New `getOAuthRedirectUri` and PKCE utils (`generateCodeVerifier/Challenge`).
>   - Google/Microsoft auth use platform-aware redirect + PKCE; desktop webview vs mobile system browser.
>   - New `useDeepLinkListener` to parse OAuth callbacks and navigate; integrated in `src/app.tsx`.
> - **Settings API Refactor**:
>   - Replace `updateSetting` with batch `updateSettings` across app, hooks, tests, and widgets.
> - **Integrations**:
>   - Add Microsoft Graph tools (`listMessages`, `getMessage`) and types.
>   - Update onboarding, integrations page, and connect-integration widget to new OAuth/return-context flow.
> - **Tests**:
>   - Comprehensive tests for deep-link listener, PKCE, OAuth redirect, settings, integrations, and tools.
> - **Dependencies**:
>   - Add `@tauri-apps/plugin-deep-link`; update lockfiles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21ca04280a3a11e3f2be9768c063b28331b39785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->