### PR TITLE
THU-192: gpt-oss frequently forgets to respond to me after doing all of its research

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -262,6 +262,9 @@ export const aiFetchStreamingResponse = async ({
             usage: finish.totalUsage,
           })
         },
+        onError: (error) => {
+          console.error('streamText error', error)
+        },
       })
     }
 
@@ -315,7 +318,7 @@ export const aiFetchStreamingResponse = async ({
             )
 
             // If we got a non-empty response, we're done
-            if (totalText.length > 0) {
+            if (totalText.trim().length > 0) {
               return
             }
 
@@ -346,7 +349,7 @@ export const aiFetchStreamingResponse = async ({
             result.toUIMessageStream<ThunderboltUIMessage>({
               sendReasoning: true,
               messageMetadata,
-              sendStart: isRetry ? false : undefined,
+              ...(isRetry && { sendStart: false }),
             }),
           )
           return

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -334,6 +334,16 @@ export const aiFetchStreamingResponse = async ({
               attemptNumber++
               continue
             }
+
+            // Empty response with no tool calls - nothing to retry, send finish and exit
+            writer.merge(
+              result.toUIMessageStream<ThunderboltUIMessage>({
+                sendReasoning: false,
+                sendStart: false,
+                messageMetadata,
+              }),
+            )
+            return
           }
 
           // Last attempt or no tool calls - just stream normally

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -266,21 +266,26 @@ export const aiFetchStreamingResponse = async ({
     }
 
     // Use createUIMessageStream to handle retries
+    // Following the official SDK pattern for multi-step streams:
+    // - First stream: sendFinish: false (in case we need to continue)
+    // - Continuation stream: sendStart: false (continues same message)
     const stream = createUIMessageStream({
       execute: async ({ writer }) => {
         let currentMessages = convertToModelMessages(messages)
         let attemptNumber = 1
+        let isRetry = false
 
         while (attemptNumber <= MAX_ATTEMPTS) {
           const result = runStreamText(currentMessages)
 
           // If this is not the last possible attempt, we need to check for empty response
           if (attemptNumber < MAX_ATTEMPTS) {
-            // Merge the stream and wait for completion to check if retry needed
+            // Merge the stream without finish event (in case we need to retry)
             writer.merge(
               result.toUIMessageStream<ThunderboltUIMessage>({
                 sendReasoning: true,
                 messageMetadata,
+                sendFinish: false,
               }),
             )
 
@@ -327,6 +332,7 @@ export const aiFetchStreamingResponse = async ({
                 },
               ]
 
+              isRetry = true
               attemptNumber++
               continue
             }
@@ -335,11 +341,12 @@ export const aiFetchStreamingResponse = async ({
             return
           }
 
-          // Last attempt or no tool calls - just stream normally
+          // Last attempt - continue same message if retry, otherwise normal
           writer.merge(
             result.toUIMessageStream<ThunderboltUIMessage>({
               sendReasoning: true,
               messageMetadata,
+              sendStart: isRetry ? false : undefined,
             }),
           )
           return

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -307,14 +307,6 @@ export const aiFetchStreamingResponse = async ({
 
             // If we got a non-empty response, we're done
             if (totalText.length > 0) {
-              // Send the finish event now
-              writer.merge(
-                result.toUIMessageStream<ThunderboltUIMessage>({
-                  sendReasoning: false,
-                  sendStart: false,
-                  messageMetadata,
-                }),
-              )
               return
             }
 
@@ -335,14 +327,7 @@ export const aiFetchStreamingResponse = async ({
               continue
             }
 
-            // Empty response with no tool calls - nothing to retry, send finish and exit
-            writer.merge(
-              result.toUIMessageStream<ThunderboltUIMessage>({
-                sendReasoning: false,
-                sendStart: false,
-                messageMetadata,
-              }),
-            )
+            // Empty response with no tool calls - nothing to retry
             return
           }
 

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -202,10 +202,9 @@ export const aiFetchStreamingResponse = async ({
         stopWhen: stepCountIs(MAX_STEPS),
 
         prepareStep: ({ steps, stepNumber, messages: stepMessages }) => {
-          // Check if we've had multiple tool-call steps without any text response
-          // This pattern often precedes the "empty response" bug
-          const toolCallStepsInARow = steps.filter((s) => s.finishReason === 'tool-calls').length
-          if (toolCallStepsInARow >= 6 && steps.length >= 7) {
+          // Check if we've had many tool-call steps - this pattern often precedes the "empty response" bug
+          const totalToolCallSteps = steps.filter((s) => s.finishReason === 'tool-calls').length
+          if (totalToolCallSteps >= 6 && steps.length >= 7) {
             return {
               messages: [
                 ...stepMessages,

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -18,6 +18,8 @@ import ky, { type KyInstance } from 'ky'
 
 import {
   convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
   extractReasoningMiddleware,
   stepCountIs,
   streamText,
@@ -183,92 +185,170 @@ export const aiFetchStreamingResponse = async ({
     })
 
     const MAX_STEPS = 20
+    const MAX_RETRIES = 2
 
-    const result = streamText({
-      temperature: 0.2,
-      model: wrappedModel,
-      system: systemPrompt,
-      messages: convertToModelMessages(messages),
-      tools: supportsTools ? toolset : undefined,
-      stopWhen: stepCountIs(MAX_STEPS),
+    const messageMetadata = () => ({ modelId })
 
-      // Guarantee the last allowed step cannot call tools
-      prepareStep: ({ steps, stepNumber, messages }) => {
-        if (steps.length >= MAX_STEPS - 1) {
-          console.info(`Final step ${stepNumber} - telling model to wrap it up...`)
-          return {
-            activeTools: [],
-            messages: [
-              ...messages,
-              {
-                // You might think that "system" would make more sense, but it many providers ignore system messages in the middle of the conversation.
-                role: 'user',
-                content:
-                  'This is the LAST STEP. You MUST reply with a final message NOW. If you have enough information to provide me with a high quality response using prior tool results, respond with your final answer. If you do not have enough information, ask if I would like you to continue.',
-              },
-            ],
+    /**
+     * Run a single streamText attempt and return the result along with metadata
+     */
+    const runStreamText = (inputMessages: ReturnType<typeof convertToModelMessages>) => {
+      return streamText({
+        temperature: 0.2,
+        model: wrappedModel,
+        system: systemPrompt,
+        messages: inputMessages,
+        tools: supportsTools ? toolset : undefined,
+        stopWhen: stepCountIs(MAX_STEPS),
+
+        prepareStep: ({ steps, stepNumber, messages: stepMessages }) => {
+          // Check if we've had multiple tool-call steps without any text response
+          // This pattern often precedes the "empty response" bug
+          const toolCallStepsInARow = steps.filter((s) => s.finishReason === 'tool-calls').length
+          if (toolCallStepsInARow >= 6 && steps.length >= 7) {
+            return {
+              messages: [
+                ...stepMessages,
+                {
+                  role: 'user' as const,
+                  content:
+                    'You have gathered information from multiple tool calls. Please synthesize the results and provide your response to the user now.',
+                },
+              ],
+            }
           }
+
+          if (steps.length >= MAX_STEPS - 1) {
+            console.info(`Final step ${stepNumber} - telling model to wrap it up...`)
+            return {
+              activeTools: [],
+              messages: [
+                ...stepMessages,
+                {
+                  role: 'user' as const,
+                  content:
+                    'RESPOND NOW. Provide your answer using the information you have gathered. Do not ask questions—give your best response immediately.',
+                },
+              ],
+            }
+          }
+        },
+
+        abortSignal,
+        onStepFinish: (step) => {
+          console.info('step', {
+            text: step.text,
+            finishReason: step.finishReason,
+            toolCallCount: step.toolCalls?.length || 0,
+          })
+
+          // When a step includes tool calls, log their names and arguments for easier debugging
+          step.toolCalls?.forEach((call, idx) => {
+            console.groupCollapsed(`Tool call #${idx + 1}: ${call.toolName}`)
+            console.log('Arguments:', call)
+            console.groupEnd()
+          })
+        },
+        onFinish: (finish) => {
+          console.info('finish', {
+            text: finish.text,
+            finishReason: finish.finishReason,
+            toolCallCount: finish.toolCalls?.length || 0,
+            usage: finish.totalUsage,
+          })
+        },
+      })
+    }
+
+    // Use createUIMessageStream to handle retries
+    const stream = createUIMessageStream({
+      execute: async ({ writer }) => {
+        let currentMessages = convertToModelMessages(messages)
+        let attemptNumber = 1
+
+        while (attemptNumber <= MAX_RETRIES) {
+          const result = runStreamText(currentMessages)
+
+          // If this is not the last possible attempt, we need to check for empty response
+          if (attemptNumber < MAX_RETRIES) {
+            // Merge the stream but don't send finish event yet (we might retry)
+            writer.merge(
+              result.toUIMessageStream<ThunderboltUIMessage>({
+                sendReasoning: true,
+                sendFinish: false,
+                messageMetadata,
+              }),
+            )
+
+            // Wait for the stream to complete to check the result
+            const response = await result.response
+            const totalText = response.messages.reduce((acc, msg) => {
+              if (msg.role === 'assistant' && 'content' in msg) {
+                const textContent = Array.isArray(msg.content)
+                  ? msg.content
+                      .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+                      .map((c) => c.text)
+                      .join('')
+                  : typeof msg.content === 'string'
+                    ? msg.content
+                    : ''
+                return acc + textContent
+              }
+              return acc
+            }, '')
+
+            const hadToolCalls = response.messages.some(
+              (msg) =>
+                msg.role === 'assistant' &&
+                'content' in msg &&
+                Array.isArray(msg.content) &&
+                msg.content.some((c) => c.type === 'tool-call'),
+            )
+
+            // If we got a non-empty response, we're done
+            if (totalText.length > 0) {
+              // Send the finish event now
+              writer.merge(
+                result.toUIMessageStream<ThunderboltUIMessage>({
+                  sendReasoning: false,
+                  sendStart: false,
+                  messageMetadata,
+                }),
+              )
+              return
+            }
+
+            // Empty response detected - prepare for retry
+            if (hadToolCalls) {
+              console.info('Empty response detected, retrying with nudge...')
+              currentMessages = [
+                ...currentMessages,
+                ...response.messages,
+                {
+                  role: 'user' as const,
+                  content:
+                    'You called tools but did not provide a response. Please synthesize all the information you gathered and respond to me now. Do not call any more tools.',
+                },
+              ]
+
+              attemptNumber++
+              continue
+            }
+          }
+
+          // Last attempt or no tool calls - just stream normally
+          writer.merge(
+            result.toUIMessageStream<ThunderboltUIMessage>({
+              sendReasoning: true,
+              messageMetadata,
+            }),
+          )
+          return
         }
-      },
-
-      abortSignal,
-      // providerOptions: {
-      //   custom: {
-      //     // reasoningEffort: 'low',
-      //   } satisfies OpenAICompatibleProviderOptions,
-      // },
-      onStepFinish: (step) => {
-        console.info('step', {
-          text: step.text,
-          finishReason: step.finishReason,
-          toolCallCount: step.toolCalls?.length || 0,
-        })
-
-        // When a step includes tool calls, log their names and arguments for easier debugging
-        step.toolCalls?.forEach((call, idx) => {
-          console.groupCollapsed(`Tool call #${idx + 1}: ${call.toolName}`)
-          console.log('Arguments:', call.input)
-          console.groupEnd()
-        })
-      },
-      onFinish: async (finish) => {
-        console.info('finish', {
-          text: finish.text,
-          finishReason: finish.finishReason,
-          toolCallCount: finish.toolCalls?.length || 0,
-          usage: finish.totalUsage,
-        })
-      },
-      onError: (error) => {
-        console.error('error', error)
-      },
-      onChunk: () => {
-        // console.log('chunk')
       },
     })
 
-    return result.toUIMessageStreamResponse<ThunderboltUIMessage>({
-      sendReasoning: true,
-      messageMetadata: ({ part }) => {
-        switch (part.type) {
-          case 'finish-step':
-            return {
-              modelId,
-              usage: part.usage,
-            }
-          case 'finish':
-            return {
-              modelId,
-              // If you wanted to get the total usage for the entire conversation, you could do this:
-              // usage: part.totalUsage,
-            }
-          default:
-            return {
-              modelId,
-            }
-        }
-      },
-    })
+    return createUIMessageStreamResponse({ stream })
   } catch (error) {
     console.error('aiFetchStreamingResponse error', error)
     return new Response(JSON.stringify({ error: (error as Error).message }), {

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -187,7 +187,12 @@ export const aiFetchStreamingResponse = async ({
     const MAX_STEPS = 20
     const MAX_ATTEMPTS = 2
 
-    const messageMetadata = () => ({ modelId })
+    const messageMetadata = ({ part }: { part: { type: string; usage?: unknown } }) => {
+      if (part.type === 'finish-step') {
+        return { modelId, usage: part.usage }
+      }
+      return { modelId }
+    }
 
     /**
      * Run a single streamText attempt and return the result along with metadata

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -184,8 +184,8 @@ export const aiFetchStreamingResponse = async ({
       ],
     })
 
-    const MAX_STEPS = 20
-    const MAX_ATTEMPTS = 2
+    const maxSteps = 20
+    const maxAttempts = 2
 
     const messageMetadata = ({ part }: { part: { type: string; usage?: LanguageModelV2Usage } }) => {
       if (part.type === 'finish-step') {
@@ -204,11 +204,11 @@ export const aiFetchStreamingResponse = async ({
         system: systemPrompt,
         messages: inputMessages,
         tools: supportsTools ? toolset : undefined,
-        stopWhen: stepCountIs(MAX_STEPS),
+        stopWhen: stepCountIs(maxSteps),
 
         prepareStep: ({ steps, stepNumber, messages: stepMessages }) => {
           // Final step: disable tools to force a response
-          if (steps.length >= MAX_STEPS - 1) {
+          if (steps.length >= maxSteps - 1) {
             console.info(`Final step ${stepNumber} - telling model to wrap it up...`)
             return {
               activeTools: [],
@@ -278,11 +278,11 @@ export const aiFetchStreamingResponse = async ({
         let attemptNumber = 1
         let isRetry = false
 
-        while (attemptNumber <= MAX_ATTEMPTS) {
+        while (attemptNumber <= maxAttempts) {
           const result = runStreamText(currentMessages)
 
           // If this is not the last possible attempt, we need to check for empty response
-          if (attemptNumber < MAX_ATTEMPTS) {
+          if (attemptNumber < maxAttempts) {
             // Merge the stream without finish event (in case we need to retry)
             writer.merge(
               result.toUIMessageStream<ThunderboltUIMessage>({

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -317,8 +317,9 @@ export const aiFetchStreamingResponse = async ({
                 msg.content.some((c) => c.type === 'tool-call'),
             )
 
-            // If we got a non-empty response, we're done
+            // If we got a non-empty response, we're done - send finish event
             if (totalText.trim().length > 0) {
+              writer.write({ type: 'finish' })
               return
             }
 
@@ -340,7 +341,8 @@ export const aiFetchStreamingResponse = async ({
               continue
             }
 
-            // Empty response with no tool calls - nothing to retry
+            // Empty response with no tool calls - send finish event and return
+            writer.write({ type: 'finish' })
             return
           }
 

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -185,7 +185,7 @@ export const aiFetchStreamingResponse = async ({
     })
 
     const MAX_STEPS = 20
-    const MAX_RETRIES = 2
+    const MAX_ATTEMPTS = 2
 
     const messageMetadata = () => ({ modelId })
 
@@ -266,16 +266,15 @@ export const aiFetchStreamingResponse = async ({
         let currentMessages = convertToModelMessages(messages)
         let attemptNumber = 1
 
-        while (attemptNumber <= MAX_RETRIES) {
+        while (attemptNumber <= MAX_ATTEMPTS) {
           const result = runStreamText(currentMessages)
 
           // If this is not the last possible attempt, we need to check for empty response
-          if (attemptNumber < MAX_RETRIES) {
-            // Merge the stream but don't send finish event yet (we might retry)
+          if (attemptNumber < MAX_ATTEMPTS) {
+            // Merge the stream and wait for completion to check if retry needed
             writer.merge(
               result.toUIMessageStream<ThunderboltUIMessage>({
                 sendReasoning: true,
-                sendFinish: false,
                 messageMetadata,
               }),
             )

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -202,21 +202,7 @@ export const aiFetchStreamingResponse = async ({
         stopWhen: stepCountIs(MAX_STEPS),
 
         prepareStep: ({ steps, stepNumber, messages: stepMessages }) => {
-          // Check if we've had many tool-call steps - this pattern often precedes the "empty response" bug
-          const totalToolCallSteps = steps.filter((s) => s.finishReason === 'tool-calls').length
-          if (totalToolCallSteps >= 6 && steps.length >= 7) {
-            return {
-              messages: [
-                ...stepMessages,
-                {
-                  role: 'user' as const,
-                  content:
-                    'You have gathered information from multiple tool calls. Please synthesize the results and provide your response to the user now.',
-                },
-              ],
-            }
-          }
-
+          // Final step: disable tools to force a response
           if (steps.length >= MAX_STEPS - 1) {
             console.info(`Final step ${stepNumber} - telling model to wrap it up...`)
             return {
@@ -227,6 +213,21 @@ export const aiFetchStreamingResponse = async ({
                   role: 'user' as const,
                   content:
                     'RESPOND NOW. Provide your answer using the information you have gathered. Do not ask questions—give your best response immediately.',
+                },
+              ],
+            }
+          }
+
+          // Nudge after many tool calls (but not on final step)
+          const totalToolCallSteps = steps.filter((s) => s.finishReason === 'tool-calls').length
+          if (totalToolCallSteps >= 6) {
+            return {
+              messages: [
+                ...stepMessages,
+                {
+                  role: 'user' as const,
+                  content:
+                    'You have gathered information from multiple tool calls. Please synthesize the results and provide your response to the user now.',
                 },
               ],
             }

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -8,7 +8,7 @@ import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
-import type { LanguageModelV2 } from '@ai-sdk/provider'
+import type { LanguageModelV2, LanguageModelV2Usage } from '@ai-sdk/provider'
 import ky, { type KyInstance } from 'ky'
 
 // Currently @openrouter/ai-sdk-provider is NOT compatible with Vercel AI SDK v5. If you enable this, you will get the following error:
@@ -187,7 +187,7 @@ export const aiFetchStreamingResponse = async ({
     const MAX_STEPS = 20
     const MAX_ATTEMPTS = 2
 
-    const messageMetadata = ({ part }: { part: { type: string; usage?: unknown } }) => {
+    const messageMetadata = ({ part }: { part: { type: string; usage?: LanguageModelV2Usage } }) => {
       if (part.type === 'finish-step') {
         return { modelId, usage: part.usage }
       }

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -1,4 +1,12 @@
 import { createPrompt } from '@/ai/prompt'
+import {
+  extractTextFromMessages,
+  hasToolCalls,
+  isFinalStep,
+  NUDGE_MESSAGES,
+  shouldRetry,
+  shouldShowPreventiveNudge,
+} from '@/ai/step-logic'
 import { getSettings } from '@/dal'
 import { DatabaseSingleton } from '@/db/singleton'
 import { modelsTable } from '@/db/tables'
@@ -208,33 +216,18 @@ export const aiFetchStreamingResponse = async ({
 
         prepareStep: ({ steps, stepNumber, messages: stepMessages }) => {
           // Final step: disable tools to force a response
-          if (steps.length >= maxSteps - 1) {
+          if (isFinalStep(steps.length, maxSteps)) {
             console.info(`Final step ${stepNumber} - telling model to wrap it up...`)
             return {
               activeTools: [],
-              messages: [
-                ...stepMessages,
-                {
-                  role: 'user' as const,
-                  content:
-                    'RESPOND NOW. Provide your answer using the information you have gathered. Do not ask questions—give your best response immediately.',
-                },
-              ],
+              messages: [...stepMessages, { role: 'user' as const, content: NUDGE_MESSAGES.finalStep }],
             }
           }
 
           // Nudge after many tool calls (but not on final step)
-          const totalToolCallSteps = steps.filter((s) => s.finishReason === 'tool-calls').length
-          if (totalToolCallSteps >= 6) {
+          if (shouldShowPreventiveNudge(steps)) {
             return {
-              messages: [
-                ...stepMessages,
-                {
-                  role: 'user' as const,
-                  content:
-                    'You have gathered information from multiple tool calls. Please synthesize the results and provide your response to the user now.',
-                },
-              ],
+              messages: [...stepMessages, { role: 'user' as const, content: NUDGE_MESSAGES.preventive }],
             }
           }
         },
@@ -294,28 +287,8 @@ export const aiFetchStreamingResponse = async ({
 
             // Wait for the stream to complete to check the result
             const response = await result.response
-            const totalText = response.messages.reduce((acc, msg) => {
-              if (msg.role === 'assistant' && 'content' in msg) {
-                const textContent = Array.isArray(msg.content)
-                  ? msg.content
-                      .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
-                      .map((c) => c.text)
-                      .join('')
-                  : typeof msg.content === 'string'
-                    ? msg.content
-                    : ''
-                return acc + textContent
-              }
-              return acc
-            }, '')
-
-            const hadToolCalls = response.messages.some(
-              (msg) =>
-                msg.role === 'assistant' &&
-                'content' in msg &&
-                Array.isArray(msg.content) &&
-                msg.content.some((c) => c.type === 'tool-call'),
-            )
+            const totalText = extractTextFromMessages(response.messages)
+            const hadToolCalls = hasToolCalls(response.messages)
 
             // If we got a non-empty response, we're done - send finish event
             if (totalText.trim().length > 0) {
@@ -323,17 +296,13 @@ export const aiFetchStreamingResponse = async ({
               return
             }
 
-            // Empty response detected - prepare for retry
-            if (hadToolCalls) {
+            // Empty response detected - prepare for retry if conditions are met
+            if (shouldRetry(totalText, hadToolCalls, attemptNumber, maxAttempts)) {
               console.info('Empty response detected, retrying with nudge...')
               currentMessages = [
                 ...currentMessages,
                 ...response.messages,
-                {
-                  role: 'user' as const,
-                  content:
-                    'You called tools but did not provide a response. Please synthesize all the information you gathered and respond to me now. Do not call any more tools.',
-                },
+                { role: 'user' as const, content: NUDGE_MESSAGES.retry },
               ]
 
               isRetry = true

--- a/src/ai/step-logic.test.ts
+++ b/src/ai/step-logic.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  extractTextFromMessages,
+  hasToolCalls,
+  isFinalStep,
+  NUDGE_MESSAGES,
+  shouldRetry,
+  shouldShowPreventiveNudge,
+} from './step-logic'
+
+describe('isFinalStep', () => {
+  test('returns true when on the last step', () => {
+    expect(isFinalStep(19, 20)).toBe(true)
+  })
+
+  test('returns true when past the threshold', () => {
+    expect(isFinalStep(20, 20)).toBe(true)
+  })
+
+  test('returns false when not yet at final step', () => {
+    expect(isFinalStep(18, 20)).toBe(false)
+  })
+
+  test('returns false on first step', () => {
+    expect(isFinalStep(0, 20)).toBe(false)
+  })
+
+  test('handles edge case of maxSteps = 1', () => {
+    expect(isFinalStep(0, 1)).toBe(true)
+  })
+})
+
+describe('shouldShowPreventiveNudge', () => {
+  const createSteps = (toolCallCount: number, otherCount = 0) => [
+    ...Array(toolCallCount).fill({ finishReason: 'tool-calls' }),
+    ...Array(otherCount).fill({ finishReason: 'stop' }),
+  ]
+
+  test('returns true when tool calls reach threshold', () => {
+    expect(shouldShowPreventiveNudge(createSteps(6))).toBe(true)
+  })
+
+  test('returns true when tool calls exceed threshold', () => {
+    expect(shouldShowPreventiveNudge(createSteps(10))).toBe(true)
+  })
+
+  test('returns false when below threshold', () => {
+    expect(shouldShowPreventiveNudge(createSteps(5))).toBe(false)
+  })
+
+  test('returns false with empty steps', () => {
+    expect(shouldShowPreventiveNudge([])).toBe(false)
+  })
+
+  test('only counts tool-calls finish reason', () => {
+    const mixedSteps = createSteps(3, 5) // 3 tool-calls, 5 stop
+    expect(shouldShowPreventiveNudge(mixedSteps)).toBe(false)
+  })
+
+  test('respects custom threshold', () => {
+    expect(shouldShowPreventiveNudge(createSteps(3), 3)).toBe(true)
+    expect(shouldShowPreventiveNudge(createSteps(2), 3)).toBe(false)
+  })
+})
+
+describe('extractTextFromMessages', () => {
+  test('extracts text from string content', () => {
+    const messages = [{ role: 'assistant', content: 'Hello world' }]
+    expect(extractTextFromMessages(messages)).toBe('Hello world')
+  })
+
+  test('extracts text from array content', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Hello ' },
+          { type: 'text', text: 'world' },
+        ],
+      },
+    ]
+    expect(extractTextFromMessages(messages)).toBe('Hello world')
+  })
+
+  test('ignores non-text content types', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Hello' },
+          { type: 'tool-call', toolName: 'search' },
+        ],
+      },
+    ]
+    expect(extractTextFromMessages(messages)).toBe('Hello')
+  })
+
+  test('ignores user messages', () => {
+    const messages = [
+      { role: 'user', content: 'User text' },
+      { role: 'assistant', content: 'Assistant text' },
+    ]
+    expect(extractTextFromMessages(messages)).toBe('Assistant text')
+  })
+
+  test('concatenates multiple assistant messages', () => {
+    const messages = [
+      { role: 'assistant', content: 'First ' },
+      { role: 'user', content: 'ignored' },
+      { role: 'assistant', content: 'Second' },
+    ]
+    expect(extractTextFromMessages(messages)).toBe('First Second')
+  })
+
+  test('returns empty string for empty messages', () => {
+    expect(extractTextFromMessages([])).toBe('')
+  })
+
+  test('handles missing content property', () => {
+    const messages = [{ role: 'assistant' }]
+    expect(extractTextFromMessages(messages)).toBe('')
+  })
+})
+
+describe('hasToolCalls', () => {
+  test('returns true when tool-call exists', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool-call', toolName: 'search' }],
+      },
+    ]
+    expect(hasToolCalls(messages)).toBe(true)
+  })
+
+  test('returns false with only text content', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+    ]
+    expect(hasToolCalls(messages)).toBe(false)
+  })
+
+  test('returns false for user messages with tool-call type', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [{ type: 'tool-call' }],
+      },
+    ]
+    expect(hasToolCalls(messages)).toBe(false)
+  })
+
+  test('returns false for string content', () => {
+    const messages = [{ role: 'assistant', content: 'Hello' }]
+    expect(hasToolCalls(messages)).toBe(false)
+  })
+
+  test('returns false for empty messages', () => {
+    expect(hasToolCalls([])).toBe(false)
+  })
+
+  test('finds tool-call among mixed content', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me search' },
+          { type: 'tool-call', toolName: 'search' },
+        ],
+      },
+    ]
+    expect(hasToolCalls(messages)).toBe(true)
+  })
+})
+
+describe('shouldRetry', () => {
+  test('returns true for empty text with tool calls and attempts remaining', () => {
+    expect(shouldRetry('', true, 1, 2)).toBe(true)
+  })
+
+  test('returns true for whitespace-only text', () => {
+    expect(shouldRetry('   \n\t  ', true, 1, 2)).toBe(true)
+  })
+
+  test('returns false when text is present', () => {
+    expect(shouldRetry('Hello', true, 1, 2)).toBe(false)
+  })
+
+  test('returns false when no tool calls were made', () => {
+    expect(shouldRetry('', false, 1, 2)).toBe(false)
+  })
+
+  test('returns false when max attempts reached', () => {
+    expect(shouldRetry('', true, 2, 2)).toBe(false)
+  })
+
+  test('returns false when past max attempts', () => {
+    expect(shouldRetry('', true, 3, 2)).toBe(false)
+  })
+
+  test('all conditions must be met', () => {
+    // Missing any single condition should return false
+    expect(shouldRetry('text', true, 1, 2)).toBe(false) // has text
+    expect(shouldRetry('', false, 1, 2)).toBe(false) // no tool calls
+    expect(shouldRetry('', true, 2, 2)).toBe(false) // no attempts left
+  })
+})
+
+describe('NUDGE_MESSAGES', () => {
+  test('finalStep message is defined and non-empty', () => {
+    expect(NUDGE_MESSAGES.finalStep).toBeTruthy()
+    expect(NUDGE_MESSAGES.finalStep.length).toBeGreaterThan(0)
+  })
+
+  test('preventive message is defined and non-empty', () => {
+    expect(NUDGE_MESSAGES.preventive).toBeTruthy()
+    expect(NUDGE_MESSAGES.preventive.length).toBeGreaterThan(0)
+  })
+
+  test('retry message is defined and non-empty', () => {
+    expect(NUDGE_MESSAGES.retry).toBeTruthy()
+    expect(NUDGE_MESSAGES.retry.length).toBeGreaterThan(0)
+  })
+})

--- a/src/ai/step-logic.ts
+++ b/src/ai/step-logic.ts
@@ -13,7 +13,7 @@ export const isFinalStep = (currentStepCount: number, maxSteps: number): boolean
 
 /**
  * Check if we should show a preventive nudge to encourage the model to respond.
- * This triggers after the model has made many consecutive tool calls without responding.
+ * This triggers after the model has made many tool calls (6+ total) without responding.
  */
 export const shouldShowPreventiveNudge = (steps: Step[], threshold = 6): boolean =>
   steps.filter((s) => s.finishReason === 'tool-calls').length >= threshold

--- a/src/ai/step-logic.ts
+++ b/src/ai/step-logic.ts
@@ -1,0 +1,75 @@
+type Step = { finishReason: string }
+
+type Message = {
+  role: string
+  content?: string | Array<{ type: string; text?: string }>
+}
+
+/**
+ * Check if the current step is the final step in the agentic loop.
+ * On the final step, we disable tools to force the model to respond.
+ */
+export const isFinalStep = (currentStepCount: number, maxSteps: number): boolean => currentStepCount >= maxSteps - 1
+
+/**
+ * Check if we should show a preventive nudge to encourage the model to respond.
+ * This triggers after the model has made many consecutive tool calls without responding.
+ */
+export const shouldShowPreventiveNudge = (steps: Step[], threshold = 6): boolean =>
+  steps.filter((s) => s.finishReason === 'tool-calls').length >= threshold
+
+/**
+ * Extract all text content from assistant messages.
+ * Used to detect empty responses that need retry.
+ */
+export const extractTextFromMessages = (messages: Message[]): string =>
+  messages.reduce((acc, msg) => {
+    if (msg.role === 'assistant' && 'content' in msg) {
+      const textContent = Array.isArray(msg.content)
+        ? msg.content
+            .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+            .map((c) => c.text)
+            .join('')
+        : typeof msg.content === 'string'
+          ? msg.content
+          : ''
+      return acc + textContent
+    }
+    return acc
+  }, '')
+
+/**
+ * Check if any assistant message contains tool calls.
+ */
+export const hasToolCalls = (messages: Message[]): boolean =>
+  messages.some(
+    (msg) =>
+      msg.role === 'assistant' &&
+      'content' in msg &&
+      Array.isArray(msg.content) &&
+      msg.content.some((c) => c.type === 'tool-call'),
+  )
+
+/**
+ * Determine if we should retry after an empty response.
+ * We only retry if:
+ * - The response text is empty (after trimming whitespace)
+ * - The model made tool calls (so there's information to synthesize)
+ * - We haven't exhausted our retry attempts
+ */
+export const shouldRetry = (
+  totalText: string,
+  hadToolCalls: boolean,
+  attemptNumber: number,
+  maxAttempts: number,
+): boolean => totalText.trim().length === 0 && hadToolCalls && attemptNumber < maxAttempts
+
+/** Nudge messages used during the agentic loop */
+export const NUDGE_MESSAGES = {
+  finalStep:
+    'RESPOND NOW. Provide your answer using the information you have gathered. Do not ask questions—give your best response immediately.',
+  preventive:
+    'You have gathered information from multiple tool calls. Please synthesize the results and provide your response to the user now.',
+  retry:
+    'You called tools but did not provide a response. Please synthesize all the information you gathered and respond to me now. Do not call any more tools.',
+} as const


### PR DESCRIPTION
Implemented a detection and retry mechanism in `src/ai/fetch.ts`:

- Empty response detection: After each stream completes, check if text length is zero and tool calls were made
- Automatic retry: If empty response detected, append tool results plus a nudge message and retry (max 2 attempts)
- Preventive nudge: After 6+ consecutive tool-call steps, inject soft guidance asking the model to respond
- Assertive final step message: At step 19, removed the "ask if I would like you to continue" escape clause

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces step-logic utilities and integrates preventive/final nudges with auto-retry into the streaming agent loop, plus tests.
> 
> - **AI streaming flow (`src/ai/fetch.ts`)**:
>   - Use `createUIMessageStream` to support multi-attempt streams with up to 2 retries on empty assistant output after tool calls.
>   - Inject nudges via `prepareStep`:
>     - Final-step nudge disables tools and forces a response (`isFinalStep`, `NUDGE_MESSAGES.finalStep`).
>     - Preventive nudge after many tool-call steps (`shouldShowPreventiveNudge`, `NUDGE_MESSAGES.preventive`).
>   - Retry path appends prior messages and a retry nudge (`NUDGE_MESSAGES.retry`).
>   - Emit `messageMetadata` with `usage` on `finish-step`; updated logging for steps/tool calls.
>   - Return response via `createUIMessageStreamResponse`.
> - **New step utilities (`src/ai/step-logic.ts`)**:
>   - `isFinalStep`, `shouldShowPreventiveNudge`, `extractTextFromMessages`, `hasToolCalls`, `shouldRetry`, and `NUDGE_MESSAGES`.
> - **Tests (`src/ai/step-logic.test.ts`)**:
>   - Unit tests covering all step-logic helpers and nudge message presence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6181800ac4270c78976ecf31db520ef140a16b9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->