### PR TITLE
THU-219: The "return" button on iOS keyboard should add a new line - not submit

### DIFF
--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -1,5 +1,6 @@
 import { useCurrentChatSession } from '@/chats/chat-store'
 import { useContextTracking as useContextTracking_default } from '@/hooks/use-context-tracking'
+import { isMobile as isPlatformMobile } from '@/lib/platform'
 import { trackEvent as trackEvent_default } from '@/lib/posthog'
 import { type Model } from '@/types'
 import { useChat as useChat_default } from '@ai-sdk/react'
@@ -122,7 +123,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
           isStreaming={isStreaming}
           onStop={stop}
           autoFocus={!isMobile}
-          submitOnEnter={!isStreaming}
+          submitOnEnter={!isStreaming && !isPlatformMobile()}
           className="flex flex-col gap-2 bg-background dark:bg-input/30 border dark:border-input p-3 rounded-2xl w-full"
           footerStartElements={
             isContextKnown && <ContextUsageIndicator usedTokens={usedTokens ?? 0} maxTokens={maxTokens ?? 0} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts chat input submit behavior on mobile to ensure the iOS "Return" key inserts a newline instead of sending the message.
> 
> - In `chat-prompt-input.tsx`, gate `PromptInput`'s `submitOnEnter` with `!isPlatformMobile()` (previously only `!isStreaming`)
> - Adds `isMobile` platform check import from `@/lib/platform`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc902da21109ec809007d0acebbb1cd536e869a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->