### PR TITLE
THU-224: Model is not responding in some scenarios after user chooses "Don't ask again" option in Connect Google/Microsoft widget.

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -141,6 +141,11 @@ export const aiFetchStreamingResponse = async ({
     date_format: 'MM/DD/YYYY',
     time_format: '12h',
     currency: 'USD',
+    integrations_do_not_ask_again: false,
+    integrations_google_credentials: '',
+    integrations_google_is_enabled: false,
+    integrations_microsoft_credentials: '',
+    integrations_microsoft_is_enabled: false,
   })
 
   const model = await db.query.modelsTable.findFirst({
@@ -166,6 +171,22 @@ export const aiFetchStreamingResponse = async ({
     console.log('Model does not support tools, skipping tool setup')
   }
 
+  // Compute integration status for the model
+  const getIntegrationStatus = (): string => {
+    // Check for disabled integrations (connected but turned off)
+    if (settings.integrationsGoogleCredentials && !settings.integrationsGoogleIsEnabled) {
+      return 'GOOGLE_DISABLED'
+    }
+    if (settings.integrationsMicrosoftCredentials && !settings.integrationsMicrosoftIsEnabled) {
+      return 'MICROSOFT_DISABLED'
+    }
+    // Check if user chose "Don't ask again"
+    if (settings.integrationsDoNotAskAgain) {
+      return 'PROMPTS_DISABLED'
+    }
+    return 'READY'
+  }
+
   const systemPrompt = createPrompt({
     modelName: model.name,
     preferredName: settings.preferredName,
@@ -181,6 +202,7 @@ export const aiFetchStreamingResponse = async ({
       timeFormat: settings.timeFormat,
       currency: settings.currency,
     },
+    integrationStatus: getIntegrationStatus(),
   })
 
   try {

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -171,20 +171,23 @@ export const aiFetchStreamingResponse = async ({
     console.log('Model does not support tools, skipping tool setup')
   }
 
-  // Compute integration status for the model
+  // Compute integration status for the model (can return multiple statuses)
   const getIntegrationStatus = (): string => {
+    const statuses: string[] = []
+
     // Check for disabled integrations (connected but turned off)
     if (settings.integrationsGoogleCredentials && !settings.integrationsGoogleIsEnabled) {
-      return 'GOOGLE_DISABLED'
+      statuses.push('GOOGLE_DISABLED')
     }
     if (settings.integrationsMicrosoftCredentials && !settings.integrationsMicrosoftIsEnabled) {
-      return 'MICROSOFT_DISABLED'
+      statuses.push('MICROSOFT_DISABLED')
     }
     // Check if user chose "Don't ask again"
     if (settings.integrationsDoNotAskAgain) {
-      return 'PROMPTS_DISABLED'
+      statuses.push('PROMPTS_DISABLED')
     }
-    return 'READY'
+
+    return statuses.length > 0 ? statuses.join(', ') : 'READY'
   }
 
   const systemPrompt = createPrompt({

--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -16,12 +16,14 @@ export type PromptParams = {
     timeFormat: string
     currency: string
   }
+  /** Integration status for the model to check before showing connect widget */
+  integrationStatus: string
 }
 
 /**
  * Creates a system prompt for the AI assistant with user context and guidelines.
  */
-export const createPrompt = ({ modelName, preferredName, location, localization }: PromptParams) => {
+export const createPrompt = ({ modelName, preferredName, location, localization, integrationStatus }: PromptParams) => {
   const contextSection = [
     `Current date/time: ${new Date().toLocaleString('en-US', {
       weekday: 'long',
@@ -38,6 +40,7 @@ export const createPrompt = ({ modelName, preferredName, location, localization 
       ? `User location: ${location.name}${location.lat && location.lng ? ` (${location.lat}, ${location.lng})` : ''}`
       : 'User location: Unknown (ask before using location-based features)',
     `User preferences: ${localization.distanceUnit}, ${localization.temperatureUnit}, ${localization.dateFormat}, ${localization.timeFormat}, ${localization.currency}`,
+    `Integration status: ${integrationStatus}`,
   ]
     .filter(Boolean)
     .join('\n')

--- a/src/ai/widget-parser.test.ts
+++ b/src/ai/widget-parser.test.ts
@@ -576,7 +576,8 @@ describe('parseContentParts', () => {
 
   describe('connect-integration widgets', () => {
     it('parses connect-integration with all attributes', () => {
-      const text = '<widget:connect-integration provider="google" service="email" reason="to check your inbox" />'
+      const text =
+        '<widget:connect-integration provider="google" service="email" reason="to check your inbox" override="" />'
       const result = parseContentParts(text)
 
       expect(result).toEqual([
@@ -588,6 +589,7 @@ describe('parseContentParts', () => {
               provider: 'google',
               service: 'email',
               reason: 'to check your inbox',
+              override: '',
             },
           },
         },
@@ -595,7 +597,7 @@ describe('parseContentParts', () => {
     })
 
     it('parses connect-integration with empty provider and reason', () => {
-      const text = '<widget:connect-integration provider="" service="email" reason="" />'
+      const text = '<widget:connect-integration provider="" service="email" reason="" override="" />'
       const result = parseContentParts(text)
 
       expect(result).toEqual([
@@ -607,6 +609,7 @@ describe('parseContentParts', () => {
               provider: '',
               service: 'email',
               reason: '',
+              override: '',
             },
           },
         },

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -93,6 +93,7 @@ export const createChatInstance = (
       {
         ...message,
         metadata: {
+          ...message?.metadata,
           modelId: selectedModel.id,
         },
       } as ThunderboltUIMessage,

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -100,6 +100,7 @@ const createChatInstance = (id: string, messages: ThunderboltUIMessage[], saveMe
       {
         ...message,
         metadata: {
+          ...message?.metadata,
           modelId: selectedModel.id,
         },
       } as ThunderboltUIMessage,

--- a/src/widgets/connect-integration/instructions.ts
+++ b/src/widgets/connect-integration/instructions.ts
@@ -71,13 +71,13 @@ When no blocking condition applies and PROMPTS_DISABLED is not set, output ONLY 
 
 **Status: GOOGLE_DISABLED (only Google disabled):**
 - "Check my Gmail" → "Your Google integration is disabled. You can enable it in Settings → Integrations."
+- "Check my emails" → "Your Google integration is disabled. You can enable it in Settings → Integrations."
 - "Check my Outlook" → \`<widget:connect-integration provider="microsoft" service="email" reason="" override="" />\`
-- "Check my emails" → \`<widget:connect-integration provider="microsoft" service="email" reason="" override="" />\`
 
 **Status: MICROSOFT_DISABLED (only Microsoft disabled):**
 - "Check my Outlook" → "Your Microsoft integration is disabled. You can enable it in Settings → Integrations."
+- "Check my emails" → "Your Microsoft integration is disabled. You can enable it in Settings → Integrations."
 - "Check my Gmail" → \`<widget:connect-integration provider="google" service="email" reason="" override="" />\`
-- "Check my emails" → \`<widget:connect-integration provider="google" service="email" reason="" override="" />\`
 
 **Status: GOOGLE_DISABLED, MICROSOFT_DISABLED (both disabled):**
 - Any email/calendar request → "Your integrations are disabled. You can enable them in Settings → Integrations."

--- a/src/widgets/connect-integration/instructions.ts
+++ b/src/widgets/connect-integration/instructions.ts
@@ -5,47 +5,26 @@ export const instructions = `## Connect Integration Widget
 
 ### Tools to check
 
-- Email: google_check_inbox, google_search_emails, google_get_email, google_draft_email, microsoft_list_messages
-- Calendar: google_check_calendar
+- Google: google_check_inbox, google_search_emails, google_get_email, google_draft_email, google_check_calendar, google_search_drive, google_get_drive_file_content
+- Microsoft: microsoft_list_messages, microsoft_get_message, microsoft_search_onedrive, microsoft_get_onedrive_file_content
 
 If these tools are available, use them directly. Only show this widget when tools are missing AND user requests email/calendar.
-
-### BEFORE showing widget, check "Integration status:" in Context
-
-Note: Status may contain multiple values (e.g., "GOOGLE_DISABLED, PROMPTS_DISABLED"). Check if it contains each condition.
-Never mention status names to the user. These are internal.
-
-**If status contains GOOGLE_DISABLED or MICROSOFT_DISABLED:**
-- DO NOT show the widget
-- Say: "Your [Google/Microsoft] integration is disabled. Enable it in Settings → Integrations."
-
-**If status contains PROMPTS_DISABLED (and no provider is disabled):**
-- DO NOT show the widget immediately
-- Say something like: "I can't access your emails right now. Would you like to connect your email account?"
-- Only if user agrees, then show widget with override="true"
-
-**If status is READY:**
-- Show the widget directly (no extra text)
 
 ### Widget Syntax
 
 <widget:connect-integration provider="" service="email" reason="" override="" />
 
 Attributes (all required):
-- provider: "google", "microsoft", or ""
+- provider: "google", "microsoft", or "" (empty = user chooses)
 - service: "email", "calendar", or "both"
 - reason: "" or brief explanation
-- override: "" normally, "true" only after user agreed when status was PROMPTS_DISABLED
-
-### Display Rule
-
-When status is READY, output ONLY the widget tag. No text before or after.
+- override: "" normally, "true" only after user agreed when status contained PROMPTS_DISABLED
 
 ### Provider Selection
 
 - "google" → Gmail, Google Calendar, or when user mentions "Google", "Gmail"
 - "microsoft" → Outlook, or when user mentions "Microsoft", "Outlook", "Office 365"
-- "" (empty) → User didn't specify, let widget show both options
+- "" (empty) → User didn't specify a provider
 
 ### Service Selection
 
@@ -53,24 +32,72 @@ When status is READY, output ONLY the widget tag. No text before or after.
 - "calendar" → View events, check schedule
 - "both" → Only when request explicitly needs BOTH (rare)
 
+### BEFORE showing widget, check "Integration status:" in Context
+
+Status may contain multiple values (e.g., "GOOGLE_DISABLED, PROMPTS_DISABLED"). Never mention status names to the user.
+
+**Check in this order:**
+
+1. **BOTH providers disabled** (status contains both GOOGLE_DISABLED and MICROSOFT_DISABLED):
+   - DO NOT show widget
+   - Say: "Your integrations are disabled. You can enable them in Settings → Integrations."
+
+2. **Only GOOGLE_DISABLED** (status contains GOOGLE_DISABLED but NOT MICROSOFT_DISABLED):
+   - If user requested Google/Gmail or didn't specify provider → DO NOT show widget. Say: "Your Google integration is disabled. You can enable it in Settings → Integrations."
+   - If user requested Microsoft/Outlook → If Microsoft is not connected, show widget with provider="microsoft" (unaffected)
+
+3. **Only MICROSOFT_DISABLED** (status contains MICROSOFT_DISABLED but NOT GOOGLE_DISABLED):
+   - If user requested Microsoft/Outlook or didn't specify provider → DO NOT show widget. Say: "Your Microsoft integration is disabled. You can enable it in Settings → Integrations."
+   - If user requested Google/Gmail → if Google is not connected, show widget with provider="google" (unaffected)
+
+4. **PROMPTS_DISABLED** (after checking provider statuses above):
+   - If showing widget is blocked by provider status → follow that rule (don't show)
+   - Otherwise, DO NOT show widget immediately. Ask: "I can't access your [email/calendar] right now. Would you like to connect your account?"
+   - Only if user agrees → show widget with override="true"
+
+5. **READY** (no special conditions):
+   - Show widget directly, no extra text
+
+### Display Rule
+
+When no blocking condition applies and PROMPTS_DISABLED is not set, output ONLY the widget tag. No text before or after.
+
 ### Examples
 
-**CORRECT - Status is READY, tools missing:**
-- "Summarize my emails" → <widget:connect-integration provider="" service="email" reason="" override="" />
-- "Check my Gmail" → <widget:connect-integration provider="google" service="email" reason="" override="" />
-- "What's on my calendar?" → <widget:connect-integration provider="" service="calendar" reason="" override="" />
+**Status: READY, tools missing:**
+- "Summarize my emails" → \`<widget:connect-integration provider="" service="email" reason="" override="" />\`
+- "Check my Gmail" → \`<widget:connect-integration provider="google" service="email" reason="" override="" />\`
+- "What's on my Outlook calendar?" → \`<widget:connect-integration provider="microsoft" service="calendar" reason="" override="" />\`
 
-**CORRECT - Status is PROMPTS_DISABLED:**
+**Status: GOOGLE_DISABLED (only Google disabled):**
+- "Check my Gmail" → "Your Google integration is disabled. You can enable it in Settings → Integrations."
+- "Check my Outlook" → \`<widget:connect-integration provider="microsoft" service="email" reason="" override="" />\`
+- "Check my emails" → \`<widget:connect-integration provider="microsoft" service="email" reason="" override="" />\`
+
+**Status: MICROSOFT_DISABLED (only Microsoft disabled):**
+- "Check my Outlook" → "Your Microsoft integration is disabled. You can enable it in Settings → Integrations."
+- "Check my Gmail" → \`<widget:connect-integration provider="google" service="email" reason="" override="" />\`
+- "Check my emails" → \`<widget:connect-integration provider="google" service="email" reason="" override="" />\`
+
+**Status: GOOGLE_DISABLED, MICROSOFT_DISABLED (both disabled):**
+- Any email/calendar request → "Your integrations are disabled. You can enable them in Settings → Integrations."
+
+**Status: PROMPTS_DISABLED:**
 - User: "Check my email"
 - You: "I can't access your emails right now. Would you like to connect your email account?"
 - User: "Yes"
-- You: <widget:connect-integration provider="" service="email" reason="" override="true" />
+- You: \`<widget:connect-integration provider="" service="email" reason="" override="true" />\`
 
-**CORRECT - Tools available:**
+**Status: GOOGLE_DISABLED, PROMPTS_DISABLED:**
+- User: "Check my Outlook" → Follow PROMPTS_DISABLED flow, then show with provider="microsoft" and override="true"
+- User: "Check my Gmail" → "Your Google integration is disabled. You can enable it in Settings → Integrations."
+
+**Tools available:**
 - "Summarize my emails" + google_check_inbox exists → Use the tool directly, don't show widget
 
 **WRONG:**
-- ❌ "I don't have access to your email" → Instead show the widget
-- ❌ Showing widget when tools are available → Use tools instead
-- ❌ Showing widget for questions like "Can you check email?" → Just explain the feature
+- ❌ "I don't have access to your email" when you should show widget
+- ❌ Showing widget when tools are available
+- ❌ Blocking Microsoft widget because Google is disabled (or vice versa)
+- ❌ Mentioning status names like "PROMPTS_DISABLED" to the user
 `

--- a/src/widgets/connect-integration/instructions.ts
+++ b/src/widgets/connect-integration/instructions.ts
@@ -12,17 +12,17 @@ If these tools are available, use them directly. Only show this widget when tool
 
 ### BEFORE showing widget, check "Integration status:" in Context
 
-Note: Never mention status names (READY, PROMPTS_DISABLED, etc.) to the user. These are internal.
+Note: Status may contain multiple values (e.g., "GOOGLE_DISABLED, PROMPTS_DISABLED"). Check if it contains each condition.
+Never mention status names to the user. These are internal.
 
-**If status is PROMPTS_DISABLED:**
-- DO NOT show the widget immediately
-- DO NOT mention the status name to the user
-- Say something like: "I can't access your emails right now. Would you like to connect your email account?"
-- Only if user agrees, then show widget with override="true"
-
-**If status is GOOGLE_DISABLED or MICROSOFT_DISABLED:**
+**If status contains GOOGLE_DISABLED or MICROSOFT_DISABLED:**
 - DO NOT show the widget
 - Say: "Your [Google/Microsoft] integration is disabled. Enable it in Settings → Integrations."
+
+**If status contains PROMPTS_DISABLED (and no provider is disabled):**
+- DO NOT show the widget immediately
+- Say something like: "I can't access your emails right now. Would you like to connect your email account?"
+- Only if user agrees, then show widget with override="true"
 
 **If status is READY:**
 - Show the widget directly (no extra text)

--- a/src/widgets/connect-integration/instructions.ts
+++ b/src/widgets/connect-integration/instructions.ts
@@ -3,9 +3,12 @@
  */
 export const instructions = `## Connect Integration Widget
 
-If email/calendar tools (google_check_inbox, microsoft_list_messages, etc.) are available, use them directly.
+### Tools to check
 
-Only show this widget when tools are missing AND user requests email/calendar.
+- Email: google_check_inbox, google_search_emails, google_get_email, google_draft_email, microsoft_list_messages
+- Calendar: google_check_calendar
+
+If these tools are available, use them directly. Only show this widget when tools are missing AND user requests email/calendar.
 
 ### BEFORE showing widget, check "Integration status:" in Context
 
@@ -37,4 +40,37 @@ Attributes (all required):
 ### Display Rule
 
 When status is READY, output ONLY the widget tag. No text before or after.
+
+### Provider Selection
+
+- "google" → Gmail, Google Calendar, or when user mentions "Google", "Gmail"
+- "microsoft" → Outlook, or when user mentions "Microsoft", "Outlook", "Office 365"
+- "" (empty) → User didn't specify, let widget show both options
+
+### Service Selection
+
+- "email" → Check inbox, search emails, read/send emails
+- "calendar" → View events, check schedule
+- "both" → Only when request explicitly needs BOTH (rare)
+
+### Examples
+
+**CORRECT - Status is READY, tools missing:**
+- "Summarize my emails" → <widget:connect-integration provider="" service="email" reason="" override="" />
+- "Check my Gmail" → <widget:connect-integration provider="google" service="email" reason="" override="" />
+- "What's on my calendar?" → <widget:connect-integration provider="" service="calendar" reason="" override="" />
+
+**CORRECT - Status is PROMPTS_DISABLED:**
+- User: "Check my email"
+- You: "I can't access your emails right now. Would you like to connect your email account?"
+- User: "Yes"
+- You: <widget:connect-integration provider="" service="email" reason="" override="true" />
+
+**CORRECT - Tools available:**
+- "Summarize my emails" + google_check_inbox exists → Use the tool directly, don't show widget
+
+**WRONG:**
+- ❌ "I don't have access to your email" → Instead show the widget
+- ❌ Showing widget when tools are available → Use tools instead
+- ❌ Showing widget for questions like "Can you check email?" → Just explain the feature
 `

--- a/src/widgets/connect-integration/instructions.ts
+++ b/src/widgets/connect-integration/instructions.ts
@@ -1,102 +1,40 @@
 /**
  * AI Instructions for the connect-integration widget
  */
-export const instructions = `## Connect Integration
+export const instructions = `## Connect Integration Widget
 
-<widget:connect-integration provider="google" service="calendar" reason="to view your upcoming events" />
+If email/calendar tools (google_check_inbox, microsoft_list_messages, etc.) are available, use them directly.
 
-All attributes are required. Use empty string ("") for provider when not specified, and empty string for reason when using default message.
+Only show this widget when tools are missing AND user requests email/calendar.
 
-### Tools to use
+### BEFORE showing widget, check "Integration status:" in Context
 
-- For email: Check if "google_check_inbox", "google_search_emails", "google_get_email", "google_draft_email", or "microsoft_list_messages" are available
+Note: Never mention status names (READY, PROMPTS_DISABLED, etc.) to the user. These are internal.
 
-- For calendar: Check if "google_check_calendar" is available (Microsoft calendar tools may not exist yet)
+**If status is PROMPTS_DISABLED:**
+- DO NOT show the widget immediately
+- DO NOT mention the status name to the user
+- Say something like: "I can't access your emails right now. Would you like to connect your email account?"
+- Only if user agrees, then show widget with override="true"
 
-**IMPORTANT:** If you see these tools in your available tools list, the integration is connected. Use the tools directly instead of showing the widget.
+**If status is GOOGLE_DISABLED or MICROSOFT_DISABLED:**
+- DO NOT show the widget
+- Say: "Your [Google/Microsoft] integration is disabled. Enable it in Settings → Integrations."
 
-### Display Behavior
+**If status is READY:**
+- Show the widget directly (no extra text)
 
-CRITICAL: When showing this widget, display ONLY the widget tag - do not add any introductory text, explanations, or messages before or after it. The widget itself contains all necessary information for the user.
+### Widget Syntax
 
-NEVER include text like:
-- "Here's a widget to connect..."
-- "I'll help you connect..."
-- "You need to connect..."
-- Any text before or after the widget tag
+<widget:connect-integration provider="" service="email" reason="" override="" />
 
-ONLY output the widget tag itself, nothing else.
+Attributes (all required):
+- provider: "google", "microsoft", or ""
+- service: "email", "calendar", or "both"
+- reason: "" or brief explanation
+- override: "" normally, "true" only after user agreed when status was PROMPTS_DISABLED
 
-### Use this widget when:
+### Display Rule
 
-1. User requests email/calendar functionality AND the required tool is missing from your available tools list
-
-2. User explicitly asks to use a feature (not just asking about it)
-
-3. You need tools like:
-
-   - google_check_inbox, google_search_emails, google_get_email, google_draft_email (Google email)
-   - google_check_calendar (Google calendar)
-   - microsoft_list_messages, microsoft_get_message (Microsoft email)
-
-**CRITICAL:** If you don't have access to the required email/calendar tools, you MUST show this widget to connect the integration. DO NOT explain that you don't have access - show the widget instead.
-
-### DO NOT use this widget if:
-
-- Tool is already available in your tool list (integration is connected and enabled) → Use the tool directly
-
-- User is just exploring/asking about features: "What can you do with Gmail?", "Can you check email?", "How does email integration work?"
-
-- User is asking for general help or information
-
-- User mentions integrations but doesn't want to use them right now: "Maybe later", "I'll connect it myself", "Just wondering"
-
-- The request doesn't require an integration (general questions, non-email/calendar tasks)
-
-**IMPORTANT:** If tools are missing, DO NOT say "I don't have access" or "I cannot fetch" - show the widget instead.
-
-### Provider Selection:
-
-- "google" → For Gmail or Google Calendar requests, or when user mentions "Google", "Gmail", "Google Calendar"
-- "microsoft" → For Outlook or Microsoft Calendar requests, or when user mentions "Microsoft", "Outlook", "MS", "Office 365"
-- If user doesn't specify provider: Use provider="" (empty string) - the widget will automatically:
-  - Use the single connected integration if only one is available
-  - Show both options if both are connected or neither is connected
-
-### Service Types:
-
-- "email" → For email-only requests (check inbox, search emails, read/send emails)
-- "calendar" → For calendar-only requests (view events, check schedule)
-- "both" → ONLY when the request explicitly requires BOTH email AND calendar in a single action (rare)
-
-Most requests are either email OR calendar, not both. Use "both" sparingly:
-
-- "Show me emails and my calendar events for today" → service="both"
-- "Check my email" → service="email" (not "both")
-- "What's on my calendar?" → service="calendar" (not "both")
-
-### Examples:
-
-CORRECT - Tool missing, user wants to use feature:
-
-- "Summarize my last 10 emails" → Tool not available, user didn't specify provider → <widget:connect-integration provider="" service="email" reason="" />
-- "What's on my calendar today?" → Tool not available, user didn't specify provider → <widget:connect-integration provider="" service="calendar" reason="" />
-- "Check my Gmail inbox" → Tool not available, user specified Gmail → <widget:connect-integration provider="google" service="email" reason="to check your inbox" />
-- "Show me my Outlook emails" → Tool not available, user specified Outlook → <widget:connect-integration provider="microsoft" service="email" reason="" />
-
-WRONG - Tool missing but explaining instead of showing widget:
-
-- "Summarize my last 10 emails" → Tool not available → ❌ "I don't have access to your email" or "I cannot fetch emails" → Instead: Show widget <widget:connect-integration provider="" service="email" reason="" />
-
-CORRECT - Tool already available, use tool directly:
-- "Summarize my last 10 emails" → Tool "google_check_inbox" exists in your tools → Call google_check_inbox tool directly, do NOT show widget
-
-WRONG - User just asking questions:
-
-- "Can you check email?" → User asking about capability → Explain feature, don't show widget
-- "What email providers do you support?" → Informational question → Answer without widget
-- "How do I connect Gmail?" → User asking how → Explain process, don't show widget automatically
-
-WRONG - Tool already available:
-- "Summarize my last 10 emails" → Tool "google_check_inbox" exists → Use the tool, don't show widget
+When status is READY, output ONLY the widget tag. No text before or after.
 `

--- a/src/widgets/connect-integration/schema.ts
+++ b/src/widgets/connect-integration/schema.ts
@@ -10,7 +10,6 @@ export const schema = z.object({
     provider: z.enum(['google', 'microsoft', '']),
     service: z.enum(['email', 'calendar', 'both']),
     reason: z.string(),
-    /** Use "true" to show widget even when user chose "Don't ask again", otherwise "" */
     override: z.enum(['true', '']),
   }),
 })

--- a/src/widgets/connect-integration/schema.ts
+++ b/src/widgets/connect-integration/schema.ts
@@ -10,6 +10,8 @@ export const schema = z.object({
     provider: z.enum(['google', 'microsoft', '']),
     service: z.enum(['email', 'calendar', 'both']),
     reason: z.string(),
+    /** Use "true" to show widget even when user chose "Don't ask again", otherwise "" */
+    override: z.enum(['true', '']),
   }),
 })
 

--- a/src/widgets/connect-integration/widget.tsx
+++ b/src/widgets/connect-integration/widget.tsx
@@ -27,6 +27,8 @@ type ConnectIntegrationWidgetProps = {
   service: 'email' | 'calendar' | 'both'
   reason: string
   messageId: string
+  /** When "true", shows widget even if user chose "Don't ask again" */
+  override: 'true' | ''
 }
 
 const getProviderName = (provider: OAuthProvider): string => {
@@ -74,7 +76,7 @@ const isProviderConnected = (
  * Widget that prompts users to connect their email/calendar accounts
  */
 export const ConnectIntegrationWidget = memo(
-  ({ provider, service, reason, messageId }: ConnectIntegrationWidgetProps) => {
+  ({ provider, service, reason, messageId, override }: ConnectIntegrationWidgetProps) => {
     const location = useLocation()
     const navigate = useNavigate()
     const { integrationsDoNotAskAgain } = useSettings({ integrations_do_not_ask_again: false })
@@ -174,7 +176,7 @@ export const ConnectIntegrationWidget = memo(
       dispatch({ type: 'SET_DISMISSED', payload: true })
     }
 
-    if (integrationsDoNotAskAgain.value) {
+    if (integrationsDoNotAskAgain.value && override !== 'true') {
       return null
     }
 


### PR DESCRIPTION
When users chose "Don't ask again" on the Connect Google/Microsoft widget, the model would sometimes output the widget tag but nothing would render — leaving users with blank responses.

### What was done

- Added integration status to the model's context so it knows when prompts are disabled or integrations are turned off
- The model now asks users if they'd like to connect before showing the widget (when "Don't ask again" was previously selected)
- Added an `override` option that lets the widget display after the user explicitly agrees to connect
- Fixed a bug where retry messages were appearing instead of being hidden (metadata was being overwritten)
- Simplified the widget instructions for better model consistency across different providers

### How it affects users

- Users who selected "Don't ask again" will now see a friendly prompt asking if they'd like to connect, rather than an empty response
- Users with disabled integrations are directed to Settings instead of seeing a broken widget
- The retry flow after OAuth connection now works correctly (hidden messages stay hidden)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds integration status to the model context and an override flag to the connect-integration widget, updates instructions/tests, and preserves message metadata to avoid blank or hidden-retry issues.
> 
> - **AI/Backend**
>   - **Settings/Context**: Fetch new integration fields and compute `integrationStatus` (`READY`, `GOOGLE_DISABLED`, `MICROSOFT_DISABLED`, `PROMPTS_DISABLED`); include in system prompt.
>   - **Prompt**: `createPrompt` accepts `integrationStatus` and embeds it in context.
> - **Connect-Integration Widget**
>   - **Schema**: Add required `args.override` (`"true" | ""`).
>   - **Component**: Accept `override` prop; suppress widget when "Do not ask again" is set unless `override="true"`; keep hidden when already connected.
>   - **Instructions**: Rewritten with provider/service selection, status-driven rules, display-only widget rule, and examples.
> - **Parser/Tests**
>   - Update tests to require/validate `override` attribute in `<widget:connect-integration ... />`.
> - **Chats**
>   - **Bug fix**: Preserve existing `message.metadata` when sending (prevents hidden retry messages from reappearing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 052d221f377a161b84e14f2011b2ce097380960d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->