### PR TITLE
THU-185: Tool info screen header (where close button is) is cut off on mobile

### DIFF
--- a/backend/src/inference/client.ts
+++ b/backend/src/inference/client.ts
@@ -23,7 +23,7 @@ let thunderboltClient: OpenAI | PostHogOpenAI | null = null
 /**
  * Get the Fireworks AI client
  */
-const getFireworksClient = (): OpenAI | PostHogOpenAI => {
+const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
   if (fireworksClient) {
     return fireworksClient
   }
@@ -37,12 +37,13 @@ const getFireworksClient = (): OpenAI | PostHogOpenAI => {
   const params = {
     apiKey: settings.fireworksApiKey,
     baseURL: 'https://api.fireworks.ai/inference/v1',
+    ...(fetchFn && { fetch: fetchFn }),
   }
 
   fireworksClient = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
-        posthog: getPostHogClient(),
+        posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
@@ -52,7 +53,7 @@ const getFireworksClient = (): OpenAI | PostHogOpenAI => {
 /**
  * Get the Thunderbolt inference client for gpt-oss
  */
-const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
+const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
   if (thunderboltClient) {
     return thunderboltClient
   }
@@ -66,12 +67,13 @@ const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
   const params = {
     apiKey: settings.thunderboltInferenceApiKey,
     baseURL: settings.thunderboltInferenceUrl,
+    ...(fetchFn && { fetch: fetchFn }),
   }
 
   thunderboltClient = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
-        posthog: getPostHogClient(),
+        posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
@@ -82,8 +84,8 @@ const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
  * Get the appropriate inference client based on provider
  * Clients are lazily initialized and reused across requests
  */
-export const getInferenceClient = (provider: InferenceProvider): InferenceClient => {
-  const client = provider === 'thunderbolt' ? getThunderboltClient() : getFireworksClient()
+export const getInferenceClient = (provider: InferenceProvider, fetchFn?: typeof fetch): InferenceClient => {
+  const client = provider === 'thunderbolt' ? getThunderboltClient(fetchFn) : getFireworksClient(fetchFn)
 
   return {
     client,

--- a/backend/src/inference/client.ts
+++ b/backend/src/inference/client.ts
@@ -24,7 +24,8 @@ let thunderboltClient: OpenAI | PostHogOpenAI | null = null
  * Get the Fireworks AI client
  */
 const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
-  if (fireworksClient) {
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (fireworksClient && !fetchFn) {
     return fireworksClient
   }
 
@@ -40,21 +41,27 @@ const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
     ...(fetchFn && { fetch: fetchFn }),
   }
 
-  fireworksClient = isPostHogConfigured()
+  const client = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
         posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
-  return fireworksClient
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    fireworksClient = client
+  }
+
+  return client
 }
 
 /**
  * Get the Thunderbolt inference client for gpt-oss
  */
 const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
-  if (thunderboltClient) {
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (thunderboltClient && !fetchFn) {
     return thunderboltClient
   }
 
@@ -70,14 +77,19 @@ const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI =>
     ...(fetchFn && { fetch: fetchFn }),
   }
 
-  thunderboltClient = isPostHogConfigured()
+  const client = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
         posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
-  return thunderboltClient
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    thunderboltClient = client
+  }
+
+  return client
 }
 
 /**

--- a/backend/src/inference/posthog-privacy.test.ts
+++ b/backend/src/inference/posthog-privacy.test.ts
@@ -1,13 +1,25 @@
 import { clearSettingsCache } from '@/config/settings'
-import { isPostHogConfigured, shutdownPostHog } from '@/posthog/client'
+import { clearPostHogClient, isPostHogConfigured, shutdownPostHog } from '@/posthog/client'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { OpenAI as PostHogOpenAI } from '@posthog/ai'
 import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test'
 import { clearInferenceClientCache, getInferenceClient } from './client'
 
+type PostHogEvent = {
+  event?: string
+  properties?: Record<string, unknown>
+}
+
+type PostHogBatchRequest = {
+  batch: PostHogEvent[]
+}
+
+type PostHogRequestBody = PostHogEvent | PostHogBatchRequest
+
 type FetchCall = {
   url: string
   options: RequestInit
-  body: any
+  body: PostHogRequestBody | null
 }
 
 /**
@@ -16,7 +28,7 @@ type FetchCall = {
  */
 describe('Inference Routes - PostHog Privacy Integration', () => {
   let capturedFetches: FetchCall[] = []
-  let mockFetch: jest.Mock
+  let mockFetch: typeof fetch
   let originalEnv: Record<string, string | undefined>
 
   beforeEach(() => {
@@ -32,10 +44,19 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
     capturedFetches = []
     mockFetch = jest.fn(async (url: string, options: RequestInit) => {
       // Capture all fetch calls
+      let parsedBody: PostHogRequestBody | null = null
+      if (options.body) {
+        try {
+          parsedBody = JSON.parse(options.body as string) as PostHogRequestBody
+        } catch {
+          // Not JSON, skip parsing
+        }
+      }
+
       capturedFetches.push({
         url,
         options,
-        body: options.body ? JSON.parse(options.body as string) : null,
+        body: parsedBody,
       })
 
       // Return appropriate mock responses based on URL
@@ -74,10 +95,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
           headers: { 'Content-Type': 'application/json' },
         },
       )
-    })
-
-    // Mock global fetch
-    global.fetch = mockFetch as any
+    }) as unknown as typeof fetch
   })
 
   afterEach(async () => {
@@ -86,7 +104,12 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
     // Clear settings and PostHog caches
     clearSettingsCache()
-    await shutdownPostHog()
+
+    // Shutdown PostHog with a short timeout (100ms) since we're using mocked fetch
+    await shutdownPostHog(100)
+
+    // Clear the PostHog client cache
+    clearPostHogClient()
 
     // Restore original env vars
     for (const [key, value] of Object.entries(originalEnv)) {
@@ -114,9 +137,10 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
       // Import and check the client
       const { getPostHogClient } = require('@/posthog/client')
-      const client = getPostHogClient()
+      const client = getPostHogClient(mockFetch)
 
       // Verify our workaround is in place
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((client as any).privacy_mode).toBe(true)
       expect(client.options.privacyMode).toBe(true)
     })
@@ -130,8 +154,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Verify it's a PostHog-wrapped client
       expect(client.constructor.name).toBe('PostHogOpenAI')
@@ -146,8 +171,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Verify client exists and is functional
       expect(client).toBeDefined()
@@ -165,9 +191,10 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      // Get the wrapped client
-      const { client } = getInferenceClient('fireworks')
+      // Get the wrapped client with injected mock fetch
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Make a completion with sensitive data
       const completion = await (client as PostHogOpenAI).chat.completions.create({
@@ -199,7 +226,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
       // If PostHog sent events, verify they don't contain conversation content
       for (const request of posthogRequests) {
-        const batch = request.body?.batch || [request.body]
+        if (!request.body) continue
+
+        const batch = 'batch' in request.body ? request.body.batch : [request.body]
 
         for (const event of batch) {
           const properties = event.properties || {}
@@ -228,8 +257,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Make multiple completions
       const conversations = [
@@ -265,11 +295,13 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
         expect(requestStr.includes('Private API keys')).toBe(false)
 
         // Also check the structured data
-        const batch = request.body?.batch || [request.body]
-        for (const event of batch) {
-          const properties = event.properties || {}
-          expect(properties.$ai_input).toBeNullOrUndefined()
-          expect(properties.$ai_output_choices).toBeNullOrUndefined()
+        if (request.body) {
+          const batch = 'batch' in request.body ? request.body.batch : [request.body]
+          for (const event of batch) {
+            const properties = event.properties || {}
+            expect(properties.$ai_input).toBeNullOrUndefined()
+            expect(properties.$ai_output_choices).toBeNullOrUndefined()
+          }
         }
       }
     })
@@ -277,6 +309,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 })
 
 expect.extend({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toBeNullOrUndefined(received: any) {
     const pass = received === null || received === undefined
     return {

--- a/backend/src/posthog/client.ts
+++ b/backend/src/posthog/client.ts
@@ -7,7 +7,7 @@ let phClient: PostHog | null = null
  * Initialize and get the PostHog analytics client
  * Uses lazy initialization with settings from environment
  */
-export const getPostHogClient = (): PostHog => {
+export const getPostHogClient = (fetchFn?: typeof fetch): PostHog => {
   if (!phClient) {
     const settings = getSettings()
 
@@ -18,11 +18,13 @@ export const getPostHogClient = (): PostHog => {
     phClient = new PostHog(settings.posthogApiKey, {
       host: settings.posthogHost,
       privacyMode: true,
+      ...(fetchFn && { fetch: fetchFn }),
     })
 
     // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
     // but PostHog Node client only stores it in `options.privacyMode`
     // Manually set it so the AI library can detect it
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(phClient as any).privacy_mode = true
   }
 
@@ -32,9 +34,9 @@ export const getPostHogClient = (): PostHog => {
 /**
  * Shutdown the PostHog client (call on app termination)
  */
-export const shutdownPostHog = async (): Promise<void> => {
+export const shutdownPostHog = async (timeoutMs = 3000): Promise<void> => {
   if (phClient) {
-    await phClient.shutdown()
+    await phClient.shutdown(timeoutMs)
     phClient = null
   }
 }
@@ -45,4 +47,11 @@ export const shutdownPostHog = async (): Promise<void> => {
 export const isPostHogConfigured = (): boolean => {
   const settings = getSettings()
   return !!settings.posthogApiKey
+}
+
+/**
+ * Clear the PostHog client cache (for testing)
+ */
+export const clearPostHogClient = (): void => {
+  phClient = null
 }

--- a/backend/src/posthog/client.ts
+++ b/backend/src/posthog/client.ts
@@ -8,27 +8,35 @@ let phClient: PostHog | null = null
  * Uses lazy initialization with settings from environment
  */
 export const getPostHogClient = (fetchFn?: typeof fetch): PostHog => {
-  if (!phClient) {
-    const settings = getSettings()
-
-    if (!settings.posthogApiKey) {
-      throw new Error('PostHog API key not configured - set POSTHOG_API_KEY environment variable')
-    }
-
-    phClient = new PostHog(settings.posthogApiKey, {
-      host: settings.posthogHost,
-      privacyMode: true,
-      ...(fetchFn && { fetch: fetchFn }),
-    })
-
-    // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
-    // but PostHog Node client only stores it in `options.privacyMode`
-    // Manually set it so the AI library can detect it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(phClient as any).privacy_mode = true
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (phClient && !fetchFn) {
+    return phClient
   }
 
-  return phClient
+  const settings = getSettings()
+
+  if (!settings.posthogApiKey) {
+    throw new Error('PostHog API key not configured - set POSTHOG_API_KEY environment variable')
+  }
+
+  const client = new PostHog(settings.posthogApiKey, {
+    host: settings.posthogHost,
+    privacyMode: true,
+    ...(fetchFn && { fetch: fetchFn }),
+  })
+
+  // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
+  // but PostHog Node client only stores it in `options.privacyMode`
+  // Manually set it so the AI library can detect it
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).privacy_mode = true
+
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    phClient = client
+  }
+
+  return client
 }
 
 /**

--- a/src/content-view/object-sidebar-content.tsx
+++ b/src/content-view/object-sidebar-content.tsx
@@ -12,7 +12,13 @@ type ObjectSidebarContentProps = {
  */
 export const ObjectSidebarContent = ({ content, onClose }: ObjectSidebarContentProps) => {
   return (
-    <div className="flex flex-col h-full">
+    <div
+      className="flex flex-col h-dvh"
+      style={{
+        paddingBottom: 'var(--safe-area-bottom-padding)',
+        paddingTop: 'var(--safe-area-top-padding)',
+      }}
+    >
       <ContentViewHeader title={content.title} onClose={onClose} className="bg-card border-b border-border" />
       <SidebarContent className="p-4 overflow-x-hidden">
         <p className="text-gray-700 dark:text-gray-300 text-sm whitespace-pre-wrap">{content.output}</p>


### PR DESCRIPTION
## Preview

### iOS
<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/a7fc5500-976e-471d-b1cb-6d0c934a89ad" />

### iOS Web
<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/7f980c34-e291-4d31-bc5e-9e73e462be97" />

### Android
<img width="394" height="896" alt="image" src="https://github.com/user-attachments/assets/fc2d0661-1930-429a-807c-37f446e1da9f" />

### Android Web

<img width="394" height="896" alt="image" src="https://github.com/user-attachments/assets/8cfceba1-70a6-42cb-b8e5-da97a738a3b9" />

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Mobile sidebar uses safe-area/h-dvh; inference/PostHog clients support injectable fetch and improved lifecycle; expanded PostHog privacy tests.
> 
> - **UI**:
>   - Adjust `src/content-view/object-sidebar-content.tsx` to use `h-dvh` and safe-area paddings, preventing header cutoff on mobile.
> - **Backend**:
>   - Make inference clients (`backend/src/inference/client.ts`) accept optional `fetch` to bypass cache (testing) and pass through to PostHog/OpenAI clients.
>   - Enhance PostHog client (`backend/src/posthog/client.ts`): optional `fetch`, cache-bypass, `shutdownPostHog(timeoutMs)`, and `clearPostHogClient`.
>   - Update/expand privacy tests (`backend/src/inference/posthog-privacy.test.ts`): inject mock `fetch`, verify `privacy_mode`, ensure no conversation content is sent, and improve batch handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc8addcc78cceb1ae76df964b6680acb5b1bc73c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->