### PR TITLE
THU-222: Adjust scroll behavior

### DIFF
--- a/src/chats/use-chat-scroll-handler.test.tsx
+++ b/src/chats/use-chat-scroll-handler.test.tsx
@@ -10,13 +10,12 @@ type MockUseAutoScrollReturn = {
   mockHook: typeof import('@/hooks/use-auto-scroll').useAutoScroll
 }
 
-const createMockUseAutoScroll = (userHasScrolled: boolean = false): MockUseAutoScrollReturn => {
+const createMockUseAutoScroll = (isAtBottom: boolean = true): MockUseAutoScrollReturn => {
   const scrollToBottom = mock((_smooth?: boolean) => {})
   const resetUserScroll = mock(() => {})
-  const scrollContainerRef = { current: null }
-  const scrollTargetRef = { current: null }
+  const scrollContainerRef = () => {}
+  const scrollTargetRef = () => {}
   const scrollHandlers = {
-    onScroll: () => {},
     onWheel: () => {},
     onTouchStart: () => {},
   }
@@ -25,7 +24,6 @@ const createMockUseAutoScroll = (userHasScrolled: boolean = false): MockUseAutoS
     dependencies?: unknown[]
     smooth?: boolean
     isStreaming?: boolean
-    onUserScroll?: (isAtBottom: boolean) => void
     rootMargin?: string
   }) => ({
     scrollContainerRef,
@@ -33,8 +31,7 @@ const createMockUseAutoScroll = (userHasScrolled: boolean = false): MockUseAutoS
     scrollToBottom,
     resetUserScroll,
     scrollHandlers,
-    userHasScrolled,
-    isAtBottom: !userHasScrolled,
+    isAtBottom,
   })) as unknown as typeof import('@/hooks/use-auto-scroll').useAutoScroll
 
   return {
@@ -74,19 +71,19 @@ describe('useChatScrollHandler', () => {
     })
 
     expect(result.current).toHaveProperty('isAtBottom')
-    expect(result.current).toHaveProperty('resetUserScroll')
     expect(result.current).toHaveProperty('scrollContainerRef')
     expect(result.current).toHaveProperty('scrollHandlers')
     expect(result.current).toHaveProperty('scrollTargetRef')
     expect(result.current).toHaveProperty('scrollToBottom')
+    expect(result.current).toHaveProperty('scrollToBottomAndActivate')
     expect(typeof result.current.scrollToBottom).toBe('function')
-    expect(typeof result.current.resetUserScroll).toBe('function')
+    expect(typeof result.current.scrollToBottomAndActivate).toBe('function')
   })
 
-  it('should return isAtBottom as true when user has not scrolled', () => {
+  it('should return isAtBottom as true when at bottom', () => {
     const mockChatInstance = createMockChatInstance()
     const mockUseChat = createMockUseChat(mockChatInstance)
-    const { mockHook } = createMockUseAutoScroll(false) // userHasScrolled = false
+    const { mockHook } = createMockUseAutoScroll(true)
 
     hydrateStore({
       chatInstance: mockChatInstance,
@@ -105,10 +102,10 @@ describe('useChatScrollHandler', () => {
     expect(result.current.isAtBottom).toBe(true)
   })
 
-  it('should return isAtBottom as false when user has scrolled', () => {
+  it('should return isAtBottom as false when not at bottom', () => {
     const mockChatInstance = createMockChatInstance()
     const mockUseChat = createMockUseChat(mockChatInstance)
-    const { mockHook } = createMockUseAutoScroll(true) // userHasScrolled = true
+    const { mockHook } = createMockUseAutoScroll(false)
 
     hydrateStore({
       chatInstance: mockChatInstance,
@@ -127,7 +124,7 @@ describe('useChatScrollHandler', () => {
     expect(result.current.isAtBottom).toBe(false)
   })
 
-  it('should call scrollToBottom and resetUserScroll when scrollToBottom is called', () => {
+  it('should only call scrollToBottom when scrollToBottom is called', () => {
     const mockChatInstance = createMockChatInstance()
     const mockUseChat = createMockUseChat(mockChatInstance)
     const { mockHook, scrollToBottom, resetUserScroll } = createMockUseAutoScroll()
@@ -148,6 +145,33 @@ describe('useChatScrollHandler', () => {
 
     act(() => {
       result.current.scrollToBottom()
+    })
+
+    expect(scrollToBottom).toHaveBeenCalled()
+    expect(resetUserScroll).not.toHaveBeenCalled()
+  })
+
+  it('should call both scrollToBottom and resetUserScroll when scrollToBottomAndActivate is called', () => {
+    const mockChatInstance = createMockChatInstance()
+    const mockUseChat = createMockUseChat(mockChatInstance)
+    const { mockHook, scrollToBottom, resetUserScroll } = createMockUseAutoScroll()
+
+    hydrateStore({
+      chatInstance: mockChatInstance,
+      chatThread: null,
+      id: 'thread-1',
+      mcpClients: [],
+      models: [],
+      selectedModel: null,
+      triggerData: null,
+    })
+
+    const { result } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
+      wrapper: createQueryTestWrapper(),
+    })
+
+    act(() => {
+      result.current.scrollToBottomAndActivate()
     })
 
     expect(scrollToBottom).toHaveBeenCalled()
@@ -188,12 +212,11 @@ describe('useChatScrollHandler', () => {
     const mockUseAutoScroll = ((options?: unknown) => {
       capturedOptions.push(options)
       return {
-        scrollContainerRef: { current: null },
-        scrollTargetRef: { current: null },
+        scrollContainerRef: () => {},
+        scrollTargetRef: () => {},
         scrollToBottom: mock(),
         resetUserScroll: mock(),
-        scrollHandlers: { onScroll: () => {}, onWheel: () => {}, onTouchStart: () => {} },
-        userHasScrolled: false,
+        scrollHandlers: { onWheel: () => {}, onTouchStart: () => {} },
         isAtBottom: true,
       }
     }) as unknown as typeof import('@/hooks/use-auto-scroll').useAutoScroll

--- a/src/chats/use-chat-scroll-handler.test.tsx
+++ b/src/chats/use-chat-scroll-handler.test.tsx
@@ -1,34 +1,25 @@
-import {
-  createMockChatInstance,
-  createMockUseChat,
-  getCurrentSession,
-  hydrateStore,
-  resetStore,
-} from '@/test-utils/chat-store-mocks'
+import { createMockChatInstance, createMockUseChat, hydrateStore, resetStore } from '@/test-utils/chat-store-mocks'
 import { createQueryTestWrapper } from '@/test-utils/react-query'
-import { getClock } from '@/testing-library'
-import type { ThunderboltUIMessage } from '@/types'
-import { type Chat } from '@ai-sdk/react'
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { useChatScrollHandler } from './use-chat-scroll-handler'
 
-// Mock useAutoScroll hook - returns stable mocks that can be accessed
 type MockUseAutoScrollReturn = {
   scrollToBottom: ReturnType<typeof mock>
   resetUserScroll: ReturnType<typeof mock>
   mockHook: typeof import('@/hooks/use-auto-scroll').useAutoScroll
 }
 
-const createMockUseAutoScroll = (
-  userHasScrolled: boolean = false,
-  isAtBottom: boolean = true,
-): MockUseAutoScrollReturn => {
+const createMockUseAutoScroll = (userHasScrolled: boolean = false): MockUseAutoScrollReturn => {
   const scrollToBottom = mock((_smooth?: boolean) => {})
   const resetUserScroll = mock(() => {})
   const scrollContainerRef = { current: null }
   const scrollTargetRef = { current: null }
-  const scrollHandlers = {}
+  const scrollHandlers = {
+    onScroll: () => {},
+    onWheel: () => {},
+    onTouchStart: () => {},
+  }
 
   const mockHook = ((_options?: {
     dependencies?: unknown[]
@@ -43,7 +34,7 @@ const createMockUseAutoScroll = (
     resetUserScroll,
     scrollHandlers,
     userHasScrolled,
-    isAtBottom,
+    isAtBottom: !userHasScrolled,
   })) as unknown as typeof import('@/hooks/use-auto-scroll').useAutoScroll
 
   return {
@@ -54,42 +45,13 @@ const createMockUseAutoScroll = (
 }
 
 describe('useChatScrollHandler', () => {
-  let originalRequestAnimationFrame: typeof requestAnimationFrame
-  let originalCancelAnimationFrame: typeof cancelAnimationFrame
-  let rafCallbacks: Array<() => void>
-  let rafIdCounter: number
-
   beforeEach(() => {
-    // Reset store state before each test
     resetStore()
-
-    // Mock requestAnimationFrame
-    rafCallbacks = []
-    rafIdCounter = 0
-    originalRequestAnimationFrame = global.requestAnimationFrame
-    originalCancelAnimationFrame = global.cancelAnimationFrame
-
-    global.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      rafCallbacks.push(() => {
-        callback(0)
-      })
-      return ++rafIdCounter
-    }) as typeof requestAnimationFrame
-
-    global.cancelAnimationFrame = mock((_id: number) => {
-      // Simple mock - just clear the callback
-    })
   })
 
   afterEach(() => {
-    // Cleanup rendered components before resetting store to prevent errors during unmount
     cleanup()
-    // Reset store state after each test
     resetStore()
-
-    // Restore original functions
-    global.requestAnimationFrame = originalRequestAnimationFrame
-    global.cancelAnimationFrame = originalCancelAnimationFrame
   })
 
   it('should return all required refs and handlers', () => {
@@ -111,6 +73,7 @@ describe('useChatScrollHandler', () => {
       wrapper: createQueryTestWrapper(),
     })
 
+    expect(result.current).toHaveProperty('isAtBottom')
     expect(result.current).toHaveProperty('resetUserScroll')
     expect(result.current).toHaveProperty('scrollContainerRef')
     expect(result.current).toHaveProperty('scrollHandlers')
@@ -120,57 +83,10 @@ describe('useChatScrollHandler', () => {
     expect(typeof result.current.resetUserScroll).toBe('function')
   })
 
-  it('should scroll to bottom and reset user scroll when new message is added', async () => {
-    const messages: ThunderboltUIMessage[] = [
-      {
-        id: 'msg-1',
-        role: 'user',
-        parts: [{ type: 'text', text: 'Hello' }],
-      },
-    ]
-    const mockChatInstance = createMockChatInstance(messages, 'ready')
-    // Create a mock that reads from the store dynamically
-    const mockUseChat = ((options?: { chat?: Chat<ThunderboltUIMessage> }) => {
-      const session = getCurrentSession()
-      const chat = options?.chat ?? session?.chatInstance
-      if (!chat) {
-        return {
-          id: 'test-chat-id',
-          status: 'ready' as const,
-          messages: [],
-          error: undefined,
-          isLoading: false,
-          reload: mock(),
-          stop: mock(),
-          append: mock(),
-          setMessages: mock(),
-          setData: mock(),
-          sendMessage: mock(),
-          regenerate: mock(),
-          resumeStream: mock(),
-          addToolResult: mock(),
-          clearError: mock(),
-        }
-      }
-      return {
-        id: chat.id,
-        status: chat.status,
-        messages: chat.messages,
-        error: undefined,
-        isLoading: false,
-        reload: mock(),
-        stop: chat.stop,
-        append: mock(),
-        setMessages: mock(),
-        setData: mock(),
-        sendMessage: chat.sendMessage,
-        regenerate: chat.regenerate,
-        resumeStream: mock(),
-        addToolResult: mock(),
-        clearError: mock(),
-      }
-    }) as unknown as typeof import('@ai-sdk/react').useChat
-    const { mockHook, scrollToBottom, resetUserScroll } = createMockUseAutoScroll(false, true)
+  it('should return isAtBottom as true when user has not scrolled', () => {
+    const mockChatInstance = createMockChatInstance()
+    const mockUseChat = createMockUseChat(mockChatInstance)
+    const { mockHook } = createMockUseAutoScroll(false) // userHasScrolled = false
 
     hydrateStore({
       chatInstance: mockChatInstance,
@@ -182,32 +98,20 @@ describe('useChatScrollHandler', () => {
       triggerData: null,
     })
 
-    const { rerender } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
+    const { result } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
       wrapper: createQueryTestWrapper(),
     })
 
-    // Initial render - no new messages yet
-    await act(async () => {
-      await getClock().tickAsync(10)
-    })
+    expect(result.current.isAtBottom).toBe(true)
+  })
 
-    // Clear any initial calls
-    scrollToBottom.mockClear()
-    resetUserScroll.mockClear()
-
-    // Add a new message
-    const newMessages: ThunderboltUIMessage[] = [
-      ...messages,
-      {
-        id: 'msg-2',
-        role: 'assistant',
-        parts: [{ type: 'text', text: 'Hi there' }],
-      },
-    ]
-    const newMockChatInstance = createMockChatInstance(newMessages, 'ready')
+  it('should return isAtBottom as false when user has scrolled', () => {
+    const mockChatInstance = createMockChatInstance()
+    const mockUseChat = createMockUseChat(mockChatInstance)
+    const { mockHook } = createMockUseAutoScroll(true) // userHasScrolled = true
 
     hydrateStore({
-      chatInstance: newMockChatInstance,
+      chatInstance: mockChatInstance,
       chatThread: null,
       id: 'thread-1',
       mcpClients: [],
@@ -216,33 +120,44 @@ describe('useChatScrollHandler', () => {
       triggerData: null,
     })
 
-    rerender()
+    const { result } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
+      wrapper: createQueryTestWrapper(),
+    })
 
-    // Execute requestAnimationFrame callbacks
-    await act(async () => {
-      // Execute all pending RAF callbacks
-      for (const callback of rafCallbacks) {
-        callback()
-      }
-      rafCallbacks = []
-      await getClock().tickAsync(10)
+    expect(result.current.isAtBottom).toBe(false)
+  })
+
+  it('should call scrollToBottom and resetUserScroll when scrollToBottom is called', () => {
+    const mockChatInstance = createMockChatInstance()
+    const mockUseChat = createMockUseChat(mockChatInstance)
+    const { mockHook, scrollToBottom, resetUserScroll } = createMockUseAutoScroll()
+
+    hydrateStore({
+      chatInstance: mockChatInstance,
+      chatThread: null,
+      id: 'thread-1',
+      mcpClients: [],
+      models: [],
+      selectedModel: null,
+      triggerData: null,
+    })
+
+    const { result } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
+      wrapper: createQueryTestWrapper(),
+    })
+
+    act(() => {
+      result.current.scrollToBottom()
     })
 
     expect(scrollToBottom).toHaveBeenCalled()
     expect(resetUserScroll).toHaveBeenCalled()
   })
 
-  it('should continue scrolling during streaming if user has not scrolled', async () => {
-    const messages: ThunderboltUIMessage[] = [
-      {
-        id: 'msg-1',
-        role: 'assistant',
-        parts: [{ type: 'text', text: 'Streaming...' }],
-      },
-    ]
-    const mockChatInstance = createMockChatInstance(messages, 'streaming')
+  it('should pass smooth parameter to scrollToBottom', () => {
+    const mockChatInstance = createMockChatInstance()
     const mockUseChat = createMockUseChat(mockChatInstance)
-    const { mockHook, scrollToBottom } = createMockUseAutoScroll(false, true) // userHasScrolled = false
+    const { mockHook, scrollToBottom } = createMockUseAutoScroll()
 
     hydrateStore({
       chatInstance: mockChatInstance,
@@ -254,129 +169,34 @@ describe('useChatScrollHandler', () => {
       triggerData: null,
     })
 
-    renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
+    const { result } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
       wrapper: createQueryTestWrapper(),
     })
 
-    // Execute requestAnimationFrame callbacks
-    await act(async () => {
-      // Execute all pending RAF callbacks
-      for (const callback of rafCallbacks) {
-        callback()
-      }
-      rafCallbacks = []
-      await getClock().tickAsync(10)
+    act(() => {
+      result.current.scrollToBottom(false)
     })
 
-    expect(scrollToBottom).toHaveBeenCalled()
+    expect(scrollToBottom).toHaveBeenCalledWith(false)
   })
 
-  it('should not scroll during streaming if user has scrolled away', async () => {
-    const messages: ThunderboltUIMessage[] = [
-      {
-        id: 'msg-1',
-        role: 'assistant',
-        parts: [{ type: 'text', text: 'Streaming...' }],
-      },
-    ]
-    const mockChatInstance = createMockChatInstance(messages, 'streaming')
+  it('should pass correct options to useAutoScroll', () => {
+    const mockChatInstance = createMockChatInstance([], 'streaming')
     const mockUseChat = createMockUseChat(mockChatInstance)
-    const { mockHook, scrollToBottom } = createMockUseAutoScroll(true, false) // userHasScrolled = true
+    const capturedOptions: unknown[] = []
 
-    hydrateStore({
-      chatInstance: mockChatInstance,
-      chatThread: null,
-      id: 'thread-1',
-      mcpClients: [],
-      models: [],
-      selectedModel: null,
-      triggerData: null,
-    })
-
-    renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
-      wrapper: createQueryTestWrapper(),
-    })
-
-    // Wait for initial effects to run (hasMessages effect will trigger)
-    await act(async () => {
-      // Execute all pending RAF callbacks from initial render
-      for (const callback of rafCallbacks) {
-        callback()
-      }
-      rafCallbacks = []
-      // Execute nested RAF from hasMessages effect
-      for (const callback of rafCallbacks) {
-        callback()
-      }
-      rafCallbacks = []
-      await getClock().tickAsync(10)
-    })
-
-    // Clear any initial calls from hasMessages effect
-    scrollToBottom.mockClear()
-
-    // Simulate streaming update with same message count (no new messages)
-    // The first effect should not trigger scroll because message count hasn't increased
-    // and userHasScrolled is true
-    await act(async () => {
-      // Execute any pending RAF callbacks
-      for (const callback of rafCallbacks) {
-        callback()
-      }
-      rafCallbacks = []
-      await getClock().tickAsync(10)
-    })
-
-    // Should not scroll if user has scrolled away and no new messages added
-    // Note: The hasMessages effect may still trigger, but the main scrolling effect should not
-    // This test verifies the hook doesn't crash and handles the userHasScrolled state
-    expect(true).toBe(true)
-  })
-
-  it('should scroll to bottom when hasMessages becomes true', async () => {
-    const mockChatInstance = createMockChatInstance([], 'ready')
-    // Create a mock that reads from the store dynamically
-    const mockUseChat = ((options?: { chat?: Chat<ThunderboltUIMessage> }) => {
-      const session = getCurrentSession()
-      const chat = options?.chat ?? session?.chatInstance
-      if (!chat) {
-        return {
-          id: 'test-chat-id',
-          status: 'ready' as const,
-          messages: [],
-          error: undefined,
-          isLoading: false,
-          reload: mock(),
-          stop: mock(),
-          append: mock(),
-          setMessages: mock(),
-          setData: mock(),
-          sendMessage: mock(),
-          regenerate: mock(),
-          resumeStream: mock(),
-          addToolResult: mock(),
-          clearError: mock(),
-        }
-      }
+    const mockUseAutoScroll = ((options?: unknown) => {
+      capturedOptions.push(options)
       return {
-        id: chat.id,
-        status: chat.status,
-        messages: chat.messages,
-        error: undefined,
-        isLoading: false,
-        reload: mock(),
-        stop: chat.stop,
-        append: mock(),
-        setMessages: mock(),
-        setData: mock(),
-        sendMessage: chat.sendMessage,
-        regenerate: chat.regenerate,
-        resumeStream: mock(),
-        addToolResult: mock(),
-        clearError: mock(),
+        scrollContainerRef: { current: null },
+        scrollTargetRef: { current: null },
+        scrollToBottom: mock(),
+        resetUserScroll: mock(),
+        scrollHandlers: { onScroll: () => {}, onWheel: () => {}, onTouchStart: () => {} },
+        userHasScrolled: false,
+        isAtBottom: true,
       }
-    }) as unknown as typeof import('@ai-sdk/react').useChat
-    const { mockHook, scrollToBottom } = createMockUseAutoScroll()
+    }) as unknown as typeof import('@/hooks/use-auto-scroll').useAutoScroll
 
     hydrateStore({
       chatInstance: mockChatInstance,
@@ -388,129 +208,15 @@ describe('useChatScrollHandler', () => {
       triggerData: null,
     })
 
-    // Initial render with no messages
-    const { rerender } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
+    renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockUseAutoScroll }), {
       wrapper: createQueryTestWrapper(),
     })
 
-    await act(async () => {
-      await getClock().tickAsync(10)
-    })
-
-    // Clear any initial calls
-    scrollToBottom.mockClear()
-
-    // Add messages - this should trigger hasMessages effect
-    const messages: ThunderboltUIMessage[] = [
-      {
-        id: 'msg-1',
-        role: 'user',
-        parts: [{ type: 'text', text: 'Hello' }],
-      },
-    ]
-    const newMockChatInstance = createMockChatInstance(messages, 'ready')
-
-    hydrateStore({
-      chatInstance: newMockChatInstance,
-      chatThread: null,
-      id: 'thread-1',
-      mcpClients: [],
-      models: [],
-      selectedModel: null,
-      triggerData: null,
-    })
-
-    rerender()
-
-    // Execute requestAnimationFrame callbacks (double RAF for hasMessages effect)
-    await act(async () => {
-      // The hasMessages effect uses nested RAF, so we need to execute them in order
-      // First RAF
-      if (rafCallbacks.length > 0) {
-        const firstRaf = rafCallbacks.shift()!
-        firstRaf()
-      }
-      // Second RAF (nested)
-      if (rafCallbacks.length > 0) {
-        const secondRaf = rafCallbacks.shift()!
-        secondRaf()
-      }
-      await getClock().tickAsync(10)
-    })
-
-    // The hasMessages effect should trigger scrollToBottom
-    // Note: This test verifies the effect runs, but the exact timing depends on RAF execution
-    expect(scrollToBottom).toHaveBeenCalled()
-  })
-
-  it('should not scroll when message count decreases', async () => {
-    const messages: ThunderboltUIMessage[] = [
-      {
-        id: 'msg-1',
-        role: 'user',
-        parts: [{ type: 'text', text: 'Hello' }],
-      },
-      {
-        id: 'msg-2',
-        role: 'assistant',
-        parts: [{ type: 'text', text: 'Hi' }],
-      },
-    ]
-    const mockChatInstance = createMockChatInstance(messages, 'ready')
-    const mockUseChat = createMockUseChat(mockChatInstance)
-    const { mockHook, scrollToBottom } = createMockUseAutoScroll()
-
-    hydrateStore({
-      chatInstance: mockChatInstance,
-      chatThread: null,
-      id: 'thread-1',
-      mcpClients: [],
-      models: [],
-      selectedModel: null,
-      triggerData: null,
-    })
-
-    const { rerender } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
-      wrapper: createQueryTestWrapper(),
-    })
-
-    // Initial render
-    await act(async () => {
-      await getClock().tickAsync(10)
-    })
-
-    // Clear any initial calls from hasMessages effect
-    scrollToBottom.mockClear()
-
-    // Remove a message (decrease count)
-    const fewerMessages: ThunderboltUIMessage[] = [messages[0]]
-    const newMockChatInstance = createMockChatInstance(fewerMessages, 'ready')
-
-    hydrateStore({
-      chatInstance: newMockChatInstance,
-      chatThread: null,
-      id: 'thread-1',
-      mcpClients: [],
-      models: [],
-      selectedModel: null,
-      triggerData: null,
-    })
-
-    rerender()
-
-    // Execute requestAnimationFrame callbacks
-    await act(async () => {
-      for (const callback of rafCallbacks) {
-        callback()
-      }
-      rafCallbacks = []
-      await getClock().tickAsync(10)
-    })
-
-    // Should not scroll when message count decreases (but hasMessages effect may still trigger)
-    // The key is that the first effect (message count change) should not trigger scroll
-    // We can't easily test this in isolation, but the test verifies the hook doesn't crash
-    expect(true).toBe(true)
+    expect(capturedOptions.length).toBeGreaterThan(0)
+    const options = capturedOptions[0] as { dependencies?: unknown[]; smooth?: boolean; isStreaming?: boolean }
+    expect(options.smooth).toBe(true)
+    expect(options.isStreaming).toBe(true)
+    expect(options.dependencies).toBeDefined()
   })
 
   it('should work with dependency injection for useChat and useAutoScroll', () => {
@@ -532,60 +238,9 @@ describe('useChatScrollHandler', () => {
       wrapper: createQueryTestWrapper(),
     })
 
-    // Hook should execute without errors and return all required properties
     expect(result.current).toBeDefined()
     expect(result.current.scrollContainerRef).toBeDefined()
     expect(result.current.scrollTargetRef).toBeDefined()
     expect(result.current.scrollHandlers).toBeDefined()
-  })
-
-  it('should pass correct options to useAutoScroll', () => {
-    const messages: ThunderboltUIMessage[] = [
-      {
-        id: 'msg-1',
-        role: 'assistant',
-        parts: [{ type: 'text', text: 'Streaming...' }],
-      },
-    ]
-    const mockChatInstance = createMockChatInstance(messages, 'streaming')
-    const mockUseChat = createMockUseChat(mockChatInstance)
-    const mockUseAutoScroll = mock(
-      (_options?: {
-        dependencies?: unknown[]
-        smooth?: boolean
-        isStreaming?: boolean
-        onUserScroll?: (isAtBottom: boolean) => void
-        rootMargin?: string
-      }) => ({
-        scrollContainerRef: { current: null },
-        scrollTargetRef: { current: null },
-        scrollToBottom: mock(),
-        resetUserScroll: mock(),
-        scrollHandlers: {},
-        userHasScrolled: false,
-        isAtBottom: true,
-      }),
-    ) as unknown as typeof import('@/hooks/use-auto-scroll').useAutoScroll
-
-    hydrateStore({
-      chatInstance: mockChatInstance,
-      chatThread: null,
-      id: 'thread-1',
-      mcpClients: [],
-      models: [],
-      selectedModel: null,
-      triggerData: null,
-    })
-
-    renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockUseAutoScroll }), {
-      wrapper: createQueryTestWrapper(),
-    })
-
-    expect(mockUseAutoScroll).toHaveBeenCalledWith({
-      dependencies: [],
-      smooth: true,
-      isStreaming: true,
-      rootMargin: '0px 0px -50px 0px',
-    })
   })
 })

--- a/src/chats/use-chat-scroll-handler.test.tsx
+++ b/src/chats/use-chat-scroll-handler.test.tsx
@@ -10,8 +10,11 @@ type MockUseAutoScrollReturn = {
   mockHook: typeof import('@/hooks/use-auto-scroll').useAutoScroll
 }
 
-const createMockUseAutoScroll = (isAtBottom: boolean = true): MockUseAutoScrollReturn => {
-  const scrollToBottom = mock((_smooth?: boolean) => {})
+const createMockUseAutoScroll = (
+  isAtBottom: boolean = true,
+  scrollSucceeds: boolean = true,
+): MockUseAutoScrollReturn => {
+  const scrollToBottom = mock((_smooth?: boolean) => scrollSucceeds)
   const resetUserScroll = mock(() => {})
   const scrollContainerRef = () => {}
   const scrollTargetRef = () => {}
@@ -151,10 +154,10 @@ describe('useChatScrollHandler', () => {
     expect(resetUserScroll).not.toHaveBeenCalled()
   })
 
-  it('should call both scrollToBottom and resetUserScroll when scrollToBottomAndActivate is called', () => {
+  it('should call both scrollToBottom and resetUserScroll when scrollToBottomAndActivate succeeds', () => {
     const mockChatInstance = createMockChatInstance()
     const mockUseChat = createMockUseChat(mockChatInstance)
-    const { mockHook, scrollToBottom, resetUserScroll } = createMockUseAutoScroll()
+    const { mockHook, scrollToBottom, resetUserScroll } = createMockUseAutoScroll(true, true)
 
     hydrateStore({
       chatInstance: mockChatInstance,
@@ -176,6 +179,33 @@ describe('useChatScrollHandler', () => {
 
     expect(scrollToBottom).toHaveBeenCalled()
     expect(resetUserScroll).toHaveBeenCalled()
+  })
+
+  it('should not call resetUserScroll when scrollToBottomAndActivate fails (container not ready)', () => {
+    const mockChatInstance = createMockChatInstance()
+    const mockUseChat = createMockUseChat(mockChatInstance)
+    const { mockHook, scrollToBottom, resetUserScroll } = createMockUseAutoScroll(true, false)
+
+    hydrateStore({
+      chatInstance: mockChatInstance,
+      chatThread: null,
+      id: 'thread-1',
+      mcpClients: [],
+      models: [],
+      selectedModel: null,
+      triggerData: null,
+    })
+
+    const { result } = renderHook(() => useChatScrollHandler({ useChat: mockUseChat, useAutoScroll: mockHook }), {
+      wrapper: createQueryTestWrapper(),
+    })
+
+    act(() => {
+      result.current.scrollToBottomAndActivate()
+    })
+
+    expect(scrollToBottom).toHaveBeenCalled()
+    expect(resetUserScroll).not.toHaveBeenCalled()
   })
 
   it('should pass smooth parameter to scrollToBottom', () => {

--- a/src/chats/use-chat-scroll-handler.ts
+++ b/src/chats/use-chat-scroll-handler.ts
@@ -16,27 +16,34 @@ export const useChatScrollHandler = ({
   const { status, messages } = useChat({ chat: chatInstance })
   const isStreaming = status === 'streaming'
 
-  const { scrollContainerRef, scrollTargetRef, scrollToBottom, resetUserScroll, scrollHandlers, userHasScrolled } =
-    useAutoScroll({
-      dependencies: [messages],
-      smooth: true,
-      isStreaming,
-    })
+  const {
+    scrollContainerRef,
+    scrollTargetRef,
+    scrollToBottom: rawScrollToBottom,
+    resetUserScroll,
+    scrollHandlers,
+    isAtBottom,
+  } = useAutoScroll({
+    dependencies: [messages],
+    smooth: true,
+    isStreaming,
+    rootMargin: '0px 0px 20px 0px',
+  })
 
-  const handleScrollToBottom = useCallback(
+  const scrollToBottomAndActivate = useCallback(
     (smooth?: boolean) => {
-      scrollToBottom(smooth)
+      rawScrollToBottom(smooth)
       resetUserScroll()
     },
-    [scrollToBottom, resetUserScroll],
+    [rawScrollToBottom, resetUserScroll],
   )
 
   return {
-    isAtBottom: !userHasScrolled,
-    resetUserScroll,
+    isAtBottom,
     scrollContainerRef,
     scrollHandlers,
     scrollTargetRef,
-    scrollToBottom: handleScrollToBottom,
+    scrollToBottom: rawScrollToBottom,
+    scrollToBottomAndActivate,
   }
 }

--- a/src/chats/use-chat-scroll-handler.ts
+++ b/src/chats/use-chat-scroll-handler.ts
@@ -1,5 +1,5 @@
 import { useAutoScroll as useAutoScroll_default } from '@/hooks/use-auto-scroll'
-import { useEffect, useRef } from 'react'
+import { useCallback } from 'react'
 import { useCurrentChatSession } from './chat-store'
 import { useChat as useChat_default } from '@ai-sdk/react'
 
@@ -13,67 +13,30 @@ export const useChatScrollHandler = ({
   useChat = useChat_default,
 }: UseChatScrollHandlerProps = {}) => {
   const { chatInstance } = useCurrentChatSession()
-
   const { status, messages } = useChat({ chat: chatInstance })
-
-  const hasMessages = messages.length
-
   const isStreaming = status === 'streaming'
 
-  const {
-    scrollContainerRef,
-    scrollTargetRef,
-    scrollToBottom,
-    resetUserScroll,
-    scrollHandlers,
-    userHasScrolled,
-    isAtBottom,
-  } = useAutoScroll({
-    dependencies: [],
-    smooth: true,
-    isStreaming,
-    rootMargin: '0px 0px -50px 0px', // 50px threshold from bottom
-  })
-
-  const previousMessageCountRef = useRef(messages.length)
-
-  useEffect(() => {
-    const currentMessageCount = messages.length
-    const previousMessageCount = previousMessageCountRef.current
-
-    // Scroll to bottom when a new message is added
-    if (currentMessageCount > previousMessageCount) {
-      requestAnimationFrame(() => {
-        scrollToBottom()
-        resetUserScroll() // Reset user scroll when new message starts
-      })
-    } else if (isStreaming && !userHasScrolled) {
-      // Continue scrolling during streaming as long as the user hasn't manually scrolled away
-      requestAnimationFrame(() => {
-        scrollToBottom()
-      })
-    }
-
-    previousMessageCountRef.current = currentMessageCount
-  }, [scrollToBottom, resetUserScroll, userHasScrolled, isAtBottom, messages, isStreaming])
-
-  useEffect(() => {
-    if (!hasMessages) return
-
-    let frame = requestAnimationFrame(() => {
-      frame = requestAnimationFrame(() => {
-        scrollToBottom(false)
-      })
+  const { scrollContainerRef, scrollTargetRef, scrollToBottom, resetUserScroll, scrollHandlers, userHasScrolled } =
+    useAutoScroll({
+      dependencies: [messages],
+      smooth: true,
+      isStreaming,
     })
 
-    return () => cancelAnimationFrame(frame)
-  }, [hasMessages, scrollToBottom])
+  const handleScrollToBottom = useCallback(
+    (smooth?: boolean) => {
+      scrollToBottom(smooth)
+      resetUserScroll()
+    },
+    [scrollToBottom, resetUserScroll],
+  )
 
   return {
+    isAtBottom: !userHasScrolled,
     resetUserScroll,
     scrollContainerRef,
     scrollHandlers,
     scrollTargetRef,
-    scrollToBottom,
+    scrollToBottom: handleScrollToBottom,
   }
 }

--- a/src/chats/use-chat-scroll-handler.ts
+++ b/src/chats/use-chat-scroll-handler.ts
@@ -32,8 +32,10 @@ export const useChatScrollHandler = ({
 
   const scrollToBottomAndActivate = useCallback(
     (smooth?: boolean) => {
-      rawScrollToBottom(smooth)
-      resetUserScroll()
+      const scrolled = rawScrollToBottom(smooth)
+      if (scrolled) {
+        resetUserScroll()
+      }
     },
     [rawScrollToBottom, resetUserScroll],
   )

--- a/src/components/chat/chat-prompt-input.test.tsx
+++ b/src/components/chat/chat-prompt-input.test.tsx
@@ -95,17 +95,11 @@ describe('ChatPromptInput', () => {
         triggerData: null,
       })
 
-      const handleResetUserScroll = mock()
       const mockUseSidebar = createMockUseSidebar()
 
-      const { container } = render(
-        <ChatPromptInput
-          handleResetUserScroll={handleResetUserScroll}
-          useChat={mockUseChat}
-          useSidebar={mockUseSidebar}
-        />,
-        { wrapper: TestWrapper },
-      )
+      const { container } = render(<ChatPromptInput useChat={mockUseChat} useSidebar={mockUseSidebar} />, {
+        wrapper: TestWrapper,
+      })
 
       expect(container).toBeInTheDocument()
     })
@@ -127,17 +121,9 @@ describe('ChatPromptInput', () => {
         triggerData: null,
       })
 
-      const handleResetUserScroll = mock()
       const mockUseSidebar = createMockUseSidebar()
 
-      render(
-        <ChatPromptInput
-          handleResetUserScroll={handleResetUserScroll}
-          useChat={mockUseChat}
-          useSidebar={mockUseSidebar}
-        />,
-        { wrapper: TestWrapper },
-      )
+      render(<ChatPromptInput useChat={mockUseChat} useSidebar={mockUseSidebar} />, { wrapper: TestWrapper })
 
       // Verify textarea is rendered
       const textarea = screen.getByPlaceholderText('Ask me anything...')
@@ -162,12 +148,10 @@ describe('ChatPromptInput', () => {
         triggerData: null,
       })
 
-      const handleResetUserScroll = mock()
       const mockUseSidebar = createMockUseSidebar()
 
       render(
         <ChatPromptInput
-          handleResetUserScroll={handleResetUserScroll}
           useChat={mockUseChat}
           useContextTracking={mockUseContextTracking}
           useSidebar={mockUseSidebar}
@@ -196,19 +180,10 @@ describe('ChatPromptInput', () => {
         triggerData: null,
       })
 
-      const handleResetUserScroll = mock()
       const mockUseSidebar = createMockUseSidebar()
       const ref = { current: null } as unknown as React.RefObject<ChatPromptInputRef>
 
-      render(
-        <ChatPromptInput
-          ref={ref}
-          handleResetUserScroll={handleResetUserScroll}
-          useChat={mockUseChat}
-          useSidebar={mockUseSidebar}
-        />,
-        { wrapper: TestWrapper },
-      )
+      render(<ChatPromptInput ref={ref} useChat={mockUseChat} useSidebar={mockUseSidebar} />, { wrapper: TestWrapper })
 
       expect(ref.current).not.toBeNull()
       expect(typeof ref.current?.focus).toBe('function')
@@ -243,19 +218,10 @@ describe('ChatPromptInput', () => {
         triggerData: null,
       })
 
-      const handleResetUserScroll = mock()
       const mockUseSidebar = createMockUseSidebar()
       const ref = { current: null } as unknown as React.RefObject<ChatPromptInputRef>
 
-      render(
-        <ChatPromptInput
-          ref={ref}
-          handleResetUserScroll={handleResetUserScroll}
-          useChat={mockUseChat}
-          useSidebar={mockUseSidebar}
-        />,
-        { wrapper: TestWrapper },
-      )
+      render(<ChatPromptInput ref={ref} useChat={mockUseChat} useSidebar={mockUseSidebar} />, { wrapper: TestWrapper })
 
       expect(ref.current).not.toBeNull()
       expect(typeof ref.current?.setInput).toBe('function')
@@ -285,17 +251,11 @@ describe('ChatPromptInput', () => {
         triggerData: null,
       })
 
-      const handleResetUserScroll = mock()
       const mockUseSidebar = createMockUseSidebar()
 
-      const { container } = render(
-        <ChatPromptInput
-          handleResetUserScroll={handleResetUserScroll}
-          useChat={mockUseChat}
-          useSidebar={mockUseSidebar}
-        />,
-        { wrapper: TestWrapper },
-      )
+      const { container } = render(<ChatPromptInput useChat={mockUseChat} useSidebar={mockUseSidebar} />, {
+        wrapper: TestWrapper,
+      })
 
       expect(container).toBeInTheDocument()
     })
@@ -316,12 +276,10 @@ describe('ChatPromptInput', () => {
         triggerData: null,
       })
 
-      const handleResetUserScroll = mock()
       const mockUseSidebar = createMockUseSidebar()
 
       const { container } = render(
         <ChatPromptInput
-          handleResetUserScroll={handleResetUserScroll}
           useChat={mockUseChat}
           useContextTracking={mockUseContextTracking}
           useSidebar={mockUseSidebar}
@@ -347,17 +305,11 @@ describe('ChatPromptInput', () => {
         triggerData: null,
       })
 
-      const handleResetUserScroll = mock()
       const mockUseSidebar = createMockUseSidebar(false, false)
 
-      const { container } = render(
-        <ChatPromptInput
-          handleResetUserScroll={handleResetUserScroll}
-          useChat={mockUseChat}
-          useSidebar={mockUseSidebar}
-        />,
-        { wrapper: TestWrapper },
-      )
+      const { container } = render(<ChatPromptInput useChat={mockUseChat} useSidebar={mockUseSidebar} />, {
+        wrapper: TestWrapper,
+      })
 
       expect(container).toBeInTheDocument()
     })

--- a/src/components/chat/chat-prompt-input.test.tsx
+++ b/src/components/chat/chat-prompt-input.test.tsx
@@ -96,13 +96,11 @@ describe('ChatPromptInput', () => {
       })
 
       const handleResetUserScroll = mock()
-      const handleScrollToBottom = mock()
       const mockUseSidebar = createMockUseSidebar()
 
       const { container } = render(
         <ChatPromptInput
           handleResetUserScroll={handleResetUserScroll}
-          handleScrollToBottom={handleScrollToBottom}
           useChat={mockUseChat}
           useSidebar={mockUseSidebar}
         />,
@@ -130,13 +128,11 @@ describe('ChatPromptInput', () => {
       })
 
       const handleResetUserScroll = mock()
-      const handleScrollToBottom = mock()
       const mockUseSidebar = createMockUseSidebar()
 
       render(
         <ChatPromptInput
           handleResetUserScroll={handleResetUserScroll}
-          handleScrollToBottom={handleScrollToBottom}
           useChat={mockUseChat}
           useSidebar={mockUseSidebar}
         />,
@@ -167,13 +163,11 @@ describe('ChatPromptInput', () => {
       })
 
       const handleResetUserScroll = mock()
-      const handleScrollToBottom = mock()
       const mockUseSidebar = createMockUseSidebar()
 
       render(
         <ChatPromptInput
           handleResetUserScroll={handleResetUserScroll}
-          handleScrollToBottom={handleScrollToBottom}
           useChat={mockUseChat}
           useContextTracking={mockUseContextTracking}
           useSidebar={mockUseSidebar}
@@ -203,7 +197,6 @@ describe('ChatPromptInput', () => {
       })
 
       const handleResetUserScroll = mock()
-      const handleScrollToBottom = mock()
       const mockUseSidebar = createMockUseSidebar()
       const ref = { current: null } as unknown as React.RefObject<ChatPromptInputRef>
 
@@ -211,7 +204,6 @@ describe('ChatPromptInput', () => {
         <ChatPromptInput
           ref={ref}
           handleResetUserScroll={handleResetUserScroll}
-          handleScrollToBottom={handleScrollToBottom}
           useChat={mockUseChat}
           useSidebar={mockUseSidebar}
         />,
@@ -252,7 +244,6 @@ describe('ChatPromptInput', () => {
       })
 
       const handleResetUserScroll = mock()
-      const handleScrollToBottom = mock()
       const mockUseSidebar = createMockUseSidebar()
       const ref = { current: null } as unknown as React.RefObject<ChatPromptInputRef>
 
@@ -260,7 +251,6 @@ describe('ChatPromptInput', () => {
         <ChatPromptInput
           ref={ref}
           handleResetUserScroll={handleResetUserScroll}
-          handleScrollToBottom={handleScrollToBottom}
           useChat={mockUseChat}
           useSidebar={mockUseSidebar}
         />,
@@ -296,13 +286,11 @@ describe('ChatPromptInput', () => {
       })
 
       const handleResetUserScroll = mock()
-      const handleScrollToBottom = mock()
       const mockUseSidebar = createMockUseSidebar()
 
       const { container } = render(
         <ChatPromptInput
           handleResetUserScroll={handleResetUserScroll}
-          handleScrollToBottom={handleScrollToBottom}
           useChat={mockUseChat}
           useSidebar={mockUseSidebar}
         />,
@@ -329,13 +317,11 @@ describe('ChatPromptInput', () => {
       })
 
       const handleResetUserScroll = mock()
-      const handleScrollToBottom = mock()
       const mockUseSidebar = createMockUseSidebar()
 
       const { container } = render(
         <ChatPromptInput
           handleResetUserScroll={handleResetUserScroll}
-          handleScrollToBottom={handleScrollToBottom}
           useChat={mockUseChat}
           useContextTracking={mockUseContextTracking}
           useSidebar={mockUseSidebar}
@@ -362,13 +348,11 @@ describe('ChatPromptInput', () => {
       })
 
       const handleResetUserScroll = mock()
-      const handleScrollToBottom = mock()
       const mockUseSidebar = createMockUseSidebar(false, false)
 
       const { container } = render(
         <ChatPromptInput
           handleResetUserScroll={handleResetUserScroll}
-          handleScrollToBottom={handleScrollToBottom}
           useChat={mockUseChat}
           useSidebar={mockUseSidebar}
         />,

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -16,7 +16,6 @@ export type ChatPromptInputRef = {
 }
 
 type ChatPromptInputProps = {
-  handleResetUserScroll(): void
   useNavigate?: typeof useNavigate_default
   useChat?: typeof useChat_default
   useContextTracking?: typeof useContextTracking_default
@@ -27,7 +26,6 @@ type ChatPromptInputProps = {
 export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputProps>(
   (
     {
-      handleResetUserScroll,
       useNavigate = useNavigate_default,
       useChat = useChat_default,
       useContextTracking = useContextTracking_default,
@@ -68,10 +66,6 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
 
         // Clear the input immediately for responsive UX
         setInput('')
-
-        // Reset user scroll state BEFORE sending - so the chat auto-scrolls for new messages
-        // Don't wait for sendMessage to complete - it resolves when streaming finishes
-        handleResetUserScroll()
 
         await sendMessage({ text: textToSend })
       } catch (error) {

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -17,7 +17,6 @@ export type ChatPromptInputRef = {
 
 type ChatPromptInputProps = {
   handleResetUserScroll(): void
-  handleScrollToBottom(): void
   useNavigate?: typeof useNavigate_default
   useChat?: typeof useChat_default
   useContextTracking?: typeof useContextTracking_default
@@ -29,7 +28,6 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
   (
     {
       handleResetUserScroll,
-      handleScrollToBottom,
       useNavigate = useNavigate_default,
       useChat = useChat_default,
       useContextTracking = useContextTracking_default,
@@ -71,13 +69,11 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
         // Clear the input immediately for responsive UX
         setInput('')
 
-        await sendMessage({ text: textToSend })
-
-        // Reset user scroll state and scroll to bottom when submitting a new message
+        // Reset user scroll state BEFORE sending - so the chat auto-scrolls for new messages
+        // Don't wait for sendMessage to complete - it resolves when streaming finishes
         handleResetUserScroll()
-        requestAnimationFrame(() => {
-          handleScrollToBottom()
-        })
+
+        await sendMessage({ text: textToSend })
       } catch (error) {
         console.error('Error submitting message:', error)
       }

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -9,6 +9,7 @@ import { ChatPromptInput, type ChatPromptInputRef } from './chat-prompt-input'
 import { useCurrentChatSession } from '@/chats/chat-store'
 import { useChat } from '@ai-sdk/react'
 import { useChatAutomation } from '@/chats/use-chat-automation'
+import { ScrollToBottomButton } from './scroll-to-bottom-button'
 
 export default function ChatUI() {
   const { chatInstance } = useCurrentChatSession()
@@ -19,7 +20,7 @@ export default function ChatUI() {
 
   const hasMessages = messages.length
 
-  const { resetUserScroll, scrollContainerRef, scrollHandlers, scrollTargetRef, scrollToBottom } =
+  const { isAtBottom, resetUserScroll, scrollContainerRef, scrollHandlers, scrollTargetRef, scrollToBottom } =
     useChatScrollHandler()
 
   const chatPromptInputRef = useRef<ChatPromptInputRef>(null)
@@ -44,17 +45,20 @@ export default function ChatUI() {
       >
         <AnimatePresence>
           {hasMessages && (
-            <motion.div
-              ref={scrollContainerRef}
-              {...scrollHandlers}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="flex-1 p-4 space-y-4 max-w-dvw hide-scrollbar overflow-y-auto"
-            >
-              <ChatMessages />
-              <div ref={scrollTargetRef} />
-            </motion.div>
+            <div className="relative flex-1 overflow-hidden">
+              <motion.div
+                ref={scrollContainerRef}
+                {...scrollHandlers}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="h-full p-4 space-y-4 max-w-dvw overflow-y-auto hide-scrollbar"
+              >
+                <ChatMessages />
+                <div ref={scrollTargetRef} />
+              </motion.div>
+              <ScrollToBottomButton isVisible={!isAtBottom} onClick={() => scrollToBottom()} className="bottom-2" />
+            </div>
           )}
         </AnimatePresence>
 
@@ -100,11 +104,7 @@ export default function ChatUI() {
                 duration: 0.25,
               }}
             >
-              <ChatPromptInput
-                handleResetUserScroll={resetUserScroll}
-                handleScrollToBottom={scrollToBottom}
-                ref={chatPromptInputRef}
-              />
+              <ChatPromptInput handleResetUserScroll={resetUserScroll} ref={chatPromptInputRef} />
             </motion.div>
           </motion.div>
         </motion.div>

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -1,7 +1,7 @@
 import { useIsMobile } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { SuggestionButtons } from './suggestion-buttons'
 import { useChatScrollHandler } from '@/chats/use-chat-scroll-handler'
 import { ChatMessages } from './chat-messages'
@@ -20,7 +20,7 @@ export default function ChatUI() {
 
   const hasMessages = messages.length
 
-  const { isAtBottom, resetUserScroll, scrollContainerRef, scrollHandlers, scrollTargetRef, scrollToBottom } =
+  const { isAtBottom, scrollContainerRef, scrollHandlers, scrollTargetRef, scrollToBottom, scrollToBottomAndActivate } =
     useChatScrollHandler()
 
   const chatPromptInputRef = useRef<ChatPromptInputRef>(null)
@@ -30,6 +30,20 @@ export default function ChatUI() {
     chatPromptInputRef.current?.setInput(prompt)
     chatPromptInputRef.current?.focus()
   }, [])
+
+  // Scroll to bottom instantly when entering an existing chat
+  // Effect re-runs when scrollToBottom changes (when container becomes available)
+  const hasScrolledInitially = useRef(false)
+  useEffect(() => {
+    if (hasMessages && !hasScrolledInitially.current) {
+      // scrollToBottom returns true if scroll was performed, false if container not ready
+      // Only mark as scrolled when it actually succeeds
+      const scrolled = scrollToBottom(false)
+      if (scrolled) {
+        hasScrolledInitially.current = true
+      }
+    }
+  }, [hasMessages, scrollToBottom])
 
   if (!isReady) {
     return null
@@ -57,7 +71,11 @@ export default function ChatUI() {
                 <ChatMessages />
                 <div ref={scrollTargetRef} />
               </motion.div>
-              <ScrollToBottomButton isVisible={!isAtBottom} onClick={() => scrollToBottom()} className="bottom-2" />
+              <ScrollToBottomButton
+                isVisible={!isAtBottom}
+                onClick={() => scrollToBottomAndActivate(true)}
+                className="bottom-2"
+              />
             </div>
           )}
         </AnimatePresence>
@@ -104,7 +122,7 @@ export default function ChatUI() {
                 duration: 0.25,
               }}
             >
-              <ChatPromptInput handleResetUserScroll={resetUserScroll} ref={chatPromptInputRef} />
+              <ChatPromptInput ref={chatPromptInputRef} />
             </motion.div>
           </motion.div>
         </motion.div>

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -50,7 +50,7 @@ export default function ChatUI() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="flex-1 p-4 space-y-4 max-w-dvw hide-scrollbar"
+              className="flex-1 p-4 space-y-4 max-w-dvw hide-scrollbar overflow-y-auto"
             >
               <ChatMessages />
               <div ref={scrollTargetRef} />

--- a/src/components/chat/reasoning-display.tsx
+++ b/src/components/chat/reasoning-display.tsx
@@ -99,9 +99,7 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
             exit={{ opacity: 0, y: -10 }}
             transition={{ duration: 0.3 }}
             className="relative text-muted-foreground leading-relaxed text-sm"
-            ref={(el) => {
-              scrollContainerRef.current = el
-            }}
+            ref={scrollContainerRef}
           >
             <div className="absolute top-0 w-full h-6 bg-gradient-to-b from-background to-transparent" />
             <div className="max-h-[200px] px-4 hide-scrollbar py-3">

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -61,12 +61,7 @@ export const ReasoningGroup = ({
         defaultOpen={false}
         title={<ReasoningGroupTitle totalDuration={totalDuration} isGroupReasoning={isGroupReasoning} tools={tools} />}
       >
-        <div
-          className="max-h-[200px] overflow-y-auto"
-          ref={(el) => {
-            scrollContainerRef.current = el
-          }}
-        >
+        <div className="max-h-[200px] overflow-y-auto" ref={scrollContainerRef}>
           {parts.map((part, index) => {
             return (
               <ReasoningItem

--- a/src/components/chat/scroll-to-bottom-button.test.tsx
+++ b/src/components/chat/scroll-to-bottom-button.test.tsx
@@ -1,0 +1,100 @@
+import { getClock } from '@/testing-library'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { ScrollToBottomButton } from './scroll-to-bottom-button'
+
+describe('ScrollToBottomButton', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  describe('visibility', () => {
+    it('should render button when isVisible is true', async () => {
+      const onClick = mock()
+
+      render(<ScrollToBottomButton isVisible={true} onClick={onClick} />)
+
+      // Wait for animation to complete
+      await act(async () => {
+        await getClock().tickAsync(300)
+      })
+
+      const button = screen.getByRole('button', { name: 'Scroll to bottom' })
+      expect(button).toBeInTheDocument()
+    })
+
+    it('should not render button when isVisible is false', () => {
+      const onClick = mock()
+
+      render(<ScrollToBottomButton isVisible={false} onClick={onClick} />)
+
+      const button = screen.queryByRole('button', { name: 'Scroll to bottom' })
+      expect(button).toBeNull()
+    })
+  })
+
+  describe('interaction', () => {
+    it('should call onClick when button is clicked', async () => {
+      const onClick = mock()
+
+      render(<ScrollToBottomButton isVisible={true} onClick={onClick} />)
+
+      // Wait for animation to complete
+      await act(async () => {
+        await getClock().tickAsync(300)
+      })
+
+      const button = screen.getByRole('button', { name: 'Scroll to bottom' })
+      fireEvent.click(button)
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('styling', () => {
+    it('should apply custom className', async () => {
+      const onClick = mock()
+
+      render(<ScrollToBottomButton isVisible={true} onClick={onClick} className="custom-class" />)
+
+      await act(async () => {
+        await getClock().tickAsync(300)
+      })
+
+      // The className is applied to the motion.div wrapper, not the button
+      // We can verify the button exists and has proper styling
+      const button = screen.getByRole('button', { name: 'Scroll to bottom' })
+      expect(button).toBeInTheDocument()
+      expect(button.className).toContain('rounded-full')
+    })
+
+    it('should have proper accessibility label', async () => {
+      const onClick = mock()
+
+      render(<ScrollToBottomButton isVisible={true} onClick={onClick} />)
+
+      await act(async () => {
+        await getClock().tickAsync(300)
+      })
+
+      const button = screen.getByRole('button', { name: 'Scroll to bottom' })
+      expect(button).toHaveAttribute('aria-label', 'Scroll to bottom')
+    })
+  })
+
+  describe('icon', () => {
+    it('should render chevron-down icon', async () => {
+      const onClick = mock()
+
+      render(<ScrollToBottomButton isVisible={true} onClick={onClick} />)
+
+      await act(async () => {
+        await getClock().tickAsync(300)
+      })
+
+      const button = screen.getByRole('button', { name: 'Scroll to bottom' })
+      const svg = button.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/chat/scroll-to-bottom-button.tsx
+++ b/src/components/chat/scroll-to-bottom-button.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { AnimatePresence, motion } from 'framer-motion'
+import { ChevronDown } from 'lucide-react'
+
+type ScrollToBottomButtonProps = {
+  isVisible: boolean
+  onClick: () => void
+  className?: string
+}
+
+export const ScrollToBottomButton = ({ isVisible, onClick, className }: ScrollToBottomButtonProps) => (
+  <AnimatePresence>
+    {isVisible && (
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 10 }}
+        transition={{ duration: 0.2 }}
+        className={cn('absolute bottom-0 left-1/2 -translate-x-1/2 z-10', className)}
+      >
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-full bg-background shadow-md size-8"
+          onClick={onClick}
+          aria-label="Scroll to bottom"
+        >
+          <ChevronDown className="size-4" />
+        </Button>
+      </motion.div>
+    )}
+  </AnimatePresence>
+)

--- a/src/components/chat/scroll-to-bottom-button.tsx
+++ b/src/components/chat/scroll-to-bottom-button.tsx
@@ -22,7 +22,7 @@ export const ScrollToBottomButton = ({ isVisible, onClick, className }: ScrollTo
         <Button
           variant="outline"
           size="icon"
-          className="rounded-full bg-background shadow-md size-8"
+          className="rounded-full bg-background/80 backdrop-blur-sm shadow-md size-8"
           onClick={onClick}
           aria-label="Scroll to bottom"
         >

--- a/src/hooks/use-auto-scroll.test.tsx
+++ b/src/hooks/use-auto-scroll.test.tsx
@@ -1,0 +1,244 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { useAutoScroll } from './use-auto-scroll'
+
+describe('useAutoScroll', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  const createMockContainer = (scrollTop = 0, scrollHeight = 1000, clientHeight = 500) => {
+    let _scrollTop = scrollTop
+    const div = document.createElement('div')
+    Object.defineProperties(div, {
+      scrollTop: {
+        get: () => _scrollTop,
+        set: (val) => {
+          _scrollTop = val
+        },
+        configurable: true,
+      },
+      scrollHeight: { value: scrollHeight, configurable: true },
+      clientHeight: { value: clientHeight, configurable: true },
+    })
+    return div
+  }
+
+  describe('initialization', () => {
+    it('should return all required refs and handlers', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      expect(result.current).toHaveProperty('scrollContainerRef')
+      expect(result.current).toHaveProperty('scrollTargetRef')
+      expect(result.current).toHaveProperty('userHasScrolled')
+      expect(result.current).toHaveProperty('isAtBottom')
+      expect(result.current).toHaveProperty('scrollToBottom')
+      expect(result.current).toHaveProperty('resetUserScroll')
+      expect(result.current).toHaveProperty('scrollHandlers')
+    })
+
+    it('should initialize with userHasScrolled as false', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      expect(result.current.userHasScrolled).toBe(false)
+    })
+
+    it('should initialize with isAtBottom as true', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      expect(result.current.isAtBottom).toBe(true)
+    })
+
+    it('should return scroll handlers with onScroll, onWheel, and onTouchStart', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      expect(typeof result.current.scrollHandlers.onScroll).toBe('function')
+      expect(typeof result.current.scrollHandlers.onWheel).toBe('function')
+      expect(typeof result.current.scrollHandlers.onTouchStart).toBe('function')
+    })
+  })
+
+  describe('scrollToBottom', () => {
+    it('should scroll container to bottom with instant scroll', () => {
+      const { result } = renderHook(() => useAutoScroll({ isStreaming: true }))
+
+      const container = createMockContainer(0, 1000, 500)
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      act(() => {
+        result.current.scrollToBottom(false) // instant scroll
+      })
+
+      expect(container.scrollTop).toBe(500) // scrollHeight - clientHeight
+    })
+
+    it('should use instant scroll when isStreaming is true', () => {
+      const { result } = renderHook(() => useAutoScroll({ isStreaming: true }))
+
+      const container = createMockContainer(0, 1000, 500)
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      act(() => {
+        result.current.scrollToBottom()
+      })
+
+      // Instant scroll should set scrollTop immediately
+      expect(container.scrollTop).toBe(500)
+    })
+
+    it('should not throw when scrollToBottom is called with smooth option', () => {
+      const { result } = renderHook(() => useAutoScroll({ smooth: true, isStreaming: false }))
+
+      const container = createMockContainer(0, 1000, 500)
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      // Verify smooth scroll can be called without throwing
+      expect(() => {
+        act(() => {
+          result.current.scrollToBottom()
+        })
+      }).not.toThrow()
+    })
+  })
+
+  describe('handleScroll', () => {
+    it('should set userHasScrolled to true when scrolled far from bottom', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      const container = createMockContainer(0, 1000, 500) // 500px from bottom (> 100px threshold)
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      act(() => {
+        result.current.scrollHandlers.onScroll()
+      })
+
+      expect(result.current.userHasScrolled).toBe(true)
+    })
+
+    it('should set userHasScrolled to false when scrolled close to bottom', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      // First scroll away
+      const container = createMockContainer(0, 1000, 500)
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      act(() => {
+        result.current.scrollHandlers.onScroll()
+      })
+
+      // Then scroll to bottom (scrollTop = scrollHeight - clientHeight - small offset)
+      Object.defineProperty(container, 'scrollTop', { value: 480, configurable: true }) // 20px from bottom (< 50px threshold)
+
+      act(() => {
+        result.current.scrollHandlers.onScroll()
+      })
+
+      expect(result.current.userHasScrolled).toBe(false)
+    })
+  })
+
+  describe('handleWheel', () => {
+    it('should set userHasScrolled to true when scrolling up', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      const container = createMockContainer(500, 1000, 500)
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      act(() => {
+        result.current.scrollHandlers.onWheel({ deltaY: -100 } as React.WheelEvent)
+      })
+
+      expect(result.current.userHasScrolled).toBe(true)
+    })
+
+    it('should not change userHasScrolled when scrolling down', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      act(() => {
+        result.current.scrollHandlers.onWheel({ deltaY: 100 } as React.WheelEvent)
+      })
+
+      expect(result.current.userHasScrolled).toBe(false)
+    })
+  })
+
+  describe('handleTouchStart', () => {
+    it('should set userHasScrolled to true when not at bottom', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      const container = createMockContainer(0, 1000, 500) // 500px from bottom
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      act(() => {
+        result.current.scrollHandlers.onTouchStart({} as React.TouchEvent)
+      })
+
+      expect(result.current.userHasScrolled).toBe(true)
+    })
+
+    it('should not set userHasScrolled when at bottom', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      const container = createMockContainer(500, 1000, 500) // at bottom
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      act(() => {
+        result.current.scrollHandlers.onTouchStart({} as React.TouchEvent)
+      })
+
+      expect(result.current.userHasScrolled).toBe(false)
+    })
+  })
+
+  describe('resetUserScroll', () => {
+    it('should reset userHasScrolled to false', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      // First set userHasScrolled to true
+      const container = createMockContainer(0, 1000, 500)
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      act(() => {
+        result.current.scrollHandlers.onScroll()
+      })
+
+      expect(result.current.userHasScrolled).toBe(true)
+
+      // Then reset
+      act(() => {
+        result.current.resetUserScroll()
+      })
+
+      expect(result.current.userHasScrolled).toBe(false)
+    })
+  })
+
+  describe('dependency-based scrolling', () => {
+    it('should not scroll when user has scrolled away', () => {
+      const { result, rerender } = renderHook(({ deps }) => useAutoScroll({ dependencies: deps, isStreaming: true }), {
+        initialProps: { deps: ['a'] },
+      })
+
+      const container = createMockContainer(0, 1000, 500)
+      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+
+      // User scrolls away
+      act(() => {
+        result.current.scrollHandlers.onScroll()
+      })
+
+      expect(result.current.userHasScrolled).toBe(true)
+
+      // Record current scrollTop
+      const scrollTopBefore = container.scrollTop
+
+      // Change dependencies
+      act(() => {
+        rerender({ deps: ['b'] })
+      })
+
+      // Should not have scrolled (scrollTop unchanged)
+      expect(container.scrollTop).toBe(scrollTopBefore)
+    })
+  })
+})

--- a/src/hooks/use-auto-scroll.test.tsx
+++ b/src/hooks/use-auto-scroll.test.tsx
@@ -24,23 +24,30 @@ describe('useAutoScroll', () => {
     return div
   }
 
+  const createMockTarget = () => document.createElement('div')
+
+  // Helper to set up refs (callback refs need to be called)
+  const setupRefs = (
+    result: { current: ReturnType<typeof useAutoScroll> },
+    container: HTMLDivElement,
+    target: HTMLDivElement,
+  ) => {
+    act(() => {
+      result.current.scrollContainerRef(container)
+      result.current.scrollTargetRef(target)
+    })
+  }
+
   describe('initialization', () => {
     it('should return all required refs and handlers', () => {
       const { result } = renderHook(() => useAutoScroll())
 
       expect(result.current).toHaveProperty('scrollContainerRef')
       expect(result.current).toHaveProperty('scrollTargetRef')
-      expect(result.current).toHaveProperty('userHasScrolled')
       expect(result.current).toHaveProperty('isAtBottom')
       expect(result.current).toHaveProperty('scrollToBottom')
       expect(result.current).toHaveProperty('resetUserScroll')
       expect(result.current).toHaveProperty('scrollHandlers')
-    })
-
-    it('should initialize with userHasScrolled as false', () => {
-      const { result } = renderHook(() => useAutoScroll())
-
-      expect(result.current.userHasScrolled).toBe(false)
     })
 
     it('should initialize with isAtBottom as true', () => {
@@ -49,12 +56,18 @@ describe('useAutoScroll', () => {
       expect(result.current.isAtBottom).toBe(true)
     })
 
-    it('should return scroll handlers with onScroll, onWheel, and onTouchStart', () => {
+    it('should return scroll handlers with onWheel and onTouchStart', () => {
       const { result } = renderHook(() => useAutoScroll())
 
-      expect(typeof result.current.scrollHandlers.onScroll).toBe('function')
       expect(typeof result.current.scrollHandlers.onWheel).toBe('function')
       expect(typeof result.current.scrollHandlers.onTouchStart).toBe('function')
+    })
+
+    it('should return callback refs', () => {
+      const { result } = renderHook(() => useAutoScroll())
+
+      expect(typeof result.current.scrollContainerRef).toBe('function')
+      expect(typeof result.current.scrollTargetRef).toBe('function')
     })
   })
 
@@ -63,10 +76,11 @@ describe('useAutoScroll', () => {
       const { result } = renderHook(() => useAutoScroll({ isStreaming: true }))
 
       const container = createMockContainer(0, 1000, 500)
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+      const target = createMockTarget()
+      setupRefs(result, container, target)
 
       act(() => {
-        result.current.scrollToBottom(false) // instant scroll
+        result.current.scrollToBottom(false)
       })
 
       expect(container.scrollTop).toBe(500) // scrollHeight - clientHeight
@@ -76,13 +90,13 @@ describe('useAutoScroll', () => {
       const { result } = renderHook(() => useAutoScroll({ isStreaming: true }))
 
       const container = createMockContainer(0, 1000, 500)
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+      const target = createMockTarget()
+      setupRefs(result, container, target)
 
       act(() => {
         result.current.scrollToBottom()
       })
 
-      // Instant scroll should set scrollTop immediately
       expect(container.scrollTop).toBe(500)
     })
 
@@ -90,9 +104,9 @@ describe('useAutoScroll', () => {
       const { result } = renderHook(() => useAutoScroll({ smooth: true, isStreaming: false }))
 
       const container = createMockContainer(0, 1000, 500)
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+      const target = createMockTarget()
+      setupRefs(result, container, target)
 
-      // Verify smooth scroll can be called without throwing
       expect(() => {
         act(() => {
           result.current.scrollToBottom()
@@ -101,144 +115,161 @@ describe('useAutoScroll', () => {
     })
   })
 
-  describe('handleScroll', () => {
-    it('should set userHasScrolled to true when scrolled far from bottom', () => {
-      const { result } = renderHook(() => useAutoScroll())
-
-      const container = createMockContainer(0, 1000, 500) // 500px from bottom (> 100px threshold)
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
-
-      act(() => {
-        result.current.scrollHandlers.onScroll()
-      })
-
-      expect(result.current.userHasScrolled).toBe(true)
-    })
-
-    it('should set userHasScrolled to false when scrolled close to bottom', () => {
-      const { result } = renderHook(() => useAutoScroll())
-
-      // First scroll away
-      const container = createMockContainer(0, 1000, 500)
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
-
-      act(() => {
-        result.current.scrollHandlers.onScroll()
-      })
-
-      // Then scroll to bottom (scrollTop = scrollHeight - clientHeight - small offset)
-      Object.defineProperty(container, 'scrollTop', { value: 480, configurable: true }) // 20px from bottom (< 50px threshold)
-
-      act(() => {
-        result.current.scrollHandlers.onScroll()
-      })
-
-      expect(result.current.userHasScrolled).toBe(false)
-    })
-  })
-
   describe('handleWheel', () => {
-    it('should set userHasScrolled to true when scrolling up', () => {
-      const { result } = renderHook(() => useAutoScroll())
+    it('should disable auto-scroll when scrolling up', () => {
+      const { result, rerender } = renderHook(({ deps }) => useAutoScroll({ dependencies: deps, isStreaming: true }), {
+        initialProps: { deps: ['a'] },
+      })
 
       const container = createMockContainer(500, 1000, 500)
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+      const target = createMockTarget()
+      setupRefs(result, container, target)
 
-      act(() => {
-        result.current.scrollHandlers.onWheel({ deltaY: -100 } as React.WheelEvent)
-      })
-
-      expect(result.current.userHasScrolled).toBe(true)
-    })
-
-    it('should not change userHasScrolled when scrolling down', () => {
-      const { result } = renderHook(() => useAutoScroll())
-
-      act(() => {
-        result.current.scrollHandlers.onWheel({ deltaY: 100 } as React.WheelEvent)
-      })
-
-      expect(result.current.userHasScrolled).toBe(false)
-    })
-  })
-
-  describe('handleTouchStart', () => {
-    it('should set userHasScrolled to true when not at bottom', () => {
-      const { result } = renderHook(() => useAutoScroll())
-
-      const container = createMockContainer(0, 1000, 500) // 500px from bottom
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
-
-      act(() => {
-        result.current.scrollHandlers.onTouchStart({} as React.TouchEvent)
-      })
-
-      expect(result.current.userHasScrolled).toBe(true)
-    })
-
-    it('should not set userHasScrolled when at bottom', () => {
-      const { result } = renderHook(() => useAutoScroll())
-
-      const container = createMockContainer(500, 1000, 500) // at bottom
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
-
-      act(() => {
-        result.current.scrollHandlers.onTouchStart({} as React.TouchEvent)
-      })
-
-      expect(result.current.userHasScrolled).toBe(false)
-    })
-  })
-
-  describe('resetUserScroll', () => {
-    it('should reset userHasScrolled to false', () => {
-      const { result } = renderHook(() => useAutoScroll())
-
-      // First set userHasScrolled to true
-      const container = createMockContainer(0, 1000, 500)
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
-
-      act(() => {
-        result.current.scrollHandlers.onScroll()
-      })
-
-      expect(result.current.userHasScrolled).toBe(true)
-
-      // Then reset
+      // Enable auto-scroll first
       act(() => {
         result.current.resetUserScroll()
       })
 
-      expect(result.current.userHasScrolled).toBe(false)
-    })
-  })
+      // Scroll up (disables auto-scroll)
+      act(() => {
+        result.current.scrollHandlers.onWheel({ deltaY: -100 } as React.WheelEvent)
+      })
 
-  describe('dependency-based scrolling', () => {
-    it('should not scroll when user has scrolled away', () => {
+      const scrollTopBefore = container.scrollTop
+
+      // Change dependencies - should NOT auto-scroll since user scrolled up
+      act(() => {
+        rerender({ deps: ['b'] })
+      })
+
+      expect(container.scrollTop).toBe(scrollTopBefore)
+    })
+
+    it('should not disable auto-scroll when scrolling down', () => {
       const { result, rerender } = renderHook(({ deps }) => useAutoScroll({ dependencies: deps, isStreaming: true }), {
         initialProps: { deps: ['a'] },
       })
 
       const container = createMockContainer(0, 1000, 500)
-      ;(result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container
+      const target = createMockTarget()
+      setupRefs(result, container, target)
 
-      // User scrolls away
+      // Enable auto-scroll
       act(() => {
-        result.current.scrollHandlers.onScroll()
+        result.current.resetUserScroll()
       })
 
-      expect(result.current.userHasScrolled).toBe(true)
+      // Scroll down (should NOT disable auto-scroll)
+      act(() => {
+        result.current.scrollHandlers.onWheel({ deltaY: 100 } as React.WheelEvent)
+      })
 
-      // Record current scrollTop
-      const scrollTopBefore = container.scrollTop
-
-      // Change dependencies
+      // Change dependencies - should still auto-scroll
       act(() => {
         rerender({ deps: ['b'] })
       })
 
-      // Should not have scrolled (scrollTop unchanged)
+      expect(container.scrollTop).toBe(500)
+    })
+  })
+
+  describe('handleTouchStart', () => {
+    it('should disable auto-scroll on any touch (user wants control)', () => {
+      const { result, rerender } = renderHook(({ deps }) => useAutoScroll({ dependencies: deps, isStreaming: true }), {
+        initialProps: { deps: ['a'] },
+      })
+
+      const container = createMockContainer(500, 1000, 500)
+      const target = createMockTarget()
+      setupRefs(result, container, target)
+
+      // Enable auto-scroll
+      act(() => {
+        result.current.resetUserScroll()
+      })
+
+      // Touch - should disable auto-scroll immediately (user wants control)
+      act(() => {
+        result.current.scrollHandlers.onTouchStart({} as React.TouchEvent)
+      })
+
+      const scrollTopBefore = container.scrollTop
+
+      // Change dependencies - should NOT auto-scroll since user touched
+      act(() => {
+        rerender({ deps: ['b'] })
+      })
+
       expect(container.scrollTop).toBe(scrollTopBefore)
+    })
+  })
+  describe('resetUserScroll', () => {
+    it('should enable auto-scroll when called', () => {
+      const { result, rerender } = renderHook(({ deps }) => useAutoScroll({ dependencies: deps, isStreaming: true }), {
+        initialProps: { deps: ['a'] },
+      })
+
+      const container = createMockContainer(0, 1000, 500)
+      const target = createMockTarget()
+      setupRefs(result, container, target)
+
+      // Auto-scroll is disabled by default, so changing deps won't scroll
+      act(() => {
+        rerender({ deps: ['b'] })
+      })
+      expect(container.scrollTop).toBe(0)
+
+      // Enable auto-scroll
+      act(() => {
+        result.current.resetUserScroll()
+      })
+
+      // Now changing deps should scroll
+      act(() => {
+        rerender({ deps: ['c'] })
+      })
+      expect(container.scrollTop).toBe(500)
+    })
+  })
+
+  describe('dependency-based scrolling', () => {
+    it('should not auto-scroll by default when dependencies change', () => {
+      const { result, rerender } = renderHook(({ deps }) => useAutoScroll({ dependencies: deps, isStreaming: true }), {
+        initialProps: { deps: ['a'] },
+      })
+
+      const container = createMockContainer(0, 1000, 500)
+      const target = createMockTarget()
+      setupRefs(result, container, target)
+
+      const scrollTopBefore = container.scrollTop
+
+      act(() => {
+        rerender({ deps: ['b'] })
+      })
+
+      expect(container.scrollTop).toBe(scrollTopBefore)
+    })
+
+    it('should auto-scroll when enabled and dependencies change', () => {
+      const { result, rerender } = renderHook(({ deps }) => useAutoScroll({ dependencies: deps, isStreaming: true }), {
+        initialProps: { deps: ['a'] },
+      })
+
+      const container = createMockContainer(0, 1000, 500)
+      const target = createMockTarget()
+      setupRefs(result, container, target)
+
+      // Enable auto-scroll
+      act(() => {
+        result.current.resetUserScroll()
+      })
+
+      act(() => {
+        rerender({ deps: ['b'] })
+      })
+
+      expect(container.scrollTop).toBe(500)
     })
   })
 })

--- a/src/hooks/use-auto-scroll.tsx
+++ b/src/hooks/use-auto-scroll.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useRef, useState, type RefObject, type WheelEvent } from 'react'
+import { useCallback, useEffect, useRef, useState, type RefObject, type TouchEvent, type WheelEvent } from 'react'
 
 // Constants for scroll behavior thresholds
 const SCROLL_THRESHOLD = {
   AWAY_FROM_BOTTOM: 100, // Distance in px to consider user has scrolled away
-  BACK_TO_BOTTOM: 10, // Distance in px to consider user is back at bottom
+  BACK_TO_BOTTOM: 50, // Distance in px to consider user is back at bottom
 } as const
 
 // Smooth scroll duration in ms
@@ -12,47 +12,12 @@ const smoothScrollDuration = 200
 // Easing function for smooth scroll (ease-out quad)
 const easeOutQuad = (t: number): number => t * (2 - t)
 
-// Track current animation to cancel if a new one starts
-let currentAnimationFrame: number | null = null
-
-/**
- * Custom smooth scroll using requestAnimationFrame.
- * More reliable on mobile than native behavior: 'smooth'.
- * Cancels any ongoing animation before starting a new one.
- */
-const animateScroll = (element: HTMLElement, targetScrollTop: number, duration: number): void => {
-  // Cancel any ongoing animation
-  if (currentAnimationFrame !== null) {
-    cancelAnimationFrame(currentAnimationFrame)
-  }
-
-  const startScrollTop = element.scrollTop
-  const distance = targetScrollTop - startScrollTop
-  const startTime = performance.now()
-
-  const step = (currentTime: number) => {
-    const elapsed = currentTime - startTime
-    const progress = Math.min(elapsed / duration, 1)
-    const easedProgress = easeOutQuad(progress)
-
-    element.scrollTop = startScrollTop + distance * easedProgress
-
-    if (progress < 1) {
-      currentAnimationFrame = requestAnimationFrame(step)
-    } else {
-      currentAnimationFrame = null
-    }
-  }
-
-  currentAnimationFrame = requestAnimationFrame(step)
-}
-
 interface UseAutoScrollOptions {
   /** Dependencies that should trigger a scroll to bottom */
   dependencies?: unknown[]
   /** Whether to use smooth scrolling */
   smooth?: boolean
-  /** Whether content is currently streaming (enables instant scrolling) */
+  /** Whether content is currently streaming (uses instant scroll to keep up) */
   isStreaming?: boolean
   /** Callback when user manually scrolls */
   onUserScroll?: (isAtBottom: boolean) => void
@@ -77,6 +42,7 @@ interface UseAutoScrollReturn {
   scrollHandlers: {
     onScroll: () => void
     onWheel: (e: WheelEvent) => void
+    onTouchStart: (e: TouchEvent) => void
   }
 }
 
@@ -96,9 +62,8 @@ interface UseAutoScrollReturn {
  * @example
  * ```tsx
  * const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
- *   isStreaming: true,
  *   dependencies: [messages],
- *   rootMargin: '0px 0px -50px 0px'
+ *   isStreaming: true,
  * })
  *
  * return (
@@ -120,10 +85,9 @@ export function useAutoScroll({
   const scrollTargetRef = useRef<HTMLDivElement>(null)
   const [userHasScrolled, setUserHasScrolled] = useState(false)
   const [isAtBottom, setIsAtBottom] = useState(true)
-  // Track the previous scrollTop value to determine scroll direction
-  const prevScrollTopRef = useRef(0)
+  const userHasScrolledRef = useRef(false)
+  const animationFrameRef = useRef<number | null>(null)
 
-  // Utility to calculate distance from bottom
   const getDistanceFromBottom = useCallback(() => {
     if (!scrollContainerRef.current) return 0
     const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current
@@ -136,11 +100,34 @@ export function useAutoScroll({
       if (!container) return
 
       const targetScrollTop = container.scrollHeight - container.clientHeight
+      // Use instant scroll during streaming to keep up with rapid content updates
       const shouldSmooth = smoothScroll ?? (!isStreaming && smooth)
 
       if (shouldSmooth) {
-        // Use custom animation for reliable smooth scroll on mobile
-        animateScroll(container, targetScrollTop, smoothScrollDuration)
+        // Cancel any ongoing animation for THIS instance
+        if (animationFrameRef.current !== null) {
+          cancelAnimationFrame(animationFrameRef.current)
+        }
+
+        const startScrollTop = container.scrollTop
+        const distance = targetScrollTop - startScrollTop
+        const startTime = performance.now()
+
+        const step = (currentTime: number) => {
+          const elapsed = currentTime - startTime
+          const progress = Math.min(elapsed / smoothScrollDuration, 1)
+          const easedProgress = easeOutQuad(progress)
+
+          container.scrollTop = startScrollTop + distance * easedProgress
+
+          if (progress < 1) {
+            animationFrameRef.current = requestAnimationFrame(step)
+          } else {
+            animationFrameRef.current = null
+          }
+        }
+
+        animationFrameRef.current = requestAnimationFrame(step)
       } else {
         container.scrollTop = targetScrollTop
       }
@@ -151,35 +138,42 @@ export function useAutoScroll({
   const handleScroll = useCallback(() => {
     if (!scrollContainerRef.current) return
 
-    const { scrollTop } = scrollContainerRef.current
     const distanceFromBottom = getDistanceFromBottom()
 
-    // Determine if the user is scrolling up (intentional) or content is pushing down (automatic)
-    const isScrollingUp = scrollTop < prevScrollTopRef.current
-
-    // If the user scrolled up beyond the threshold, pause auto-scroll
-    if (isScrollingUp && distanceFromBottom > SCROLL_THRESHOLD.AWAY_FROM_BOTTOM) {
+    // Simple logic: far from bottom = paused, close to bottom = resume
+    // Update both ref (immediate) and state (for UI)
+    if (distanceFromBottom > SCROLL_THRESHOLD.AWAY_FROM_BOTTOM) {
+      userHasScrolledRef.current = true
       setUserHasScrolled(true)
-    }
-
-    // If we were previously paused and returned close enough to the bottom, resume auto-scroll
-    if (!isScrollingUp && distanceFromBottom < SCROLL_THRESHOLD.BACK_TO_BOTTOM && userHasScrolled) {
+    } else if (distanceFromBottom < SCROLL_THRESHOLD.BACK_TO_BOTTOM) {
+      userHasScrolledRef.current = false
       setUserHasScrolled(false)
     }
-
-    // Update previous scrollTop for next comparison
-    prevScrollTopRef.current = scrollTop
-  }, [userHasScrolled, getDistanceFromBottom])
+  }, [getDistanceFromBottom])
 
   const handleWheel = useCallback((e: WheelEvent) => {
-    if (e.deltaY < 0) setUserHasScrolled(true)
+    // Scrolling up on desktop
+    if (e.deltaY < 0) {
+      userHasScrolledRef.current = true
+      setUserHasScrolled(true)
+    }
   }, [])
 
+  // On mobile, touchstart fires BEFORE scroll - mark that user is interacting
+  // Only pause if not already at bottom (allows tapping without pausing)
+  const handleTouchStart = useCallback(() => {
+    const distanceFromBottom = getDistanceFromBottom()
+    if (distanceFromBottom > SCROLL_THRESHOLD.BACK_TO_BOTTOM) {
+      userHasScrolledRef.current = true
+      setUserHasScrolled(true)
+    }
+  }, [getDistanceFromBottom])
+
   const resetUserScroll = useCallback(() => {
+    userHasScrolledRef.current = false
     setUserHasScrolled(false)
   }, [])
 
-  // Set up Intersection Observer for accurate bottom detection
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current
     const scrollTarget = scrollTargetRef.current
@@ -208,11 +202,21 @@ export function useAutoScroll({
 
   // Handle initial mount and dependency-based scrolling
   useEffect(() => {
-    if (!userHasScrolled) {
+    // Check ref for immediate/sync value (avoids stale state on mobile)
+    if (!userHasScrolledRef.current) {
       scrollToBottom()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...dependencies])
+
+  // Cleanup animation frame on unmount
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current)
+      }
+    }
+  }, [])
 
   return {
     scrollContainerRef,
@@ -221,6 +225,6 @@ export function useAutoScroll({
     isAtBottom,
     scrollToBottom,
     resetUserScroll,
-    scrollHandlers: { onScroll: handleScroll, onWheel: handleWheel },
+    scrollHandlers: { onScroll: handleScroll, onWheel: handleWheel, onTouchStart: handleTouchStart },
   }
 }

--- a/src/hooks/use-auto-scroll.tsx
+++ b/src/hooks/use-auto-scroll.tsx
@@ -6,9 +6,50 @@ const SCROLL_THRESHOLD = {
   BACK_TO_BOTTOM: 10, // Distance in px to consider user is back at bottom
 } as const
 
+// Smooth scroll duration in ms
+const smoothScrollDuration = 200
+
+// Easing function for smooth scroll (ease-out quad)
+const easeOutQuad = (t: number): number => t * (2 - t)
+
+// Track current animation to cancel if a new one starts
+let currentAnimationFrame: number | null = null
+
+/**
+ * Custom smooth scroll using requestAnimationFrame.
+ * More reliable on mobile than native behavior: 'smooth'.
+ * Cancels any ongoing animation before starting a new one.
+ */
+const animateScroll = (element: HTMLElement, targetScrollTop: number, duration: number): void => {
+  // Cancel any ongoing animation
+  if (currentAnimationFrame !== null) {
+    cancelAnimationFrame(currentAnimationFrame)
+  }
+
+  const startScrollTop = element.scrollTop
+  const distance = targetScrollTop - startScrollTop
+  const startTime = performance.now()
+
+  const step = (currentTime: number) => {
+    const elapsed = currentTime - startTime
+    const progress = Math.min(elapsed / duration, 1)
+    const easedProgress = easeOutQuad(progress)
+
+    element.scrollTop = startScrollTop + distance * easedProgress
+
+    if (progress < 1) {
+      currentAnimationFrame = requestAnimationFrame(step)
+    } else {
+      currentAnimationFrame = null
+    }
+  }
+
+  currentAnimationFrame = requestAnimationFrame(step)
+}
+
 interface UseAutoScrollOptions {
   /** Dependencies that should trigger a scroll to bottom */
-  dependencies?: any[]
+  dependencies?: unknown[]
   /** Whether to use smooth scrolling */
   smooth?: boolean
   /** Whether content is currently streaming (enables instant scrolling) */
@@ -91,17 +132,17 @@ export function useAutoScroll({
 
   const scrollToBottom = useCallback(
     (smoothScroll?: boolean) => {
-      const target = scrollTargetRef.current
-      if (!target) return
+      const container = scrollContainerRef.current
+      if (!container) return
 
-      try {
-        target.scrollIntoView({
-          behavior: (smoothScroll ?? (!isStreaming && smooth)) ? 'smooth' : 'auto',
-          block: 'end',
-        })
-      } catch (_) {
-        // Fallback for older browsers
-        scrollContainerRef.current?.scrollTo(0, scrollContainerRef.current.scrollHeight)
+      const targetScrollTop = container.scrollHeight - container.clientHeight
+      const shouldSmooth = smoothScroll ?? (!isStreaming && smooth)
+
+      if (shouldSmooth) {
+        // Use custom animation for reliable smooth scroll on mobile
+        animateScroll(container, targetScrollTop, smoothScrollDuration)
+      } else {
+        container.scrollTop = targetScrollTop
       }
     },
     [smooth, isStreaming],

--- a/src/hooks/use-auto-scroll.tsx
+++ b/src/hooks/use-auto-scroll.tsx
@@ -1,124 +1,73 @@
-import { useCallback, useEffect, useRef, useState, type RefObject, type TouchEvent, type WheelEvent } from 'react'
+import { useCallback, useEffect, useRef, useState, type RefCallback, type TouchEvent, type WheelEvent } from 'react'
 
-// Constants for scroll behavior thresholds
-const SCROLL_THRESHOLD = {
-  AWAY_FROM_BOTTOM: 100, // Distance in px to consider user has scrolled away
-  BACK_TO_BOTTOM: 50, // Distance in px to consider user is back at bottom
-} as const
+const smoothScrollDuration = 300
 
-// Smooth scroll duration in ms
-const smoothScrollDuration = 200
+const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3)
 
-// Easing function for smooth scroll (ease-out quad)
-const easeOutQuad = (t: number): number => t * (2 - t)
-
-interface UseAutoScrollOptions {
-  /** Dependencies that should trigger a scroll to bottom */
+type UseAutoScrollOptions = {
   dependencies?: unknown[]
-  /** Whether to use smooth scrolling */
   smooth?: boolean
-  /** Whether content is currently streaming (uses instant scroll to keep up) */
   isStreaming?: boolean
-  /** Callback when user manually scrolls */
-  onUserScroll?: (isAtBottom: boolean) => void
-  /** Root margin for intersection observer (default: '0px') */
   rootMargin?: string
 }
 
-interface UseAutoScrollReturn {
-  /** Ref to attach to the scrollable container */
-  scrollContainerRef: RefObject<HTMLDivElement | null>
-  /** Ref to attach to the element at the bottom */
-  scrollTargetRef: RefObject<HTMLDivElement | null>
-  /** Whether the user has manually scrolled away from bottom */
-  userHasScrolled: boolean
-  /** Whether the scroll position is at the bottom */
+type UseAutoScrollReturn = {
+  scrollContainerRef: RefCallback<HTMLDivElement>
+  scrollTargetRef: RefCallback<HTMLDivElement>
   isAtBottom: boolean
-  /** Manually scroll to bottom */
-  scrollToBottom: (smooth?: boolean) => void
-  /** Reset the user scroll state */
+  /** Scrolls to bottom. Returns true if scroll was performed, false if container not ready. */
+  scrollToBottom: (smooth?: boolean) => boolean
   resetUserScroll: () => void
-  /** Event handlers to attach to the scrollable container */
   scrollHandlers: {
-    onScroll: () => void
     onWheel: (e: WheelEvent) => void
     onTouchStart: (e: TouchEvent) => void
   }
 }
 
 /**
- * useAutoScroll - A React hook for managing auto-scroll behavior in chat-like interfaces
- *
- * Features:
- * - Automatically scrolls to bottom when new content is added
- * - Detects user scroll intent and pauses auto-scroll
- * - Re-engages auto-scroll when user returns to bottom
- * - Optimized for streaming content with instant scrolling option
- * - Uses Intersection Observer for performance
- *
- * @param options Configuration options for the hook
- * @returns Refs and handlers to implement auto-scroll behavior
- *
- * @example
- * ```tsx
- * const { scrollContainerRef, scrollTargetRef, scrollHandlers } = useAutoScroll({
- *   dependencies: [messages],
- *   isStreaming: true,
- * })
- *
- * return (
- *   <div ref={scrollContainerRef} {...scrollHandlers}>
- *     {content}
- *     <div ref={scrollTargetRef} />
- *   </div>
- * )
- * ```
+ * Manages auto-scroll behavior for chat-like interfaces.
+ * Uses IntersectionObserver for bottom detection and handles user scroll intent.
  */
-export function useAutoScroll({
+export const useAutoScroll = ({
   dependencies = [],
   smooth = true,
   isStreaming = false,
-  onUserScroll,
   rootMargin = '0px',
-}: UseAutoScrollOptions = {}): UseAutoScrollReturn {
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const scrollTargetRef = useRef<HTMLDivElement>(null)
-  const [userHasScrolled, setUserHasScrolled] = useState(false)
+}: UseAutoScrollOptions = {}): UseAutoScrollReturn => {
+  // Use state for DOM elements to trigger re-renders when they're attached
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null)
+  const [scrollTarget, setScrollTarget] = useState<HTMLDivElement | null>(null)
   const [isAtBottom, setIsAtBottom] = useState(true)
-  const userHasScrolledRef = useRef(false)
+  // Ref for sync access in effects - auto-scroll disabled by default
+  const userHasScrolledRef = useRef(true)
   const animationFrameRef = useRef<number | null>(null)
 
-  const getDistanceFromBottom = useCallback(() => {
-    if (!scrollContainerRef.current) return 0
-    const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current
-    return scrollHeight - scrollTop - clientHeight
-  }, [])
+  // Callback refs that trigger state updates
+  const scrollContainerRef = useCallback((el: HTMLDivElement | null) => setScrollContainer(el), [])
+  const scrollTargetRef = useCallback((el: HTMLDivElement | null) => setScrollTarget(el), [])
 
   const scrollToBottom = useCallback(
-    (smoothScroll?: boolean) => {
-      const container = scrollContainerRef.current
-      if (!container) return
+    (smoothScroll?: boolean): boolean => {
+      if (!scrollContainer) return false
 
-      const targetScrollTop = container.scrollHeight - container.clientHeight
-      // Use instant scroll during streaming to keep up with rapid content updates
+      const targetScrollTop = scrollContainer.scrollHeight - scrollContainer.clientHeight
       const shouldSmooth = smoothScroll ?? (!isStreaming && smooth)
 
       if (shouldSmooth) {
-        // Cancel any ongoing animation for THIS instance
         if (animationFrameRef.current !== null) {
           cancelAnimationFrame(animationFrameRef.current)
         }
 
-        const startScrollTop = container.scrollTop
+        const startScrollTop = scrollContainer.scrollTop
         const distance = targetScrollTop - startScrollTop
         const startTime = performance.now()
 
         const step = (currentTime: number) => {
           const elapsed = currentTime - startTime
           const progress = Math.min(elapsed / smoothScrollDuration, 1)
-          const easedProgress = easeOutQuad(progress)
+          const easedProgress = easeOutCubic(progress)
 
-          container.scrollTop = startScrollTop + distance * easedProgress
+          scrollContainer.scrollTop = startScrollTop + distance * easedProgress
 
           if (progress < 1) {
             animationFrameRef.current = requestAnimationFrame(step)
@@ -129,62 +78,46 @@ export function useAutoScroll({
 
         animationFrameRef.current = requestAnimationFrame(step)
       } else {
-        container.scrollTop = targetScrollTop
+        scrollContainer.scrollTop = targetScrollTop
       }
+
+      return true
     },
-    [smooth, isStreaming],
+    [scrollContainer, smooth, isStreaming],
   )
 
-  const handleScroll = useCallback(() => {
-    if (!scrollContainerRef.current) return
-
-    const distanceFromBottom = getDistanceFromBottom()
-
-    // Simple logic: far from bottom = paused, close to bottom = resume
-    // Update both ref (immediate) and state (for UI)
-    if (distanceFromBottom > SCROLL_THRESHOLD.AWAY_FROM_BOTTOM) {
-      userHasScrolledRef.current = true
-      setUserHasScrolled(true)
-    } else if (distanceFromBottom < SCROLL_THRESHOLD.BACK_TO_BOTTOM) {
-      userHasScrolledRef.current = false
-      setUserHasScrolled(false)
-    }
-  }, [getDistanceFromBottom])
-
   const handleWheel = useCallback((e: WheelEvent) => {
-    // Scrolling up on desktop
     if (e.deltaY < 0) {
       userHasScrolledRef.current = true
-      setUserHasScrolled(true)
     }
   }, [])
 
-  // On mobile, touchstart fires BEFORE scroll - mark that user is interacting
-  // Only pause if not already at bottom (allows tapping without pausing)
+  // Any touch interaction disables auto-scroll - user wants control
   const handleTouchStart = useCallback(() => {
-    const distanceFromBottom = getDistanceFromBottom()
-    if (distanceFromBottom > SCROLL_THRESHOLD.BACK_TO_BOTTOM) {
-      userHasScrolledRef.current = true
-      setUserHasScrolled(true)
-    }
-  }, [getDistanceFromBottom])
+    userHasScrolledRef.current = true
+  }, [])
 
   const resetUserScroll = useCallback(() => {
     userHasScrolledRef.current = false
-    setUserHasScrolled(false)
   }, [])
 
+  // IntersectionObserver for bottom detection - runs when elements are available
   useEffect(() => {
-    const scrollContainer = scrollContainerRef.current
-    const scrollTarget = scrollTargetRef.current
-
     if (!scrollTarget || !scrollContainer) return
+
+    let isFirstObservation = true
 
     const observer = new IntersectionObserver(
       ([entry]) => {
         const atBottom = entry.isIntersecting
         setIsAtBottom(atBottom)
-        onUserScroll?.(atBottom)
+
+        // Enable auto-scroll when user scrolls to bottom (not on initial setup)
+        if (atBottom && !isFirstObservation) {
+          userHasScrolledRef.current = false
+        }
+
+        isFirstObservation = false
       },
       {
         root: scrollContainer,
@@ -195,19 +128,16 @@ export function useAutoScroll({
 
     observer.observe(scrollTarget)
 
-    return () => {
-      observer.disconnect()
-    }
-  }, [rootMargin, onUserScroll])
+    return () => observer.disconnect()
+  }, [scrollContainer, scrollTarget, rootMargin, ...dependencies])
 
-  // Handle initial mount and dependency-based scrolling
+  // Scroll when dependencies change (if auto-scroll is enabled)
   useEffect(() => {
-    // Check ref for immediate/sync value (avoids stale state on mobile)
-    if (!userHasScrolledRef.current) {
+    if (!userHasScrolledRef.current && scrollContainer) {
       scrollToBottom()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...dependencies])
+  }, [scrollContainer, ...dependencies])
 
   // Cleanup animation frame on unmount
   useEffect(() => {
@@ -221,10 +151,9 @@ export function useAutoScroll({
   return {
     scrollContainerRef,
     scrollTargetRef,
-    userHasScrolled,
     isAtBottom,
     scrollToBottom,
     resetUserScroll,
-    scrollHandlers: { onScroll: handleScroll, onWheel: handleWheel, onTouchStart: handleTouchStart },
+    scrollHandlers: { onWheel: handleWheel, onTouchStart: handleTouchStart },
   }
 }


### PR DESCRIPTION
The chat now follows Claude's scroll pattern: it scrolls to the bottom when a response starts streaming, but then respects the user's scroll position. If you scroll up to read earlier content, the app no longer forces you back down during or after streaming.

A floating "scroll to bottom" button now appears whenever you're not at the bottom of the chat, making it easy to jump back down when you're ready.

Previously, the auto-scroll to bottom when AI finished generating was disruptive — especially when reading longer responses mid-stream. This change puts users in control of their reading pace while still providing a quick way to catch up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a non-intrusive auto-scroll model and adds a quick-return control to improve chat readability and control.
> 
> - Refactors `useAutoScroll` with callback refs, `isAtBottom`, wheel/touch handlers to disable auto-scroll, IntersectionObserver-based bottom detection, and smooth/instant scrolling; `scrollToBottom` now returns a boolean
> - Simplifies `useChatScrollHandler`: depends on `messages`, exposes `isAtBottom` and `scrollToBottomAndActivate`, and removes RAF-based scrolling logic
> - Updates `ChatUI` to show `ScrollToBottomButton` when not at bottom, restructure scroll container, and do one-time initial scroll for existing chats
> - Removes scroll control props from `ChatPromptInput` and stops forcing scroll after send
> - Adjusts reasoning views to use new callback refs
> - Adds `ScrollToBottomButton` component with tests and introduces comprehensive tests for `use-auto-scroll`; updates existing tests to new APIs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3b6c000996ee37d4a5ed2ef93136c63047951ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->