### PR TITLE
THU-182: Enabling preview features (eg Tasks) is not updating the state

### DIFF
--- a/backend/src/inference/client.ts
+++ b/backend/src/inference/client.ts
@@ -23,7 +23,7 @@ let thunderboltClient: OpenAI | PostHogOpenAI | null = null
 /**
  * Get the Fireworks AI client
  */
-const getFireworksClient = (): OpenAI | PostHogOpenAI => {
+const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
   if (fireworksClient) {
     return fireworksClient
   }
@@ -37,12 +37,13 @@ const getFireworksClient = (): OpenAI | PostHogOpenAI => {
   const params = {
     apiKey: settings.fireworksApiKey,
     baseURL: 'https://api.fireworks.ai/inference/v1',
+    ...(fetchFn && { fetch: fetchFn }),
   }
 
   fireworksClient = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
-        posthog: getPostHogClient(),
+        posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
@@ -52,7 +53,7 @@ const getFireworksClient = (): OpenAI | PostHogOpenAI => {
 /**
  * Get the Thunderbolt inference client for gpt-oss
  */
-const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
+const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
   if (thunderboltClient) {
     return thunderboltClient
   }
@@ -66,12 +67,13 @@ const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
   const params = {
     apiKey: settings.thunderboltInferenceApiKey,
     baseURL: settings.thunderboltInferenceUrl,
+    ...(fetchFn && { fetch: fetchFn }),
   }
 
   thunderboltClient = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
-        posthog: getPostHogClient(),
+        posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
@@ -82,8 +84,8 @@ const getThunderboltClient = (): OpenAI | PostHogOpenAI => {
  * Get the appropriate inference client based on provider
  * Clients are lazily initialized and reused across requests
  */
-export const getInferenceClient = (provider: InferenceProvider): InferenceClient => {
-  const client = provider === 'thunderbolt' ? getThunderboltClient() : getFireworksClient()
+export const getInferenceClient = (provider: InferenceProvider, fetchFn?: typeof fetch): InferenceClient => {
+  const client = provider === 'thunderbolt' ? getThunderboltClient(fetchFn) : getFireworksClient(fetchFn)
 
   return {
     client,

--- a/backend/src/inference/client.ts
+++ b/backend/src/inference/client.ts
@@ -24,7 +24,8 @@ let thunderboltClient: OpenAI | PostHogOpenAI | null = null
  * Get the Fireworks AI client
  */
 const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
-  if (fireworksClient) {
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (fireworksClient && !fetchFn) {
     return fireworksClient
   }
 
@@ -40,21 +41,27 @@ const getFireworksClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
     ...(fetchFn && { fetch: fetchFn }),
   }
 
-  fireworksClient = isPostHogConfigured()
+  const client = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
         posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
-  return fireworksClient
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    fireworksClient = client
+  }
+
+  return client
 }
 
 /**
  * Get the Thunderbolt inference client for gpt-oss
  */
 const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI => {
-  if (thunderboltClient) {
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (thunderboltClient && !fetchFn) {
     return thunderboltClient
   }
 
@@ -70,14 +77,19 @@ const getThunderboltClient = (fetchFn?: typeof fetch): OpenAI | PostHogOpenAI =>
     ...(fetchFn && { fetch: fetchFn }),
   }
 
-  thunderboltClient = isPostHogConfigured()
+  const client = isPostHogConfigured()
     ? new PostHogOpenAI({
         ...params,
         posthog: getPostHogClient(fetchFn),
       })
     : new OpenAI(params)
 
-  return thunderboltClient
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    thunderboltClient = client
+  }
+
+  return client
 }
 
 /**

--- a/backend/src/inference/posthog-privacy.test.ts
+++ b/backend/src/inference/posthog-privacy.test.ts
@@ -1,13 +1,25 @@
 import { clearSettingsCache } from '@/config/settings'
-import { isPostHogConfigured, shutdownPostHog } from '@/posthog/client'
+import { clearPostHogClient, isPostHogConfigured, shutdownPostHog } from '@/posthog/client'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { OpenAI as PostHogOpenAI } from '@posthog/ai'
 import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test'
 import { clearInferenceClientCache, getInferenceClient } from './client'
 
+type PostHogEvent = {
+  event?: string
+  properties?: Record<string, unknown>
+}
+
+type PostHogBatchRequest = {
+  batch: PostHogEvent[]
+}
+
+type PostHogRequestBody = PostHogEvent | PostHogBatchRequest
+
 type FetchCall = {
   url: string
   options: RequestInit
-  body: any
+  body: PostHogRequestBody | null
 }
 
 /**
@@ -16,7 +28,7 @@ type FetchCall = {
  */
 describe('Inference Routes - PostHog Privacy Integration', () => {
   let capturedFetches: FetchCall[] = []
-  let mockFetch: jest.Mock
+  let mockFetch: typeof fetch
   let originalEnv: Record<string, string | undefined>
 
   beforeEach(() => {
@@ -32,10 +44,19 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
     capturedFetches = []
     mockFetch = jest.fn(async (url: string, options: RequestInit) => {
       // Capture all fetch calls
+      let parsedBody: PostHogRequestBody | null = null
+      if (options.body) {
+        try {
+          parsedBody = JSON.parse(options.body as string) as PostHogRequestBody
+        } catch {
+          // Not JSON, skip parsing
+        }
+      }
+
       capturedFetches.push({
         url,
         options,
-        body: options.body ? JSON.parse(options.body as string) : null,
+        body: parsedBody,
       })
 
       // Return appropriate mock responses based on URL
@@ -74,10 +95,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
           headers: { 'Content-Type': 'application/json' },
         },
       )
-    })
-
-    // Mock global fetch
-    global.fetch = mockFetch as any
+    }) as unknown as typeof fetch
   })
 
   afterEach(async () => {
@@ -86,7 +104,12 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
     // Clear settings and PostHog caches
     clearSettingsCache()
-    await shutdownPostHog()
+
+    // Shutdown PostHog with a short timeout (100ms) since we're using mocked fetch
+    await shutdownPostHog(100)
+
+    // Clear the PostHog client cache
+    clearPostHogClient()
 
     // Restore original env vars
     for (const [key, value] of Object.entries(originalEnv)) {
@@ -114,9 +137,10 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
       // Import and check the client
       const { getPostHogClient } = require('@/posthog/client')
-      const client = getPostHogClient()
+      const client = getPostHogClient(mockFetch)
 
       // Verify our workaround is in place
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((client as any).privacy_mode).toBe(true)
       expect(client.options.privacyMode).toBe(true)
     })
@@ -130,8 +154,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Verify it's a PostHog-wrapped client
       expect(client.constructor.name).toBe('PostHogOpenAI')
@@ -146,8 +171,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Verify client exists and is functional
       expect(client).toBeDefined()
@@ -165,9 +191,10 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      // Get the wrapped client
-      const { client } = getInferenceClient('fireworks')
+      // Get the wrapped client with injected mock fetch
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Make a completion with sensitive data
       const completion = await (client as PostHogOpenAI).chat.completions.create({
@@ -199,7 +226,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 
       // If PostHog sent events, verify they don't contain conversation content
       for (const request of posthogRequests) {
-        const batch = request.body?.batch || [request.body]
+        if (!request.body) continue
+
+        const batch = 'batch' in request.body ? request.body.batch : [request.body]
 
         for (const event of batch) {
           const properties = event.properties || {}
@@ -228,8 +257,9 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       // Clear caches so new env vars are picked up
       clearSettingsCache()
       clearInferenceClientCache()
+      clearPostHogClient()
 
-      const { client } = getInferenceClient('fireworks')
+      const { client } = getInferenceClient('fireworks', mockFetch)
 
       // Make multiple completions
       const conversations = [
@@ -265,11 +295,13 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
         expect(requestStr.includes('Private API keys')).toBe(false)
 
         // Also check the structured data
-        const batch = request.body?.batch || [request.body]
-        for (const event of batch) {
-          const properties = event.properties || {}
-          expect(properties.$ai_input).toBeNullOrUndefined()
-          expect(properties.$ai_output_choices).toBeNullOrUndefined()
+        if (request.body) {
+          const batch = 'batch' in request.body ? request.body.batch : [request.body]
+          for (const event of batch) {
+            const properties = event.properties || {}
+            expect(properties.$ai_input).toBeNullOrUndefined()
+            expect(properties.$ai_output_choices).toBeNullOrUndefined()
+          }
         }
       }
     })
@@ -277,6 +309,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
 })
 
 expect.extend({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toBeNullOrUndefined(received: any) {
     const pass = received === null || received === undefined
     return {

--- a/backend/src/posthog/client.ts
+++ b/backend/src/posthog/client.ts
@@ -7,7 +7,7 @@ let phClient: PostHog | null = null
  * Initialize and get the PostHog analytics client
  * Uses lazy initialization with settings from environment
  */
-export const getPostHogClient = (): PostHog => {
+export const getPostHogClient = (fetchFn?: typeof fetch): PostHog => {
   if (!phClient) {
     const settings = getSettings()
 
@@ -18,11 +18,13 @@ export const getPostHogClient = (): PostHog => {
     phClient = new PostHog(settings.posthogApiKey, {
       host: settings.posthogHost,
       privacyMode: true,
+      ...(fetchFn && { fetch: fetchFn }),
     })
 
     // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
     // but PostHog Node client only stores it in `options.privacyMode`
     // Manually set it so the AI library can detect it
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(phClient as any).privacy_mode = true
   }
 
@@ -32,9 +34,9 @@ export const getPostHogClient = (): PostHog => {
 /**
  * Shutdown the PostHog client (call on app termination)
  */
-export const shutdownPostHog = async (): Promise<void> => {
+export const shutdownPostHog = async (timeoutMs = 3000): Promise<void> => {
   if (phClient) {
-    await phClient.shutdown()
+    await phClient.shutdown(timeoutMs)
     phClient = null
   }
 }
@@ -45,4 +47,11 @@ export const shutdownPostHog = async (): Promise<void> => {
 export const isPostHogConfigured = (): boolean => {
   const settings = getSettings()
   return !!settings.posthogApiKey
+}
+
+/**
+ * Clear the PostHog client cache (for testing)
+ */
+export const clearPostHogClient = (): void => {
+  phClient = null
 }

--- a/backend/src/posthog/client.ts
+++ b/backend/src/posthog/client.ts
@@ -8,27 +8,35 @@ let phClient: PostHog | null = null
  * Uses lazy initialization with settings from environment
  */
 export const getPostHogClient = (fetchFn?: typeof fetch): PostHog => {
-  if (!phClient) {
-    const settings = getSettings()
-
-    if (!settings.posthogApiKey) {
-      throw new Error('PostHog API key not configured - set POSTHOG_API_KEY environment variable')
-    }
-
-    phClient = new PostHog(settings.posthogApiKey, {
-      host: settings.posthogHost,
-      privacyMode: true,
-      ...(fetchFn && { fetch: fetchFn }),
-    })
-
-    // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
-    // but PostHog Node client only stores it in `options.privacyMode`
-    // Manually set it so the AI library can detect it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(phClient as any).privacy_mode = true
+  // Don't use cache when fetchFn is provided (primarily for testing)
+  if (phClient && !fetchFn) {
+    return phClient
   }
 
-  return phClient
+  const settings = getSettings()
+
+  if (!settings.posthogApiKey) {
+    throw new Error('PostHog API key not configured - set POSTHOG_API_KEY environment variable')
+  }
+
+  const client = new PostHog(settings.posthogApiKey, {
+    host: settings.posthogHost,
+    privacyMode: true,
+    ...(fetchFn && { fetch: fetchFn }),
+  })
+
+  // Workaround: PostHog AI library checks for `privacy_mode` property (snake_case)
+  // but PostHog Node client only stores it in `options.privacyMode`
+  // Manually set it so the AI library can detect it
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).privacy_mode = true
+
+  // Only cache if no custom fetchFn was provided
+  if (!fetchFn) {
+    phClient = client
+  }
+
+  return client
 }
 
 /**

--- a/src/hooks/use-settings.test.ts
+++ b/src/hooks/use-settings.test.ts
@@ -1,6 +1,7 @@
 import { deserializeValue } from '@/lib/serialization'
 import { describe, expect, it } from 'bun:test'
 import type { BooleanSettingHook, StringSettingHook } from './use-settings'
+import { shouldInvalidateSettingsSubset } from './use-settings'
 
 /**
  * Tests for type safety guarantees of useSettings hook
@@ -79,5 +80,71 @@ describe('useSettings type safety', () => {
       const val: string | null = mockStringHook.value
       expect(val).toBe(null)
     })
+  })
+})
+
+describe('shouldInvalidateSettingsSubset', () => {
+  it('should return true when query is a settings query and key is in subset', () => {
+    const query = { queryKey: ['settings', 'a', 'b', 'c'] as const }
+    expect(shouldInvalidateSettingsSubset(query, 'a')).toBe(true)
+    expect(shouldInvalidateSettingsSubset(query, 'b')).toBe(true)
+    expect(shouldInvalidateSettingsSubset(query, 'c')).toBe(true)
+  })
+
+  it('should return false when query is a settings query but key is not in subset', () => {
+    const query = { queryKey: ['settings', 'a', 'b'] as const }
+    expect(shouldInvalidateSettingsSubset(query, 'c')).toBe(false)
+    expect(shouldInvalidateSettingsSubset(query, 'd')).toBe(false)
+  })
+
+  it('should return false for non-settings queries', () => {
+    const query1 = { queryKey: ['users', '123'] as const }
+    const query2 = { queryKey: ['posts'] as const }
+    const query3 = { queryKey: ['other', 'a', 'b'] as const }
+
+    expect(shouldInvalidateSettingsSubset(query1, 'a')).toBe(false)
+    expect(shouldInvalidateSettingsSubset(query2, 'a')).toBe(false)
+    expect(shouldInvalidateSettingsSubset(query3, 'a')).toBe(false)
+  })
+
+  it('should return false when queryKey is not an array', () => {
+    const query1 = { queryKey: 'settings' as any }
+    const query2 = { queryKey: null as any }
+    const query3 = { queryKey: undefined as any }
+
+    expect(shouldInvalidateSettingsSubset(query1, 'a')).toBe(false)
+    expect(shouldInvalidateSettingsSubset(query2, 'a')).toBe(false)
+    expect(shouldInvalidateSettingsSubset(query3, 'a')).toBe(false)
+  })
+
+  it('should return false when queryKey is an empty array', () => {
+    const query = { queryKey: [] as const }
+    expect(shouldInvalidateSettingsSubset(query, 'a')).toBe(false)
+  })
+
+  it('should return false when settings query has no subset keys', () => {
+    const query = { queryKey: ['settings'] as const }
+    expect(shouldInvalidateSettingsSubset(query, 'a')).toBe(false)
+  })
+
+  it('should handle single key in subset', () => {
+    const query = { queryKey: ['settings', 'single_key'] as const }
+    expect(shouldInvalidateSettingsSubset(query, 'single_key')).toBe(true)
+    expect(shouldInvalidateSettingsSubset(query, 'other_key')).toBe(false)
+  })
+
+  it('should handle multiple keys in subset correctly', () => {
+    const query = { queryKey: ['settings', 'key1', 'key2', 'key3'] as const }
+    expect(shouldInvalidateSettingsSubset(query, 'key1')).toBe(true)
+    expect(shouldInvalidateSettingsSubset(query, 'key2')).toBe(true)
+    expect(shouldInvalidateSettingsSubset(query, 'key3')).toBe(true)
+    expect(shouldInvalidateSettingsSubset(query, 'key4')).toBe(false)
+  })
+
+  it('should be case-sensitive for key matching', () => {
+    const query = { queryKey: ['settings', 'KeyName'] as const }
+    expect(shouldInvalidateSettingsSubset(query, 'KeyName')).toBe(true)
+    expect(shouldInvalidateSettingsSubset(query, 'keyname')).toBe(false)
+    expect(shouldInvalidateSettingsSubset(query, 'KEYNAME')).toBe(false)
   })
 })

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -130,11 +130,11 @@ type UseSettingsSchemaResult<T extends SettingSchema, CamelCase extends boolean 
  * This helper checks:
  *   1. Whether the query belongs to the settings subsystem
  *      (queryKey[0] === 'settings')
- *   2. Whether the updated key exists in that query’s subset
+ *   2. Whether the updated key exists in that query's subset
  *
  * If both conditions match, the query should be invalidated.
  */
-function shouldInvalidateSettingsSubset(query: { queryKey: readonly unknown[] }, key: string) {
+export function shouldInvalidateSettingsSubset(query: { queryKey: readonly unknown[] }, key: string) {
   const keys = query.queryKey
 
   // must be a settings query

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -104,6 +104,50 @@ type UseSettingsSchemaResult<T extends SettingSchema, CamelCase extends boolean 
     }
 
 /**
+ * Determines whether a given query should be invalidated after updating
+ * a specific setting key.
+ *
+ * Why this is needed:
+ * -------------------
+ * The `useSettings` hook creates react-query entries whose query keys look like:
+ *
+ *    ['settings', 'a', 'b', 'c']
+ *
+ * where `'a'`, `'b'`, `'c'` represent the specific setting keys requested
+ * by that hook instance (its "schema subset").
+ *
+ * Different components may request different subsets of settings:
+ *
+ *    useSettings({ a: true, b: true }) → ['settings', 'a', 'b']
+ *    useSettings({ b: true })          → ['settings', 'b']
+ *
+ * When one setting is updated (e.g., 'b'), we must invalidate **all** queries
+ * whose subset includes that key — not just the one that performed the update.
+ *
+ * React Query cannot know this relationship automatically, so we use a custom
+ * predicate function during `invalidateQueries` to detect all affected subsets.
+ *
+ * This helper checks:
+ *   1. Whether the query belongs to the settings subsystem
+ *      (queryKey[0] === 'settings')
+ *   2. Whether the updated key exists in that query’s subset
+ *
+ * If both conditions match, the query should be invalidated.
+ */
+function shouldInvalidateSettingsSubset(query: { queryKey: readonly unknown[] }, key: string) {
+  const keys = query.queryKey
+
+  // must be a settings query
+  if (!Array.isArray(keys) || keys[0] !== 'settings') return false
+
+  // 'subset' = all keys after the prefix
+  const subset = keys.slice(1) as string[]
+
+  // invalidate if this subset contains the updated key
+  return subset.includes(key)
+}
+
+/**
  * Hook for managing multiple settings with modification tracking and reset capability
  *
  * Returns an object where each key is a setting, allowing clean destructuring.
@@ -178,8 +222,10 @@ export function useSettings<T extends SettingSchema>(
       value: any
       options?: { recomputeHash?: boolean; updateHashOnly?: boolean }
     }) => updateSettings({ [key]: value }, options),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings', ...keys] })
+    onSuccess: (_, { key }) => {
+      queryClient.invalidateQueries({
+        predicate: (query) => shouldInvalidateSettingsSubset(query, key),
+      })
     },
   })
 
@@ -191,8 +237,10 @@ export function useSettings<T extends SettingSchema>(
       }
       await resetSettingToDefault(key, defaultSetting)
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings', ...keys] })
+    onSuccess: (_, key) => {
+      queryClient.invalidateQueries({
+        predicate: (query) => shouldInvalidateSettingsSubset(query, key),
+      })
     },
   })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes settings not updating by invalidating all relevant settings queries; adds injectable fetch to inference/PostHog clients and strengthens PostHog privacy tests.
> 
> - **Settings (frontend)**:
>   - Add `shouldInvalidateSettingsSubset` to target invalidation of all affected `['settings', ...subset]` queries.
>   - Update `useSettings` mutations to use predicate-based `invalidateQueries`.
> - **Inference/Analytics (backend)**:
>   - Allow optional `fetch` injection in `getFireworksClient`, `getThunderboltClient`, and `getInferenceClient` (bypasses cache for testing).
>   - Update `getPostHogClient` to accept optional `fetch`, set `privacy_mode`, and add `clearPostHogClient`; `shutdownPostHog` now supports timeout.
> - **Tests**:
>   - Add/expand PostHog privacy integration tests to ensure no conversation content is sent while metadata is retained.
>   - Add unit tests for `shouldInvalidateSettingsSubset` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c85a480b07df9d7119ce0c1c4a3fd9b90850f388. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->