### PR TITLE
THU-188: Fix mobile Google Auth nav bug

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6520,7 +6520,7 @@ dependencies = [
 
 [[package]]
 name = "thunderbolt"
-version = "0.1.23"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "serde",

--- a/src/components/connect-provider-button.tsx
+++ b/src/components/connect-provider-button.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 type ConnectProviderButtonProps = {
   provider: OAuthProvider
   isConnected?: boolean
+  isProcessing?: boolean
   onSuccess?: () => void
   onError?: (error: Error) => void
   onDisconnect?: () => void
@@ -29,6 +30,7 @@ type ConnectProviderButtonProps = {
 export const ConnectProviderButton = ({
   provider,
   isConnected = false,
+  isProcessing = false,
   onSuccess,
   onError,
   onDisconnect,
@@ -43,35 +45,28 @@ export const ConnectProviderButton = ({
   allowDisconnect = false,
   useOAuthConnectHook,
 }: ConnectProviderButtonProps) => {
-  const [isConnecting, setIsConnecting] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
 
   // Use injected hook for testing, or real implementation in production
   const oauthHook = useOAuthConnectHook ?? useOAuthConnect
-  const { connect } = oauthHook({
-    onSuccess: () => {
-      onSuccess?.()
-    },
-    onError: (error) => {
-      onError?.(error)
-    },
+  const { connect, isConnecting: isConnectingFromHook } = oauthHook({
+    connectingKey: provider,
+    onSuccess,
+    onError,
     setPreferredName,
     returnContext,
   })
+
+  const isConnecting = isConnectingFromHook || isProcessing
 
   const handleClick = async () => {
     if (isConnected && allowDisconnect) {
       onDisconnect?.()
       return
     }
-    if (isConnected) return
+    if (isConnected || isConnecting) return
 
-    setIsConnecting(true)
-    try {
-      await connect(provider)
-    } finally {
-      setIsConnecting(false)
-    }
+    await connect(provider)
   }
 
   const providerName = provider === 'microsoft' ? 'Microsoft' : 'Google'

--- a/src/components/onboarding/onboarding-auth-step.test.tsx
+++ b/src/components/onboarding/onboarding-auth-step.test.tsx
@@ -58,6 +58,7 @@ describe('OnboardingAuthStep', () => {
     const mockOAuthConnectHook = () => ({
       connect: mockConnect,
       processCallback: mockProcessCallback,
+      isConnecting: false,
       error: null,
       clearError: mockClearError,
     })
@@ -128,8 +129,8 @@ describe('OnboardingAuthStep', () => {
     it('should not call connect when button is disabled', () => {
       renderComponent({ isProcessing: true })
 
-      // When processing, the button shows "Connected!" and is disabled
-      const connectButton = screen.getByRole('button', { name: /Connected!/i })
+      // When processing, the button shows "Connecting..." and is disabled
+      const connectButton = screen.getByRole('button', { name: /Connecting/i })
       fireEvent.click(connectButton)
 
       expect(mockConnect).not.toHaveBeenCalled()
@@ -138,20 +139,20 @@ describe('OnboardingAuthStep', () => {
 
   describe('Loading states', () => {
     it('should show loading state when isProcessing is true', () => {
+      renderComponent({ isProcessing: true })
+
+      const connectButton = screen.getByRole('button', { name: /Connecting/i })
+      expect(connectButton).toBeInTheDocument()
+    })
+
+    it('should show connecting state when OAuth callback is in location state', () => {
       mockLocation.state = { oauth: { code: 'test_code', state: 'test_state' } } as {
         oauth: { code: string; state: string }
       }
 
       renderComponent()
 
-      const connectButton = screen.getByRole('button', { name: /Connect Google/i })
-      expect(connectButton).toBeInTheDocument()
-    })
-
-    it('should show connected state during connection', () => {
-      renderComponent({ isProcessing: true })
-
-      const connectButton = screen.getByRole('button', { name: /Connected!/i })
+      const connectButton = screen.getByRole('button', { name: /Connecting/i })
       expect(connectButton).toBeInTheDocument()
     })
 
@@ -627,15 +628,46 @@ describe('OnboardingAuthStep', () => {
         oauth: { code: string; state: string }
       }
 
-      renderComponent()
+      const { rerender } = render(
+        <OnboardingAuthStep
+          providers={['google']}
+          isProcessing={false}
+          isConnected={false}
+          onConnectionChange={mockOnConnectionChange}
+          useOAuthConnectHook={() => ({
+            connect: mockConnect,
+            processCallback: mockProcessCallback,
+            isConnecting: false,
+            error: null,
+            clearError: mockClearError,
+          })}
+        />,
+        { wrapper: createQueryTestWrapper() },
+      )
 
       await waitFor(() => {
         expect(mockProcessCallback).toHaveBeenCalled()
       })
 
-      // Clear the error state and try again
+      // Clear the location state and rerender to simulate returning to normal state
       mockLocation.state = null
       mockProcessCallback.mockClear()
+
+      rerender(
+        <OnboardingAuthStep
+          providers={['google']}
+          isProcessing={false}
+          isConnected={false}
+          onConnectionChange={mockOnConnectionChange}
+          useOAuthConnectHook={() => ({
+            connect: mockConnect,
+            processCallback: mockProcessCallback,
+            isConnecting: false,
+            error: null,
+            clearError: mockClearError,
+          })}
+        />,
+      )
 
       const connectButton = screen.getByRole('button', { name: /Connect Google/i })
       fireEvent.click(connectButton)

--- a/src/components/onboarding/onboarding-auth-step.tsx
+++ b/src/components/onboarding/onboarding-auth-step.tsx
@@ -6,7 +6,7 @@ import { useOAuthConnect } from '@/hooks/use-oauth-connect'
 import type { UseOAuthConnectResult } from '@/hooks/use-oauth-connect'
 import { type OAuthProvider } from '@/lib/auth'
 import { Calendar, File, Mail } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 import { IconCircle } from './icon-circle'
 import { OnboardingFeatureCard } from './onboarding-feature-card'
@@ -33,6 +33,11 @@ export const OnboardingAuthStep = ({
   // Determine which provider to use for this step (first in list)
   const provider = providers[0]
 
+  const [isProcessingCallback, setIsProcessingCallback] = useState(() => {
+    const locationState = location.state as { oauth?: { code?: string; state?: string; error?: string } } | null
+    return !!locationState?.oauth
+  })
+
   // Use injected hook for testing, or real implementation in production
   const oauthHook = useOAuthConnectHook ?? useOAuthConnect
   const { processCallback } = oauthHook({
@@ -49,11 +54,13 @@ export const OnboardingAuthStep = ({
     if (!oauth) return
 
     const handleCallback = async () => {
+      setIsProcessingCallback(true)
       try {
         await processCallback(oauth)
       } catch (err) {
         console.error('Failed to complete OAuth:', err)
       } finally {
+        setIsProcessingCallback(false)
         navigate('.', { replace: true, state: null })
       }
     }
@@ -105,7 +112,8 @@ export const OnboardingAuthStep = ({
         <div className="flex items-start rounded-lg pt-5">
           <ConnectProviderButton
             provider={provider}
-            isConnected={isConnected || isProcessing}
+            isConnected={isConnected}
+            isProcessing={isProcessing || isProcessingCallback}
             onSuccess={() => {
               onConnectionChange(true)
             }}

--- a/src/hooks/use-deep-link-listener.ts
+++ b/src/hooks/use-deep-link-listener.ts
@@ -2,7 +2,7 @@ import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link'
 import { getSettings } from '@/dal'
 import { isTauri } from '@/lib/platform'
 import { useEffect } from 'react'
-import { useLocation, useNavigate } from 'react-router'
+import { useNavigate } from 'react-router'
 
 type DeepLinkHandler = (urls: string[]) => void | Promise<void>
 
@@ -74,7 +74,6 @@ type DeepLinkDependencies = {
  */
 export const useDeepLinkListener = (handler?: DeepLinkHandler, dependencies?: DeepLinkDependencies) => {
   const navigate = useNavigate()
-  const location = useLocation()
 
   // Use injected dependencies or fall back to real implementations
   const {
@@ -142,5 +141,6 @@ export const useDeepLinkListener = (handler?: DeepLinkHandler, dependencies?: De
         unlisten()
       }
     }
-  }, [handler, navigate, location.pathname, checkIsTauri, getCurrentUrls, listenToOpenUrl, getSettingsData])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 }

--- a/src/hooks/use-oauth-connect.ts
+++ b/src/hooks/use-oauth-connect.ts
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 /** OAuth connecting state expires after 15 seconds */
-const CONNECTING_TIMEOUT_MS = 15 * 1000
+const connectingTimeoutMs = 15 * 1000
 
 const getConnectingKey = (key: string) => `oauth_connecting_${key}`
 const getTimestampKey = (key: string) => `oauth_connecting_${key}_timestamp`
@@ -95,7 +95,7 @@ const getInitialConnectingState = (key: string | undefined): boolean => {
   const startTime = timestamp ? parseInt(timestamp, 10) : 0
   const elapsed = Date.now() - startTime
 
-  return elapsed <= CONNECTING_TIMEOUT_MS
+  return elapsed <= connectingTimeoutMs
 }
 
 /**
@@ -148,7 +148,7 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
     const startTime = timestamp ? parseInt(timestamp, 10) : 0
     const elapsed = Date.now() - startTime
 
-    if (elapsed > CONNECTING_TIMEOUT_MS) {
+    if (elapsed > connectingTimeoutMs) {
       clearConnecting(activeKey)
     }
   }, [activeKey])
@@ -160,7 +160,7 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
     const timestamp = sessionStorage.getItem(getTimestampKey(activeKey))
     const startTime = timestamp ? parseInt(timestamp, 10) : Date.now()
     const elapsed = Date.now() - startTime
-    const remaining = CONNECTING_TIMEOUT_MS - elapsed
+    const remaining = connectingTimeoutMs - elapsed
 
     if (remaining <= 0) {
       clearConnecting(activeKey)

--- a/src/hooks/use-oauth-connect.ts
+++ b/src/hooks/use-oauth-connect.ts
@@ -4,8 +4,23 @@ import { startOAuthFlowWebview } from '@/lib/oauth-webview'
 import { generateCodeChallenge, generateCodeVerifier } from '@/lib/pkce'
 import { isMobile, isTauri } from '@/lib/platform'
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
+
+/** OAuth connecting state expires after 15 seconds */
+const CONNECTING_TIMEOUT_MS = 15 * 1000
+
+const getConnectingKey = (key: string) => `oauth_connecting_${key}`
+const getTimestampKey = (key: string) => `oauth_connecting_${key}_timestamp`
+
+/**
+ * Clears the OAuth connecting state from sessionStorage for a given key.
+ * Can be called from outside React components.
+ */
+export const clearOAuthConnectingState = (key: string) => {
+  sessionStorage.removeItem(getConnectingKey(key))
+  sessionStorage.removeItem(getTimestampKey(key))
+}
 
 type OAuthDependencies = {
   startOAuthFlowWebview?: typeof startOAuthFlowWebview
@@ -15,6 +30,8 @@ type OAuthDependencies = {
 }
 
 type UseOAuthConnectOptions = {
+  /** Unique key for persisting connecting state (e.g., provider name or widget ID) */
+  connectingKey?: string
   onSuccess?: () => void
   onError?: (error: Error) => void
   setPreferredName?: boolean
@@ -25,6 +42,7 @@ type UseOAuthConnectOptions = {
 type UseOAuthConnectResult = {
   connect: (provider: OAuthProvider) => Promise<void>
   processCallback: (callbackData: OAuthCallbackData) => Promise<boolean>
+  isConnecting: boolean
   error: string | null
   clearError: () => void
 }
@@ -66,15 +84,38 @@ const saveOAuthCredentials = async (
 }
 
 /**
+ * Checks if there's a valid (non-expired) connecting state in sessionStorage.
+ */
+const getInitialConnectingState = (key: string | undefined): boolean => {
+  if (!key) return false
+  const wasConnecting = sessionStorage.getItem(getConnectingKey(key)) === 'true'
+  if (!wasConnecting) return false
+
+  const timestamp = sessionStorage.getItem(getTimestampKey(key))
+  const startTime = timestamp ? parseInt(timestamp, 10) : 0
+  const elapsed = Date.now() - startTime
+
+  return elapsed <= CONNECTING_TIMEOUT_MS
+}
+
+/**
  * Handles OAuth connection flow for any provider.
  * For Tauri: Opens separate webview window and processes result immediately.
  * For web: Redirects to OAuth provider and processes callback on return.
- *
- * @param options.dependencies - Injectable dependencies for testing (optional)
  */
 export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthConnectResult => {
-  const { onSuccess, onError, setPreferredName = false, returnContext = 'integrations', dependencies } = options
+  const {
+    connectingKey,
+    onSuccess,
+    onError,
+    setPreferredName = false,
+    returnContext = 'integrations',
+    dependencies,
+  } = options
   const [error, setError] = useState<string | null>(null)
+  // Initialize from sessionStorage synchronously to avoid flash of "Connect" button
+  const [isConnecting, setIsConnecting] = useState(() => getInitialConnectingState(connectingKey))
+  const [activeKey, setActiveKey] = useState<string | null>(connectingKey ?? null)
 
   // Use injected dependencies or fall back to real implementations
   const {
@@ -84,8 +125,59 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
     getUserInfo: getUser = getUserInfo,
   } = dependencies || {}
 
+  const clearConnecting = (key: string) => {
+    clearOAuthConnectingState(key)
+    setIsConnecting(false)
+  }
+
+  const startConnecting = (key: string) => {
+    setActiveKey(key)
+    setIsConnecting(true)
+    sessionStorage.setItem(getConnectingKey(key), 'true')
+    sessionStorage.setItem(getTimestampKey(key), Date.now().toString())
+  }
+
+  // Clear expired connecting state from sessionStorage on mount
+  useEffect(() => {
+    if (!activeKey) return
+
+    const wasConnecting = sessionStorage.getItem(getConnectingKey(activeKey)) === 'true'
+    if (!wasConnecting) return
+
+    const timestamp = sessionStorage.getItem(getTimestampKey(activeKey))
+    const startTime = timestamp ? parseInt(timestamp, 10) : 0
+    const elapsed = Date.now() - startTime
+
+    if (elapsed > CONNECTING_TIMEOUT_MS) {
+      clearConnecting(activeKey)
+    }
+  }, [activeKey])
+
+  // Active timer to clear connecting state when timeout expires
+  useEffect(() => {
+    if (!isConnecting || !activeKey) return
+
+    const timestamp = sessionStorage.getItem(getTimestampKey(activeKey))
+    const startTime = timestamp ? parseInt(timestamp, 10) : Date.now()
+    const elapsed = Date.now() - startTime
+    const remaining = CONNECTING_TIMEOUT_MS - elapsed
+
+    if (remaining <= 0) {
+      clearConnecting(activeKey)
+      return
+    }
+
+    const timer = setTimeout(() => {
+      clearConnecting(activeKey)
+    }, remaining)
+
+    return () => clearTimeout(timer)
+  }, [isConnecting, activeKey])
+
   const connect = async (provider: OAuthProvider) => {
     setError(null)
+    const key = connectingKey ?? provider
+    startConnecting(key)
 
     try {
       if (isTauri()) {
@@ -115,12 +207,16 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
           // For desktop: Use webview flow
           const result = await startFlow(provider)
 
-          if (!result) return
+          if (!result) {
+            clearConnecting(key)
+            return
+          }
 
           const { tokens, userInfo } = result
 
           await saveOAuthCredentials(provider, tokens, userInfo, { setPreferredName })
 
+          clearConnecting(key)
           onSuccess?.()
         }
       } else {
@@ -129,6 +225,12 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
         await redirect(provider)
       }
     } catch (e: unknown) {
+      // "Redirecting for OAuth" is thrown intentionally by redirectOAuthFlow to satisfy TypeScript's never return type
+      // It's not a real error, so we ignore it
+      if (e instanceof Error && e.message === 'Redirecting for OAuth') {
+        return
+      }
+      clearConnecting(key)
       const message = e instanceof Error ? e.message : 'Failed to complete authentication'
       setError(message)
       onError?.(e instanceof Error ? e : new Error(message))
@@ -144,18 +246,7 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
 
     const { code, state: returnedState, error: oauthError } = callbackData
 
-    if (oauthError) {
-      const message = oauthError
-      setError(message)
-      onError?.(new Error(message))
-      return false
-    }
-
-    if (!code || !returnedState) {
-      return false
-    }
-
-    // Get OAuth state from sqlite settings
+    // Get OAuth state from sqlite settings (needed for both success and error cleanup)
     const settings = await getSettings({
       oauth_state: String,
       oauth_provider: String,
@@ -166,7 +257,29 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
     const provider = settings.oauthProvider as OAuthProvider | null
     const codeVerifier = settings.oauthVerifier
 
+    // Helper to cleanup connecting state - uses connectingKey if available, otherwise provider
+    const cleanup = () => {
+      const key = connectingKey ?? provider
+      if (key) {
+        clearConnecting(key)
+      }
+    }
+
+    if (oauthError) {
+      cleanup()
+      const message = oauthError
+      setError(message)
+      onError?.(new Error(message))
+      return false
+    }
+
+    if (!code || !returnedState) {
+      cleanup()
+      return false
+    }
+
     if (!provider || !codeVerifier || storedState !== returnedState) {
+      cleanup()
       const message = 'OAuth validation failed'
       setError(message)
       onError?.(new Error(message))
@@ -187,9 +300,11 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
         deleteSetting('oauth_return_context'),
       ])
 
+      cleanup()
       onSuccess?.()
       return true
     } catch (e: unknown) {
+      cleanup()
       const message = e instanceof Error ? e.message : 'Failed to complete authentication'
       setError(message)
       onError?.(e instanceof Error ? e : new Error(message))
@@ -199,7 +314,7 @@ export const useOAuthConnect = (options: UseOAuthConnectOptions = {}): UseOAuthC
 
   const clearError = () => setError(null)
 
-  return { connect, processCallback, error, clearError }
+  return { connect, processCallback, isConnecting, error, clearError }
 }
 
 export type { OAuthCallbackData, OAuthDependencies, UseOAuthConnectResult }

--- a/src/settings/integrations.tsx
+++ b/src/settings/integrations.tsx
@@ -49,6 +49,11 @@ export default function IntegrationsPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  const [isProcessingCallback, setIsProcessingCallback] = useState(() => {
+    const oauth = (location.state as { oauth?: unknown } | null)?.oauth
+    return !!oauth
+  })
+
   const { processCallback } = useOAuthConnect({
     onSuccess: () => {
       loadIntegrations()
@@ -65,15 +70,17 @@ export default function IntegrationsPage() {
 
   // Handle OAuth callback when navigated back from /oauth/callback
   useEffect(() => {
-    const oauth = (location.state as any)?.oauth
+    const oauth = (location.state as { oauth?: { code?: string; state?: string; error?: string } } | null)?.oauth
     if (!oauth) return
 
     const handleCallback = async () => {
+      setIsProcessingCallback(true)
       try {
         await processCallback(oauth)
       } catch (err) {
         console.error('Failed to complete OAuth:', err)
       } finally {
+        setIsProcessingCallback(false)
         navigate('.', { replace: true, state: null })
       }
     }
@@ -103,29 +110,21 @@ export default function IntegrationsPage() {
       // Thunderbolt Pro integration ----------------------------------------
       const proStatus = await getProStatus()
 
-      let gParsedCredentials: any = null
-      let gUserEmail: string | undefined = undefined
-
-      if (integrationsGoogleCredentials) {
+      const parseCredentials = (credentialsJson: string): Integration['credentials'] | undefined => {
+        if (!credentialsJson) return undefined
         try {
-          gParsedCredentials = JSON.parse(integrationsGoogleCredentials)
-          gUserEmail = gParsedCredentials.profile?.email
+          return JSON.parse(credentialsJson) as Integration['credentials']
         } catch (e) {
-          console.error('Failed to parse Google credentials:', e)
+          console.error('Failed to parse credentials:', e)
+          return undefined
         }
       }
 
-      let mParsedCredentials: any = null
-      let mUserEmail: string | undefined = undefined
+      const gParsedCredentials = parseCredentials(integrationsGoogleCredentials)
+      const gUserEmail = gParsedCredentials?.profile?.email
 
-      if (integrationsMicrosoftCredentials) {
-        try {
-          mParsedCredentials = JSON.parse(integrationsMicrosoftCredentials)
-          mUserEmail = mParsedCredentials.profile?.email
-        } catch (e) {
-          console.error('Failed to parse Microsoft credentials:', e)
-        }
-      }
+      const mParsedCredentials = parseCredentials(integrationsMicrosoftCredentials)
+      const mUserEmail = mParsedCredentials?.profile?.email
 
       const integrations = [
         {
@@ -261,6 +260,7 @@ export default function IntegrationsPage() {
                   <ConnectProviderButton
                     provider={integration.provider as OAuthProvider}
                     isConnected={false}
+                    isProcessing={isProcessingCallback}
                     onSuccess={() => {
                       loadIntegrations()
                     }}

--- a/src/widgets/connect-integration/widget.tsx
+++ b/src/widgets/connect-integration/widget.tsx
@@ -83,7 +83,11 @@ export const ConnectIntegrationWidget = memo(
     const queryClient = useQueryClient()
     const displayReason = reason === '' ? getDefaultReason(service) : reason
 
-    const { connect, processCallback, error } = useOAuthConnect({
+    // Use widget-specific connecting key (messageId is unique per widget instance)
+    const connectingKey = `widget_${messageId}`
+
+    const { connect, processCallback, isConnecting, error } = useOAuthConnect({
+      connectingKey,
       onSuccess: async () => {
         const connectedProvider = sessionStorage.getItem(
           getOAuthWidgetKey(messageId, 'provider'),
@@ -91,11 +95,9 @@ export const ConnectIntegrationWidget = memo(
 
         if (!connectedProvider) {
           console.warn('No provider found in sessionStorage for OAuth completion')
-          sessionStorage.removeItem(getOAuthWidgetKey(messageId, 'connecting'))
           return
         }
 
-        sessionStorage.removeItem(getOAuthWidgetKey(messageId, 'connecting'))
         dispatch({ type: 'CONNECT_SUCCESS', payload: connectedProvider })
         await queryClient.refetchQueries({ queryKey: ['integrationStatus'] })
 
@@ -115,37 +117,31 @@ export const ConnectIntegrationWidget = memo(
       const storedProvider = sessionStorage.getItem(getOAuthWidgetKey(messageId, 'provider')) as OAuthProvider | null
 
       if (!storedProvider) {
-        sessionStorage.removeItem(getOAuthWidgetKey(messageId, 'connecting'))
         return
       }
 
       dispatch({ type: 'SET_SELECTED_PROVIDER', payload: storedProvider })
-      dispatch({ type: 'SET_CONNECTING', payload: true })
 
       try {
         const success = await processCallback(oauth)
         if (!success) {
           dispatch({ type: 'CONNECT_FAILED', payload: null })
-          sessionStorage.removeItem(getOAuthWidgetKey(messageId, 'connecting'))
         }
       } catch (err) {
         console.error('Failed to complete OAuth:', err)
         dispatch({ type: 'CONNECT_FAILED', payload: null })
-        sessionStorage.removeItem(getOAuthWidgetKey(messageId, 'connecting'))
       } finally {
         navigate(location.pathname, { replace: true, state: null })
       }
     }
 
+    // Restore selected provider from sessionStorage on mount
     useEffect(() => {
-      const isConnecting = sessionStorage.getItem(getOAuthWidgetKey(messageId, 'connecting')) === 'true'
       const storedProvider = sessionStorage.getItem(getOAuthWidgetKey(messageId, 'provider')) as OAuthProvider | null
-
-      if (isConnecting && storedProvider) {
-        dispatch({ type: 'SET_CONNECTING', payload: true })
+      if (storedProvider && isConnecting) {
         dispatch({ type: 'SET_SELECTED_PROVIDER', payload: storedProvider })
       }
-    }, [messageId, dispatch])
+    }, [messageId, dispatch, isConnecting])
 
     useEffect(() => {
       const locationState = location.state as { oauth?: { code?: string; state?: string; error?: string } } | null
@@ -159,17 +155,13 @@ export const ConnectIntegrationWidget = memo(
 
     const handleConnect = async () => {
       if (!state.selectedProvider) return
-      dispatch({ type: 'SET_CONNECTING', payload: true })
 
       sessionStorage.setItem(getOAuthWidgetKey(messageId, 'provider'), state.selectedProvider)
-      sessionStorage.setItem(getOAuthWidgetKey(messageId, 'connecting'), 'true')
-      sessionStorage.setItem('oauth_return_context', location.pathname)
 
       try {
         await connect(state.selectedProvider as OAuthProvider)
       } catch (err) {
         console.error('Failed to connect integration:', err)
-        sessionStorage.removeItem(getOAuthWidgetKey(messageId, 'connecting'))
       }
     }
 
@@ -241,7 +233,7 @@ export const ConnectIntegrationWidget = memo(
               <div className="w-full grid grid-cols-2 gap-3">
                 <button
                   onClick={() => dispatch({ type: 'SET_SELECTED_PROVIDER', payload: 'google' })}
-                  disabled={state.isConnecting}
+                  disabled={isConnecting}
                   className="flex flex-col items-center justify-center p-4 border border-border rounded-lg hover:bg-accent hover:border-accent-foreground/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                 >
                   <div className="flex items-center justify-center w-20 h-20 mb-2 overflow-hidden">
@@ -257,7 +249,7 @@ export const ConnectIntegrationWidget = memo(
 
                 <button
                   onClick={() => dispatch({ type: 'SET_SELECTED_PROVIDER', payload: 'microsoft' })}
-                  disabled={state.isConnecting}
+                  disabled={isConnecting}
                   className="flex flex-col items-center justify-center p-4 border border-border rounded-lg hover:bg-accent hover:border-accent-foreground/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                 >
                   <div className="flex items-center justify-center w-20 h-20 mb-2 overflow-hidden">
@@ -275,10 +267,10 @@ export const ConnectIntegrationWidget = memo(
 
             <div className="mt-auto w-full">
               <div className="w-full flex gap-2">
-                <Button onClick={handleNotNow} disabled={state.isConnecting} variant="ghost" className="flex-1">
+                <Button onClick={handleNotNow} disabled={isConnecting} variant="ghost" className="flex-1">
                   Not now
                 </Button>
-                <Button onClick={handleDoNotAskAgain} disabled={state.isConnecting} variant="ghost" className="flex-1">
+                <Button onClick={handleDoNotAskAgain} disabled={isConnecting} variant="ghost" className="flex-1">
                   Do not ask again
                 </Button>
               </div>
@@ -340,7 +332,7 @@ export const ConnectIntegrationWidget = memo(
           {provider === '' && (
             <Button
               onClick={() => dispatch({ type: 'SET_SELECTED_PROVIDER', payload: null })}
-              disabled={state.isConnecting}
+              disabled={isConnecting}
               variant="ghost"
               size="icon"
               className="absolute top-2 left-2"
@@ -361,7 +353,7 @@ export const ConnectIntegrationWidget = memo(
               </h3>
             </div>
 
-            {error && error !== 'Redirecting for OAuth' && (
+            {error && (
               <div className="w-full p-3 rounded-md bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800">
                 <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
               </div>
@@ -370,21 +362,21 @@ export const ConnectIntegrationWidget = memo(
             <div className="w-full space-y-2">
               <Button
                 onClick={handleConnect}
-                disabled={state.isConnecting || !state.selectedProvider}
+                disabled={isConnecting || !state.selectedProvider}
                 className="w-full"
                 size="lg"
               >
-                {state.isConnecting ? 'Connecting...' : `Connect ${providerName}`}
+                {isConnecting ? 'Connecting...' : `Connect ${providerName}`}
               </Button>
             </div>
           </div>
 
           <div className="self-end w-full">
             <div className="w-full flex gap-2">
-              <Button onClick={handleNotNow} disabled={state.isConnecting} variant="ghost" className="flex-1">
+              <Button onClick={handleNotNow} disabled={isConnecting} variant="ghost" className="flex-1">
                 Not now
               </Button>
-              <Button onClick={handleDoNotAskAgain} disabled={state.isConnecting} variant="ghost" className="flex-1">
+              <Button onClick={handleDoNotAskAgain} disabled={isConnecting} variant="ghost" className="flex-1">
                 Do not ask again
               </Button>
             </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Persists OAuth "connecting" state with timeout, centralizes callback handling, and updates buttons, widgets, and tests to reflect accurate connecting/connected UI and disablement.
> 
> - **OAuth Hook (`hooks/use-oauth-connect.ts`)**:
>   - Add persistent `isConnecting` state (sessionStorage + 15s timeout), `connectingKey`, and `clearOAuthConnectingState`.
>   - Expose `isConnecting` in hook result; ensure cleanup on success/error/cancel; ignore "Redirecting for OAuth".
>   - Improve callback processing: validate/cleanup state, save credentials, and clear SQLite/session state.
> - **Deep Link Handling (`hooks/use-deep-link-listener.ts`)**:
>   - Simplify effect deps to run once; navigate based on stored `oauth_return_context`.
> - **UI Components**:
>   - `ConnectProviderButton`: accept `isProcessing`, consume hook `isConnecting` (via `connectingKey`), prevent clicks while connecting, show "Connecting...".
>   - Onboarding (`components/onboarding/onboarding-auth-step.tsx`): track callback processing (`isProcessingCallback`), pass to button; adjust disconnect logic.
>   - Integrations Settings (`settings/integrations.tsx`): track callback processing; refactor credentials parsing; pass processing state to button.
>   - Connect Integration Widget (`widgets/connect-integration/widget.tsx`): use hook `isConnecting` with widget-specific `connectingKey`; remove manual session flags; disable controls and show errors accordingly.
> - **Tests (`components/onboarding/onboarding-auth-step.test.tsx`)**:
>   - Update expectations to "Connecting..." and add `isConnecting` to mocked hook; add rerender flow for recovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da2997d847844dc4b489fd0dbd8253212b1adf7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->