### PR TITLE
THU-140: fix oauth integration for Desktop

### DIFF
--- a/src/integrations/google/auth.ts
+++ b/src/integrations/google/auth.ts
@@ -13,7 +13,7 @@ const fetchBackendConfig = memoize(async (): Promise<AuthProviderBackendConfig> 
 
 export const getOAuthConfig = async (): Promise<OAuthConfig> => {
   const { client_id } = await fetchBackendConfig()
-  const redirectUri = await getOAuthRedirectUri()
+  const redirectUri = getOAuthRedirectUri()
 
   return {
     clientId: client_id,

--- a/src/integrations/microsoft/auth.ts
+++ b/src/integrations/microsoft/auth.ts
@@ -13,7 +13,7 @@ const fetchBackendConfig = memoize(async (): Promise<AuthProviderBackendConfig> 
 
 export const getOAuthConfig = async (): Promise<OAuthConfig> => {
   const { client_id } = await fetchBackendConfig()
-  const redirectUri = await getOAuthRedirectUri()
+  const redirectUri = getOAuthRedirectUri()
 
   return {
     clientId: client_id,

--- a/src/lib/oauth-redirect.test.ts
+++ b/src/lib/oauth-redirect.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { getOAuthRedirectUri } from './oauth-redirect'
 
 describe('getOAuthRedirectUri', () => {
-  it('returns web callback for non-Tauri environment', async () => {
+  it('returns web callback for non-Tauri environment', () => {
     const originalLocation = window.location
     const mockLocation = { origin: 'https://app.example.com' } as Location
     Object.defineProperty(window, 'location', {
@@ -11,7 +11,7 @@ describe('getOAuthRedirectUri', () => {
       configurable: true,
     })
 
-    const uri = await getOAuthRedirectUri()
+    const uri = getOAuthRedirectUri()
 
     expect(uri).toBe('https://app.example.com/oauth/callback')
 
@@ -23,14 +23,14 @@ describe('getOAuthRedirectUri', () => {
     })
   })
 
-  it('returns App Link for mobile platforms', async () => {
-    const uri = await getOAuthRedirectUri()
+  it('returns App Link for mobile platforms', () => {
+    const uri = getOAuthRedirectUri()
 
     // In test environment (not Tauri), should return web callback
     expect(uri).toContain('/oauth/callback')
   })
 
-  it('returns valid URL format', async () => {
+  it('returns valid URL format', () => {
     const originalLocation = window.location
     const mockLocation = { origin: 'https://test.example.com' } as Location
     Object.defineProperty(window, 'location', {
@@ -39,7 +39,7 @@ describe('getOAuthRedirectUri', () => {
       configurable: true,
     })
 
-    const uri = await getOAuthRedirectUri()
+    const uri = getOAuthRedirectUri()
 
     // Should be a valid URL
     expect(() => new URL(uri)).not.toThrow()

--- a/src/lib/oauth-redirect.ts
+++ b/src/lib/oauth-redirect.ts
@@ -1,23 +1,20 @@
-import { isTauri } from '@/lib/platform'
+import { isMobile, isTauri } from '@/lib/platform'
 
 /**
  * Determines the correct OAuth redirect URI based on the platform
  *
  * - Web: Uses the web callback route at the current origin
  * - Mobile (iOS/Android): Uses App Link / Universal Link (https://thunderbolt.io/oauth/callback)
- * - Desktop (Tauri): Uses localhost URL that Google accepts and Tauri intercepts
+ * - Desktop (Tauri): Uses local webview callback
  *
  * @returns The appropriate redirect URI for the current platform
  */
-export const getOAuthRedirectUri = async (): Promise<string> => {
+export const getOAuthRedirectUri = (): string => {
   if (!isTauri()) {
     return window.location.origin + '/oauth/callback'
   }
 
-  const { platform } = await import('@tauri-apps/plugin-os')
-  const currentPlatform = await platform()
-
-  if (currentPlatform === 'ios' || currentPlatform === 'android') {
+  if (isMobile()) {
     // Mobile: Use App Link / Universal Link (verified HTTPS domain)
     return 'https://thunderbolt.io/oauth/callback'
   }

--- a/src/lib/oauth-redirect.ts
+++ b/src/lib/oauth-redirect.ts
@@ -5,7 +5,7 @@ import { isTauri } from '@/lib/platform'
  *
  * - Web: Uses the web callback route at the current origin
  * - Mobile (iOS/Android): Uses App Link / Universal Link (https://thunderbolt.io/oauth/callback)
- * - Desktop (Tauri): Uses local webview callback
+ * - Desktop (Tauri): Uses localhost URL that Google accepts and Tauri intercepts
  *
  * @returns The appropriate redirect URI for the current platform
  */
@@ -18,6 +18,7 @@ export const getOAuthRedirectUri = async (): Promise<string> => {
   const currentPlatform = await platform()
 
   if (currentPlatform === 'ios' || currentPlatform === 'android') {
+    // Mobile: Use App Link / Universal Link (verified HTTPS domain)
     return 'https://thunderbolt.io/oauth/callback'
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make OAuth redirect URI determination synchronous and update Google/Microsoft integrations and tests accordingly.
> 
> - **OAuth Redirect Logic**:
>   - Refactor `getOAuthRedirectUri` to be synchronous and rely on `isMobile()` + `isTauri()` instead of dynamic OS lookup.
>   - Web returns `origin + /oauth/callback`; Tauri mobile uses `https://thunderbolt.io/oauth/callback`; Tauri desktop uses `origin + /oauth-callback.html`.
> - **Integrations**:
>   - Update `src/integrations/google/auth.ts` and `src/integrations/microsoft/auth.ts` to use sync `getOAuthRedirectUri()` in `getOAuthConfig`.
> - **Tests**:
>   - Update `src/lib/oauth-redirect.test.ts` to remove async/await and align with synchronous API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 348162cb09df4e8589d1a677432b0393cbfe50e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->