### PR TITLE
THU-207: Exploring Slightly Different Reasoning Metadata Approach

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6520,7 +6520,7 @@ dependencies = [
 
 [[package]]
 name = "thunderbolt"
-version = "0.1.27"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "serde",

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -16,7 +16,7 @@ import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
-import type { LanguageModelV2, LanguageModelV2Usage } from '@ai-sdk/provider'
+import type { LanguageModelV2 } from '@ai-sdk/provider'
 import ky, { type KyInstance } from 'ky'
 
 // Currently @openrouter/ai-sdk-provider is NOT compatible with Vercel AI SDK v5. If you enable this, you will get the following error:
@@ -36,6 +36,7 @@ import {
   type ToolSet,
 } from 'ai'
 import { eq } from 'drizzle-orm'
+import { createMessageMetadata } from './message-metadata'
 
 export type MCPClient = Awaited<ReturnType<typeof experimental_createMCPClient>>
 
@@ -263,55 +264,10 @@ export const aiFetchStreamingResponse = async ({
         let currentMessages = convertToModelMessages(messages)
         let attemptNumber = 1
         let isRetry = false
-        let reasoningIdCounter = 0
-
-        /**
-         * Creates a messageMetadata function that generates incremental IDs for reasoning parts.
-         * This is necessary because all reasoning-start parts come with the same id `reasoning-0`,
-         * so we generate unique IDs (reasoning-0, reasoning-1, etc.) and track timing metadata
-         * for reasoning and tool calls across the stream.
-         */
-        const createMessageMetadata = () => {
-          return ({
-            part,
-          }: {
-            part: { type: string; id?: string; toolCallId?: string; usage?: LanguageModelV2Usage }
-          }) => {
-            switch (part.type) {
-              case 'finish-step':
-                return { modelId, usage: part.usage }
-              case 'tool-call':
-                return {
-                  reasoningTime: { [part.toolCallId ?? part.id ?? 'unknown']: { startedAt: Date.now() } },
-                }
-              case 'reasoning-start': {
-                const reasoningId: string = `reasoning-${reasoningIdCounter}`
-                reasoningIdCounter++
-                return {
-                  reasoningTime: { [reasoningId]: { startedAt: Date.now() } },
-                }
-              }
-              case 'tool-result':
-                return {
-                  reasoningTime: { [part.toolCallId ?? part.id ?? 'unknown']: { finishedAt: Date.now() } },
-                }
-              case 'reasoning-end': {
-                // Find the corresponding reasoning-start ID by decrementing the counter
-                // Since reasoning-end comes after reasoning-start, we need to use the previous ID
-                const reasoningId: string = `reasoning-${reasoningIdCounter - 1}`
-                return {
-                  reasoningTime: { [reasoningId]: { finishedAt: Date.now() } },
-                }
-              }
-              default:
-                return { modelId }
-            }
-          }
-        }
 
         while (attemptNumber <= maxAttempts) {
           const result = runStreamText(currentMessages)
-          const messageMetadata = createMessageMetadata()
+          const messageMetadata = createMessageMetadata(modelId)
 
           // If this is not the last possible attempt, we need to check for empty response
           if (attemptNumber < maxAttempts) {

--- a/src/ai/message-metadata.test.ts
+++ b/src/ai/message-metadata.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import { createMessageMetadata } from './message-metadata'
+
+describe('createMessageMetadata', () => {
+  const modelId = 'test-model'
+  let originalDateNow: () => number
+
+  beforeEach(() => {
+    originalDateNow = Date.now
+  })
+
+  afterEach(() => {
+    Date.now = originalDateNow
+  })
+
+  describe('default behavior', () => {
+    it('returns modelId for unknown part types', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'unknown-type' } })
+
+      expect(result).toEqual({ modelId })
+    })
+
+    it('returns modelId and usage for finish-step', () => {
+      const metadata = createMessageMetadata(modelId)
+      const usage = { inputTokens: 100, outputTokens: 50, totalTokens: 150 }
+
+      const result = metadata({ part: { type: 'finish-step', usage } })
+
+      expect(result).toEqual({ modelId, usage })
+    })
+  })
+
+  describe('tool call timing', () => {
+    it('returns modelId on tool-call start', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'tool-call', toolCallId: 'call-123' } })
+
+      expect(result).toEqual({ modelId })
+    })
+
+    it('returns duration on tool-result', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'tool-call', toolCallId: 'call-123' } })
+
+      currentTime = 1500 // 500ms later
+      const result = metadata({ part: { type: 'tool-result', toolCallId: 'call-123' } })
+
+      expect(result).toEqual({ reasoningTime: { 'call-123': 500 } })
+    })
+
+    it('uses part.id as fallback when toolCallId is missing', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'tool-call', id: 'id-456' } })
+
+      currentTime = 2000
+      const result = metadata({ part: { type: 'tool-result', id: 'id-456' } })
+
+      expect(result).toEqual({ reasoningTime: { 'id-456': 1000 } })
+    })
+
+    it('uses "unknown" when no id is provided', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'tool-call' } })
+
+      currentTime = 1200
+      const result = metadata({ part: { type: 'tool-result' } })
+
+      expect(result).toEqual({ reasoningTime: { unknown: 200 } })
+    })
+
+    it('returns modelId when tool-result has no matching start', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'tool-result', toolCallId: 'no-start' } })
+
+      expect(result).toEqual({ modelId })
+    })
+
+    it('tracks multiple concurrent tool calls', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'tool-call', toolCallId: 'call-a' } })
+
+      currentTime = 1100
+      metadata({ part: { type: 'tool-call', toolCallId: 'call-b' } })
+
+      currentTime = 1300
+      const resultB = metadata({ part: { type: 'tool-result', toolCallId: 'call-b' } })
+
+      currentTime = 1500
+      const resultA = metadata({ part: { type: 'tool-result', toolCallId: 'call-a' } })
+
+      expect(resultB).toEqual({ reasoningTime: { 'call-b': 200 } })
+      expect(resultA).toEqual({ reasoningTime: { 'call-a': 500 } })
+    })
+  })
+
+  describe('reasoning timing', () => {
+    it('returns modelId on reasoning-start', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'reasoning-start' } })
+
+      expect(result).toEqual({ modelId })
+    })
+
+    it('returns duration on reasoning-end', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'reasoning-start' } })
+
+      currentTime = 1800
+      const result = metadata({ part: { type: 'reasoning-end' } })
+
+      expect(result).toEqual({ reasoningTime: { 'reasoning-0': 800 } })
+    })
+
+    it('generates incrementing reasoning IDs', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      metadata({ part: { type: 'reasoning-start' } })
+      currentTime = 1100
+      metadata({ part: { type: 'reasoning-end' } })
+
+      currentTime = 2000
+      metadata({ part: { type: 'reasoning-start' } })
+      currentTime = 2200
+      const result = metadata({ part: { type: 'reasoning-end' } })
+
+      expect(result).toEqual({ reasoningTime: { 'reasoning-1': 200 } })
+    })
+
+    it('handles nested reasoning blocks with LIFO order', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      // Start outer reasoning
+      metadata({ part: { type: 'reasoning-start' } }) // reasoning-0
+
+      currentTime = 1100
+      // Start inner reasoning
+      metadata({ part: { type: 'reasoning-start' } }) // reasoning-1
+
+      currentTime = 1300
+      // End inner reasoning first (LIFO)
+      const innerResult = metadata({ part: { type: 'reasoning-end' } })
+
+      currentTime = 1500
+      // End outer reasoning
+      const outerResult = metadata({ part: { type: 'reasoning-end' } })
+
+      expect(innerResult).toEqual({ reasoningTime: { 'reasoning-1': 200 } })
+      expect(outerResult).toEqual({ reasoningTime: { 'reasoning-0': 500 } })
+    })
+
+    it('returns modelId when reasoning-end has no matching start', () => {
+      const metadata = createMessageMetadata(modelId)
+
+      const result = metadata({ part: { type: 'reasoning-end' } })
+
+      expect(result).toEqual({ modelId })
+    })
+  })
+
+  describe('mixed events', () => {
+    it('handles interleaved tool calls and reasoning', () => {
+      const metadata = createMessageMetadata(modelId)
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      // Tool call starts
+      metadata({ part: { type: 'tool-call', toolCallId: 'call-1' } })
+
+      currentTime = 1050
+      // Reasoning starts while tool is running
+      metadata({ part: { type: 'reasoning-start' } })
+
+      currentTime = 1200
+      // Reasoning ends
+      const reasoningResult = metadata({ part: { type: 'reasoning-end' } })
+
+      currentTime = 1400
+      // Tool completes
+      const toolResult = metadata({ part: { type: 'tool-result', toolCallId: 'call-1' } })
+
+      expect(reasoningResult).toEqual({ reasoningTime: { 'reasoning-0': 150 } })
+      expect(toolResult).toEqual({ reasoningTime: { 'call-1': 400 } })
+    })
+  })
+
+  describe('isolation between instances', () => {
+    it('each instance has independent state', () => {
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      const metadata1 = createMessageMetadata('model-1')
+      const metadata2 = createMessageMetadata('model-2')
+
+      // Start tool in instance 1
+      metadata1({ part: { type: 'tool-call', toolCallId: 'call-1' } })
+
+      currentTime = 1500
+
+      // Instance 2 should not have the start time
+      const result2 = metadata2({ part: { type: 'tool-result', toolCallId: 'call-1' } })
+      expect(result2).toEqual({ modelId: 'model-2' })
+
+      // Instance 1 should have it
+      const result1 = metadata1({ part: { type: 'tool-result', toolCallId: 'call-1' } })
+      expect(result1).toEqual({ reasoningTime: { 'call-1': 500 } })
+    })
+
+    it('each instance has independent reasoning counter', () => {
+      let currentTime = 1000
+      Date.now = () => currentTime
+
+      const metadata1 = createMessageMetadata('model-1')
+      const metadata2 = createMessageMetadata('model-2')
+
+      // Both instances start reasoning
+      metadata1({ part: { type: 'reasoning-start' } })
+      metadata2({ part: { type: 'reasoning-start' } })
+
+      currentTime = 1100
+
+      // Both should use reasoning-0 independently
+      const result1 = metadata1({ part: { type: 'reasoning-end' } })
+      const result2 = metadata2({ part: { type: 'reasoning-end' } })
+
+      expect(result1).toEqual({ reasoningTime: { 'reasoning-0': 100 } })
+      expect(result2).toEqual({ reasoningTime: { 'reasoning-0': 100 } })
+    })
+  })
+})

--- a/src/ai/message-metadata.ts
+++ b/src/ai/message-metadata.ts
@@ -1,0 +1,60 @@
+import type { LanguageModelV2Usage } from '@ai-sdk/provider'
+import type { UIMessageMetadata } from '@/types'
+
+type StreamPart = {
+  type: string
+  id?: string
+  toolCallId?: string
+  usage?: LanguageModelV2Usage
+}
+
+/**
+ * Creates a messageMetadata function that tracks timing for reasoning and tool calls.
+ * Start times are tracked locally; only duration is emitted on completion.
+ *
+ * @param modelId - The model ID to include in metadata
+ * @returns A function that processes stream parts and returns appropriate metadata
+ */
+export const createMessageMetadata = (modelId: string) => {
+  const startTimes = new Map<string, number>()
+  const reasoningStack: string[] = []
+  let reasoningIdCounter = 0
+
+  return ({ part }: { part: StreamPart }): UIMessageMetadata => {
+    switch (part.type) {
+      case 'finish-step':
+        return { modelId, usage: part.usage }
+
+      case 'tool-call': {
+        const id = part.toolCallId ?? part.id ?? 'unknown'
+        startTimes.set(id, Date.now())
+        return { modelId }
+      }
+
+      case 'reasoning-start': {
+        const id = `reasoning-${reasoningIdCounter++}`
+        startTimes.set(id, Date.now())
+        reasoningStack.push(id)
+        return { modelId }
+      }
+
+      case 'tool-result': {
+        const id = part.toolCallId ?? part.id ?? 'unknown'
+        const startTime = startTimes.get(id)
+        const duration = startTime ? Date.now() - startTime : undefined
+        return duration ? { reasoningTime: { [id]: duration } } : { modelId }
+      }
+
+      case 'reasoning-end': {
+        const id = reasoningStack.pop()
+        if (!id) return { modelId }
+        const startTime = startTimes.get(id)
+        const duration = startTime ? Date.now() - startTime : undefined
+        return duration ? { reasoningTime: { [id]: duration } } : { modelId }
+      }
+
+      default:
+        return { modelId }
+    }
+  }
+}

--- a/src/components/chat/assistant-message.test.tsx
+++ b/src/components/chat/assistant-message.test.tsx
@@ -37,7 +37,7 @@ const createToolGroupPart = (tools: ToolUIPart[]): ReasoningGroupUIPart =>
 
 describe('mountMessageParts', () => {
   const testMessageId = 'test-message-id'
-  const testReasoningTime: Record<string, { startedAt: number; finishedAt: number }> = {}
+  const testReasoningTime: Record<string, number> = {}
 
   describe('empty parts', () => {
     it('renders synthetic loading part when no parts exist', () => {

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -9,9 +9,9 @@ import { splitPartType } from '@/lib/utils'
 import type { ThunderboltUIMessage } from '@/types'
 import type { TextUIPart } from 'ai'
 import { memo, type ReactNode } from 'react'
+import { ReasoningGroup } from './reasoning-group'
 import { SyntheticLoadingPart } from './synthetic-loading-part'
 import { TextPart } from './text-part'
-import { ReasoningGroup } from './reasoning-group'
 
 interface AssistantMessageProps {
   message: ThunderboltUIMessage
@@ -30,7 +30,7 @@ export const mountMessageParts = (
   groupedParts: GroupedUIPart[],
   isStreaming: boolean,
   messageId: string,
-  reasoningTime: Record<string, { startedAt?: number; finishedAt?: number }>,
+  reasoningTime: Record<string, number>,
 ) => {
   const partElements: ReactNode[] = []
 

--- a/src/components/chat/reasoning-group-title.tsx
+++ b/src/components/chat/reasoning-group-title.tsx
@@ -1,4 +1,4 @@
-import { cn, formatDuration, splitPartType } from '@/lib/utils'
+import { formatDuration, splitPartType } from '@/lib/utils'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
 import { type ToolUIPart } from 'ai'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -17,52 +17,33 @@ export const ReasoningGroupTitle = ({ totalDuration, isThinking, tools }: Reason
     setActiveIndex(tools.length - 1)
   }, [tools.length])
 
+  const activeTool = tools[activeIndex]
+  const activeToolMetadata = activeTool
+    ? getToolMetadataSync(splitPartType(activeTool.type)[1], activeTool.input)
+    : null
+
   return (
     <div className="relative">
       <AnimatePresence mode="wait">
-        {isThinking ? (
-          tools.map((tool, index) => {
-            const isActive = index === activeIndex
-            const isBelow = index < activeIndex
-
-            const [, toolName] = splitPartType(tool.type)
-            const metadata = getToolMetadataSync(toolName, tool.input)
-
-            return (
-              <motion.div
-                key={index}
-                initial={{ y: 20, opacity: 0 }}
-                animate={{
-                  y: isActive ? 0 : isBelow ? -10 : 20,
-                  opacity: isActive ? 1 : 0,
-                  scale: isActive ? 1 : 0.98,
-                  zIndex: isActive ? 10 : isBelow ? index : 0,
-                }}
-                exit={{ y: -20, opacity: 0 }}
-                transition={{
-                  duration: 0.3,
-                  ease: [0.4, 0, 0.2, 1], // Custom easing function
-                }}
-                className={cn('w-full', !isActive && 'pointer-events-none absolute inset-0')}
-              >
-                <span className="text-xs text-muted-foreground italic animate-pulse truncate min-w-0">
-                  {metadata.loadingMessage}
-                </span>
-              </motion.div>
-            )
-          })
+        {isThinking && activeToolMetadata ? (
+          <motion.div
+            key={`tool-${activeIndex}`}
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1, scale: 1 }}
+            exit={{ y: -20, opacity: 0 }}
+            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+            className="w-full"
+          >
+            <span className="text-xs text-muted-foreground italic animate-pulse truncate min-w-0">
+              {activeToolMetadata.loadingMessage}
+            </span>
+          </motion.div>
         ) : (
           <motion.div
+            key="completed"
             initial={{ y: 20, opacity: 0 }}
-            animate={{
-              y: 0,
-              opacity: 1,
-              scale: 1,
-            }}
-            transition={{
-              duration: 0.3,
-              ease: [0.4, 0, 0.2, 1], // Custom easing function
-            }}
+            animate={{ y: 0, opacity: 1, scale: 1 }}
+            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
             className="w-full"
           >
             {tools.length > 0

--- a/src/components/chat/reasoning-group.test.tsx
+++ b/src/components/chat/reasoning-group.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'bun:test'
-import '@testing-library/jest-dom'
-import { ReasoningGroup } from './reasoning-group'
-import type { ReasoningGroupItem } from '@/lib/assistant-message'
-import type { ReasoningUIPart, ToolUIPart } from 'ai'
 import { ContentViewProvider } from '@/content-view/context'
+import type { ReasoningGroupItem } from '@/lib/assistant-message'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import type { ReasoningUIPart, ToolUIPart } from 'ai'
+import { describe, expect, it } from 'bun:test'
+import { ReasoningGroup } from './reasoning-group'
 
 const createMockReasoningPart = (
   state: 'streaming' | 'complete' = 'complete',
@@ -48,7 +48,7 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => {
   return <ContentViewProvider>{children}</ContentViewProvider>
 }
 
-const testReasoningTime: Record<string, { startedAt: number; finishedAt: number }> = {}
+const testReasoningTime: Record<string, number> = {}
 
 describe('ReasoningGroup', () => {
   describe('rendering', () => {
@@ -286,9 +286,9 @@ describe('ReasoningGroup', () => {
         { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' },
       ]
       const reasoningTime = {
-        [searchTool.toolCallId]: { startedAt: 0, finishedAt: 1000 },
-        [readFileTool.toolCallId]: { startedAt: 1000, finishedAt: 2500 },
-        'reasoning-0': { startedAt: 2500, finishedAt: 3000 },
+        [searchTool.toolCallId]: 1000,
+        [readFileTool.toolCallId]: 1500,
+        'reasoning-0': 500,
       }
       render(
         <ReasoningGroup
@@ -316,7 +316,7 @@ describe('ReasoningGroup', () => {
         { type: 'tool', content: readFileTool, id: readFileTool.toolCallId },
       ]
       const reasoningTime = {
-        [readFileTool.toolCallId]: { startedAt: 0, finishedAt: 2000 },
+        [readFileTool.toolCallId]: 2000,
       }
       render(
         <ReasoningGroup

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -1,19 +1,19 @@
-import { type ReasoningGroupItem } from '@/lib/assistant-message'
-import { Expandable } from '../ui/expandable'
-import { CheckIcon, Loader2 } from 'lucide-react'
-import { type ReasoningUIPart, type ToolUIPart } from 'ai'
-import { ReasoningDisplay } from './reasoning-display'
-import { useAutoScroll } from '@/hooks/use-auto-scroll'
-import { ReasoningItem } from './reasoning-item'
-import { ReasoningGroupTitle } from './reasoning-group-title'
 import { useObjectView } from '@/content-view/context'
+import { useAutoScroll } from '@/hooks/use-auto-scroll'
+import { type ReasoningGroupItem } from '@/lib/assistant-message'
+import { type ReasoningUIPart, type ToolUIPart } from 'ai'
+import { CheckIcon, Loader2 } from 'lucide-react'
+import { Expandable } from '../ui/expandable'
+import { ReasoningDisplay } from './reasoning-display'
+import { ReasoningGroupTitle } from './reasoning-group-title'
+import { ReasoningItem } from './reasoning-item'
 
 type ReasoningGroupProps = {
   parts: ReasoningGroupItem[]
   isStreaming: boolean
   isLastPartInMessage: boolean
   hasTextPart: boolean
-  reasoningTime: Record<string, { startedAt?: number; finishedAt?: number }>
+  reasoningTime: Record<string, number>
 }
 
 export const ReasoningGroup = ({
@@ -38,12 +38,7 @@ export const ReasoningGroup = ({
     ? `reasoning-${currentReasoningPart.content.text.substring(0, 50)}-${parts.indexOf(currentReasoningPart)}`
     : ''
 
-  const totalDuration = Object.values(reasoningTime ?? {}).reduce((previous, current) => {
-    if (current.finishedAt === undefined) {
-      return previous
-    }
-    return (previous + ((current.finishedAt ?? 0) - (current.startedAt ?? 0))) as number
-  }, 0)
+  const totalDuration = Object.values(reasoningTime ?? {}).reduce((previous, current) => previous + current, 0)
 
   const { scrollContainerRef, scrollTargetRef } = useAutoScroll({
     dependencies: [parts.length],

--- a/src/components/chat/reasoning-item.test.tsx
+++ b/src/components/chat/reasoning-item.test.tsx
@@ -1,9 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, mock } from 'bun:test'
-import '@testing-library/jest-dom'
-import { ReasoningItem } from './reasoning-item'
 import type { ReasoningGroupItem } from '@/lib/assistant-message'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReasoningUIPart, ToolUIPart } from 'ai'
+import { describe, expect, it, mock } from 'bun:test'
+import { ReasoningItem } from './reasoning-item'
 
 const createMockReasoningPart = (state: 'streaming' | 'complete' = 'complete', duration?: number): ReasoningUIPart => {
   const part = {
@@ -40,7 +40,7 @@ const createMockToolPart = (
 }
 
 describe('ReasoningItem', () => {
-  const testReasoningTime = { startedAt: 0, finishedAt: 1000 }
+  const testReasoningTime = 1000
 
   describe('reasoning type', () => {
     it('should render reasoning item with "Thinking" label', () => {
@@ -84,11 +84,8 @@ describe('ReasoningItem', () => {
       const reasoningPart = createMockReasoningPart('complete', 1500)
       const part: ReasoningGroupItem = { type: 'reasoning', content: reasoningPart, id: 'reasoning-0' }
       const mockOnClick = mock()
-      // reasoningTime takes precedence over metadata duration
-      // Use non-zero startedAt since 0 is falsy and would fail the component's check
-      const reasoningTime = { startedAt: 100, finishedAt: 1600 }
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={reasoningTime} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={1500} />)
 
       // formatDuration(1500) should format to something like "1.5s"
       expect(screen.getByText(/1\.5s|1s/i)).toBeInTheDocument()
@@ -206,11 +203,8 @@ describe('ReasoningItem', () => {
       const toolPart = createMockToolPart('test_tool', 'output-available', 2500)
       const part: ReasoningGroupItem = { type: 'tool', content: toolPart, id: toolPart.toolCallId }
       const mockOnClick = mock()
-      // reasoningTime takes precedence over metadata duration
-      // Use non-zero startedAt since 0 is falsy and would fail the component's check
-      const reasoningTime = { startedAt: 100, finishedAt: 2600 }
 
-      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={reasoningTime} />)
+      render(<ReasoningItem part={part} onClick={mockOnClick} reasoningTime={2500} />)
 
       // formatDuration(2500) should format to something like "2.5s"
       expect(screen.getByText(/2\.5s|2s/i)).toBeInTheDocument()

--- a/src/components/chat/reasoning-item.tsx
+++ b/src/components/chat/reasoning-item.tsx
@@ -1,13 +1,13 @@
 import { type ReasoningGroupItem } from '@/lib/assistant-message'
-import { Brain, DotIcon, Loader2 } from 'lucide-react'
-import { formatDuration, splitPartType } from '@/lib/utils'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
+import { formatDuration, splitPartType } from '@/lib/utils'
 import { type ReasoningUIPart, type ToolUIPart } from 'ai'
+import { Brain, DotIcon, Loader2 } from 'lucide-react'
 
 type ReasoningItemProps = {
   part: ReasoningGroupItem
   onClick: () => void
-  reasoningTime?: { startedAt?: number; finishedAt?: number }
+  reasoningTime?: number
 }
 
 const getItemData = (part: ReasoningGroupItem) => {
@@ -64,11 +64,7 @@ export const ReasoningItem = ({ part, onClick, reasoningTime }: ReasoningItemPro
         <span className="text-sm font-medium truncate text-foreground">{itemData.displayName}</span>
       </div>
       <span className="text-xs text-muted-foreground flex-shrink-0">
-        {reasoningTime?.finishedAt && reasoningTime?.startedAt
-          ? formatDuration(reasoningTime.finishedAt - reasoningTime.startedAt)
-          : itemData.isLoading
-            ? '...'
-            : '—'}
+        {reasoningTime ? formatDuration(reasoningTime) : itemData.isLoading ? '...' : '—'}
       </span>
     </button>
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export type UIMessageMetadata = {
   modelId?: string
   usage?: LanguageModelV2Usage
   oauthRetry?: boolean
-  reasoningTime?: Record<string, { startedAt?: number; finishedAt?: number }>
+  reasoningTime?: Record<string, number>
 }
 
 export type SideviewType = 'message' | 'thread' | 'imap'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches reasoning/tool timing to duration-based metadata with a new message-metadata helper, updates streaming and UI to consume it, and adds comprehensive tests.
> 
> - **AI/Streaming**:
>   - Add `src/ai/message-metadata.ts` with `createMessageMetadata(modelId)` to track reasoning/tool durations and emit `reasoningTime` as milliseconds.
>   - Use `createMessageMetadata(modelId)` in `src/ai/fetch.ts` UI stream; remove unused `LanguageModelV2Usage` import.
> - **Types**:
>   - Change `UIMessageMetadata.reasoningTime` to `Record<string, number>` in `src/types.ts`.
> - **UI**:
>   - Update `assistant-message`, `reasoning-group`, and `reasoning-item` to accept duration-based `reasoningTime`, compute totals by summing, and display formatted durations.
>   - Simplify `ReasoningGroupTitle` thinking state to show the active tool’s loading message.
> - **Tests**:
>   - Add `src/ai/message-metadata.test.ts` covering tool/reasoning timing, nesting, and isolation.
>   - Update chat component tests to align with duration-based metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f218ae0ce3fae328f7a3240b4cd9be43d8fa8a51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->