### PR TITLE
THU-179: Prevent <widget tag flicker

### DIFF
--- a/src/ai/widget-parser.test.ts
+++ b/src/ai/widget-parser.test.ts
@@ -374,6 +374,48 @@ describe('parseContentParts', () => {
         { type: 'text', content: 'Some text' },
       ])
     })
+
+    it('removes lone < at the end (potential widget start)', () => {
+      const text = 'Some text <'
+      const result = parseContentParts(text)
+
+      expect(result).toEqual([{ type: 'text', content: 'Some text' }])
+    })
+
+    it('removes partial <w prefix at the end', () => {
+      const text = 'Some text <w'
+      const result = parseContentParts(text)
+
+      expect(result).toEqual([{ type: 'text', content: 'Some text' }])
+    })
+
+    it('removes partial <wi prefix at the end', () => {
+      const text = 'Some text <wi'
+      const result = parseContentParts(text)
+
+      expect(result).toEqual([{ type: 'text', content: 'Some text' }])
+    })
+
+    it('removes partial <widget prefix at the end (without colon)', () => {
+      const text = 'Some text <widget'
+      const result = parseContentParts(text)
+
+      expect(result).toEqual([{ type: 'text', content: 'Some text' }])
+    })
+
+    it('does not remove non-widget HTML tags like <div', () => {
+      const text = 'Some text <div'
+      const result = parseContentParts(text)
+
+      expect(result).toEqual([{ type: 'text', content: 'Some text <div' }])
+    })
+
+    it('does not remove < followed by space', () => {
+      const text = '5 < 10'
+      const result = parseContentParts(text)
+
+      expect(result).toEqual([{ type: 'text', content: '5 < 10' }])
+    })
   })
 
   describe('extensibility', () => {

--- a/src/ai/widget-parser.ts
+++ b/src/ai/widget-parser.ts
@@ -106,7 +106,10 @@ export const parseContentParts = (text: string): ContentPart[] => {
     let textAfter = text.slice(lastIndex).trim()
 
     // Remove incomplete widget tags at the end (for streaming)
-    const incompleteWidgetTagMatch = textAfter.match(/<widget:[a-z0-9-]*(?:\s+[^>]*)?$/)
+    // Matches: < | <w | <wi | <wid | <widg | <widge | <widget | <widget:... (incomplete)
+    const incompleteWidgetTagMatch = textAfter.match(
+      /<(?:widget:[a-z0-9-]*(?:\s+[^>]*)?|w(?:i(?:d(?:g(?:e(?:t)?)?)?)?)?)?$/i,
+    )
     if (incompleteWidgetTagMatch) {
       textAfter = textAfter.slice(0, incompleteWidgetTagMatch.index).trim()
     }


### PR DESCRIPTION
## Fix widget tag flash during streaming

During streaming, users would briefly see `<widget` text flash before the widget rendered. 

**Root cause:** The incomplete tag regex only matched `<widget:...` but not partial prefixes like `<`, `<w`, `<wi`, etc.

**Fix:** Updated the regex in `parseContentParts` to also strip partial widget prefixes at the end of streaming text.

```typescript
/<(?:widget:[a-z0-9-]*(?:\s+[^>]*)?|w(?:i(?:d(?:g(?:e(?:t)?)?)?)?)?)?$/i
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand incomplete-tag regex to remove partial `<widget` prefixes (including `<`, `<w`, `<wi`, etc.) at stream end and add coverage tests.
> 
> - **Parser** (`src/ai/widget-parser.ts`):
>   - Broaden incomplete-tag detection to remove partial widget prefixes at the end of text using regex: `/<(?:widget:[a-z0-9-]*(?:\s+[^>]*)?|w(?:i(?:d(?:g(?:e(?:t)?)?)?)?)?)?$/i`.
> - **Tests** (`src/ai/widget-parser.test.ts`):
>   - Add streaming edge-case tests for trimming lone `<`, `<w`, `<wi`, `<widget` and incomplete `widget:` prefixes.
>   - Ensure non-widget sequences like `<div` and `<` followed by space (e.g., `5 < 10`) are preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d56c30cb932751b321599dd35018896ad3986da8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->