### PR TITLE
refactor: remove sendMessage from chat store and implement validation in chat instance

### DIFF
--- a/src/chats/chat-store.test.ts
+++ b/src/chats/chat-store.test.ts
@@ -6,10 +6,31 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock 
 import { useChatStore } from './chat-store'
 
 // Mock Chat instance - minimal implementation for testing
-const createMockChatInstance = (messages: ThunderboltUIMessage[] = []): Chat<ThunderboltUIMessage> => {
-  const sendMessage = mock((_params: { text: string; metadata?: Record<string, unknown> }) => {
+const createMockChatInstance = (
+  messages: ThunderboltUIMessage[] = [],
+): Chat<ThunderboltUIMessage> & {
+  _originalSendMessage: ReturnType<typeof mock>
+} => {
+  const originalSendMessage = mock(async (_params: { text: string; metadata?: Record<string, unknown> }) => {
     // Mock implementation
   })
+
+  // Wrap sendMessage with validation logic to match real implementation
+  const sendMessage = async (params: { text: string; metadata?: Record<string, unknown> }) => {
+    const { chatThread, selectedModel } = useChatStore.getState()
+
+    if (!selectedModel) {
+      throw new Error('No selected model')
+    }
+
+    if (chatThread && chatThread.isEncrypted !== selectedModel.isConfidential) {
+      throw new Error(
+        `This model is not available for ${chatThread.isEncrypted === 1 ? 'encrypted' : 'unencrypted'} conversations.`,
+      )
+    }
+
+    return originalSendMessage(params)
+  }
 
   return {
     id: 'test-chat-id',
@@ -23,7 +44,8 @@ const createMockChatInstance = (messages: ThunderboltUIMessage[] = []): Chat<Thu
     setMessages: mock(),
     setData: mock(),
     setStatus: mock(),
-  } as unknown as Chat<ThunderboltUIMessage>
+    _originalSendMessage: originalSendMessage,
+  } as unknown as Chat<ThunderboltUIMessage> & { _originalSendMessage: ReturnType<typeof mock> }
 }
 
 const createMockModel = (overrides?: Partial<Model>): Model => {
@@ -137,21 +159,6 @@ describe('chat-store', () => {
   })
 
   describe('sendMessage', () => {
-    it('should throw error when chatInstance is null', async () => {
-      const model = createMockModel()
-      useChatStore.getState().hydrate({
-        chatInstance: null,
-        chatThread: null,
-        id: 'test-id',
-        mcpClients: [],
-        models: [model],
-        selectedModel: model,
-        triggerData: null,
-      })
-
-      await expect(useChatStore.getState().sendMessage('test message')).rejects.toThrow('No chat instance')
-    })
-
     it('should throw error when selectedModel is null', async () => {
       const chatInstance = createMockChatInstance()
       useChatStore.getState().hydrate({
@@ -164,9 +171,10 @@ describe('chat-store', () => {
         triggerData: null,
       })
 
-      await expect(useChatStore.getState().sendMessage('test message')).rejects.toThrow('No selected model')
+      await expect(useChatStore.getState().chatInstance?.sendMessage({ text: 'test message' })).rejects.toThrow(
+        'No selected model',
+      )
     })
-
     it('should throw error when chatThread encryption does not match model confidentiality', async () => {
       const chatInstance = createMockChatInstance()
       const encryptedThread = createMockChatThread({ isEncrypted: 1 })
@@ -182,7 +190,7 @@ describe('chat-store', () => {
         triggerData: null,
       })
 
-      await expect(useChatStore.getState().sendMessage('test message')).rejects.toThrow(
+      await expect(useChatStore.getState().chatInstance?.sendMessage({ text: 'test message' })).rejects.toThrow(
         'This model is not available for encrypted conversations.',
       )
     })
@@ -202,7 +210,7 @@ describe('chat-store', () => {
         triggerData: null,
       })
 
-      await expect(useChatStore.getState().sendMessage('test message')).rejects.toThrow(
+      await expect(useChatStore.getState().chatInstance?.sendMessage({ text: 'test message' })).rejects.toThrow(
         'This model is not available for unencrypted conversations.',
       )
     })
@@ -228,13 +236,10 @@ describe('chat-store', () => {
         triggerData: null,
       })
 
-      await useChatStore.getState().sendMessage('test message')
+      await useChatStore.getState().chatInstance?.sendMessage({ text: 'test message' })
 
-      expect(chatInstanceWithMessages.sendMessage).toHaveBeenCalledWith({
+      expect(chatInstanceWithMessages._originalSendMessage).toHaveBeenCalledWith({
         text: 'test message',
-        metadata: {
-          modelId: model.id,
-        },
       })
 
       // trackEvent is called but we don't verify it to avoid module mocking
@@ -260,14 +265,11 @@ describe('chat-store', () => {
         triggerData: null,
       })
 
-      await useChatStore.getState().sendMessage('third message')
+      await useChatStore.getState().chatInstance?.sendMessage({ text: 'third message' })
 
       // Verify sendMessage was called with correct parameters
-      expect(chatInstance.sendMessage).toHaveBeenCalledWith({
+      expect(chatInstance._originalSendMessage).toHaveBeenCalledWith({
         text: 'third message',
-        metadata: {
-          modelId: model.id,
-        },
       })
 
       // trackEvent is called but we don't verify it to avoid module mocking

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -18,7 +18,6 @@ type ChatStoreState = {
 type ChatStoreActions = {
   hydrate(data: ChatStoreState): void
   reset(): void
-  sendMessage(text: string): Promise<void>
   setChatThread(chatThread: ChatThread | null): void
   setSelectedModel(modelId: string | null): void
 }
@@ -40,37 +39,6 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
 
   hydrate: (data) => {
     set(data)
-  },
-
-  sendMessage: async (text) => {
-    const { chatInstance, chatThread, selectedModel } = get()
-
-    if (!chatInstance) {
-      throw new Error('No chat instance')
-    }
-
-    if (!selectedModel) {
-      throw new Error('No selected model')
-    }
-
-    if (chatThread && chatThread.isEncrypted !== selectedModel?.isConfidential) {
-      throw new Error(
-        `This model is not available for ${chatThread.isEncrypted === 1 ? 'encrypted' : 'unencrypted'} conversations.`,
-      )
-    }
-
-    chatInstance.sendMessage({
-      text,
-      metadata: {
-        modelId: selectedModel.id,
-      },
-    })
-
-    trackEvent('chat_send_prompt', {
-      model: selectedModel,
-      length: text.length,
-      prompt_number: chatInstance.messages.length + 1,
-    })
   },
 
   setChatThread: (chatThread) => {

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -96,7 +96,15 @@ const createChatInstance = (id: string, messages: ThunderboltUIMessage[], saveMe
       prompt_number: instance.messages.length + 1,
     })
 
-    return originalSendMessage(message, options)
+    return originalSendMessage(
+      {
+        ...message,
+        metadata: {
+          modelId: selectedModel.id,
+        },
+      } as ThunderboltUIMessage,
+      options,
+    )
   }
 
   return instance

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -73,6 +73,32 @@ const createChatInstance = (id: string, messages: ThunderboltUIMessage[], saveMe
     },
   })
 
+  const originalSendMessage = instance.sendMessage.bind(instance)
+
+  // Override the sendMessage method to check if the model is available for the chat thread
+  instance.sendMessage = async function (message, options) {
+    const { chatThread, selectedModel } = useChatStore.getState()
+
+    if (!selectedModel) {
+      throw new Error('No selected model')
+    }
+
+    if (chatThread && chatThread.isEncrypted !== selectedModel?.isConfidential) {
+      throw new Error(
+        `This model is not available for ${chatThread.isEncrypted === 1 ? 'encrypted' : 'unencrypted'} conversations.`,
+      )
+    }
+
+    trackEvent('chat_send_prompt', {
+      model: selectedModel,
+      // @ts-ignore
+      length: message?.text?.length ?? 0,
+      prompt_number: instance.messages.length + 1,
+    })
+
+    return originalSendMessage(message, options)
+  }
+
   return instance
 }
 

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -42,16 +42,15 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
   ) => {
     const navigate = useNavigate()
 
-    const { chatInstance, chatThreadId, sendMessage, selectedModel } = useChatStore(
+    const { chatInstance, chatThreadId, selectedModel } = useChatStore(
       useShallow((state) => ({
         chatInstance: state.chatInstance!,
         chatThreadId: state.id!,
-        sendMessage: state.sendMessage,
         selectedModel: state.selectedModel!,
       })),
     )
 
-    const { messages, status, stop } = useChat({ chat: chatInstance })
+    const { messages, status, stop, sendMessage } = useChat({ chat: chatInstance })
 
     const isStreaming = status === 'streaming'
 
@@ -67,22 +66,29 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
     })
 
     const handleSubmit = async () => {
-      const textToSend = input.trim()
-      if (isStreaming || !textToSend) return
+      try {
+        // Prevent submitting while streaming or if input is empty
+        const textToSend = input.trim()
+        if (isStreaming || !textToSend) return
 
-      if (isOverflowing) {
-        handleShowOverflowModal(selectedModel, textToSend.length, messages.length + 1)
-        return
+        if (isOverflowing) {
+          handleShowOverflowModal(selectedModel, textToSend.length, messages.length + 1)
+          return
+        }
+
+        // Clear the input immediately for responsive UX
+        setInput('')
+
+        await sendMessage({ text: textToSend })
+
+        // Reset user scroll state and scroll to bottom when submitting a new message
+        handleResetUserScroll()
+        requestAnimationFrame(() => {
+          handleScrollToBottom()
+        })
+      } catch (error) {
+        console.error('Error submitting message:', error)
       }
-
-      setInput('')
-
-      await sendMessage(textToSend)
-
-      handleResetUserScroll()
-      requestAnimationFrame(() => {
-        handleScrollToBottom()
-      })
     }
 
     const handleNewChat = async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Shifts message sending and validation into the Chat instance, removes store-level sendMessage, updates UI to use useChat.sendMessage, and adapts tests accordingly.
> 
> - **Chat runtime**:
>   - Override `Chat.sendMessage` in `use-hydrate-chat-store` to enforce model/thread compatibility, require `selectedModel`, inject `metadata.modelId`, and track `chat_send_prompt`.
>   - Maintain reply tracking via `onFinish` (`chat_receive_reply`).
> - **Store (`src/chats/chat-store.ts`)**:
>   - Remove `sendMessage` action; store now handles hydration, thread/model selection, and reset only.
> - **UI (`chat-prompt-input.tsx`)**:
>   - Switch to `useChat({ chat }).sendMessage({ text })`; clear input early, add error handling, and keep overflow checks/scroll behavior.
> - **Tests (`chat-store.test.ts`)**:
>   - Update mocks to wrap `sendMessage` and expose `_originalSendMessage`.
>   - Adjust expectations to call `chatInstance.sendMessage({ text })` and verify `_originalSendMessage` calls; remove reliance on store `sendMessage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc9b8a2b20d65b81d02143f6c52b386c1ae32f3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->