### PR TITLE
fix: set up uuidv7 for assistant messages

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -18,6 +18,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import type { LanguageModelV2 } from '@ai-sdk/provider'
 import ky, { type KyInstance } from 'ky'
+import { v7 as uuidv7 } from 'uuid'
 
 // Currently @openrouter/ai-sdk-provider is NOT compatible with Vercel AI SDK v5. If you enable this, you will get the following error:
 // > [Error] Chat error: – Error: Unhandled chunk type: text-start — run-tools-transformation.ts:275
@@ -261,6 +262,7 @@ export const aiFetchStreamingResponse = async ({
     // - First stream: sendFinish: false (in case we need to continue)
     // - Continuation stream: sendStart: false (continues same message)
     const stream = createUIMessageStream({
+      generateId: uuidv7,
       execute: async ({ writer }) => {
         let currentMessages = convertToModelMessages(messages)
         let attemptNumber = 1


### PR DESCRIPTION
The user message side (client) was properly configured with `generateId: uuidv7` from the start. But the assistant message side (server) was never configured to use UUIDv7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures server-side assistant message streaming to generate UUIDv7 IDs.
> 
> - **Backend**:
>   - **Assistant message streaming**: Import `uuidv7` and set `generateId: uuidv7` in `createUIMessageStream` within `src/ai/fetch.ts` to ensure UUIDv7 IDs are used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c6fc4173a158e25cbf170597b21b415f945591c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->