### PR TITLE
THU-217: Disable surveys in PostHog initialization

### DIFF
--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -72,6 +72,7 @@ export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult
         capture_exceptions: true,
         capture_pageview: false,
         capture_pageleave: false,
+        disable_surveys: true,
         persistence: 'localStorage',
         before_send: (event) => {
           if (!event) return null


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disable PostHog surveys by setting `disable_surveys: true` in the PostHog client initialization.
> 
> - **Analytics**:
>   - **PostHog init**: Set `disable_surveys: true` in `src/lib/posthog.tsx` to turn off surveys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63db35cc308a462bbd22f6cca85e7015b2ba1d91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->