### PR TITLE
test: mock posthog-js globally to prevent browser detection errors in…

### DIFF
--- a/src/testing-library.ts
+++ b/src/testing-library.ts
@@ -3,7 +3,24 @@ import { installFakeTimers } from '@/test-utils/fake-timers'
 import type { InstalledClock } from '@sinonjs/fake-timers'
 import * as matchers from '@testing-library/jest-dom/matchers'
 import { cleanup, configure } from '@testing-library/react'
-import { afterEach, beforeEach, expect } from 'bun:test'
+import { afterEach, beforeEach, expect, mock } from 'bun:test'
+
+// Mock posthog-js globally to prevent browser detection errors in tests
+// PostHog tries to access browser APIs like navigator.userAgent.match() during module load,
+// which fails in Happy-DOM's test environment
+mock.module('posthog-js', () => ({
+  default: {
+    init: () => null,
+    capture: () => {},
+    identify: () => {},
+    reset: () => {},
+    opt_out_capturing: () => {},
+    opt_in_capturing: () => {},
+    has_opted_out_capturing: () => false,
+    get_distinct_id: () => 'test-distinct-id',
+    captureException: () => {},
+  },
+}))
 
 expect.extend(matchers)
 


### PR DESCRIPTION
After pulling the latest changes from `main` branch and run `bun install` the tests started failing with the error below:

```
# Unhandled error between tests
-------------------------------
TypeError: undefined is not an object (evaluating 't.match')
      at le (/Users/raivieiraadriano92/dev/thunderbolt/node_modules/posthog-js/dist/main.js:1:24601)
-------------------------------
```

It seems PostHog is trying to access browser APIs during module load, which fails in Happy-DOM's test environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Globally mocks `posthog-js` in `src/testing-library.ts` to prevent browser API access errors in Happy-DOM during tests.
> 
> - **Testing**
>   - **Global mock for analytics**: Add `mock.module('posthog-js', ...)` in `src/testing-library.ts` (via `bun:test`) to stub methods like `init`, `capture`, `identify`, `reset`, etc., preventing browser API access (e.g., `navigator.userAgent.match`) during module load under Happy-DOM.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c11d2650cd9e496bb36f95a2075c6f25a6fe651. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->