### PR TITLE
THU-186: Make reasoning preview text area fixed height

### DIFF
--- a/backend/src/inference/client.ts
+++ b/backend/src/inference/client.ts
@@ -23,7 +23,7 @@ let thunderboltClient: OpenAI | PostHogOpenAI | null = null
 /**
  * Get the Fireworks AI client
  */
-const getFireworksClient = (): OpenAI | PostHogOpenAI => {
+const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
   if (fireworksClient) {
     return fireworksClient
   }
@@ -37,12 +37,13 @@ const getFireworksClient = (): OpenAI | PostHogOpenAI => {
   const params = {
     apiKey: settings.fireworksApiKey,
     baseURL: 'https://api.fireworks.ai/inference/v1',
+    ...(fetchFn && { fetch: fetchFn }),
   }
 
   fireworksClient = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
-        posthog: getPostHogClient(),
+        posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
@@ -52,7 +53,7 @@ const getFireworksClient = (): OpenAI | PostHogOpenAI => {
 /**
  * Get the Thunderbolt inference client for gpt-oss
  */
-const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
+const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
   if (thunderboltClient) {
     return thunderboltClient
   }
@@ -66,12 +67,13 @@ const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
   const params = {
     apiKey: settings.thunderboltInferenceApiKey,
     baseURL: settings.thunderboltInferenceUrl,
+    ...(fetchFn && { fetch: fetchFn }),
   }
 
   thunderboltClient = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
-        posthog: getPostHogClient(),
+        posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
@@ -82,8 +84,8 @@ const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
  * Get the appropriate inference client based on provider
  * Clients are lazily initialized and reused across requests
  */
-export const getInferenceClient = (provider: InferenceProvider): InferenceClient => {
-  const client = provider === 'thunderbolt' ? getThunderboltClient() : getFireworksClient()
+export const getInferenceClient = (provider: InferenceProvider, fetchFn?: typeof fetch): InferenceClient => {
+  const client = provider === 'thunderbolt' ? getThunderboltClient(fetchFn) : getFireworksClient(fetchFn)
 
   return {
     client,

--- a/backend/src/inference/client.ts
+++ b/backend/src/inference/client.ts
@@ -24,7 +24,8 @@ let thunderboltClient: OpenAI | PostHogOpenAI | null = null
  * Get the Fireworks AI client
  */
 const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
-  if (fireworksClient) {
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (fireworksClient && !fetchFn) {
     return fireworksClient
   }
 
@@ -40,21 +41,27 @@ const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
     ...(fetchFn && { fetch: fetchFn }),
   }
 
-  fireworksClient = isPostHogConfigured()
+  const client = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
         posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
-  return fireworksClient
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    fireworksClient = client
+  }
+
+  return client
 }
 
 /**
  * Get the Thunderbolt inference client for gpt-oss
  */
 const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
-  if (thunderboltClient) {
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (thunderboltClient && !fetchFn) {
     return thunderboltClient
   }
 
@@ -70,14 +77,19 @@ const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI =>
     ...(fetchFn && { fetch: fetchFn }),
   }
 
-  thunderboltClient = isPostHogConfigured()
+  const client = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
         posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
-  return thunderboltClient
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    thunderboltClient = client
+  }
+
+  return client
 }
 
 /**

--- a/backend/src/inference/posthog-privacy.test.ts
+++ b/backend/src/inference/posthog-privacy.test.ts
@@ -1,13 +1,25 @@
 import { clearSettingsCache } from '@/config/settings'
-import { isPostHogConfigured, shutdownPostHog } from '@/posthog/client'
+import { clearPostHogClient, isPostHogConfigured, shutdownPostHog } from '@/posthog/client'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { OpenAI as PostHogOpenAI } from '@posthog/ai'
 import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test'
 import { clearInferenceClientCache, getInferenceClient } from './client'
 
+type PostHogEvent = {
+  event?: string
+  properties?: Record<string, unknown>
+}
+
+type PostHogBatchRequest = {
+  batch: PostHogEvent[]
+}
+
+type PostHogRequestBody = PostHogEvent | PostHogBatchRequest
+
 type FetchCall = {
   url: string
   options: RequestInit
-  body: any
+  body: PostHogRequestBody | null
 }
 
 /**
@@ -16,7 +28,7 @@ type FetchCall = {
  */
 describe('Inference Routes - PostHog Privacy Integration', () => {
   let capturedFetches: FetchCall[] = []
-  let mockFetch: jest.Mock
+  let mockFetch: typeof fetch
   let originalEnv: Record<string, string | undefined>
 
   beforeEach(() => {
@@ -32,10 +44,19 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
     capturedFetches = []
     mockFetch = jest.fn(async (url: string, options: RequestInit) => {
       // Capture all fetch calls
+      let parsedBody: PostHogRequestBody | null = null
+      if (options.body) {
+        try {
+          parsedBody = JSON.parse(options.body as string) as PostHogRequestBody
+        } catch {
+          // Not JSON, skip parsing
+        }
+      }
+
       capturedFetches.push({
         url,
         options,
-        body: options.body ? JSON.parse(options.body as string) : null,
+        body: parsedBody,
       })
 
       // Return appropriate mock responses based on URL
@@ -74,10 +95,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
           headers: { 'Content-Type': 'application/json' },
         },
       )
-    })
-
-    // Mock global fetch
-    global.fetch = mockFetch as any
+    }) as unknown as typeof fetch
   })
 
   afterEach(async () => {
@@ -86,7 +104,12 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
     // Clear settings and PostHog caches
     clearSettingsCache()
-    await shutdownPostHog()
+
+    // Shutdown PostHog with a short timeout (100ms) since we're using mocked fetch
+    await shutdownPostHog(100)
+
+    // Clear the PostHog client cache
+    clearPostHogClient()
 
     // Restore original env vars
     for (const [key, value] of Object.entries(originalEnv)) {
@@ -114,9 +137,10 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
       // Import and check the client
       const { getPostHogClient } = require('@/posthog/client')
-      const client = getPostHogClient()
+      const client = getPostHogClient(mockFetch)
 
       // Verify our workaround is in place
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((client as any).privacy_mode).toBe(true)
       expect(client.options.privacyMode).toBe(true)
     })
@@ -130,8 +154,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Verify it's a PostHog-wrapped client
       expect(client.constructor.name).toBe('PostHogOpenAI')
@@ -146,8 +171,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Verify client exists and is functional
       expect(client).toBeDefined()
@@ -165,9 +191,10 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      // Get the wrapped client
-      const { client } = getInferenceClient('fireworks')
+      // Get the wrapped client with injected mock fetch
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Make a completion with sensitive data
       const completion = await (client as PostHogOpenAI).chat.completions.create({
@@ -199,7 +226,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
       // If PostHog sent events, verify they don't contain conversation content
       for (const request of posthogRequests) {
-        const batch = request.body?.batch || [request.body]
+        if (!request.body) continue
+
+        const batch = 'batch' in request.body ? request.body.batch : [request.body]
 
         for (const event of batch) {
           const properties = event.properties || {}
@@ -228,8 +257,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Make multiple completions
       const conversations = [
@@ -265,11 +295,13 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
         expect(requestStr.includes('Private API keys')).toBe(false)
 
         // Also check the structured data
-        const batch = request.body?.batch || [request.body]
-        for (const event of batch) {
-          const properties = event.properties || {}
-          expect(properties.$ai_input).toBeNullOrUndefined()
-          expect(properties.$ai_output_choices).toBeNullOrUndefined()
+        if (request.body) {
+          const batch = 'batch' in request.body ? request.body.batch : [request.body]
+          for (const event of batch) {
+            const properties = event.properties || {}
+            expect(properties.$ai_input).toBeNullOrUndefined()
+            expect(properties.$ai_output_choices).toBeNullOrUndefined()
+          }
         }
       }
     })
@@ -277,6 +309,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 })
 
 expect.extend({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toBeNullOrUndefined(received: any) {
     const pass = received === null || received === undefined
     return {

--- a/backend/src/posthog/client.ts
+++ b/backend/src/posthog/client.ts
@@ -7,7 +7,7 @@ let phClient: PostHog | null = null
  * Initialize and get the PostHog analytics client
  * Uses lazy initialization with settings from environment
  */
-export const getPostHogClient = (): PostHog => {
+export const getPostHogClient = (fetchFn?: typeof fetch): PostHog => {
   if (!phClient) {
     const settings = getSettings()
 
@@ -18,11 +18,13 @@ export const getPostHogClient = (): PostHog => {
     phClient = new PostHog(settings.posthogApiKey, {
       host: settings.posthogHost,
       privacyMode: true,
+      ...(fetchFn && { fetch: fetchFn }),
     })
 
     // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
     // but PostHog Node client only stores it in `options.privacyMode`
     // Manually set it so the AI library can detect it
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(phClient as any).privacy_mode = true
   }
 
@@ -32,9 +34,9 @@ export const getPostHogClient = (): PostHog => {
 /**
  * Shutdown the PostHog client (call on app termination)
  */
-export const shutdownPostHog = async (): Promise<void> => {
+export const shutdownPostHog = async (timeoutMs = 3000): Promise<void> => {
   if (phClient) {
-    await phClient.shutdown()
+    await phClient.shutdown(timeoutMs)
     phClient = null
   }
 }
@@ -45,4 +47,11 @@ export const shutdownPostHog = async (): Promise<void> => {
 export const isPostHogConfigured = (): boolean => {
   const settings = getSettings()
   return !!settings.posthogApiKey
+}
+
+/**
+ * Clear the PostHog client cache (for testing)
+ */
+export const clearPostHogClient = (): void => {
+  phClient = null
 }

--- a/backend/src/posthog/client.ts
+++ b/backend/src/posthog/client.ts
@@ -8,27 +8,35 @@ let phClient: PostHog | null = null
  * Uses lazy initialization with settings from environment
  */
 export const getPostHogClient = (fetchFn?: typeof fetch): PostHog => {
-  if (!phClient) {
-    const settings = getSettings()
-
-    if (!settings.posthogApiKey) {
-      throw new Error('PostHog API key not configured - set POSTHOG_API_KEY environment variable')
-    }
-
-    phClient = new PostHog(settings.posthogApiKey, {
-      host: settings.posthogHost,
-      privacyMode: true,
-      ...(fetchFn && { fetch: fetchFn }),
-    })
-
-    // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
-    // but PostHog Node client only stores it in `options.privacyMode`
-    // Manually set it so the AI library can detect it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(phClient as any).privacy_mode = true
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (phClient && !fetchFn) {
+    return phClient
   }
 
-  return phClient
+  const settings = getSettings()
+
+  if (!settings.posthogApiKey) {
+    throw new Error('PostHog API key not configured - set POSTHOG_API_KEY environment variable')
+  }
+
+  const client = new PostHog(settings.posthogApiKey, {
+    host: settings.posthogHost,
+    privacyMode: true,
+    ...(fetchFn && { fetch: fetchFn }),
+  })
+
+  // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
+  // but PostHog Node client only stores it in `options.privacyMode`
+  // Manually set it so the AI library can detect it
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).privacy_mode = true
+
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    phClient = client
+  }
+
+  return client
 }
 
 /**

--- a/src/components/chat/reasoning-display.tsx
+++ b/src/components/chat/reasoning-display.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
 
 type ReasoningDisplayProps = {
-  text: string
+  text?: string
   isStreaming: boolean
   instanceKey: string // Unique key to identify different reasoning instances
 }
@@ -16,17 +16,19 @@ type ReasoningDisplayProps = {
  * - Cleans up timers properly
  */
 export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDisplayProps) => {
-  const [displayText, setDisplayText] = useState(text)
+  const [displayText, setDisplayText] = useState(text ?? '')
   const [shouldShow, setShouldShow] = useState(isStreaming)
   const [currentKey, setCurrentKey] = useState(instanceKey)
   const displayStartTimeRef = useRef(Date.now())
   const fadeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
+  const hasText = Boolean(text && text.trim())
+
   // Update display text and reset timers when text or key changes
   useEffect(() => {
     // New reasoning instance or text changed
     if (text !== displayText || instanceKey !== currentKey) {
-      setDisplayText(text)
+      setDisplayText(text ?? '')
       setCurrentKey(instanceKey)
       setShouldShow(true)
       displayStartTimeRef.current = Date.now()
@@ -39,9 +41,9 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
     }
   }, [text, displayText, instanceKey, currentKey])
 
-  // Handle fade-out logic when streaming stops
+  // Handle fade-out logic when streaming stops (only if there's text)
   useEffect(() => {
-    if (!isStreaming && shouldShow) {
+    if (!isStreaming && shouldShow && hasText) {
       // Clear any existing timeout
       if (fadeTimeoutRef.current) {
         clearTimeout(fadeTimeoutRef.current)
@@ -68,7 +70,7 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
         fadeTimeoutRef.current = null
       }
     }
-  }, [isStreaming, shouldShow])
+  }, [isStreaming, shouldShow, hasText])
 
   // Reset shouldShow when streaming starts again
   useEffect(() => {
@@ -85,28 +87,31 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
     rootMargin: '0px',
   })
 
+  // Always render the container with min-height, but only show content when there's text
   return (
-    <AnimatePresence mode="wait">
-      {shouldShow && displayText && (
-        <motion.div
-          key={instanceKey}
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -10 }}
-          transition={{ duration: 0.3 }}
-          className="relative text-muted-foreground leading-relaxed text-sm mt-1"
-          ref={(el) => {
-            scrollContainerRef.current = el
-          }}
-        >
-          <div className="absolute top-0 w-full h-6 bg-gradient-to-b from-background to-transparent" />
-          <div className="max-h-[200px] px-4 hide-scrollbar py-3">
-            {displayText}
-            <div ref={scrollTargetRef} />
-          </div>
-          <div className="absolute bottom-0 w-full h-6 bg-gradient-to-b from-transparent to-background" />
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <div className="relative mt-1 min-h-[200px]">
+      <AnimatePresence mode="wait">
+        {shouldShow && hasText && (
+          <motion.div
+            key={instanceKey}
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.3 }}
+            className="relative text-muted-foreground leading-relaxed text-sm"
+            ref={(el) => {
+              scrollContainerRef.current = el
+            }}
+          >
+            <div className="absolute top-0 w-full h-6 bg-gradient-to-b from-background to-transparent" />
+            <div className="max-h-[200px] px-4 hide-scrollbar py-3">
+              {displayText}
+              <div ref={scrollTargetRef} />
+            </div>
+            <div className="absolute bottom-0 w-full h-6 bg-gradient-to-b from-transparent to-background" />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
   )
 }

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -70,10 +70,10 @@ export const ReasoningGroup = ({ parts, isStreaming, isLastPartInMessage, hasTex
           <div ref={scrollTargetRef} />
         </div>
       </Expandable>
-      {!hasTextPart && currentReasoningPart && (
+      {!hasTextPart && (
         <ReasoningDisplay
-          text={currentReasoningPart.content.text}
-          isStreaming={currentReasoningPart.content.state === 'streaming'}
+          text={currentReasoningPart?.content.text}
+          isStreaming={currentReasoningPart?.content.state === 'streaming'}
           instanceKey={reasoningInstanceKey}
         />
       )}


### PR DESCRIPTION
## Preview

https://github.com/user-attachments/assets/2058390c-4d07-466d-b74a-e93b77e60789

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes reasoning preview to a fixed height and adds injectable fetch to inference/PostHog clients with expanded privacy-safe PostHog tests.
> 
> - **Frontend (UI)**:
>   - **Reasoning preview**: `src/components/chat/reasoning-display.tsx` now supports optional `text`, renders a fixed min-height container (`min-h-[200px]`), and only fades out when content exists; refined animation/render conditions.
>   - **Reasoning group**: `src/components/chat/reasoning-group.tsx` always shows `ReasoningDisplay` when no text part, using optional chaining for safety.
> - **Backend**:
>   - **Injectable fetch + caching**: `backend/src/inference/client.ts` and `backend/src/posthog/client.ts` accept optional `fetch` to bypass cache (for testing), cache only when not provided.
>   - **PostHog client**: supports injected `fetch`, preserves `privacy_mode` flag, adds `shutdownPostHog(timeoutMs)` and `clearPostHogClient()`.
> - **Tests**:
>   - Expanded `posthog-privacy.test.ts` to use typed mocked `fetch`, inject into clients, ensure no conversation content is sent to PostHog (single and batch), and manage caches/shutdowns for isolation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a05c610039c86f6e4eac86a7dfe58f4893f68c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->