### PR TITLE
add privacy policy + terms of service to raw html for google

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",

--- a/index.html
+++ b/index.html
@@ -14,5 +14,11 @@
   <body>
     <div id="root"></div>
     <script src="/src/index.tsx" type="module"></script>
+    <footer style="display: none">
+      <a href="https://www.thunderbird.net/en-US/privacy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+      <a href="https://www.mozilla.org/en-US/about/legal/terms/mozilla/" target="_blank" rel="noopener noreferrer"
+        >Terms of Service</a
+      >
+    </footer>
   </body>
 </html>

--- a/src/components/onboarding/onboarding-privacy-step.test.tsx
+++ b/src/components/onboarding/onboarding-privacy-step.test.tsx
@@ -5,6 +5,7 @@ import { OnboardingPrivacyStep } from './onboarding-privacy-step'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { setupTestDatabase, resetTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { useOnboardingState } from '@/hooks/use-onboarding-state'
+import { privacyPolicyUrl, termsOfServiceUrl } from '@/lib/constants'
 
 const TestOnboardingPrivacyStep = () => {
   const { state, actions } = useOnboardingState()
@@ -76,7 +77,7 @@ describe('OnboardingPrivacyStep', () => {
 
       const link = screen.getByRole('link', { name: 'Privacy Policy' })
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('href', 'https://www.thunderbird.net/en-US/privacy/')
+      expect(link).toHaveAttribute('href', privacyPolicyUrl)
       expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     })
@@ -86,7 +87,7 @@ describe('OnboardingPrivacyStep', () => {
 
       const link = screen.getByRole('link', { name: 'Terms of Service' })
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('href', 'https://www.mozilla.org/en-US/about/legal/terms/mozilla/')
+      expect(link).toHaveAttribute('href', termsOfServiceUrl)
       expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     })

--- a/src/components/onboarding/onboarding-privacy-step.tsx
+++ b/src/components/onboarding/onboarding-privacy-step.tsx
@@ -1,6 +1,7 @@
 import { AppLogo } from '@/components/app-logo'
 import { Checkbox } from '@/components/ui/checkbox'
 import type { OnboardingState } from '@/hooks/use-onboarding-state'
+import { privacyPolicyUrl, termsOfServiceUrl } from '@/lib/constants'
 import { Database, EyeOff, ServerOff } from 'lucide-react'
 import { IconCircle } from './icon-circle'
 import { OnboardingFeatureCard } from './onboarding-feature-card'
@@ -59,7 +60,7 @@ export const OnboardingPrivacyStep = ({ state, actions }: OnboardingPrivacyStepP
           <label htmlFor="terms-agreement" className="text-base text-muted-foreground leading-relaxed cursor-pointer">
             I agree to the{' '}
             <a
-              href="https://www.thunderbird.net/en-US/privacy/"
+              href={privacyPolicyUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary underline hover:no-underline font-medium"
@@ -68,7 +69,7 @@ export const OnboardingPrivacyStep = ({ state, actions }: OnboardingPrivacyStepP
             </a>{' '}
             and{' '}
             <a
-              href="https://www.mozilla.org/en-US/about/legal/terms/mozilla/"
+              href={termsOfServiceUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary underline hover:no-underline font-medium"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Application-wide constants
+ */
+
+/** Privacy Policy URL */
+export const privacyPolicyUrl = 'https://www.thunderbird.net/en-US/privacy/'
+
+/** Terms of Service URL */
+export const termsOfServiceUrl = 'https://www.mozilla.org/en-US/about/legal/terms/mozilla/'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds hidden footer links for Privacy Policy and Terms; introduces `src/lib/constants.ts` for URLs and updates onboarding component/tests to use them.
> 
> - **Frontend**:
>   - **Legal links**: Add hidden footer with "Privacy Policy" and "Terms of Service" links in `index.html`.
>   - **Constants**: Create `src/lib/constants.ts` exporting `privacyPolicyUrl` and `termsOfServiceUrl`.
>   - **Onboarding**: Update `src/components/onboarding/onboarding-privacy-step.tsx` to use constants instead of hardcoded URLs.
> - **Tests**:
>   - Update `src/components/onboarding/onboarding-privacy-step.test.tsx` to assert links against constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7e1940f22af3eaa5f29522b1e6ea9ca9c3b429b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->