### PR TITLE
Revert "add privacy policy + terms of service to raw html for google"

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",

--- a/index.html
+++ b/index.html
@@ -14,11 +14,5 @@
   <body>
     <div id="root"></div>
     <script src="/src/index.tsx" type="module"></script>
-    <footer style="display: none">
-      <a href="https://www.thunderbird.net/en-US/privacy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
-      <a href="https://www.mozilla.org/en-US/about/legal/terms/mozilla/" target="_blank" rel="noopener noreferrer"
-        >Terms of Service</a
-      >
-    </footer>
   </body>
 </html>

--- a/src/components/onboarding/onboarding-privacy-step.test.tsx
+++ b/src/components/onboarding/onboarding-privacy-step.test.tsx
@@ -5,7 +5,6 @@ import { OnboardingPrivacyStep } from './onboarding-privacy-step'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { setupTestDatabase, resetTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { useOnboardingState } from '@/hooks/use-onboarding-state'
-import { privacyPolicyUrl, termsOfServiceUrl } from '@/lib/constants'
 
 const TestOnboardingPrivacyStep = () => {
   const { state, actions } = useOnboardingState()
@@ -77,7 +76,7 @@ describe('OnboardingPrivacyStep', () => {
 
       const link = screen.getByRole('link', { name: 'Privacy Policy' })
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('href', privacyPolicyUrl)
+      expect(link).toHaveAttribute('href', 'https://www.thunderbird.net/en-US/privacy/')
       expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     })
@@ -87,7 +86,7 @@ describe('OnboardingPrivacyStep', () => {
 
       const link = screen.getByRole('link', { name: 'Terms of Service' })
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('href', termsOfServiceUrl)
+      expect(link).toHaveAttribute('href', 'https://www.mozilla.org/en-US/about/legal/terms/mozilla/')
       expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     })

--- a/src/components/onboarding/onboarding-privacy-step.tsx
+++ b/src/components/onboarding/onboarding-privacy-step.tsx
@@ -1,7 +1,6 @@
 import { AppLogo } from '@/components/app-logo'
 import { Checkbox } from '@/components/ui/checkbox'
 import type { OnboardingState } from '@/hooks/use-onboarding-state'
-import { privacyPolicyUrl, termsOfServiceUrl } from '@/lib/constants'
 import { Database, EyeOff, ServerOff } from 'lucide-react'
 import { IconCircle } from './icon-circle'
 import { OnboardingFeatureCard } from './onboarding-feature-card'
@@ -60,7 +59,7 @@ export const OnboardingPrivacyStep = ({ state, actions }: OnboardingPrivacyStepP
           <label htmlFor="terms-agreement" className="text-base text-muted-foreground leading-relaxed cursor-pointer">
             I agree to the{' '}
             <a
-              href={privacyPolicyUrl}
+              href="https://www.thunderbird.net/en-US/privacy/"
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary underline hover:no-underline font-medium"
@@ -69,7 +68,7 @@ export const OnboardingPrivacyStep = ({ state, actions }: OnboardingPrivacyStepP
             </a>{' '}
             and{' '}
             <a
-              href={termsOfServiceUrl}
+              href="https://www.mozilla.org/en-US/about/legal/terms/mozilla/"
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary underline hover:no-underline font-medium"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,9 +1,0 @@
-/**
- * Application-wide constants
- */
-
-/** Privacy Policy URL */
-export const privacyPolicyUrl = 'https://www.thunderbird.net/en-US/privacy/'
-
-/** Terms of Service URL */
-export const termsOfServiceUrl = 'https://www.mozilla.org/en-US/about/legal/terms/mozilla/'


### PR DESCRIPTION
Reverts thunderbird/thunderbolt#264

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the hidden footer links from `index.html`, inlines Privacy/Terms URLs in the onboarding component/tests, and deletes the shared constants file.
> 
> - **UI**:
>   - Remove hidden Privacy/Terms footer from `index.html`.
>   - Inline `Privacy Policy` and `Terms of Service` URLs in `src/components/onboarding/onboarding-privacy-step.tsx` (drop constants import).
> - **Tests**:
>   - Update link assertions in `onboarding-privacy-step.test.tsx` to expect hardcoded URLs (remove constants import).
> - **Code cleanup**:
>   - Delete `src/lib/constants.ts` (removed `privacyPolicyUrl` and `termsOfServiceUrl`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7067b2c0b6b73d47def29b249dde7b2886d17e06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->