### PR TITLE
THU-144: Preview link images are not showing up on mobile app builds

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,10 +23,10 @@
       "csp": {
         "default-src": "'self' tauri: asset:",
         "connect-src": "*",
-        "img-src": "'self' asset: data: https://thunderbolt-cloud.onrender.com",
+        "img-src": "'self' asset: data: https://thunderbolt.io",
         "font-src": "'self' data:",
         "style-src": "'self' 'unsafe-inline'",
-        "script-src": "'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8000 https://thunderbolt-cloud.onrender.com"
+        "script-src": "'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8000 https://thunderbolt.io"
       }
     },
     "withGlobalTauri": true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       "csp": {
         "default-src": "'self' tauri: asset:",
         "connect-src": "*",
-        "img-src": "'self' asset: data:",
+        "img-src": "'self' asset: data: https://thunderbolt-cloud.onrender.com",
         "font-src": "'self' data:",
         "style-src": "'self' 'unsafe-inline'",
         "script-src": "'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8000 https://thunderbolt-cloud.onrender.com"
@@ -34,19 +34,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ],
+    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
     "iOS": {
-      "frameworks": [
-        "MetalPerformanceShaders.framework",
-        "MetalKit.framework",
-        "Metal.framework"
-      ],
+      "frameworks": ["MetalPerformanceShaders.framework", "MetalKit.framework", "Metal.framework"],
       "developmentTeam": "BUMSKVQ3D9"
     },
     "android": {
@@ -57,13 +47,9 @@
     "deep-link": {
       "mobile": [
         {
-          "scheme": [
-            "https"
-          ],
+          "scheme": ["https"],
           "host": "thunderbolt.io",
-          "pathPrefix": [
-            "/oauth/callback"
-          ],
+          "pathPrefix": ["/oauth/callback"],
           "appLink": true
         }
       ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       "csp": {
         "default-src": "'self' tauri: asset:",
         "connect-src": "*",
-        "img-src": "'self' asset: data: https://thunderbolt.io",
+        "img-src": "'self' asset: data: https://api.thunderbolt.io",
         "font-src": "'self' data:",
         "style-src": "'self' 'unsafe-inline'",
         "script-src": "'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8000 https://thunderbolt.io"


### PR DESCRIPTION
…ender.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Tauri CSP to allow images from api.thunderbolt.io and scripts from thunderbolt.io.
> 
> - **Config (Tauri `tauri.conf.json`)**:
>   - **CSP updates**:
>     - `img-src`: allow `https://api.thunderbolt.io`.
>     - `script-src`: switch remote origin to `https://thunderbolt.io` (from `thunderbolt-cloud.onrender.com`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e2468fb5b67c3fd76ffab4cd6ce33a0897d8cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->