### PR TITLE
THU-207: The metadata times for each tool call / total response are showing up as 0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6520,7 +6520,7 @@ dependencies = [
 
 [[package]]
 name = "thunderbolt"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "serde",

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -16,7 +16,7 @@ import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
-import type { LanguageModelV2, LanguageModelV2Usage } from '@ai-sdk/provider'
+import type { LanguageModelV2 } from '@ai-sdk/provider'
 import ky, { type KyInstance } from 'ky'
 
 // Currently @openrouter/ai-sdk-provider is NOT compatible with Vercel AI SDK v5. If you enable this, you will get the following error:
@@ -36,6 +36,7 @@ import {
   type ToolSet,
 } from 'ai'
 import { eq } from 'drizzle-orm'
+import { createMessageMetadata } from './message-metadata'
 
 export type MCPClient = Awaited<ReturnType<typeof experimental_createMCPClient>>
 
@@ -263,55 +264,10 @@ export const aiFetchStreamingResponse = async ({
         let currentMessages = convertToModelMessages(messages)
         let attemptNumber = 1
         let isRetry = false
-        let reasoningIdCounter = 0
-
-        /**
-         * Creates a messageMetadata function that generates incremental IDs for reasoning parts.
-         * This is necessary because all reasoning-start parts come with the same id `reasoning-0`,
-         * so we generate unique IDs (reasoning-0, reasoning-1, etc.) and track timing metadata
-         * for reasoning and tool calls across the stream.
-         */
-        const createMessageMetadata = () => {
-          return ({
-            part,
-          }: {
-            part: { type: string; id?: string; toolCallId?: string; usage?: LanguageModelV2Usage }
-          }) => {
-            switch (part.type) {
-              case 'finish-step':
-                return { modelId, usage: part.usage }
-              case 'tool-call':
-                return {
-                  reasoningTime: { [part.toolCallId ?? part.id ?? 'unknown']: { startedAt: Date.now() } },
-                }
-              case 'reasoning-start': {
-                const reasoningId: string = `reasoning-${reasoningIdCounter}`
-                reasoningIdCounter++
-                return {
-                  reasoningTime: { [reasoningId]: { startedAt: Date.now() } },
-                }
-              }
-              case 'tool-result':
-                return {
-                  reasoningTime: { [part.toolCallId ?? part.id ?? 'unknown']: { finishedAt: Date.now() } },
-                }
-              case 'reasoning-end': {
-                // Find the corresponding reasoning-start ID by decrementing the counter
-                // Since reasoning-end comes after reasoning-start, we need to use the previous ID
-                const reasoningId: string = `reasoning-${reasoningIdCounter - 1}`
-                return {
-                  reasoningTime: { [reasoningId]: { finishedAt: Date.now() } },
-                }
-              }
-              default:
-                return { modelId }
-            }
-          }
-        }
 
         while (attemptNumber <= maxAttempts) {
           const result = runStreamText(currentMessages)
-          const messageMetadata = createMessageMetadata()
+          const messageMetadata = createMessageMetadata(modelId)
 
           // If this is not the last possible attempt, we need to check for empty response
           if (attemptNumber < maxAttempts) {

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -195,13 +195,6 @@ export const aiFetchStreamingResponse = async ({
     const maxSteps = 20
     const maxAttempts = 2
 
-    const messageMetadata = ({ part }: { part: { type: string; usage?: LanguageModelV2Usage } }) => {
-      if (part.type === 'finish-step') {
-        return { modelId, usage: part.usage }
-      }
-      return { modelId }
-    }
-
     /**
      * Run a single streamText attempt and return the result along with metadata
      */
@@ -270,9 +263,55 @@ export const aiFetchStreamingResponse = async ({
         let currentMessages = convertToModelMessages(messages)
         let attemptNumber = 1
         let isRetry = false
+        let reasoningIdCounter = 0
+
+        /**
+         * Creates a messageMetadata function that generates incremental IDs for reasoning parts.
+         * This is necessary because all reasoning-start parts come with the same id `reasoning-0`,
+         * so we generate unique IDs (reasoning-0, reasoning-1, etc.) and track timing metadata
+         * for reasoning and tool calls across the stream.
+         */
+        const createMessageMetadata = () => {
+          return ({
+            part,
+          }: {
+            part: { type: string; id?: string; toolCallId?: string; usage?: LanguageModelV2Usage }
+          }) => {
+            switch (part.type) {
+              case 'finish-step':
+                return { modelId, usage: part.usage }
+              case 'tool-call':
+                return {
+                  reasoningTime: { [part.toolCallId ?? part.id ?? 'unknown']: { startedAt: Date.now() } },
+                }
+              case 'reasoning-start': {
+                const reasoningId: string = `reasoning-${reasoningIdCounter}`
+                reasoningIdCounter++
+                return {
+                  reasoningTime: { [reasoningId]: { startedAt: Date.now() } },
+                }
+              }
+              case 'tool-result':
+                return {
+                  reasoningTime: { [part.toolCallId ?? part.id ?? 'unknown']: { finishedAt: Date.now() } },
+                }
+              case 'reasoning-end': {
+                // Find the corresponding reasoning-start ID by decrementing the counter
+                // Since reasoning-end comes after reasoning-start, we need to use the previous ID
+                const reasoningId: string = `reasoning-${reasoningIdCounter - 1}`
+                return {
+                  reasoningTime: { [reasoningId]: { finishedAt: Date.now() } },
+                }
+              }
+              default:
+                return { modelId }
+            }
+          }
+        }
 
         while (attemptNumber <= maxAttempts) {
           const result = runStreamText(currentMessages)
+          const messageMetadata = createMessageMetadata()
 
           // If this is not the last possible attempt, we need to check for empty response
           if (attemptNumber < maxAttempts) {

--- a/src/ai/message-metadata.test.ts
+++ b/src/ai/message-metadata.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import { createMessageMetadata } from './message-metadata'
+
+describe('createMessageMetadata', () => {
+  const modelId = 'test-model'
+  let originalDateNow: () => number
+
+  beforeEach(() => {
+    originalDateNow = Date.now
+  })
+
+  afterEach(() => {
+    Date.now = originalDateNow
+  })
+
+  describe('default behavior', () => {
+    it('returns modelId for unknown part types', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'unknown-type' } })
+
+      expect(result).toEqual({ modelId })
+    })
+
+    it('returns modelId and usage for finish-step', () => {
+      const metadata = createMessageMetadata(modelId)
+      const usage = { inputTokens: 100, outputTokens: 50, totalTokens: 150 }
+
+      const result = metadata({ part: { type: 'finish-step', usage } })
+
+      expect(result).toEqual({ modelId, usage })
+    })
+  })
+
+  describe('tool call timing', () => {
+    it('returns modelId on tool-call start', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'tool-call', toolCallId: 'call-123' } })
+
+      expect(result).toEqual({ modelId })
+    })
+
+    it('returns duration on tool-result', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'tool-call', toolCallId: 'call-123' } })
+
+      currentTime = 1500 // 500ms later
+      const result = metadata({ part: { type: 'tool-result', toolCallId: 'call-123' } })
+
+      expect(result).toEqual({ reasoningTime: { 'call-123': 500 } })
+    })
+
+    it('uses part.id as fallback when toolCallId is missing', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'tool-call', id: 'id-456' } })
+
+      currentTime = 2000
+      const result = metadata({ part: { type: 'tool-result', id: 'id-456' } })
+
+      expect(result).toEqual({ reasoningTime: { 'id-456': 1000 } })
+    })
+
+    it('uses "unknown" when no id is provided', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'tool-call' } })
+
+      currentTime = 1200
+      const result = metadata({ part: { type: 'tool-result' } })
+
+      expect(result).toEqual({ reasoningTime: { unknown: 200 } })
+    })
+
+    it('returns modelId when tool-result has no matching start', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'tool-result', toolCallId: 'no-start' } })
+
+      expect(result).toEqual({ modelId })
+    })
+
+    it('tracks multiple concurrent tool calls', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'tool-call', toolCallId: 'call-a' } })
+
+      currentTime = 1100
+      metadata({ part: { type: 'tool-call', toolCallId: 'call-b' } })
+
+      currentTime = 1300
+      const resultB = metadata({ part: { type: 'tool-result', toolCallId: 'call-b' } })
+
+      currentTime = 1500
+      const resultA = metadata({ part: { type: 'tool-result', toolCallId: 'call-a' } })
+
+      expect(resultB).toEqual({ reasoningTime: { 'call-b': 200 } })
+      expect(resultA).toEqual({ reasoningTime: { 'call-a': 500 } })
+    })
+  })
+
+  describe('reasoning timing', () => {
+    it('returns modelId on reasoning-start', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'reasoning-start' } })
+
+      expect(result).toEqual({ modelId })
+    })
+
+    it('returns duration on reasoning-end', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'reasoning-start' } })
+
+      currentTime = 1800
+      const result = metadata({ part: { type: 'reasoning-end' } })
+
+      expect(result).toEqual({ reasoningTime: { 'reasoning-0': 800 } })
+    })
+
+    it('generates incrementing reasoning IDs', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'reasoning-start' } })
+      currentTime = 1100
+      metadata({ part: { type: 'reasoning-end' } })
+
+      currentTime = 2000
+      metadata({ part: { type: 'reasoning-start' } })
+      currentTime = 2200
+      const result = metadata({ part: { type: 'reasoning-end' } })
+
+      expect(result).toEqual({ reasoningTime: { 'reasoning-1': 200 } })
+    })
+
+    it('handles nested reasoning blocks with LIFO order', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      // Start outer reasoning
+      metadata({ part: { type: 'reasoning-start' } }) // reasoning-0
+
+      currentTime = 1100
+      // Start inner reasoning
+      metadata({ part: { type: 'reasoning-start' } }) // reasoning-1
+
+      currentTime = 1300
+      // End inner reasoning first (LIFO)
+      const innerResult = metadata({ part: { type: 'reasoning-end' } })
+
+      currentTime = 1500
+      // End outer reasoning
+      const outerResult = metadata({ part: { type: 'reasoning-end' } })
+
+      expect(innerResult).toEqual({ reasoningTime: { 'reasoning-1': 200 } })
+      expect(outerResult).toEqual({ reasoningTime: { 'reasoning-0': 500 } })
+    })
+
+    it('returns modelId when reasoning-end has no matching start', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'reasoning-end' } })
+
+      expect(result).toEqual({ modelId })
+    })
+  })
+
+  describe('mixed events', () => {
+    it('handles interleaved tool calls and reasoning', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      // Tool call starts
+      metadata({ part: { type: 'tool-call', toolCallId: 'call-1' } })
+
+      currentTime = 1050
+      // Reasoning starts while tool is running
+      metadata({ part: { type: 'reasoning-start' } })
+
+      currentTime = 1200
+      // Reasoning ends
+      const reasoningResult = metadata({ part: { type: 'reasoning-end' } })
+
+      currentTime = 1400
+      // Tool completes
+      const toolResult = metadata({ part: { type: 'tool-result', toolCallId: 'call-1' } })
+
+      expect(reasoningResult).toEqual({ reasoningTime: { 'reasoning-0': 150 } })
+      expect(toolResult).toEqual({ reasoningTime: { 'call-1': 400 } })
+    })
+  })
+
+  describe('isolation between instances', () => {
+    it('each instance has independent state', () => {
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      const metadata1 = createMessageMetadata('model-1')
+      const metadata2 = createMessageMetadata('model-2')
+
+      // Start tool in instance 1
+      metadata1({ part: { type: 'tool-call', toolCallId: 'call-1' } })
+
+      currentTime = 1500
+
+      // Instance 2 should not have the start time
+      const result2 = metadata2({ part: { type: 'tool-result', toolCallId: 'call-1' } })
+      expect(result2).toEqual({ modelId: 'model-2' })
+
+      // Instance 1 should have it
+      const result1 = metadata1({ part: { type: 'tool-result', toolCallId: 'call-1' } })
+      expect(result1).toEqual({ reasoningTime: { 'call-1': 500 } })
+    })
+
+    it('each instance has independent reasoning counter', () => {
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      const metadata1 = createMessageMetadata('model-1')
+      const metadata2 = createMessageMetadata('model-2')
+
+      // Both instances start reasoning
+      metadata1({ part: { type: 'reasoning-start' } })
+      metadata2({ part: { type: 'reasoning-start' } })
+
+      currentTime = 1100
+
+      // Both should use reasoning-0 independently
+      const result1 = metadata1({ part: { type: 'reasoning-end' } })
+      const result2 = metadata2({ part: { type: 'reasoning-end' } })
+
+      expect(result1).toEqual({ reasoningTime: { 'reasoning-0': 100 } })
+      expect(result2).toEqual({ reasoningTime: { 'reasoning-0': 100 } })
+    })
+  })
+})

--- a/src/ai/message-metadata.ts
+++ b/src/ai/message-metadata.ts
@@ -1,0 +1,60 @@
+import type { LanguageModelV2Usage } from '@ai-sdk/provider'
+import type { UIMessageMetadata } from '@/types'
+
+type StreamPart = {
+  type: string
+  id?: string
+  toolCallId?: string
+  usage?: LanguageModelV2Usage
+}
+
+/**
+ * Creates a messageMetadata function that tracks timing for reasoning and tool calls.
+ * Start times are tracked locally; only duration is emitted on completion.
+ *
+ * @param modelId - The model ID to include in metadata
+ * @returns A function that processes stream parts and returns appropriate metadata
+ */
+export const createMessageMetadata = (modelId: string) => {
+  const startTimes = new Map<string, number>()
+  const reasoningStack: string[] = []
+  let reasoningIdCounter = 0
+
+  return ({ part }: { part: StreamPart }): UIMessageMetadata => {
+    switch (part.type) {
+      case 'finish-step':
+        return { modelId, usage: part.usage }
+
+      case 'tool-call': {
+        const id = part.toolCallId ?? part.id ?? 'unknown'
+        startTimes.set(id, Date.now())
+        return { modelId }
+      }
+
+      case 'reasoning-start': {
+        const id = `reasoning-${reasoningIdCounter++}`
+        startTimes.set(id, Date.now())
+        reasoningStack.push(id)
+        return { modelId }
+      }
+
+      case 'tool-result': {
+        const id = part.toolCallId ?? part.id ?? 'unknown'
+        const startTime = startTimes.get(id)
+        const duration = startTime ? Date.now() - startTime : undefined
+        return duration ? { reasoningTime: { [id]: duration } } : { modelId }
+      }
+
+      case 'reasoning-end': {
+        const id = reasoningStack.pop()
+        if (!id) return { modelId }
+        const startTime = startTimes.get(id)
+        const duration = startTime ? Date.now() - startTime : undefined
+        return duration ? { reasoningTime: { [id]: duration } } : { modelId }
+      }
+
+      default:
+        return { modelId }
+    }
+  }
+}

--- a/src/components/chat/assistant-message.test.tsx
+++ b/src/components/chat/assistant-message.test.tsx
@@ -37,7 +37,7 @@ const createToolGroupPart = (tools: ToolUIPart[]): ReasoningGroupUIPart =>
 
 describe('mountMessageParts', () => {
   const testMessageId = 'test-message-id'
-  const testReasoningTime: Record<string, { startedAt: number; finishedAt: number }> = {}
+  const testReasoningTime: Record<string, number> = {}
 
   describe('empty parts', () => {
     it('renders synthetic loading part when no parts exist', () => {

--- a/src/components/chat/assistant-message.test.tsx
+++ b/src/components/chat/assistant-message.test.tsx
@@ -25,7 +25,7 @@ const createToolPart = (state: ToolUIPart['state'], toolName = 'search'): ToolUI
   }) as unknown as ToolUIPart
 
 const createReasoningGroupPart = (
-  items: Array<{ type: 'reasoning' | 'tool'; content: ReasoningUIPart | ToolUIPart }>,
+  items: Array<{ type: 'reasoning' | 'tool'; content: ReasoningUIPart | ToolUIPart; id: string }>,
 ): ReasoningGroupUIPart =>
   ({
     type: 'reasoning_group',
@@ -33,14 +33,15 @@ const createReasoningGroupPart = (
   }) as ReasoningGroupUIPart
 
 const createToolGroupPart = (tools: ToolUIPart[]): ReasoningGroupUIPart =>
-  createReasoningGroupPart(tools.map((tool) => ({ type: 'tool' as const, content: tool })))
+  createReasoningGroupPart(tools.map((tool) => ({ type: 'tool' as const, content: tool, id: tool.toolCallId })))
 
 describe('mountMessageParts', () => {
   const testMessageId = 'test-message-id'
+  const testReasoningTime: Record<string, { startedAt: number; finishedAt: number }> = {}
 
   describe('empty parts', () => {
     it('renders synthetic loading part when no parts exist', () => {
-      const result = mountMessageParts([], true, testMessageId)
+      const result = mountMessageParts([], true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
       // Check that it's the synthetic loading component by checking the result structure
@@ -51,8 +52,10 @@ describe('mountMessageParts', () => {
   describe('reasoning parts', () => {
     it('renders reasoning part', () => {
       const reasoningPart = createReasoningPart('Let me think about this...')
-      const parts: GroupedUIPart[] = [createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart }])]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const parts: GroupedUIPart[] = [
+        createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]),
+      ]
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
       expect(result[0]).toBeDefined()
@@ -62,7 +65,7 @@ describe('mountMessageParts', () => {
   describe('text parts', () => {
     it('renders text part', () => {
       const parts: GroupedUIPart[] = [createTextPart('Hello world')]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
       expect(result[0]).toBeDefined()
@@ -71,7 +74,7 @@ describe('mountMessageParts', () => {
     it('detects text part presence for tool group logic', () => {
       const toolGroup = createToolGroupPart([createToolPart('output-available')])
       const parts: GroupedUIPart[] = [toolGroup, createTextPart('Response text')]
-      const result = mountMessageParts(parts, true, testMessageId)
+      const result = mountMessageParts(parts, true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(2)
       // Both parts should be rendered
@@ -84,7 +87,7 @@ describe('mountMessageParts', () => {
     it('renders tool group with single tool', () => {
       const toolGroup = createToolGroupPart([createToolPart('output-available')])
       const parts: GroupedUIPart[] = [toolGroup]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
       expect(result[0]).toBeDefined()
@@ -97,7 +100,7 @@ describe('mountMessageParts', () => {
         createToolPart('output-available', 'get_weather'),
       ])
       const parts: GroupedUIPart[] = [toolGroup]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
       expect(result[0]).toBeDefined()
@@ -106,8 +109,8 @@ describe('mountMessageParts', () => {
     it('passes isStreaming prop to tool group', () => {
       const toolGroup = createToolGroupPart([createToolPart('output-available')])
       const parts: GroupedUIPart[] = [toolGroup]
-      const streamingResult = mountMessageParts(parts, true, testMessageId)
-      const notStreamingResult = mountMessageParts(parts, false, testMessageId)
+      const streamingResult = mountMessageParts(parts, true, testMessageId, testReasoningTime)
+      const notStreamingResult = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(streamingResult[0]).toBeDefined()
       expect(notStreamingResult[0]).toBeDefined()
@@ -118,7 +121,7 @@ describe('mountMessageParts', () => {
       const toolGroup1 = createToolGroupPart([createToolPart('output-available')])
       const toolGroup2 = createToolGroupPart([createToolPart('output-available')])
       const parts: GroupedUIPart[] = [toolGroup1, toolGroup2]
-      const result = mountMessageParts(parts, true, testMessageId)
+      const result = mountMessageParts(parts, true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(2)
       // Both tool groups should render
@@ -129,7 +132,7 @@ describe('mountMessageParts', () => {
     it('passes hasTextInMessage flag when text part exists', () => {
       const toolGroup = createToolGroupPart([createToolPart('output-available')])
       const parts: GroupedUIPart[] = [toolGroup, createTextPart('Some text')]
-      const result = mountMessageParts(parts, true, testMessageId)
+      const result = mountMessageParts(parts, true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(2)
     })
@@ -137,7 +140,7 @@ describe('mountMessageParts', () => {
     it('does not set hasTextInMessage when only tools exist', () => {
       const toolGroup = createToolGroupPart([createToolPart('output-available')])
       const parts: GroupedUIPart[] = [toolGroup]
-      const result = mountMessageParts(parts, true, testMessageId)
+      const result = mountMessageParts(parts, true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
     })
@@ -147,11 +150,11 @@ describe('mountMessageParts', () => {
     it('renders multiple different part types in order', () => {
       const reasoningPart = createReasoningPart('Thinking...')
       const parts: GroupedUIPart[] = [
-        createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart }]),
+        createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]),
         createToolGroupPart([createToolPart('output-available')]),
         createTextPart('Here is the result'),
       ]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(3)
       expect(result[0]).toBeDefined()
@@ -162,14 +165,14 @@ describe('mountMessageParts', () => {
     it('handles complex message with reasoning, tools, and text', () => {
       const reasoningPart = createReasoningPart('Let me search for that')
       const parts: GroupedUIPart[] = [
-        createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart }]),
+        createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]),
         createToolGroupPart([
           createToolPart('output-available', 'search'),
           createToolPart('output-available', 'fetch_content'),
         ]),
         createTextPart('Based on the search results, I found...'),
       ]
-      const result = mountMessageParts(parts, true, testMessageId)
+      const result = mountMessageParts(parts, true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(3)
     })
@@ -177,10 +180,10 @@ describe('mountMessageParts', () => {
     it('handles message with only reasoning and text (no tools)', () => {
       const reasoningPart = createReasoningPart('Thinking...')
       const parts: GroupedUIPart[] = [
-        createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart }]),
+        createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]),
         createTextPart('Direct answer'),
       ]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(2)
     })
@@ -193,7 +196,7 @@ describe('mountMessageParts', () => {
         createToolPart('input-streaming'), // Still loading
       ])
       const parts: GroupedUIPart[] = [toolGroup]
-      const result = mountMessageParts(parts, true, testMessageId)
+      const result = mountMessageParts(parts, true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
     })
@@ -201,7 +204,7 @@ describe('mountMessageParts', () => {
     it('handles streaming message with completed tools but no text yet', () => {
       const toolGroup = createToolGroupPart([createToolPart('output-available'), createToolPart('output-available')])
       const parts: GroupedUIPart[] = [toolGroup]
-      const result = mountMessageParts(parts, true, testMessageId)
+      const result = mountMessageParts(parts, true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
       // Should show loading indicator for next action
@@ -212,7 +215,7 @@ describe('mountMessageParts', () => {
         createToolGroupPart([createToolPart('output-available')]),
         createTextPart('Complete response'),
       ]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(2)
     })
@@ -222,22 +225,24 @@ describe('mountMessageParts', () => {
     it('handles tool group with errored tools', () => {
       const toolGroup = createToolGroupPart([createToolPart('output-available'), createToolPart('output-error')])
       const parts: GroupedUIPart[] = [toolGroup]
-      const result = mountMessageParts(parts, true, testMessageId)
+      const result = mountMessageParts(parts, true, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
     })
 
     it('handles message with only reasoning', () => {
       const reasoningPart = createReasoningPart('Just thinking out loud...')
-      const parts: GroupedUIPart[] = [createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart }])]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const parts: GroupedUIPart[] = [
+        createReasoningGroupPart([{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]),
+      ]
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
     })
 
     it('handles message with only tools (no text or reasoning)', () => {
       const parts: GroupedUIPart[] = [createToolGroupPart([createToolPart('output-available')])]
-      const result = mountMessageParts(parts, false, testMessageId)
+      const result = mountMessageParts(parts, false, testMessageId, testReasoningTime)
 
       expect(result).toHaveLength(1)
     })

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -30,7 +30,7 @@ export const mountMessageParts = (
   groupedParts: GroupedUIPart[],
   isStreaming: boolean,
   messageId: string,
-  reasoningTime: Record<string, { startedAt: number; finishedAt: number }>,
+  reasoningTime: Record<string, { startedAt?: number; finishedAt?: number }>,
 ) => {
   const partElements: ReactNode[] = []
 
@@ -80,7 +80,7 @@ export const AssistantMessage = memo(({ message, isStreaming }: AssistantMessage
     groupedParts,
     isStreaming,
     message.id,
-    message.metadata?.reasoningTime,
+    message.metadata?.reasoningTime ?? {},
   )
 
   return (

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -8,11 +8,10 @@ import {
 import { splitPartType } from '@/lib/utils'
 import type { ThunderboltUIMessage } from '@/types'
 import type { TextUIPart } from 'ai'
-import { memo, useEffect, useRef, type ReactNode } from 'react'
+import { memo, type ReactNode } from 'react'
 import { SyntheticLoadingPart } from './synthetic-loading-part'
 import { TextPart } from './text-part'
 import { ReasoningGroup } from './reasoning-group'
-import { updateMessage } from '@/dal'
 
 interface AssistantMessageProps {
   message: ThunderboltUIMessage
@@ -27,7 +26,12 @@ const animationClasses = 'animate-in slide-in-from-bottom-2 fade-in duration-300
  * Handles different part types (reasoning, tools, text) and manages loading states.
  * @internal - Exported for testing only
  */
-export const mountMessageParts = (groupedParts: GroupedUIPart[], isStreaming: boolean, messageId: string) => {
+export const mountMessageParts = (
+  groupedParts: GroupedUIPart[],
+  isStreaming: boolean,
+  messageId: string,
+  reasoningTime: Record<string, { startedAt: number; finishedAt: number }>,
+) => {
   const partElements: ReactNode[] = []
 
   if (groupedParts.length === 0 && isStreaming) {
@@ -53,6 +57,7 @@ export const mountMessageParts = (groupedParts: GroupedUIPart[], isStreaming: bo
             isStreaming={isStreaming}
             isLastPartInMessage={isLastPart}
             hasTextPart={hasTextPart}
+            reasoningTime={reasoningTime}
           />,
         )
         break
@@ -66,79 +71,17 @@ export const mountMessageParts = (groupedParts: GroupedUIPart[], isStreaming: bo
   return partElements
 }
 
-const useTrackMessagePartDuration = (parts: any[]) => {
-  const partsStartTimes = useRef(new Map<number, number>())
-  const partsEndTimes = useRef(new Map<number, number>())
-
-  useEffect(() => {
-    parts.forEach((part, index) => {
-      const isPartStreaming =
-        part.state !== 'done' && part.state !== 'output-available' && part.state !== 'output-error'
-
-      if (isPartStreaming && !partsStartTimes.current.has(index)) {
-        partsStartTimes.current.set(index, Date.now())
-      }
-
-      if (!isPartStreaming && !partsEndTimes.current.has(index)) {
-        partsEndTimes.current.set(index, Date.now())
-      }
-    })
-  }, [parts])
-
-  return parts.map((item, index) => {
-    const startTime = partsStartTimes.current.get(index)
-    const endTime = partsEndTimes.current.get(index)
-    const duration = endTime && startTime ? endTime - startTime : null
-
-    const [partType] = splitPartType(item.type)
-
-    return {
-      ...item,
-      ...(['tool', 'reasoning'].includes(partType) && duration
-        ? {
-            metadata: {
-              ...(item as any).metadata,
-              duration,
-            },
-          }
-        : {}),
-    }
-  })
-}
-
-type UseSaveMessagePartsDurationParams = {
-  isStreaming: boolean
-  message: ThunderboltUIMessage
-  updatedParts: any[]
-}
-
-const useSaveMessagePartsDuration = ({ isStreaming, message, updatedParts }: UseSaveMessagePartsDurationParams) => {
-  const refIsStreaming = useRef(isStreaming)
-
-  useEffect(() => {
-    if (refIsStreaming.current && !isStreaming) {
-      refIsStreaming.current = false
-
-      // delay the update to ensure the parts are updated in the database
-      const timeout = setTimeout(async () => {
-        await updateMessage(message.id, { parts: updatedParts })
-      }, 500)
-
-      return () => clearTimeout(timeout)
-    }
-  }, [isStreaming, message, updatedParts])
-}
-
 export const AssistantMessage = memo(({ message, isStreaming }: AssistantMessageProps) => {
-  const partsWithDuration = useTrackMessagePartDuration(message.parts)
-
-  useSaveMessagePartsDuration({ isStreaming, message, updatedParts: partsWithDuration })
-
-  const filteredParts = filterMessageParts(partsWithDuration) as GroupableUIPart[]
+  const filteredParts = filterMessageParts(message.parts) as GroupableUIPart[]
 
   const groupedParts = groupMessageParts(filteredParts)
 
-  const partElements: ReactNode[] = mountMessageParts(groupedParts, isStreaming, message.id)
+  const partElements: ReactNode[] = mountMessageParts(
+    groupedParts,
+    isStreaming,
+    message.id,
+    message.metadata?.reasoningTime,
+  )
 
   return (
     <div>

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -9,9 +9,9 @@ import { splitPartType } from '@/lib/utils'
 import type { ThunderboltUIMessage } from '@/types'
 import type { TextUIPart } from 'ai'
 import { memo, type ReactNode } from 'react'
+import { ReasoningGroup } from './reasoning-group'
 import { SyntheticLoadingPart } from './synthetic-loading-part'
 import { TextPart } from './text-part'
-import { ReasoningGroup } from './reasoning-group'
 
 interface AssistantMessageProps {
   message: ThunderboltUIMessage
@@ -30,7 +30,7 @@ export const mountMessageParts = (
   groupedParts: GroupedUIPart[],
   isStreaming: boolean,
   messageId: string,
-  reasoningTime: Record<string, { startedAt?: number; finishedAt?: number }>,
+  reasoningTime: Record<string, number>,
 ) => {
   const partElements: ReactNode[] = []
 

--- a/src/components/chat/reasoning-group-title.tsx
+++ b/src/components/chat/reasoning-group-title.tsx
@@ -1,4 +1,4 @@
-import { cn, formatDuration, splitPartType } from '@/lib/utils'
+import { formatDuration, splitPartType } from '@/lib/utils'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
 import { type ToolUIPart } from 'ai'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -17,52 +17,33 @@ export const ReasoningGroupTitle = ({ totalDuration, isThinking, tools }: Reason
     setActiveIndex(tools.length - 1)
   }, [tools.length])
 
+  const activeTool = tools[activeIndex]
+  const activeToolMetadata = activeTool
+    ? getToolMetadataSync(splitPartType(activeTool.type)[1], activeTool.input)
+    : null
+
   return (
     <div className="relative">
       <AnimatePresence mode="wait">
-        {isThinking ? (
-          tools.map((tool, index) => {
-            const isActive = index === activeIndex
-            const isBelow = index < activeIndex
-
-            const [, toolName] = splitPartType(tool.type)
-            const metadata = getToolMetadataSync(toolName, tool.input)
-
-            return (
-              <motion.div
-                key={index}
-                initial={{ y: 20, opacity: 0 }}
-                animate={{
-                  y: isActive ? 0 : isBelow ? -10 : 20,
-                  opacity: isActive ? 1 : 0,
-                  scale: isActive ? 1 : 0.98,
-                  zIndex: isActive ? 10 : isBelow ? index : 0,
-                }}
-                exit={{ y: -20, opacity: 0 }}
-                transition={{
-                  duration: 0.3,
-                  ease: [0.4, 0, 0.2, 1], // Custom easing function
-                }}
-                className={cn('w-full', !isActive && 'pointer-events-none absolute inset-0')}
-              >
-                <span className="text-xs text-muted-foreground italic animate-pulse truncate min-w-0">
-                  {metadata.loadingMessage}
-                </span>
-              </motion.div>
-            )
-          })
+        {isThinking && activeToolMetadata ? (
+          <motion.div
+            key={`tool-${activeIndex}`}
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1, scale: 1 }}
+            exit={{ y: -20, opacity: 0 }}
+            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+            className="w-full"
+          >
+            <span className="text-xs text-muted-foreground italic animate-pulse truncate min-w-0">
+              {activeToolMetadata.loadingMessage}
+            </span>
+          </motion.div>
         ) : (
           <motion.div
+            key="completed"
             initial={{ y: 20, opacity: 0 }}
-            animate={{
-              y: 0,
-              opacity: 1,
-              scale: 1,
-            }}
-            transition={{
-              duration: 0.3,
-              ease: [0.4, 0, 0.2, 1], // Custom easing function
-            }}
+            animate={{ y: 0, opacity: 1, scale: 1 }}
+            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
             className="w-full"
           >
             {tools.length > 0

--- a/src/components/chat/reasoning-group.test.tsx
+++ b/src/components/chat/reasoning-group.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'bun:test'
-import '@testing-library/jest-dom'
-import { ReasoningGroup } from './reasoning-group'
-import type { ReasoningGroupItem } from '@/lib/assistant-message'
-import type { ReasoningUIPart, ToolUIPart } from 'ai'
 import { ContentViewProvider } from '@/content-view/context'
+import type { ReasoningGroupItem } from '@/lib/assistant-message'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import type { ReasoningUIPart, ToolUIPart } from 'ai'
+import { describe, expect, it } from 'bun:test'
+import { ReasoningGroup } from './reasoning-group'
 
 const createMockReasoningPart = (
   state: 'streaming' | 'complete' = 'complete',
@@ -48,7 +48,7 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => {
   return <ContentViewProvider>{children}</ContentViewProvider>
 }
 
-const testReasoningTime: Record<string, { startedAt: number; finishedAt: number }> = {}
+const testReasoningTime: Record<string, number> = {}
 
 describe('ReasoningGroup', () => {
   describe('rendering', () => {
@@ -286,9 +286,9 @@ describe('ReasoningGroup', () => {
         { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' },
       ]
       const reasoningTime = {
-        [searchTool.toolCallId]: { startedAt: 0, finishedAt: 1000 },
-        [readFileTool.toolCallId]: { startedAt: 1000, finishedAt: 2500 },
-        'reasoning-0': { startedAt: 2500, finishedAt: 3000 },
+        [searchTool.toolCallId]: 1000,
+        [readFileTool.toolCallId]: 1500,
+        'reasoning-0': 500,
       }
       render(
         <ReasoningGroup
@@ -316,7 +316,7 @@ describe('ReasoningGroup', () => {
         { type: 'tool', content: readFileTool, id: readFileTool.toolCallId },
       ]
       const reasoningTime = {
-        [readFileTool.toolCallId]: { startedAt: 0, finishedAt: 2000 },
+        [readFileTool.toolCallId]: 2000,
       }
       render(
         <ReasoningGroup

--- a/src/components/chat/reasoning-group.test.tsx
+++ b/src/components/chat/reasoning-group.test.tsx
@@ -48,25 +48,45 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => {
   return <ContentViewProvider>{children}</ContentViewProvider>
 }
 
+const testReasoningTime: Record<string, { startedAt: number; finishedAt: number }> = {}
+
 describe('ReasoningGroup', () => {
   describe('rendering', () => {
     it('should render Expandable component with ReasoningGroupTitle', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: createMockToolPart('search') }]
-      render(<ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />, {
-        wrapper: TestWrapper,
-      })
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
 
       // Check that Expandable is rendered (it should contain the title)
       expect(screen.getByText(/completed|searching|processing/i)).toBeInTheDocument()
     })
 
     it('should render ReasoningItem for each part', () => {
+      const searchTool = createMockToolPart('search')
+      const readFileTool = createMockToolPart('read_file')
       const parts: ReasoningGroupItem[] = [
-        { type: 'tool', content: createMockToolPart('search') },
-        { type: 'tool', content: createMockToolPart('read_file') },
+        { type: 'tool', content: searchTool, id: searchTool.toolCallId },
+        { type: 'tool', content: readFileTool, id: readFileTool.toolCallId },
       ]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -77,9 +97,16 @@ describe('ReasoningGroup', () => {
     })
 
     it('should render CheckIcon when not thinking', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: createMockToolPart('search') }]
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -89,9 +116,16 @@ describe('ReasoningGroup', () => {
     })
 
     it('should render Loader2 when thinking', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: createMockToolPart('search') }]
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={true} isLastPartInMessage={true} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={true}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -103,9 +137,16 @@ describe('ReasoningGroup', () => {
 
   describe('isThinking logic', () => {
     it('should be thinking when isLastPartInMessage and isStreaming are both true', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: createMockToolPart('search') }]
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={true} isLastPartInMessage={true} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={true}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -115,9 +156,16 @@ describe('ReasoningGroup', () => {
     })
 
     it('should not be thinking when isLastPartInMessage is false', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: createMockToolPart('search') }]
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={true} isLastPartInMessage={false} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={true}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -127,9 +175,16 @@ describe('ReasoningGroup', () => {
     })
 
     it('should not be thinking when isStreaming is false', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: createMockToolPart('search') }]
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={true} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -141,9 +196,16 @@ describe('ReasoningGroup', () => {
 
   describe('ReasoningDisplay conditional rendering', () => {
     it('should render ReasoningDisplay when hasTextPart is false and reasoning part exists', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'reasoning', content: createMockReasoningPart('streaming') }]
+      const reasoningPart = createMockReasoningPart('streaming')
+      const parts: ReasoningGroupItem[] = [{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={true} isLastPartInMessage={true} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={true}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -153,30 +215,60 @@ describe('ReasoningGroup', () => {
     })
 
     it('should not render ReasoningDisplay when hasTextPart is true', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'reasoning', content: createMockReasoningPart('complete') }]
-      render(<ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={true} />, {
-        wrapper: TestWrapper,
-      })
+      const reasoningPart = createMockReasoningPart('complete')
+      const parts: ReasoningGroupItem[] = [{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={true}
+          reasoningTime={testReasoningTime}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
 
       // ReasoningDisplay should not render
       expect(screen.queryByText('Let me think about this...')).not.toBeInTheDocument()
     })
 
     it('should not render ReasoningDisplay when no reasoning part exists', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: createMockToolPart('search') }]
-      render(<ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />, {
-        wrapper: TestWrapper,
-      })
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
 
       // ReasoningDisplay should not render
       expect(screen.queryByText('Let me think about this...')).not.toBeInTheDocument()
     })
 
     it('should render ReasoningDisplay with streaming state when reasoning is streaming', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'reasoning', content: createMockReasoningPart('streaming') }]
-      render(<ReasoningGroup parts={parts} isStreaming={true} isLastPartInMessage={true} hasTextPart={false} />, {
-        wrapper: TestWrapper,
-      })
+      const reasoningPart = createMockReasoningPart('streaming')
+      const parts: ReasoningGroupItem[] = [{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={true}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
 
       // ReasoningDisplay should render the reasoning text
       expect(screen.getByText('Let me think about this...')).toBeInTheDocument()
@@ -185,14 +277,31 @@ describe('ReasoningGroup', () => {
 
   describe('duration calculation', () => {
     it('should calculate total duration from all parts', () => {
+      const searchTool = createMockToolPart('search', 'output-available', 1000)
+      const readFileTool = createMockToolPart('read_file', 'output-available', 1500)
+      const reasoningPart = createMockReasoningPart('complete', 500)
       const parts: ReasoningGroupItem[] = [
-        { type: 'tool', content: createMockToolPart('search', 'output-available', 1000) },
-        { type: 'tool', content: createMockToolPart('read_file', 'output-available', 1500) },
-        { type: 'reasoning', content: createMockReasoningPart('complete', 500) },
+        { type: 'tool', content: searchTool, id: searchTool.toolCallId },
+        { type: 'tool', content: readFileTool, id: readFileTool.toolCallId },
+        { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' },
       ]
-      render(<ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />, {
-        wrapper: TestWrapper,
-      })
+      const reasoningTime = {
+        [searchTool.toolCallId]: { startedAt: 0, finishedAt: 1000 },
+        [readFileTool.toolCallId]: { startedAt: 1000, finishedAt: 2500 },
+        'reasoning-0': { startedAt: 2500, finishedAt: 3000 },
+      }
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={reasoningTime}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
 
       // Total duration should be 3000ms (1000 + 1500 + 500)
       // The ReasoningGroupTitle should display this duration
@@ -200,13 +309,27 @@ describe('ReasoningGroup', () => {
     })
 
     it('should handle parts without duration', () => {
+      const searchTool = createMockToolPart('search')
+      const readFileTool = createMockToolPart('read_file', 'output-available', 2000)
       const parts: ReasoningGroupItem[] = [
-        { type: 'tool', content: createMockToolPart('search') },
-        { type: 'tool', content: createMockToolPart('read_file', 'output-available', 2000) },
+        { type: 'tool', content: searchTool, id: searchTool.toolCallId },
+        { type: 'tool', content: readFileTool, id: readFileTool.toolCallId },
       ]
-      render(<ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />, {
-        wrapper: TestWrapper,
-      })
+      const reasoningTime = {
+        [readFileTool.toolCallId]: { startedAt: 0, finishedAt: 2000 },
+      }
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={reasoningTime}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
 
       // Total duration should be 2000ms (0 + 2000)
       expect(screen.getByText(/2\.0s|2s/i)).toBeInTheDocument()
@@ -215,9 +338,16 @@ describe('ReasoningGroup', () => {
 
   describe('onClick handler', () => {
     it('should call openObjectSidebar when ReasoningItem is clicked', () => {
-      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: createMockToolPart('search') }]
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -232,9 +362,15 @@ describe('ReasoningGroup', () => {
 
     it('should call openObjectSidebar with reasoning part when reasoning item is clicked', () => {
       const reasoningPart = createMockReasoningPart('complete')
-      const parts: ReasoningGroupItem[] = [{ type: 'reasoning', content: reasoningPart }]
+      const parts: ReasoningGroupItem[] = [{ type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -248,13 +384,22 @@ describe('ReasoningGroup', () => {
 
   describe('tools filtering', () => {
     it('should filter tools from parts correctly', () => {
+      const searchTool = createMockToolPart('search')
+      const reasoningPart = createMockReasoningPart('streaming')
+      const readFileTool = createMockToolPart('read_file')
       const parts: ReasoningGroupItem[] = [
-        { type: 'tool', content: createMockToolPart('search') },
-        { type: 'reasoning', content: createMockReasoningPart('streaming') },
-        { type: 'tool', content: createMockToolPart('read_file') },
+        { type: 'tool', content: searchTool, id: searchTool.toolCallId },
+        { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' },
+        { type: 'tool', content: readFileTool, id: readFileTool.toolCallId },
       ]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={true} isLastPartInMessage={true} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={true}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 
@@ -270,9 +415,18 @@ describe('ReasoningGroup', () => {
 
     it('should handle empty parts array', () => {
       const parts: ReasoningGroupItem[] = []
-      render(<ReasoningGroup parts={parts} isStreaming={false} isLastPartInMessage={false} hasTextPart={false} />, {
-        wrapper: TestWrapper,
-      })
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
 
       // Should still render the Expandable component
       // The title should show "Thought for 0s" or similar
@@ -282,13 +436,22 @@ describe('ReasoningGroup', () => {
 
   describe('currentReasoningPart', () => {
     it('should use the last reasoning part for ReasoningDisplay', () => {
+      const firstReasoning = createMockReasoningPart('streaming', undefined, 'First reasoning')
+      const searchTool = createMockToolPart('search')
+      const lastReasoning = createMockReasoningPart('streaming', undefined, 'Last reasoning')
       const parts: ReasoningGroupItem[] = [
-        { type: 'reasoning', content: createMockReasoningPart('streaming', undefined, 'First reasoning') },
-        { type: 'tool', content: createMockToolPart('search') },
-        { type: 'reasoning', content: createMockReasoningPart('streaming', undefined, 'Last reasoning') },
+        { type: 'reasoning', content: firstReasoning, id: 'reasoning-0' },
+        { type: 'tool', content: searchTool, id: searchTool.toolCallId },
+        { type: 'reasoning', content: lastReasoning, id: 'reasoning-1' },
       ]
       const { container } = render(
-        <ReasoningGroup parts={parts} isStreaming={true} isLastPartInMessage={true} hasTextPart={false} />,
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={true}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
         { wrapper: TestWrapper },
       )
 

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -6,7 +6,6 @@ import { ReasoningDisplay } from './reasoning-display'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { ReasoningItem } from './reasoning-item'
 import { ReasoningGroupTitle } from './reasoning-group-title'
-import { useMemo } from 'react'
 import { useObjectView } from '@/content-view/context'
 
 type ReasoningGroupProps = {
@@ -14,9 +13,16 @@ type ReasoningGroupProps = {
   isStreaming: boolean
   isLastPartInMessage: boolean
   hasTextPart: boolean
+  reasoningTime: Record<string, { startedAt: number; finishedAt: number }>
 }
 
-export const ReasoningGroup = ({ parts, isStreaming, isLastPartInMessage, hasTextPart }: ReasoningGroupProps) => {
+export const ReasoningGroup = ({
+  parts,
+  isStreaming,
+  isLastPartInMessage,
+  hasTextPart,
+  reasoningTime,
+}: ReasoningGroupProps) => {
   const { openObjectSidebar } = useObjectView()
 
   const tools = parts.filter((part) => part.type === 'tool').map((part) => part.content) as ToolUIPart[]
@@ -32,13 +38,9 @@ export const ReasoningGroup = ({ parts, isStreaming, isLastPartInMessage, hasTex
     ? `reasoning-${currentReasoningPart.content.text.substring(0, 50)}-${parts.indexOf(currentReasoningPart)}`
     : ''
 
-  const totalDuration = useMemo(
-    () =>
-      parts.reduce((previous, current) => {
-        return (previous + ((current.content as any).metadata?.duration ?? 0)) as number
-      }, 0),
-    [parts],
-  )
+  const totalDuration = Object.values(reasoningTime ?? {}).reduce((previous, current) => {
+    return (previous + (current.finishedAt - current.startedAt)) as number
+  }, 0)
 
   const { scrollContainerRef, scrollTargetRef } = useAutoScroll({
     dependencies: [parts.length],
@@ -67,13 +69,16 @@ export const ReasoningGroup = ({ parts, isStreaming, isLastPartInMessage, hasTex
             scrollContainerRef.current = el
           }}
         >
-          {parts.map((part, index) => (
-            <ReasoningItem
-              key={index}
-              part={part}
-              onClick={() => openObjectSidebar(part.content as ToolUIPart | ReasoningUIPart)}
-            />
-          ))}
+          {parts.map((part, index) => {
+            return (
+              <ReasoningItem
+                key={index}
+                part={part}
+                onClick={() => openObjectSidebar(part.content as ToolUIPart | ReasoningUIPart)}
+                reasoningTime={reasoningTime?.[part.id]}
+              />
+            )
+          })}
           <div ref={scrollTargetRef} />
         </div>
       </Expandable>

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -1,19 +1,19 @@
-import { type ReasoningGroupItem } from '@/lib/assistant-message'
-import { Expandable } from '../ui/expandable'
-import { CheckIcon, Loader2 } from 'lucide-react'
-import { type ReasoningUIPart, type ToolUIPart } from 'ai'
-import { ReasoningDisplay } from './reasoning-display'
-import { useAutoScroll } from '@/hooks/use-auto-scroll'
-import { ReasoningItem } from './reasoning-item'
-import { ReasoningGroupTitle } from './reasoning-group-title'
 import { useObjectView } from '@/content-view/context'
+import { useAutoScroll } from '@/hooks/use-auto-scroll'
+import { type ReasoningGroupItem } from '@/lib/assistant-message'
+import { type ReasoningUIPart, type ToolUIPart } from 'ai'
+import { CheckIcon, Loader2 } from 'lucide-react'
+import { Expandable } from '../ui/expandable'
+import { ReasoningDisplay } from './reasoning-display'
+import { ReasoningGroupTitle } from './reasoning-group-title'
+import { ReasoningItem } from './reasoning-item'
 
 type ReasoningGroupProps = {
   parts: ReasoningGroupItem[]
   isStreaming: boolean
   isLastPartInMessage: boolean
   hasTextPart: boolean
-  reasoningTime: Record<string, { startedAt?: number; finishedAt?: number }>
+  reasoningTime: Record<string, number>
 }
 
 export const ReasoningGroup = ({
@@ -38,12 +38,7 @@ export const ReasoningGroup = ({
     ? `reasoning-${currentReasoningPart.content.text.substring(0, 50)}-${parts.indexOf(currentReasoningPart)}`
     : ''
 
-  const totalDuration = Object.values(reasoningTime ?? {}).reduce((previous, current) => {
-    if (current.finishedAt === undefined) {
-      return previous
-    }
-    return (previous + ((current.finishedAt ?? 0) - (current.startedAt ?? 0))) as number
-  }, 0)
+  const totalDuration = Object.values(reasoningTime ?? {}).reduce((previous, current) => previous + current, 0)
 
   const { scrollContainerRef, scrollTargetRef } = useAutoScroll({
     dependencies: [parts.length],

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -13,7 +13,7 @@ type ReasoningGroupProps = {
   isStreaming: boolean
   isLastPartInMessage: boolean
   hasTextPart: boolean
-  reasoningTime: Record<string, { startedAt: number; finishedAt: number }>
+  reasoningTime: Record<string, { startedAt?: number; finishedAt?: number }>
 }
 
 export const ReasoningGroup = ({
@@ -39,7 +39,10 @@ export const ReasoningGroup = ({
     : ''
 
   const totalDuration = Object.values(reasoningTime ?? {}).reduce((previous, current) => {
-    return (previous + (current.finishedAt - current.startedAt)) as number
+    if (current.finishedAt === undefined) {
+      return previous
+    }
+    return (previous + ((current.finishedAt ?? 0) - (current.startedAt ?? 0))) as number
   }, 0)
 
   const { scrollContainerRef, scrollTargetRef } = useAutoScroll({

--- a/src/components/chat/reasoning-item.test.tsx
+++ b/src/components/chat/reasoning-item.test.tsx
@@ -40,23 +40,25 @@ const createMockToolPart = (
 }
 
 describe('ReasoningItem', () => {
+  const testReasoningTime = { startedAt: 0, finishedAt: 1000 }
+
   describe('reasoning type', () => {
     it('should render reasoning item with "Thinking" label', () => {
       const reasoningPart = createMockReasoningPart()
-      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart }
+      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       expect(screen.getByText('Thinking')).toBeInTheDocument()
     })
 
     it('should render Brain icon when not loading', () => {
       const reasoningPart = createMockReasoningPart('complete')
-      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart }
+      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       // Check that Brain icon is rendered (it's an SVG, so we check for the button)
       const button = screen.getByRole('button')
@@ -67,10 +69,10 @@ describe('ReasoningItem', () => {
 
     it('should render loader when reasoning is streaming', () => {
       const reasoningPart = createMockReasoningPart('streaming')
-      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart }
+      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       // Check for loader (Loader2 has animate-spin class)
       const button = screen.getByRole('button')
@@ -80,10 +82,13 @@ describe('ReasoningItem', () => {
 
     it('should display duration when available', () => {
       const reasoningPart = createMockReasoningPart('complete', 1500)
-      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart }
+      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
+      // reasoningTime takes precedence over metadata duration
+      // Use non-zero startedAt since 0 is falsy and would fail the component's check
+      const reasoningTime = { startedAt: 100, finishedAt: 1600 }
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={reasoningTime} />)
 
       // formatDuration(1500) should format to something like "1.5s"
       expect(screen.getByText(/1\.5s|1s/i)).toBeInTheDocument()
@@ -91,7 +96,7 @@ describe('ReasoningItem', () => {
 
     it('should display "..." when loading and no duration', () => {
       const reasoningPart = createMockReasoningPart('streaming')
-      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart }
+      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
 
       render(<ReasoningItem part={part} onClick={mockOnClick} />)
@@ -101,7 +106,7 @@ describe('ReasoningItem', () => {
 
     it('should display "—" when not loading and no duration', () => {
       const reasoningPart = createMockReasoningPart('complete')
-      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart }
+      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
 
       render(<ReasoningItem part={part} onClick={mockOnClick} />)
@@ -111,10 +116,10 @@ describe('ReasoningItem', () => {
 
     it('should call onClick when clicked', () => {
       const reasoningPart = createMockReasoningPart()
-      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart }
+      const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       const button = screen.getByRole('button')
       fireEvent.click(button)
@@ -126,10 +131,10 @@ describe('ReasoningItem', () => {
   describe('tool type', () => {
     it('should render tool item with display name from metadata', () => {
       const toolPart = createMockToolPart('search')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       // The display name comes from getToolMetadataSync which formats the tool name
       // For 'search', it should format to something like "Search"
@@ -138,10 +143,10 @@ describe('ReasoningItem', () => {
 
     it('should render tool icon when not loading', () => {
       const toolPart = createMockToolPart('test_tool', 'output-available')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       const button = screen.getByRole('button')
       expect(button).toBeInTheDocument()
@@ -151,10 +156,10 @@ describe('ReasoningItem', () => {
 
     it('should render loader when tool is loading', () => {
       const toolPart = createMockToolPart('test_tool', 'input-streaming')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       const button = screen.getByRole('button')
       const loader = button.querySelector('.animate-spin')
@@ -163,10 +168,10 @@ describe('ReasoningItem', () => {
 
     it('should render loader when tool state is not output-available or output-error', () => {
       const toolPart = createMockToolPart('test_tool', 'input-available')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       const button = screen.getByRole('button')
       const loader = button.querySelector('.animate-spin')
@@ -175,10 +180,10 @@ describe('ReasoningItem', () => {
 
     it('should not render loader when tool state is output-available', () => {
       const toolPart = createMockToolPart('test_tool', 'output-available')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       const button = screen.getByRole('button')
       const loader = button.querySelector('.animate-spin')
@@ -187,10 +192,10 @@ describe('ReasoningItem', () => {
 
     it('should not render loader when tool state is output-error', () => {
       const toolPart = createMockToolPart('test_tool', 'output-error')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       const button = screen.getByRole('button')
       const loader = button.querySelector('.animate-spin')
@@ -199,10 +204,13 @@ describe('ReasoningItem', () => {
 
     it('should display duration when available', () => {
       const toolPart = createMockToolPart('test_tool', 'output-available', 2500)
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
+      // reasoningTime takes precedence over metadata duration
+      // Use non-zero startedAt since 0 is falsy and would fail the component's check
+      const reasoningTime = { startedAt: 100, finishedAt: 2600 }
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={reasoningTime} />)
 
       // formatDuration(2500) should format to something like "2.5s"
       expect(screen.getByText(/2\.5s|2s/i)).toBeInTheDocument()
@@ -210,7 +218,7 @@ describe('ReasoningItem', () => {
 
     it('should display "..." when loading and no duration', () => {
       const toolPart = createMockToolPart('test_tool', 'input-streaming')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
       render(<ReasoningItem part={part} onClick={mockOnClick} />)
@@ -220,7 +228,7 @@ describe('ReasoningItem', () => {
 
     it('should display "—" when not loading and no duration', () => {
       const toolPart = createMockToolPart('test_tool', 'output-available')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
       render(<ReasoningItem part={part} onClick={mockOnClick} />)
@@ -230,10 +238,10 @@ describe('ReasoningItem', () => {
 
     it('should call onClick when clicked', () => {
       const toolPart = createMockToolPart('test_tool', 'output-available')
-      const part: ReasoningGroupItem = { type: 'tool', content: toolPart }
+      const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />)
 
       const button = screen.getByRole('button')
       fireEvent.click(button)
@@ -244,10 +252,12 @@ describe('ReasoningItem', () => {
 
   describe('edge cases', () => {
     it('should return null for unknown part type', () => {
-      const part = { type: 'unknown' as 'tool' | 'reasoning', content: {} } as ReasoningGroupItem
+      const part = { type: 'unknown' as 'tool' | 'reasoning', content: {}, id: 'unknown-0' } as ReasoningGroupItem
       const mockOnClick = mock()
 
-      const { container } = render(<ReasoningItem part={part} onClick={mockOnClick} />)
+      const { container } = render(
+        <ReasoningItem part={part} onClick={mockOnClick} reasoningTime={testReasoningTime} />,
+      )
 
       expect(container.firstChild).toBeNull()
     })

--- a/src/components/chat/reasoning-item.test.tsx
+++ b/src/components/chat/reasoning-item.test.tsx
@@ -1,9 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, mock } from 'bun:test'
-import '@testing-library/jest-dom'
-import { ReasoningItem } from './reasoning-item'
 import type { ReasoningGroupItem } from '@/lib/assistant-message'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReasoningUIPart, ToolUIPart } from 'ai'
+import { describe, expect, it, mock } from 'bun:test'
+import { ReasoningItem } from './reasoning-item'
 
 const createMockReasoningPart = (state: 'streaming' | 'complete' = 'complete', duration?: number): ReasoningUIPart => {
   const part = {
@@ -40,7 +40,7 @@ const createMockToolPart = (
 }
 
 describe('ReasoningItem', () => {
-  const testReasoningTime = { startedAt: 0, finishedAt: 1000 }
+  const testReasoningTime = 1000
 
   describe('reasoning type', () => {
     it('should render reasoning item with "Thinking" label', () => {
@@ -84,11 +84,8 @@ describe('ReasoningItem', () => {
       const reasoningPart = createMockReasoningPart('complete', 1500)
       const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
-      // reasoningTime takes precedence over metadata duration
-      // Use non-zero startedAt since 0 is falsy and would fail the component's check
-      const reasoningTime = { startedAt: 100, finishedAt: 1600 }
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={reasoningTime} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={1500} />)
 
       // formatDuration(1500) should format to something like "1.5s"
       expect(screen.getByText(/1\.5s|1s/i)).toBeInTheDocument()
@@ -206,11 +203,8 @@ describe('ReasoningItem', () => {
       const toolPart = createMockToolPart('test_tool', 'output-available', 2500)
       const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
-      // reasoningTime takes precedence over metadata duration
-      // Use non-zero startedAt since 0 is falsy and would fail the component's check
-      const reasoningTime = { startedAt: 100, finishedAt: 2600 }
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={reasoningTime} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={2500} />)
 
       // formatDuration(2500) should format to something like "2.5s"
       expect(screen.getByText(/2\.5s|2s/i)).toBeInTheDocument()

--- a/src/components/chat/reasoning-item.tsx
+++ b/src/components/chat/reasoning-item.tsx
@@ -1,13 +1,13 @@
 import { type ReasoningGroupItem } from '@/lib/assistant-message'
-import { Brain, DotIcon, Loader2 } from 'lucide-react'
-import { formatDuration, splitPartType } from '@/lib/utils'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
+import { formatDuration, splitPartType } from '@/lib/utils'
 import { type ReasoningUIPart, type ToolUIPart } from 'ai'
+import { Brain, DotIcon, Loader2 } from 'lucide-react'
 
 type ReasoningItemProps = {
   part: ReasoningGroupItem
   onClick: () => void
-  reasoningTime?: { startedAt?: number; finishedAt?: number }
+  reasoningTime?: number
 }
 
 const getItemData = (part: ReasoningGroupItem) => {
@@ -64,11 +64,7 @@ export const ReasoningItem = ({ part, onClick, reasoningTime }: ReasoningItemPro
         <span className="text-sm font-medium truncate text-foreground">{itemData.displayName}</span>
       </div>
       <span className="text-xs text-muted-foreground flex-shrink-0">
-        {reasoningTime?.finishedAt && reasoningTime?.startedAt
-          ? formatDuration(reasoningTime.finishedAt - reasoningTime.startedAt)
-          : itemData.isLoading
-            ? '...'
-            : '—'}
+        {reasoningTime ? formatDuration(reasoningTime) : itemData.isLoading ? '...' : '—'}
       </span>
     </button>
   )

--- a/src/components/chat/reasoning-item.tsx
+++ b/src/components/chat/reasoning-item.tsx
@@ -7,7 +7,7 @@ import { type ReasoningUIPart, type ToolUIPart } from 'ai'
 type ReasoningItemProps = {
   part: ReasoningGroupItem
   onClick: () => void
-  reasoningTime: { startedAt: number; finishedAt: number }
+  reasoningTime?: { startedAt?: number; finishedAt?: number }
 }
 
 const getItemData = (part: ReasoningGroupItem) => {
@@ -64,7 +64,7 @@ export const ReasoningItem = ({ part, onClick, reasoningTime }: ReasoningItemPro
         <span className="text-sm font-medium truncate text-foreground">{itemData.displayName}</span>
       </div>
       <span className="text-xs text-muted-foreground flex-shrink-0">
-        {reasoningTime
+        {reasoningTime?.finishedAt && reasoningTime?.startedAt
           ? formatDuration(reasoningTime.finishedAt - reasoningTime.startedAt)
           : itemData.isLoading
             ? '...'

--- a/src/components/chat/reasoning-item.tsx
+++ b/src/components/chat/reasoning-item.tsx
@@ -7,6 +7,7 @@ import { type ReasoningUIPart, type ToolUIPart } from 'ai'
 type ReasoningItemProps = {
   part: ReasoningGroupItem
   onClick: () => void
+  reasoningTime: { startedAt: number; finishedAt: number }
 }
 
 const getItemData = (part: ReasoningGroupItem) => {
@@ -40,7 +41,7 @@ const getItemData = (part: ReasoningGroupItem) => {
   }
 }
 
-export const ReasoningItem = ({ part, onClick }: ReasoningItemProps) => {
+export const ReasoningItem = ({ part, onClick, reasoningTime }: ReasoningItemProps) => {
   const itemData = getItemData(part)
 
   if (!itemData) {
@@ -63,7 +64,11 @@ export const ReasoningItem = ({ part, onClick }: ReasoningItemProps) => {
         <span className="text-sm font-medium truncate text-foreground">{itemData.displayName}</span>
       </div>
       <span className="text-xs text-muted-foreground flex-shrink-0">
-        {itemData.duration ? formatDuration(itemData.duration) : itemData.isLoading ? '...' : '—'}
+        {reasoningTime
+          ? formatDuration(reasoningTime.finishedAt - reasoningTime.startedAt)
+          : itemData.isLoading
+            ? '...'
+            : '—'}
       </span>
     </button>
   )

--- a/src/lib/assistant-message.test.ts
+++ b/src/lib/assistant-message.test.ts
@@ -26,8 +26,8 @@ describe('assistant-message utilities', () => {
       expect(grouped[0]).toEqual({
         type: 'reasoning_group',
         items: [
-          { type: 'tool', content: toolAlpha },
-          { type: 'tool', content: toolBeta },
+          { type: 'tool', content: toolAlpha, id: toolAlpha.toolCallId },
+          { type: 'tool', content: toolBeta, id: toolBeta.toolCallId },
         ],
       })
       expect(grouped[1]).toBe(textPart)
@@ -45,10 +45,10 @@ describe('assistant-message utilities', () => {
       expect(grouped[0]).toEqual({
         type: 'reasoning_group',
         items: [
-          { type: 'tool', content: toolAlpha },
-          { type: 'tool', content: toolBeta },
-          { type: 'reasoning', content: reasoningPart },
-          { type: 'tool', content: toolGamma },
+          { type: 'tool', content: toolAlpha, id: toolAlpha.toolCallId },
+          { type: 'tool', content: toolBeta, id: toolBeta.toolCallId },
+          { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' },
+          { type: 'tool', content: toolGamma, id: toolGamma.toolCallId },
         ],
       })
     })
@@ -65,14 +65,14 @@ describe('assistant-message utilities', () => {
       expect(grouped[0]).toEqual({
         type: 'reasoning_group',
         items: [
-          { type: 'tool', content: toolAlpha },
-          { type: 'tool', content: toolBeta },
+          { type: 'tool', content: toolAlpha, id: toolAlpha.toolCallId },
+          { type: 'tool', content: toolBeta, id: toolBeta.toolCallId },
         ],
       })
       expect(grouped[1]).toBe(textPart)
       expect(grouped[2]).toEqual({
         type: 'reasoning_group',
-        items: [{ type: 'tool', content: toolGamma }],
+        items: [{ type: 'tool', content: toolGamma, id: toolGamma.toolCallId }],
       })
     })
   })

--- a/src/lib/assistant-message.ts
+++ b/src/lib/assistant-message.ts
@@ -12,7 +12,7 @@ export type GroupableUIPart = ReasoningUIPart | TextUIPart | ToolUIPart
  * Created by `groupMessageParts` to render related reasoning + tool calls in a single group
  * for better UX (showing them as a batch rather than scattered individually).
  */
-export type ReasoningGroupItem<T = unknown> = { type: 'tool' | 'reasoning'; content: T }
+export type ReasoningGroupItem<T = unknown> = { type: 'tool' | 'reasoning'; content: T; id: string }
 
 export type ReasoningGroupUIPart = {
   type: 'reasoning_group'
@@ -67,6 +67,10 @@ export const groupMessageParts = (parts: GroupableUIPart[]): GroupedUIPart[] => 
     currentItems = []
   }
 
+  // This is used to generate a unique id for each reasoning part
+  // with this id we can get the reasoning time for each part we have saved message metadata
+  let reasoningIdCounter = 0
+
   // Walk through the incoming parts and buffer every consecutive tool call.
   parts.forEach((part) => {
     const [partType] = splitPartType(part.type)
@@ -74,10 +78,11 @@ export const groupMessageParts = (parts: GroupableUIPart[]): GroupedUIPart[] => 
     if (partType === 'tool' || partType === 'reasoning') {
       if (partType === 'tool') {
         const toolPart = part as ToolUIPart
-        currentItems.push({ type: 'tool', content: toolPart })
+        currentItems.push({ type: 'tool', content: toolPart, id: toolPart.toolCallId })
       } else {
         const reasoningPart = part as ReasoningUIPart
-        currentItems.push({ type: 'reasoning', content: reasoningPart })
+        currentItems.push({ type: 'reasoning', content: reasoningPart, id: `reasoning-${reasoningIdCounter}` })
+        reasoningIdCounter++
       }
       return
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type UIMessageMetadata = {
   modelId?: string
   usage?: LanguageModelV2Usage
   oauthRetry?: boolean
+  reasoningTime?: Record<string, { startedAt?: number; finishedAt?: number }>
 }
 
 export type SideviewType = 'message' | 'thread' | 'imap'

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export type UIMessageMetadata = {
   modelId?: string
   usage?: LanguageModelV2Usage
   oauthRetry?: boolean
-  reasoningTime?: Record<string, { startedAt?: number; finishedAt?: number }>
+  reasoningTime?: Record<string, number>
 }
 
 export type SideviewType = 'message' | 'thread' | 'imap'


### PR DESCRIPTION
…f part.metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tracks timing for reasoning and tool calls during streaming and surfaces per-step and total durations in the chat UI.
> 
> - **AI streaming (backend)**:
>   - Add `createMessageMetadata` to track durations for `reasoning` and `tool` events; emit `usage` and `reasoningTime` in message metadata (`src/ai/message-metadata.ts`, tests added).
>   - Integrate metadata into streaming via `messageMetadata` in `aiFetchStreamingResponse` (`src/ai/fetch.ts`).
> - **Types**:
>   - Extend `UIMessageMetadata` with `reasoningTime: Record<string, number>` (`src/types.ts`).
> - **Message grouping/rendering (frontend)**:
>   - Assign stable IDs to grouped `reasoning`/`tool` items to map timings (`src/lib/assistant-message.ts`).
>   - Remove client-side duration tracking; consume `message.metadata.reasoningTime` in `AssistantMessage` and pass to children (`src/components/chat/assistant-message.tsx`).
>   - Show per-item duration in `ReasoningItem` and compute total in `ReasoningGroup`/title (`src/components/chat/reasoning-item.tsx`, `reasoning-group.tsx`, `reasoning-group-title.tsx`).
> - **Tests**:
>   - Update and add tests across AI metadata and chat components to validate timing and rendering behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 876e343de7d3ec573ad077bac1cd127c8d9f756b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->