### PR TITLE
add claude to github actions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,64 @@
+name: Claude Code Assistant
+
+on:
+  # Trigger on @claude mentions in comments and issues
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+  # Automatic PR reviews when PRs are opened
+  pull_request:
+    types: [opened]
+
+jobs:
+  # Interactive @claude mentions
+  claude-interactive:
+    if: |
+      github.event_name != 'pull_request' && (
+        contains(github.event.comment.body, '@claude') ||
+        contains(github.event.review.body, '@claude') ||
+        contains(github.event.issue.title, '@claude') ||
+        contains(github.event.issue.body, '@claude')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Execute Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+
+  # Automatic PR code reviews
+  claude-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: PR Review with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+          prompt: "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `/.github/workflows/claude.yml` to enable interactive @claude responses and automated PR reviews via `anthropics/claude-code-action`.
> 
> - **GitHub Actions**:
>   - Add workflow `/.github/workflows/claude.yml`.
>   - **Jobs**:
>     - `claude-interactive`: Responds to `@claude` mentions in issues/comments/reviews; checks out repo and runs `anthropics/claude-code-action@v1`.
>     - `claude-review`: On PR open, runs automated review with `anthropics/claude-code-action@v1`, using `anthropic_api_key` secret, custom review prompt, and allows inline comment tool.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4e35b8fa8b77b6f5d6d33fa5a6fdc6d976f0f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->