### PR TITLE
THU-195: Invalidate chatThreads query after running automation to ensure the sidebar is updated

### DIFF
--- a/src/automations/index.tsx
+++ b/src/automations/index.tsx
@@ -64,6 +64,7 @@ export default function AutomationsPage() {
       const prompt = prompts.find((p) => p.id === promptId)
 
       const threadId = await runAutomation(promptId)
+      queryClient.invalidateQueries({ queryKey: ['chatThreads'] })
       navigate(`/chats/${threadId}`)
       trackEvent('automation_run', {
         automation_id: promptId,


### PR DESCRIPTION
…updated data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Invalidate `chatThreads` query after running an automation so the chat sidebar reflects the new thread.
> 
> - **Automations (`src/automations/index.tsx`)**:
>   - After `runAutomation`, add `queryClient.invalidateQueries({ queryKey: ['chatThreads'] })` to refresh chat threads before navigating.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fddf5bc569e26a81cfacf3f0464502cde096ba97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->