### PR TITLE
Fix: No Answer, repeated Twice

### DIFF
--- a/backend/src/pro/exa.test.ts
+++ b/backend/src/pro/exa.test.ts
@@ -45,13 +45,16 @@ const createTestExaPlugin = (mockExaClient: any) => {
           throw new Error('Fetch content service is not configured.')
         }
 
-        const maxCharacters = 16000
+        const defaultMaxChars = 16000
+        const hardCap = 64000
+        const minChars = 1000
+        const requestedMax = body.max_length ?? defaultMaxChars
+        const maxCharacters = Math.min(Math.max(requestedMax, minChars), hardCap)
 
         const response = await store.exaClient.getContents([body.url], {
           livecrawlTimeout: 5000,
           extras: { imageLinks: 1 },
           text: { maxCharacters },
-          summary: { query: 'Main content and key information' },
         })
 
         const result = response.results[0]
@@ -59,10 +62,22 @@ const createTestExaPlugin = (mockExaClient: any) => {
           return { data: null, success: true }
         }
 
+        // Use >= as a conservative check: if Exa returns exactly maxCharacters,
+        // the original content was likely longer and got truncated by Exa's API
+        const wasTruncated = (result.text?.length ?? 0) >= maxCharacters
+        let text = result.text ?? ''
+
+        // If truncated and not at hard cap, suggest fetching more
+        if (wasTruncated && maxCharacters < hardCap) {
+          const nextSize = Math.min(maxCharacters * 2, hardCap)
+          text += `\n\n[Content truncated. Call fetch_content with max_length=${nextSize} for more.]`
+        }
+
         return {
           data: {
             ...result,
-            wasTruncated: (result.text?.length ?? 0) >= maxCharacters,
+            text,
+            wasTruncated,
           },
           success: true,
         }
@@ -70,6 +85,7 @@ const createTestExaPlugin = (mockExaClient: any) => {
       {
         body: t.Object({
           url: t.String(),
+          max_length: t.Optional(t.Number()),
         }),
       },
     )
@@ -276,7 +292,6 @@ describe('Pro - Exa Plugin', () => {
           url: 'https://example.com',
           title: 'Test Page',
           text: 'This is the fetched content',
-          summary: 'A summary of the content',
           author: 'Test Author',
         },
       ]
@@ -303,7 +318,6 @@ describe('Pro - Exa Plugin', () => {
         livecrawlTimeout: 5000,
         extras: { imageLinks: 1 },
         text: { maxCharacters: 16000 },
-        summary: { query: 'Main content and key information' },
       })
     })
 
@@ -411,12 +425,11 @@ describe('Pro - Exa Plugin', () => {
           livecrawlTimeout: 5000,
           extras: { imageLinks: 1 },
           text: { maxCharacters: 16000 },
-          summary: { query: 'Main content and key information' },
         })
       }
     })
 
-    it('should set wasTruncated to true when text reaches max characters limit', async () => {
+    it('should set wasTruncated to true and append instruction when text reaches max characters limit', async () => {
       // Create text that is exactly at the limit (16,000 chars)
       const longText = 'A'.repeat(16000)
       const mockContent = [
@@ -424,7 +437,6 @@ describe('Pro - Exa Plugin', () => {
           url: 'https://example.com/long',
           title: 'Long Page',
           text: longText,
-          summary: 'Summary of long content',
         },
       ]
       mockGetContents.mockResolvedValueOnce({ results: mockContent })
@@ -440,7 +452,7 @@ describe('Pro - Exa Plugin', () => {
       expect(response.status).toBe(200)
       const data = await response.json()
       expect(data.data.wasTruncated).toBe(true)
-      expect(data.data.summary).toBe('Summary of long content')
+      expect(data.data.text).toContain('[Content truncated. Call fetch_content with max_length=32000 for more.]')
     })
 
     it('should set wasTruncated to false when text is under the limit', async () => {
@@ -450,7 +462,6 @@ describe('Pro - Exa Plugin', () => {
           url: 'https://example.com/short',
           title: 'Short Page',
           text: shortText,
-          summary: 'Summary of short content',
         },
       ]
       mockGetContents.mockResolvedValueOnce({ results: mockContent })
@@ -473,7 +484,6 @@ describe('Pro - Exa Plugin', () => {
         {
           url: 'https://example.com/no-text',
           title: 'Page Without Text',
-          summary: 'Summary only',
         },
       ]
       mockGetContents.mockResolvedValueOnce({ results: mockContent })
@@ -489,6 +499,134 @@ describe('Pro - Exa Plugin', () => {
       expect(response.status).toBe(200)
       const data = await response.json()
       expect(data.data.wasTruncated).toBe(false)
+    })
+
+    it('should respect custom max_length parameter', async () => {
+      const mockContent = [
+        {
+          url: 'https://example.com',
+          title: 'Test Page',
+          text: 'Short content',
+        },
+      ]
+      mockGetContents.mockResolvedValueOnce({ results: mockContent })
+
+      const response = await app.handle(
+        new Request('http://localhost/fetch-content', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: 'https://example.com', max_length: 32000 }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
+        livecrawlTimeout: 5000,
+        extras: { imageLinks: 1 },
+        text: { maxCharacters: 32000 },
+      })
+    })
+
+    it('should enforce hard cap of 64000 characters', async () => {
+      const mockContent = [
+        {
+          url: 'https://example.com',
+          title: 'Test Page',
+          text: 'Content',
+        },
+      ]
+      mockGetContents.mockResolvedValueOnce({ results: mockContent })
+
+      const response = await app.handle(
+        new Request('http://localhost/fetch-content', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: 'https://example.com', max_length: 100000 }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
+        livecrawlTimeout: 5000,
+        extras: { imageLinks: 1 },
+        text: { maxCharacters: 64000 },
+      })
+    })
+
+    it('should enforce minimum of 1000 characters', async () => {
+      const mockContent = [
+        {
+          url: 'https://example.com',
+          title: 'Test Page',
+          text: 'Content',
+        },
+      ]
+      mockGetContents.mockResolvedValueOnce({ results: mockContent })
+
+      const response = await app.handle(
+        new Request('http://localhost/fetch-content', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: 'https://example.com', max_length: 100 }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
+        livecrawlTimeout: 5000,
+        extras: { imageLinks: 1 },
+        text: { maxCharacters: 1000 },
+      })
+    })
+
+    it('should not append instruction when at hard cap', async () => {
+      const longText = 'A'.repeat(64000)
+      const mockContent = [
+        {
+          url: 'https://example.com/long',
+          title: 'Long Page',
+          text: longText,
+        },
+      ]
+      mockGetContents.mockResolvedValueOnce({ results: mockContent })
+
+      const response = await app.handle(
+        new Request('http://localhost/fetch-content', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: 'https://example.com/long', max_length: 64000 }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.data.wasTruncated).toBe(true)
+      expect(data.data.text).not.toContain('[Content truncated.')
+    })
+
+    it('should suggest doubling max_length in truncation instruction', async () => {
+      const longText = 'A'.repeat(32000)
+      const mockContent = [
+        {
+          url: 'https://example.com/long',
+          title: 'Long Page',
+          text: longText,
+        },
+      ]
+      mockGetContents.mockResolvedValueOnce({ results: mockContent })
+
+      const response = await app.handle(
+        new Request('http://localhost/fetch-content', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: 'https://example.com/long', max_length: 32000 }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.data.wasTruncated).toBe(true)
+      expect(data.data.text).toContain('[Content truncated. Call fetch_content with max_length=64000 for more.]')
     })
   })
 })

--- a/backend/src/pro/exa.test.ts
+++ b/backend/src/pro/exa.test.ts
@@ -45,16 +45,25 @@ const createTestExaPlugin = (mockExaClient: any) => {
           throw new Error('Fetch content service is not configured.')
         }
 
+        const maxCharacters = 16000
+
         const response = await store.exaClient.getContents([body.url], {
-          livecrawlTimeout: 5_000,
+          livecrawlTimeout: 5000,
           extras: { imageLinks: 1 },
-          text: {
-            maxCharacters: 5_000,
-          },
+          text: { maxCharacters },
+          summary: { query: 'Main content and key information' },
         })
 
+        const result = response.results[0]
+        if (!result) {
+          return { data: null, success: true }
+        }
+
         return {
-          data: response.results[0] || null,
+          data: {
+            ...result,
+            wasTruncated: (result.text?.length ?? 0) >= maxCharacters,
+          },
           success: true,
         }
       },
@@ -267,6 +276,7 @@ describe('Pro - Exa Plugin', () => {
           url: 'https://example.com',
           title: 'Test Page',
           text: 'This is the fetched content',
+          summary: 'A summary of the content',
           author: 'Test Author',
         },
       ]
@@ -283,15 +293,17 @@ describe('Pro - Exa Plugin', () => {
       expect(response.status).toBe(200)
       const data = await response.json()
       expect(data).toEqual({
-        data: mockContent[0],
+        data: {
+          ...mockContent[0],
+          wasTruncated: false,
+        },
         success: true,
       })
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
-        livecrawlTimeout: 5_000,
+        livecrawlTimeout: 5000,
         extras: { imageLinks: 1 },
-        text: {
-          maxCharacters: 5_000,
-        },
+        text: { maxCharacters: 16000 },
+        summary: { query: 'Main content and key information' },
       })
     })
 
@@ -396,13 +408,87 @@ describe('Pro - Exa Plugin', () => {
 
         expect(response.status).toBe(200)
         expect(mockGetContents).toHaveBeenCalledWith([url], {
-          livecrawlTimeout: 5_000,
+          livecrawlTimeout: 5000,
           extras: { imageLinks: 1 },
-          text: {
-            maxCharacters: 5_000,
-          },
+          text: { maxCharacters: 16000 },
+          summary: { query: 'Main content and key information' },
         })
       }
+    })
+
+    it('should set wasTruncated to true when text reaches max characters limit', async () => {
+      // Create text that is exactly at the limit (16,000 chars)
+      const longText = 'A'.repeat(16000)
+      const mockContent = [
+        {
+          url: 'https://example.com/long',
+          title: 'Long Page',
+          text: longText,
+          summary: 'Summary of long content',
+        },
+      ]
+      mockGetContents.mockResolvedValueOnce({ results: mockContent })
+
+      const response = await app.handle(
+        new Request('http://localhost/fetch-content', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: 'https://example.com/long' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.data.wasTruncated).toBe(true)
+      expect(data.data.summary).toBe('Summary of long content')
+    })
+
+    it('should set wasTruncated to false when text is under the limit', async () => {
+      const shortText = 'Short content'
+      const mockContent = [
+        {
+          url: 'https://example.com/short',
+          title: 'Short Page',
+          text: shortText,
+          summary: 'Summary of short content',
+        },
+      ]
+      mockGetContents.mockResolvedValueOnce({ results: mockContent })
+
+      const response = await app.handle(
+        new Request('http://localhost/fetch-content', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: 'https://example.com/short' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.data.wasTruncated).toBe(false)
+    })
+
+    it('should handle content with no text field', async () => {
+      const mockContent = [
+        {
+          url: 'https://example.com/no-text',
+          title: 'Page Without Text',
+          summary: 'Summary only',
+        },
+      ]
+      mockGetContents.mockResolvedValueOnce({ results: mockContent })
+
+      const response = await app.handle(
+        new Request('http://localhost/fetch-content', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: 'https://example.com/no-text' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.data.wasTruncated).toBe(false)
     })
   })
 })

--- a/backend/src/pro/exa.test.ts
+++ b/backend/src/pro/exa.test.ts
@@ -52,7 +52,7 @@ const createTestExaPlugin = (mockExaClient: any) => {
         const maxCharacters = Math.min(Math.max(requestedMax, minChars), hardCap)
 
         const response = await store.exaClient.getContents([body.url], {
-          livecrawlTimeout: 5000,
+          livecrawlTimeout: 5_000,
           extras: { imageLinks: 1 },
           text: { maxCharacters },
         })
@@ -314,7 +314,7 @@ describe('Pro - Exa Plugin', () => {
         success: true,
       })
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
-        livecrawlTimeout: 5000,
+        livecrawlTimeout: 5_000,
         extras: { imageLinks: 1 },
         text: { maxCharacters: 16_000 },
       })
@@ -421,7 +421,7 @@ describe('Pro - Exa Plugin', () => {
 
         expect(response.status).toBe(200)
         expect(mockGetContents).toHaveBeenCalledWith([url], {
-          livecrawlTimeout: 5000,
+          livecrawlTimeout: 5_000,
           extras: { imageLinks: 1 },
           text: { maxCharacters: 16_000 },
         })
@@ -520,7 +520,7 @@ describe('Pro - Exa Plugin', () => {
 
       expect(response.status).toBe(200)
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
-        livecrawlTimeout: 5000,
+        livecrawlTimeout: 5_000,
         extras: { imageLinks: 1 },
         text: { maxCharacters: 32_000 },
       })
@@ -546,7 +546,7 @@ describe('Pro - Exa Plugin', () => {
 
       expect(response.status).toBe(200)
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
-        livecrawlTimeout: 5000,
+        livecrawlTimeout: 5_000,
         extras: { imageLinks: 1 },
         text: { maxCharacters: 64_000 },
       })
@@ -572,7 +572,7 @@ describe('Pro - Exa Plugin', () => {
 
       expect(response.status).toBe(200)
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
-        livecrawlTimeout: 5000,
+        livecrawlTimeout: 5_000,
         extras: { imageLinks: 1 },
         text: { maxCharacters: 1_000 },
       })

--- a/backend/src/pro/exa.test.ts
+++ b/backend/src/pro/exa.test.ts
@@ -45,9 +45,9 @@ const createTestExaPlugin = (mockExaClient: any) => {
           throw new Error('Fetch content service is not configured.')
         }
 
-        const defaultMaxChars = 16000
-        const hardCap = 64000
-        const minChars = 1000
+        const defaultMaxChars = 16_000
+        const hardCap = 64_000
+        const minChars = 1_000
         const requestedMax = body.max_length ?? defaultMaxChars
         const maxCharacters = Math.min(Math.max(requestedMax, minChars), hardCap)
 
@@ -64,20 +64,19 @@ const createTestExaPlugin = (mockExaClient: any) => {
 
         // Use >= as a conservative check: if Exa returns exactly maxCharacters,
         // the original content was likely longer and got truncated by Exa's API
-        const wasTruncated = (result.text?.length ?? 0) >= maxCharacters
-        let text = result.text ?? ''
+        const isTruncated = (result.text?.length ?? 0) >= maxCharacters
 
         // If truncated and not at hard cap, suggest fetching more
-        if (wasTruncated && maxCharacters < hardCap) {
-          const nextSize = Math.min(maxCharacters * 2, hardCap)
-          text += `\n\n[Content truncated. Call fetch_content with max_length=${nextSize} for more.]`
-        }
+        const truncationHint =
+          isTruncated && maxCharacters < hardCap
+            ? `\n\n[Content truncated. Call fetch_content with max_length=${Math.min(maxCharacters * 2, hardCap)} for more.]`
+            : ''
 
         return {
           data: {
             ...result,
-            text,
-            wasTruncated,
+            text: (result.text ?? '') + truncationHint,
+            isTruncated,
           },
           success: true,
         }
@@ -310,14 +309,14 @@ describe('Pro - Exa Plugin', () => {
       expect(data).toEqual({
         data: {
           ...mockContent[0],
-          wasTruncated: false,
+          isTruncated: false,
         },
         success: true,
       })
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
         livecrawlTimeout: 5000,
         extras: { imageLinks: 1 },
-        text: { maxCharacters: 16000 },
+        text: { maxCharacters: 16_000 },
       })
     })
 
@@ -424,14 +423,14 @@ describe('Pro - Exa Plugin', () => {
         expect(mockGetContents).toHaveBeenCalledWith([url], {
           livecrawlTimeout: 5000,
           extras: { imageLinks: 1 },
-          text: { maxCharacters: 16000 },
+          text: { maxCharacters: 16_000 },
         })
       }
     })
 
-    it('should set wasTruncated to true and append instruction when text reaches max characters limit', async () => {
+    it('should set isTruncated to true and append instruction when text reaches max characters limit', async () => {
       // Create text that is exactly at the limit (16,000 chars)
-      const longText = 'A'.repeat(16000)
+      const longText = 'A'.repeat(16_000)
       const mockContent = [
         {
           url: 'https://example.com/long',
@@ -451,11 +450,11 @@ describe('Pro - Exa Plugin', () => {
 
       expect(response.status).toBe(200)
       const data = await response.json()
-      expect(data.data.wasTruncated).toBe(true)
+      expect(data.data.isTruncated).toBe(true)
       expect(data.data.text).toContain('[Content truncated. Call fetch_content with max_length=32000 for more.]')
     })
 
-    it('should set wasTruncated to false when text is under the limit', async () => {
+    it('should set isTruncated to false when text is under the limit', async () => {
       const shortText = 'Short content'
       const mockContent = [
         {
@@ -476,7 +475,7 @@ describe('Pro - Exa Plugin', () => {
 
       expect(response.status).toBe(200)
       const data = await response.json()
-      expect(data.data.wasTruncated).toBe(false)
+      expect(data.data.isTruncated).toBe(false)
     })
 
     it('should handle content with no text field', async () => {
@@ -498,7 +497,7 @@ describe('Pro - Exa Plugin', () => {
 
       expect(response.status).toBe(200)
       const data = await response.json()
-      expect(data.data.wasTruncated).toBe(false)
+      expect(data.data.isTruncated).toBe(false)
     })
 
     it('should respect custom max_length parameter', async () => {
@@ -523,7 +522,7 @@ describe('Pro - Exa Plugin', () => {
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
         livecrawlTimeout: 5000,
         extras: { imageLinks: 1 },
-        text: { maxCharacters: 32000 },
+        text: { maxCharacters: 32_000 },
       })
     })
 
@@ -549,7 +548,7 @@ describe('Pro - Exa Plugin', () => {
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
         livecrawlTimeout: 5000,
         extras: { imageLinks: 1 },
-        text: { maxCharacters: 64000 },
+        text: { maxCharacters: 64_000 },
       })
     })
 
@@ -575,12 +574,12 @@ describe('Pro - Exa Plugin', () => {
       expect(mockGetContents).toHaveBeenCalledWith(['https://example.com'], {
         livecrawlTimeout: 5000,
         extras: { imageLinks: 1 },
-        text: { maxCharacters: 1000 },
+        text: { maxCharacters: 1_000 },
       })
     })
 
     it('should not append instruction when at hard cap', async () => {
-      const longText = 'A'.repeat(64000)
+      const longText = 'A'.repeat(64_000)
       const mockContent = [
         {
           url: 'https://example.com/long',
@@ -600,12 +599,12 @@ describe('Pro - Exa Plugin', () => {
 
       expect(response.status).toBe(200)
       const data = await response.json()
-      expect(data.data.wasTruncated).toBe(true)
+      expect(data.data.isTruncated).toBe(true)
       expect(data.data.text).not.toContain('[Content truncated.')
     })
 
     it('should suggest doubling max_length in truncation instruction', async () => {
-      const longText = 'A'.repeat(32000)
+      const longText = 'A'.repeat(32_000)
       const mockContent = [
         {
           url: 'https://example.com/long',
@@ -625,7 +624,7 @@ describe('Pro - Exa Plugin', () => {
 
       expect(response.status).toBe(200)
       const data = await response.json()
-      expect(data.data.wasTruncated).toBe(true)
+      expect(data.data.isTruncated).toBe(true)
       expect(data.data.text).toContain('[Content truncated. Call fetch_content with max_length=64000 for more.]')
     })
   })

--- a/backend/src/pro/exa.ts
+++ b/backend/src/pro/exa.ts
@@ -53,13 +53,16 @@ export const exaPlugin = new Elysia({ name: 'exa' })
         throw new Error('Fetch content service is not configured.')
       }
 
-      const maxCharacters = 16000
+      const defaultMaxChars = 16000
+      const hardCap = 64000
+      const minChars = 1000
+      const requestedMax = body.max_length ?? defaultMaxChars
+      const maxCharacters = Math.min(Math.max(requestedMax, minChars), hardCap)
 
       const response = await store.exaClient.getContents([body.url], {
         livecrawlTimeout: 5000,
         extras: { imageLinks: 1 },
         text: { maxCharacters },
-        summary: { query: 'Main content and key information' },
       })
 
       const result = response.results[0]
@@ -67,11 +70,22 @@ export const exaPlugin = new Elysia({ name: 'exa' })
         return { data: null, success: true }
       }
 
+      // Use >= as a conservative check: if Exa returns exactly maxCharacters,
+      // the original content was likely longer and got truncated by Exa's API
+      const wasTruncated = (result.text?.length ?? 0) >= maxCharacters
+      let text = result.text ?? ''
+
+      // If truncated and not at hard cap, suggest fetching more
+      if (wasTruncated && maxCharacters < hardCap) {
+        const nextSize = Math.min(maxCharacters * 2, hardCap)
+        text += `\n\n[Content truncated. Call fetch_content with max_length=${nextSize} for more.]`
+      }
+
       return {
         data: {
           ...result,
-          // Flag when content was truncated so the model knows full content wasn't returned
-          wasTruncated: (result.text?.length ?? 0) >= maxCharacters,
+          text,
+          wasTruncated,
         },
         success: true,
       }
@@ -79,6 +93,7 @@ export const exaPlugin = new Elysia({ name: 'exa' })
     {
       body: t.Object({
         url: t.String(),
+        max_length: t.Optional(t.Number()),
       }),
     },
   )

--- a/backend/src/pro/exa.ts
+++ b/backend/src/pro/exa.ts
@@ -60,7 +60,7 @@ export const exaPlugin = new Elysia({ name: 'exa' })
       const maxCharacters = Math.min(Math.max(requestedMax, minChars), hardCap)
 
       const response = await store.exaClient.getContents([body.url], {
-        livecrawlTimeout: 5000,
+        livecrawlTimeout: 5_000,
         extras: { imageLinks: 1 },
         text: { maxCharacters },
       })

--- a/backend/src/pro/exa.ts
+++ b/backend/src/pro/exa.ts
@@ -53,9 +53,9 @@ export const exaPlugin = new Elysia({ name: 'exa' })
         throw new Error('Fetch content service is not configured.')
       }
 
-      const defaultMaxChars = 16000
-      const hardCap = 64000
-      const minChars = 1000
+      const defaultMaxChars = 16_000
+      const hardCap = 64_000
+      const minChars = 1_000
       const requestedMax = body.max_length ?? defaultMaxChars
       const maxCharacters = Math.min(Math.max(requestedMax, minChars), hardCap)
 
@@ -72,20 +72,19 @@ export const exaPlugin = new Elysia({ name: 'exa' })
 
       // Use >= as a conservative check: if Exa returns exactly maxCharacters,
       // the original content was likely longer and got truncated by Exa's API
-      const wasTruncated = (result.text?.length ?? 0) >= maxCharacters
-      let text = result.text ?? ''
+      const isTruncated = (result.text?.length ?? 0) >= maxCharacters
 
       // If truncated and not at hard cap, suggest fetching more
-      if (wasTruncated && maxCharacters < hardCap) {
-        const nextSize = Math.min(maxCharacters * 2, hardCap)
-        text += `\n\n[Content truncated. Call fetch_content with max_length=${nextSize} for more.]`
-      }
+      const truncationHint =
+        isTruncated && maxCharacters < hardCap
+          ? `\n\n[Content truncated. Call fetch_content with max_length=${Math.min(maxCharacters * 2, hardCap)} for more.]`
+          : ''
 
       return {
         data: {
           ...result,
-          text,
-          wasTruncated,
+          text: (result.text ?? '') + truncationHint,
+          isTruncated,
         },
         success: true,
       }

--- a/backend/src/pro/exa.ts
+++ b/backend/src/pro/exa.ts
@@ -53,14 +53,26 @@ export const exaPlugin = new Elysia({ name: 'exa' })
         throw new Error('Fetch content service is not configured.')
       }
 
+      const maxCharacters = 16000
+
       const response = await store.exaClient.getContents([body.url], {
-        livecrawlTimeout: 5_000,
+        livecrawlTimeout: 5000,
         extras: { imageLinks: 1 },
-        text: true,
+        text: { maxCharacters },
+        summary: { query: 'Main content and key information' },
       })
 
+      const result = response.results[0]
+      if (!result) {
+        return { data: null, success: true }
+      }
+
       return {
-        data: response.results[0] || null,
+        data: {
+          ...result,
+          // Flag when content was truncated so the model knows full content wasn't returned
+          wasTruncated: (result.text?.length ?? 0) >= maxCharacters,
+        },
         success: true,
       }
     },

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -44,10 +44,10 @@ export type FetchContentRequest = z.infer<typeof fetchContentRequestSchema>
 /**
  * FetchContentData extends Exa's SearchResult with additional fields for graceful degradation.
  * - text: Truncated to maxCharacters (16K) to prevent context overflow
- * - wasTruncated: Flag indicating if text was truncated
+ * - isTruncated: Flag indicating if text was truncated
  */
 export type FetchContentData = SearchResult<{ text: { maxCharacters: number } }> & {
-  wasTruncated: boolean
+  isTruncated: boolean
 }
 
 export type FetchContentResponse = {

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -44,11 +44,9 @@ export type FetchContentRequest = z.infer<typeof fetchContentRequestSchema>
 /**
  * FetchContentData extends Exa's SearchResult with additional fields for graceful degradation.
  * - text: Truncated to maxCharacters (16K) to prevent context overflow
- * - summary: AI-generated summary of the FULL content (not truncated)
  * - wasTruncated: Flag indicating if text was truncated
  */
 export type FetchContentData = SearchResult<{ text: { maxCharacters: number } }> & {
-  summary?: string
   wasTruncated: boolean
 }
 

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -42,11 +42,18 @@ export const fetchContentRequestSchema = z.object({
 export type FetchContentRequest = z.infer<typeof fetchContentRequestSchema>
 
 /**
- * FetchContentResponse returns the raw SearchResult from Exa's getContents API.
- * The SearchResult includes properties like url, title, text, favicon, image, author, publishedDate, etc.
+ * FetchContentData extends Exa's SearchResult with additional fields for graceful degradation.
+ * - text: Truncated to maxCharacters (16K) to prevent context overflow
+ * - summary: AI-generated summary of the FULL content (not truncated)
+ * - wasTruncated: Flag indicating if text was truncated
  */
+export type FetchContentData = SearchResult<{ text: { maxCharacters: number } }> & {
+  summary?: string
+  wasTruncated: boolean
+}
+
 export type FetchContentResponse = {
-  data: SearchResult<{ text: { maxCharacters: number } }> | null
+  data: FetchContentData | null
   success: boolean
   error?: string | null
 }

--- a/src/integrations/google/tools.ts
+++ b/src/integrations/google/tools.ts
@@ -226,7 +226,7 @@ export type DriveFileContent = {
   mime_type: string
   content: string | null
   /** When true, content was truncated to prevent context overflow */
-  wasTruncated?: boolean
+  isTruncated?: boolean
   /** When true, text extraction was not possible */
   extraction_failed?: boolean
   /** Category of failure: 'unsupported_type' | 'access_denied' | 'not_found' */
@@ -743,18 +743,13 @@ export const getDriveFileContent = async (
       }
     }
 
-    // Truncate if too long for LLM context
-    const wasTruncated = content.length > llmContentCharLimit
-    if (wasTruncated) {
-      content = truncateText(content, llmContentCharLimit)
-    }
-
+    const isTruncated = content.length > llmContentCharLimit
     return {
       file_id: fileId,
       file_name: fileName,
       mime_type: mimeType,
-      content,
-      wasTruncated,
+      content: isTruncated ? content.substring(0, llmContentCharLimit) + '...[truncated]' : content,
+      isTruncated,
     }
   } catch (error: unknown) {
     const httpError = error as { response?: { status: number } }

--- a/src/integrations/google/tools.ts
+++ b/src/integrations/google/tools.ts
@@ -1,3 +1,4 @@
+import { llmContentCharLimit, truncateText } from '@/lib/utils'
 import type { ToolConfig } from '@/types'
 import ky, { type KyInstance } from 'ky'
 import { z } from 'zod'
@@ -9,7 +10,6 @@ import {
   getHeader,
   parseEmailAddress,
   transformDriveQuery,
-  truncateText,
 } from './utils'
 
 // =============================================================================
@@ -225,6 +225,8 @@ export type DriveFileContent = {
   file_name: string
   mime_type: string
   content: string | null
+  /** When true, content was truncated to prevent context overflow */
+  wasTruncated?: boolean
   /** When true, text extraction was not possible */
   extraction_failed?: boolean
   /** Category of failure: 'unsupported_type' | 'access_denied' | 'not_found' */
@@ -741,11 +743,18 @@ export const getDriveFileContent = async (
       }
     }
 
+    // Truncate if too long for LLM context
+    const wasTruncated = content.length >= llmContentCharLimit
+    if (wasTruncated) {
+      content = truncateText(content, llmContentCharLimit)
+    }
+
     return {
       file_id: fileId,
       file_name: fileName,
       mime_type: mimeType,
       content,
+      wasTruncated,
     }
   } catch (error: unknown) {
     const httpError = error as { response?: { status: number } }

--- a/src/integrations/google/tools.ts
+++ b/src/integrations/google/tools.ts
@@ -744,7 +744,7 @@ export const getDriveFileContent = async (
     }
 
     // Truncate if too long for LLM context
-    const wasTruncated = content.length >= llmContentCharLimit
+    const wasTruncated = content.length > llmContentCharLimit
     if (wasTruncated) {
       content = truncateText(content, llmContentCharLimit)
     }

--- a/src/integrations/google/utils.ts
+++ b/src/integrations/google/utils.ts
@@ -56,14 +56,6 @@ export const extractBody = (payload: any, mimeType: string): string => {
 }
 
 /**
- * Truncate text to reasonable length for LLMs
- */
-export const truncateText = (text: string, maxLength = 4000): string => {
-  if (text.length <= maxLength) return text
-  return text.substring(0, maxLength) + '...[truncated]'
-}
-
-/**
  * Build raw email message for drafts
  */
 export const buildRawMessage = (params: DraftEmailParams): string => {

--- a/src/integrations/microsoft/tools.ts
+++ b/src/integrations/microsoft/tools.ts
@@ -283,7 +283,7 @@ export const getOneDriveFileContent = async (
         .text()
 
       // Truncate if too long for LLM context
-      const wasTruncated = textContent.length >= llmContentCharLimit
+      const wasTruncated = textContent.length > llmContentCharLimit
       if (wasTruncated) {
         textContent = truncateText(textContent, llmContentCharLimit)
       }

--- a/src/integrations/microsoft/tools.ts
+++ b/src/integrations/microsoft/tools.ts
@@ -1,7 +1,7 @@
 // New file with Microsoft Graph tools
 
 import { getSettings, updateSettings } from '@/dal'
-import { llmContentCharLimit, truncateText } from '@/lib/utils'
+import { llmContentCharLimit } from '@/lib/utils'
 import type { ToolConfig } from '@/types'
 import ky, { type KyInstance } from 'ky'
 import { z } from 'zod'
@@ -103,7 +103,7 @@ export type OneDriveFileContent = {
   file_name: string
   mime_type: string
   content: string | null
-  wasTruncated?: boolean
+  isTruncated?: boolean
   extraction_failed?: boolean
   failure_reason?: 'unsupported_type' | 'access_denied' | 'not_found'
   file_category?: 'pdf' | 'image' | 'video' | 'audio' | 'binary' | 'office' | 'unknown'
@@ -276,24 +276,20 @@ export const getOneDriveFileContent = async (
 
     // Only support text files for now
     if (mimeType.startsWith('text/')) {
-      let textContent = await httpClient
+      const textContent = await httpClient
         .get(`https://graph.microsoft.com/v1.0/me/drive/items/${params.file_id}/content`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         })
         .text()
 
-      // Truncate if too long for LLM context
-      const wasTruncated = textContent.length > llmContentCharLimit
-      if (wasTruncated) {
-        textContent = truncateText(textContent, llmContentCharLimit)
-      }
+      const isTruncated = textContent.length > llmContentCharLimit
 
       return {
         file_id: params.file_id,
         file_name: fileName,
         mime_type: mimeType,
-        content: textContent,
-        wasTruncated,
+        content: isTruncated ? textContent.substring(0, llmContentCharLimit) + '...[truncated]' : textContent,
+        isTruncated,
       }
     }
 

--- a/src/integrations/microsoft/tools.ts
+++ b/src/integrations/microsoft/tools.ts
@@ -1,6 +1,7 @@
 // New file with Microsoft Graph tools
 
 import { getSettings, updateSettings } from '@/dal'
+import { llmContentCharLimit, truncateText } from '@/lib/utils'
 import type { ToolConfig } from '@/types'
 import ky, { type KyInstance } from 'ky'
 import { z } from 'zod'
@@ -102,6 +103,7 @@ export type OneDriveFileContent = {
   file_name: string
   mime_type: string
   content: string | null
+  wasTruncated?: boolean
   extraction_failed?: boolean
   failure_reason?: 'unsupported_type' | 'access_denied' | 'not_found'
   file_category?: 'pdf' | 'image' | 'video' | 'audio' | 'binary' | 'office' | 'unknown'
@@ -274,17 +276,24 @@ export const getOneDriveFileContent = async (
 
     // Only support text files for now
     if (mimeType.startsWith('text/')) {
-      const textResponse = await httpClient
+      let textContent = await httpClient
         .get(`https://graph.microsoft.com/v1.0/me/drive/items/${params.file_id}/content`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         })
         .text()
 
+      // Truncate if too long for LLM context
+      const wasTruncated = textContent.length >= llmContentCharLimit
+      if (wasTruncated) {
+        textContent = truncateText(textContent, llmContentCharLimit)
+      }
+
       return {
         file_id: params.file_id,
         file_name: fileName,
         mime_type: mimeType,
-        content: textResponse,
+        content: textContent,
+        wasTruncated,
       }
     }
 

--- a/src/integrations/thunderbolt-pro/api.ts
+++ b/src/integrations/thunderbolt-pro/api.ts
@@ -56,7 +56,7 @@ export const fetchContent = async (
         timeout: requestTimeout,
         json: {
           url: params.url,
-          ...(params.max_length && { max_length: params.max_length }),
+          ...(params.max_length !== undefined && { max_length: params.max_length }),
         },
       })
       .json<{ data: FetchContentData; success: boolean; error?: string }>()

--- a/src/integrations/thunderbolt-pro/api.ts
+++ b/src/integrations/thunderbolt-pro/api.ts
@@ -63,6 +63,7 @@ export const fetchContent = async (
     if (!response.success) {
       throw new Error(response.error || 'Fetch content failed')
     }
+
     return response.data
   } catch (error) {
     console.error('Fetch content error:', error)

--- a/src/integrations/thunderbolt-pro/api.ts
+++ b/src/integrations/thunderbolt-pro/api.ts
@@ -56,6 +56,7 @@ export const fetchContent = async (
         timeout: requestTimeout,
         json: {
           url: params.url,
+          ...(params.max_length && { max_length: params.max_length }),
         },
       })
       .json<{ data: FetchContentData; success: boolean; error?: string }>()

--- a/src/integrations/thunderbolt-pro/schemas.ts
+++ b/src/integrations/thunderbolt-pro/schemas.ts
@@ -85,13 +85,13 @@ export type SearchResultData = {
 /**
  * Data type for fetched webpage content.
  * - text: May be truncated to ~16K chars to prevent context overflow
- * - wasTruncated: True if text was truncated
+ * - isTruncated: True if text was truncated
  */
 export type FetchContentData = {
   url: string
   title: string | null
   text: string
-  wasTruncated?: boolean
+  isTruncated?: boolean
   highlights?: string[]
   highlightScores?: number[]
   favicon: string | null

--- a/src/integrations/thunderbolt-pro/schemas.ts
+++ b/src/integrations/thunderbolt-pro/schemas.ts
@@ -16,6 +16,12 @@ export const searchSchema = z
 export const fetchContentSchema = z
   .object({
     url: z.string().describe('Webpage URL to fetch content from'),
+    max_length: z
+      .number()
+      .optional()
+      .describe(
+        'Maximum content length in characters (default: 16000, max: 64000). Increase if content was truncated.',
+      ),
   })
   .strict()
 
@@ -79,14 +85,12 @@ export type SearchResultData = {
 /**
  * Data type for fetched webpage content.
  * - text: May be truncated to ~16K chars to prevent context overflow
- * - summary: AI-generated summary of the FULL content (always complete)
- * - wasTruncated: True if text was truncated; model should use summary for full context
+ * - wasTruncated: True if text was truncated
  */
 export type FetchContentData = {
   url: string
   title: string | null
   text: string
-  summary?: string
   wasTruncated?: boolean
   highlights?: string[]
   highlightScores?: number[]

--- a/src/integrations/thunderbolt-pro/schemas.ts
+++ b/src/integrations/thunderbolt-pro/schemas.ts
@@ -77,13 +77,17 @@ export type SearchResultData = {
 }
 
 /**
- * Data type for fetched webpage content
+ * Data type for fetched webpage content.
+ * - text: May be truncated to ~16K chars to prevent context overflow
+ * - summary: AI-generated summary of the FULL content (always complete)
+ * - wasTruncated: True if text was truncated; model should use summary for full context
  */
 export type FetchContentData = {
   url: string
   title: string | null
   text: string
-  summary: string
+  summary?: string
+  wasTruncated?: boolean
   highlights?: string[]
   highlightScores?: number[]
   favicon: string | null

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -241,3 +241,17 @@ export const isLocalhostUrl = (url: string | null): boolean => {
   if (!url) return false
   return url.startsWith('http://localhost')
 }
+
+/**
+ * Maximum content length for LLM context (16K chars ≈ 4K tokens)
+ * Used by fetch_content, Google Drive, and OneDrive file retrieval
+ */
+export const llmContentCharLimit = 16000
+
+/**
+ * Truncate text to prevent context overflow in LLM requests
+ */
+export const truncateText = (text: string, maxLength = 4000): string => {
+  if (text.length <= maxLength) return text
+  return text.substring(0, maxLength) + '...[truncated]'
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,7 +246,7 @@ export const isLocalhostUrl = (url: string | null): boolean => {
  * Maximum content length for LLM context (16K chars ≈ 4K tokens)
  * Used by fetch_content, Google Drive, and OneDrive file retrieval
  */
-export const llmContentCharLimit = 16000
+export const llmContentCharLimit = 16_000
 
 /**
  * Truncate text to prevent context overflow in LLM requests


### PR DESCRIPTION
Large documents (SEC filings, long webpages, Drive/OneDrive files) were causing 400/502 errors because accumulated tool results exceeded the AI model's context window.

### Changes

**Content limits across all retrieval sources:**
- `fetch_content`: 16K default, up to 64K via `max_length` parameter
- Google Drive / OneDrive file retrieval: 16K hard limit
- All sources now return a `wasTruncated` flag

**Progressive fetch for web content:**
- When content is truncated below the 64K cap, the response includes an instruction for the model to re-fetch with a larger `max_length`
- Models can progressively request more content: 16K → 32K → 64K
- At the hard cap, no instruction is appended (nothing more to fetch)

**Code quality:**
- Consolidated `truncateText` utility into shared `src/lib/utils.ts`
- Added input validation (min 1K, max 64K characters)
- Comprehensive test coverage for new functionality


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 16K default (1K min, 64K max) content limits with isTruncated flags and progressive re-fetch hints across fetch_content, Google Drive, and OneDrive; updates schemas, API passthrough, and tests.
> 
> - **Backend (Pro/Exa)**:
>   - `POST /fetch-content`: adds `max_length` (default `16_000`, min `1_000`, max `64_000`) and passes `text: { maxCharacters }` to Exa.
>   - Returns enriched `data` with `isTruncated` and appends fetch-hint when truncated below hard cap.
>   - Types: introduce `FetchContentData` with `isTruncated`; update `FetchContentResponse`.
> - **Thunderbolt Pro (frontend API + schemas)**:
>   - `fetchContentSchema`: adds optional `max_length` docs; `FetchContentData` gains optional `isTruncated`.
>   - API: forwards `max_length` to `/pro/fetch-content`.
> - **Google Integration**:
>   - Drive content retrieval truncates to `llmContentCharLimit` (16K) and sets `isTruncated`.
>   - Centralizes `truncateText` import from `src/lib/utils`.
> - **Microsoft Integration (new)**:
>   - OneDrive text retrieval with 16K cap; returns `isTruncated` or structured failure metadata for unsupported types.
> - **Utils**:
>   - Add `llmContentCharLimit` (16K) and shared `truncateText` in `src/lib/utils.ts`.
> - **Tests**:
>   - Expand Exa tests for limits, truncation hints (including doubling suggestion), min/max enforcement, and hard-cap behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a772fc29de90e89d8b4c654fa8578607f2df7d3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->