### PR TITLE
Replace direct database operations with DAL functions

### DIFF
--- a/src/automations/automation-form-modal.tsx
+++ b/src/automations/automation-form-modal.tsx
@@ -11,15 +11,22 @@ import {
 } from '@/components/ui/responsive-modal'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DatabaseSingleton } from '@/db/singleton'
-import { promptsTable, triggersTable } from '@/db/tables'
+import { promptsTable } from '@/db/tables'
 import { useSettings } from '@/hooks/use-settings'
 import { trackEvent } from '@/lib/posthog'
-import { getAvailableModels, getSelectedModel, updateAutomation } from '@/dal'
+import {
+  createTrigger,
+  deleteTriggerByPromptId,
+  getAvailableModels,
+  getSelectedModel,
+  getTriggersByPromptId,
+  updateAutomation,
+  updateTriggerByPromptId,
+} from '@/dal'
 import { generateTitle } from '@/lib/title-generator'
 import type { Model, Prompt } from '@/types'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { eq } from 'drizzle-orm'
 import { useCallback, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { v7 as uuidv7 } from 'uuid'
@@ -105,7 +112,7 @@ export default function AutomationFormModal({
       if (prompt) {
         // Load existing trigger data if editing
         const loadTriggerData = async () => {
-          const existingTriggers = await db.select().from(triggersTable).where(eq(triggersTable.promptId, prompt.id))
+          const existingTriggers = await getTriggersByPromptId(prompt.id)
           const trigger = existingTriggers[0] // Assuming one trigger per prompt
 
           const promptText = prompt.prompt
@@ -159,7 +166,7 @@ export default function AutomationFormModal({
 
       // Create trigger if specified and not manual
       if (values.triggerType === 'time' && values.triggerTime) {
-        await db.insert(triggersTable).values({
+        await createTrigger({
           id: uuidv7(),
           triggerType: values.triggerType,
           triggerTime: values.triggerTime,
@@ -191,24 +198,21 @@ export default function AutomationFormModal({
       })
 
       // Handle trigger updates when editing
-      const existingTriggers = await db.select().from(triggersTable).where(eq(triggersTable.promptId, prompt.id))
+      const existingTriggers = await getTriggersByPromptId(prompt.id)
       const hasNewTriggerData = values.triggerType === 'time' && values.triggerTime
 
       if (hasNewTriggerData) {
         // User wants to add/update a trigger
         if (existingTriggers.length > 0) {
           // Update existing trigger
-          await db
-            .update(triggersTable)
-            .set({
-              triggerType: 'time',
-              triggerTime: values.triggerTime!,
-              isEnabled: 1,
-            })
-            .where(eq(triggersTable.promptId, prompt.id))
+          await updateTriggerByPromptId(prompt.id, {
+            triggerType: 'time',
+            triggerTime: values.triggerTime!,
+            isEnabled: 1,
+          })
         } else {
           // Create new trigger
-          await db.insert(triggersTable).values({
+          await createTrigger({
             id: uuidv7(),
             triggerType: 'time',
             triggerTime: values.triggerTime!,
@@ -219,7 +223,7 @@ export default function AutomationFormModal({
       } else {
         // User selected manual or removed trigger data, delete any existing triggers
         if (existingTriggers.length > 0) {
-          await db.delete(triggersTable).where(eq(triggersTable.promptId, prompt.id))
+          await deleteTriggerByPromptId(prompt.id)
         }
       }
     },

--- a/src/automations/index.tsx
+++ b/src/automations/index.tsx
@@ -16,9 +16,14 @@ import { Card, CardContent } from '@/components/ui/card'
 import { SearchInput } from '@/components/ui/search-input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { deleteAutomation, getAllPrompts, resetAutomationToDefault, runAutomation } from '@/dal'
-import { DatabaseSingleton } from '@/db/singleton'
-import { triggersTable } from '@/db/tables'
+import {
+  deleteAutomation,
+  getAllPrompts,
+  getTriggersByPromptId,
+  resetAutomationToDefault,
+  runAutomation,
+  updateTrigger,
+} from '@/dal'
 import { defaultAutomations } from '@/defaults/automations'
 import { isAutomationModified } from '@/defaults/utils'
 import { useSettings } from '@/hooks/use-settings'
@@ -26,7 +31,6 @@ import { trackEvent } from '@/lib/posthog'
 import { cn } from '@/lib/utils'
 import type { Prompt, Trigger } from '@/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { eq } from 'drizzle-orm'
 import { Pen, Play, Plus, Search, Trash2 } from 'lucide-react'
 import { memo, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
@@ -237,14 +241,13 @@ interface PromptCardProps {
 }
 
 const PromptCard = memo(({ prompt, triggersEnabled, onRun, onEdit, onDelete, onReset }: PromptCardProps) => {
-  const db = DatabaseSingleton.instance.db
   const queryClient = useQueryClient()
 
   // Query triggers for this prompt
   const { data: triggers = [] } = useQuery({
     queryKey: ['triggers', prompt.id],
     queryFn: async (): Promise<Trigger[]> => {
-      return db.select().from(triggersTable).where(eq(triggersTable.promptId, prompt.id))
+      return getTriggersByPromptId(prompt.id)
     },
   })
 
@@ -260,10 +263,7 @@ const PromptCard = memo(({ prompt, triggersEnabled, onRun, onEdit, onDelete, onR
   const toggleTriggerMutation = useMutation({
     mutationFn: async (enabled: boolean) => {
       if (primaryTrigger) {
-        await db
-          .update(triggersTable)
-          .set({ isEnabled: enabled ? 1 : 0 })
-          .where(eq(triggersTable.id, primaryTrigger.id))
+        await updateTrigger(primaryTrigger.id, { isEnabled: enabled ? 1 : 0 })
       }
     },
     onSuccess: () => {

--- a/src/automations/use-trigger-scheduler.ts
+++ b/src/automations/use-trigger-scheduler.ts
@@ -1,8 +1,5 @@
-import { DatabaseSingleton } from '@/db/singleton'
-import { triggersTable } from '@/db/tables'
 import { useSettings } from '@/hooks/use-settings'
-import { runAutomation } from '@/dal'
-import { eq } from 'drizzle-orm'
+import { getAllTriggers, runAutomation } from '@/dal'
 import { useEffect, useRef } from 'react'
 
 export const useTriggerScheduler = () => {
@@ -12,8 +9,6 @@ export const useTriggerScheduler = () => {
   const timers = useRef<number[]>([])
 
   useEffect(() => {
-    const db = DatabaseSingleton.instance.db
-
     const plan = async () => {
       if (!isTriggersEnabled.value) {
         return
@@ -22,7 +17,7 @@ export const useTriggerScheduler = () => {
       timers.current.forEach(clearTimeout)
       timers.current = []
 
-      const triggers = await db.select().from(triggersTable).where(eq(triggersTable.isEnabled, 1))
+      const triggers = await getAllTriggers()
 
       triggers.forEach((t) => {
         if (t.triggerTime) {

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -1,5 +1,6 @@
 // Models
 export {
+  deleteModel,
   getAllModels,
   getAvailableModels,
   getDefaultModelForThread,
@@ -38,10 +39,10 @@ export {
 export { getChatMessages, getLastMessage, saveMessagesWithContextUpdate, updateMessage } from './chat-messages'
 
 // Tasks
-export { getIncompleteTasks, getIncompleteTasksCount, updateTask } from './tasks'
+export { deleteManyTasks, deleteTask, getIncompleteTasks, getIncompleteTasksCount, updateTask } from './tasks'
 
 // MCP Servers
-export { getAllMcpServers, getHttpMcpServers } from './mcp-servers'
+export { deleteMcpServer, getAllMcpServers, getHttpMcpServers } from './mcp-servers'
 
 // Prompts
 export {
@@ -52,3 +53,14 @@ export {
   runAutomation,
   updateAutomation,
 } from './prompts'
+
+// Triggers
+export {
+  createTrigger,
+  deleteTrigger,
+  deleteTriggerByPromptId,
+  getAllTriggers,
+  getTriggersByPromptId,
+  updateTrigger,
+  updateTriggerByPromptId,
+} from './triggers'

--- a/src/dal/mcp-servers.test.ts
+++ b/src/dal/mcp-servers.test.ts
@@ -2,7 +2,7 @@ import { DatabaseSingleton } from '@/db/singleton'
 import { mcpServersTable } from '@/db/tables'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { v7 as uuidv7 } from 'uuid'
-import { getAllMcpServers, getHttpMcpServers } from './mcp-servers'
+import { deleteMcpServer, getAllMcpServers, getHttpMcpServers } from './mcp-servers'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 
 beforeAll(async () => {
@@ -103,6 +103,19 @@ describe('MCP Servers DAL', () => {
       expect(servers.map((s) => s.id)).toContain(serverId1)
       expect(servers.map((s) => s.id)).toContain(serverId2)
       expect(servers.map((s) => s.id)).not.toContain(serverId3)
+    })
+  })
+
+  describe('deleteMcpServer', () => {
+    it('should delete a MCP server by ID', async () => {
+      const db = DatabaseSingleton.instance.db
+      const serverId = uuidv7()
+      await db
+        .insert(mcpServersTable)
+        .values({ id: serverId, name: 'Test MCP Server', type: 'http', url: 'http://example.com', enabled: 1 })
+      await deleteMcpServer(serverId)
+      const servers = await getAllMcpServers()
+      expect(servers).toHaveLength(0)
     })
   })
 })

--- a/src/dal/mcp-servers.ts
+++ b/src/dal/mcp-servers.ts
@@ -21,3 +21,11 @@ export const getHttpMcpServers = async (): Promise<McpServer[]> => {
     .from(mcpServersTable)
     .where(and(eq(mcpServersTable.type, 'http'), isNotNull(mcpServersTable.url)))
 }
+
+/**
+ * Deletes a specific MCP server by ID
+ */
+export const deleteMcpServer = async (id: string): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.delete(mcpServersTable).where(eq(mcpServersTable.id, id))
+}

--- a/src/dal/models.test.ts
+++ b/src/dal/models.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import {
+  deleteModel,
   getAllModels,
   getAvailableModels,
   getDefaultModelForThread,
@@ -403,6 +404,18 @@ describe('Models DAL', () => {
       // Should fall back to system model when the last message's model doesn't exist
       const model = await getDefaultModelForThread(threadId)
       expect(model.id).toBe(systemModelId)
+    })
+  })
+  describe('deleteModel', () => {
+    it('should delete a model by ID', async () => {
+      const db = DatabaseSingleton.instance.db
+      const modelId = uuidv7()
+      await db
+        .insert(modelsTable)
+        .values({ id: modelId, provider: 'openai', name: 'Test Model', model: 'gpt-4', isSystem: 0, enabled: 1 })
+      await deleteModel(modelId)
+      const model = await getModel(modelId)
+      expect(model).toBe(null)
     })
   })
 })

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -139,3 +139,11 @@ export const resetModelToDefault = async (id: string, defaultModel: Model): Prom
   const { defaultHash, ...defaultFields } = defaultModel
   await db.update(modelsTable).set(defaultFields).where(eq(modelsTable.id, id))
 }
+
+/**
+ * Deletes a specific model by ID
+ */
+export const deleteModel = async (id: string): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.delete(modelsTable).where(eq(modelsTable.id, id))
+}

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -6,6 +6,7 @@ import type { AutomationRun, Prompt } from '../types'
 import { convertUIMessageToDbChatMessage } from '../lib/utils'
 import { getModel } from './models'
 import { createChatThread } from './chat-threads'
+import { deleteTriggerByPromptId } from './triggers'
 
 /**
  * Gets all prompts, optionally filtered by search query
@@ -79,9 +80,8 @@ export const resetAutomationToDefault = async (id: string, defaultAutomation: Pr
 export const deleteAutomation = async (id: string): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   // Import locally to avoid circular dependency
-  const { triggersTable } = await import('../db/tables')
   // Delete triggers first (due to foreign key)
-  await db.delete(triggersTable).where(eq(triggersTable.promptId, id))
+  await deleteTriggerByPromptId(id)
   // Use soft delete - set deletedAt timestamp instead of hard delete
   await db.update(promptsTable).set({ deletedAt: Date.now() }).where(eq(promptsTable.id, id))
 }

--- a/src/dal/tasks.test.ts
+++ b/src/dal/tasks.test.ts
@@ -2,7 +2,7 @@ import { DatabaseSingleton } from '@/db/singleton'
 import { tasksTable } from '@/db/tables'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { v7 as uuidv7 } from 'uuid'
-import { getIncompleteTasks, getIncompleteTasksCount } from './tasks'
+import { deleteManyTasks, deleteTask, getIncompleteTasks, getIncompleteTasksCount } from './tasks'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 
 beforeAll(async () => {
@@ -135,6 +135,32 @@ describe('Tasks DAL', () => {
 
       const count = await getIncompleteTasksCount()
       expect(count).toBe(2)
+    })
+  })
+
+  describe('deleteTask', () => {
+    it('should delete a task by ID', async () => {
+      const db = DatabaseSingleton.instance.db
+      const taskId = uuidv7()
+      await db.insert(tasksTable).values({ id: taskId, item: 'Test task', isComplete: 0, order: 1 })
+      await deleteTask(taskId)
+      const tasks = await getIncompleteTasks()
+      expect(tasks).toEqual([])
+    })
+  })
+
+  describe('deleteManyTasks', () => {
+    it('should delete many tasks by ID', async () => {
+      const db = DatabaseSingleton.instance.db
+      const taskId1 = uuidv7()
+      const taskId2 = uuidv7()
+      await db.insert(tasksTable).values([
+        { id: taskId1, item: 'Test task 1', isComplete: 0, order: 1 },
+        { id: taskId2, item: 'Test task 2', isComplete: 0, order: 2 },
+      ])
+      await deleteManyTasks([taskId1, taskId2])
+      const tasks = await getIncompleteTasks()
+      expect(tasks).toEqual([])
     })
   })
 })

--- a/src/dal/tasks.ts
+++ b/src/dal/tasks.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, like, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, inArray, like, sql } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
 import { tasksTable } from '../db/tables'
 import type { Task } from '../types'
@@ -43,4 +43,20 @@ export const updateTask = async (id: string, updates: Partial<Task>): Promise<vo
   // Don't allow updating defaultHash - it must be preserved for modification tracking
   const { defaultHash, ...updateFields } = updates as Partial<Task> & { defaultHash?: string }
   await db.update(tasksTable).set(updateFields).where(eq(tasksTable.id, id))
+}
+
+/**
+ * Deletes a specific task by ID
+ */
+export const deleteTask = async (id: string): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.delete(tasksTable).where(eq(tasksTable.id, id))
+}
+
+/**
+ * Deletes many tasks by ID
+ */
+export const deleteManyTasks = async (ids: string[]): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.delete(tasksTable).where(inArray(tasksTable.id, ids))
 }

--- a/src/dal/triggers.test.ts
+++ b/src/dal/triggers.test.ts
@@ -1,0 +1,454 @@
+import { DatabaseSingleton } from '@/db/singleton'
+import { promptsTable, triggersTable } from '@/db/tables'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { v7 as uuidv7 } from 'uuid'
+import {
+  createTrigger,
+  deleteTrigger,
+  deleteTriggerByPromptId,
+  getAllTriggers,
+  getTriggersByPromptId,
+  updateTrigger,
+  updateTriggerByPromptId,
+} from './triggers'
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
+
+beforeAll(async () => {
+  await setupTestDatabase()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+/** Helper to create a prompt in the database */
+const createPrompt = async (id: string) => {
+  const db = DatabaseSingleton.instance.db
+  await db.insert(promptsTable).values({
+    id,
+    title: 'Test Prompt',
+    prompt: 'This is a test prompt',
+    modelId: uuidv7(),
+  })
+}
+
+describe('Triggers DAL', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  describe('getAllTriggers', () => {
+    it('should return empty array when no triggers exist', async () => {
+      const triggers = await getAllTriggers()
+      expect(triggers).toEqual([])
+    })
+
+    it('should return only enabled triggers', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId1 = uuidv7()
+      const promptId2 = uuidv7()
+
+      await createPrompt(promptId1)
+      await createPrompt(promptId2)
+
+      const enabledTriggerId = uuidv7()
+      const disabledTriggerId = uuidv7()
+
+      await db.insert(triggersTable).values([
+        {
+          id: enabledTriggerId,
+          triggerType: 'time',
+          triggerTime: '08:00',
+          promptId: promptId1,
+          isEnabled: 1,
+        },
+        {
+          id: disabledTriggerId,
+          triggerType: 'time',
+          triggerTime: '09:00',
+          promptId: promptId2,
+          isEnabled: 0,
+        },
+      ])
+
+      const triggers = await getAllTriggers()
+      expect(triggers).toHaveLength(1)
+      expect(triggers[0]?.id).toBe(enabledTriggerId)
+    })
+
+    it('should return all enabled triggers', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId1 = uuidv7()
+      const promptId2 = uuidv7()
+
+      await createPrompt(promptId1)
+      await createPrompt(promptId2)
+
+      const triggerId1 = uuidv7()
+      const triggerId2 = uuidv7()
+
+      await db.insert(triggersTable).values([
+        {
+          id: triggerId1,
+          triggerType: 'time',
+          triggerTime: '08:00',
+          promptId: promptId1,
+          isEnabled: 1,
+        },
+        {
+          id: triggerId2,
+          triggerType: 'time',
+          triggerTime: '09:00',
+          promptId: promptId2,
+          isEnabled: 1,
+        },
+      ])
+
+      const triggers = await getAllTriggers()
+      expect(triggers).toHaveLength(2)
+      expect(triggers.map((t) => t.id)).toContain(triggerId1)
+      expect(triggers.map((t) => t.id)).toContain(triggerId2)
+    })
+  })
+
+  describe('getTriggersByPromptId', () => {
+    it('should return empty array when no triggers exist for prompt', async () => {
+      const triggers = await getTriggersByPromptId('nonexistent-prompt-id')
+      expect(triggers).toEqual([])
+    })
+
+    it('should return triggers for a specific prompt', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const otherPromptId = uuidv7()
+
+      await createPrompt(promptId)
+      await createPrompt(otherPromptId)
+
+      const triggerId1 = uuidv7()
+      const triggerId2 = uuidv7()
+      const otherTriggerId = uuidv7()
+
+      await db.insert(triggersTable).values([
+        {
+          id: triggerId1,
+          triggerType: 'time',
+          triggerTime: '08:00',
+          promptId,
+          isEnabled: 1,
+        },
+        {
+          id: triggerId2,
+          triggerType: 'time',
+          triggerTime: '09:00',
+          promptId,
+          isEnabled: 0,
+        },
+        {
+          id: otherTriggerId,
+          triggerType: 'time',
+          triggerTime: '10:00',
+          promptId: otherPromptId,
+          isEnabled: 1,
+        },
+      ])
+
+      const triggers = await getTriggersByPromptId(promptId)
+      expect(triggers).toHaveLength(2)
+      expect(triggers.map((t) => t.id)).toContain(triggerId1)
+      expect(triggers.map((t) => t.id)).toContain(triggerId2)
+      expect(triggers.map((t) => t.id)).not.toContain(otherTriggerId)
+    })
+  })
+
+  describe('createTrigger', () => {
+    it('should create a new trigger', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId = uuidv7()
+
+      await createPrompt(promptId)
+
+      await createTrigger({
+        id: triggerId,
+        triggerType: 'time',
+        triggerTime: '08:00',
+        promptId,
+        isEnabled: 1,
+      })
+
+      const result = await db.select().from(triggersTable).where(eq(triggersTable.id, triggerId)).get()
+      expect(result).not.toBeUndefined()
+      expect(result?.id).toBe(triggerId)
+      expect(result?.triggerType).toBe('time')
+      expect(result?.triggerTime).toBe('08:00')
+      expect(result?.promptId).toBe(promptId)
+      expect(result?.isEnabled).toBe(1)
+    })
+
+    it('should create a disabled trigger', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId = uuidv7()
+
+      await createPrompt(promptId)
+
+      await createTrigger({
+        id: triggerId,
+        triggerType: 'time',
+        triggerTime: '12:00',
+        promptId,
+        isEnabled: 0,
+      })
+
+      const result = await db.select().from(triggersTable).where(eq(triggersTable.id, triggerId)).get()
+      expect(result?.isEnabled).toBe(0)
+    })
+  })
+
+  describe('updateTrigger', () => {
+    it('should update trigger time', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId = uuidv7()
+
+      await createPrompt(promptId)
+
+      await db.insert(triggersTable).values({
+        id: triggerId,
+        triggerType: 'time',
+        triggerTime: '08:00',
+        promptId,
+        isEnabled: 1,
+      })
+
+      await updateTrigger(triggerId, { triggerTime: '10:00' })
+
+      const result = await db.select().from(triggersTable).where(eq(triggersTable.id, triggerId)).get()
+      expect(result?.triggerTime).toBe('10:00')
+    })
+
+    it('should update isEnabled status', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId = uuidv7()
+
+      await createPrompt(promptId)
+
+      await db.insert(triggersTable).values({
+        id: triggerId,
+        triggerType: 'time',
+        triggerTime: '08:00',
+        promptId,
+        isEnabled: 1,
+      })
+
+      await updateTrigger(triggerId, { isEnabled: 0 })
+
+      const result = await db.select().from(triggersTable).where(eq(triggersTable.id, triggerId)).get()
+      expect(result?.isEnabled).toBe(0)
+    })
+
+    it('should update multiple fields at once', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId = uuidv7()
+
+      await createPrompt(promptId)
+
+      await db.insert(triggersTable).values({
+        id: triggerId,
+        triggerType: 'time',
+        triggerTime: '08:00',
+        promptId,
+        isEnabled: 1,
+      })
+
+      await updateTrigger(triggerId, { triggerTime: '14:30', isEnabled: 0 })
+
+      const result = await db.select().from(triggersTable).where(eq(triggersTable.id, triggerId)).get()
+      expect(result?.triggerTime).toBe('14:30')
+      expect(result?.isEnabled).toBe(0)
+    })
+  })
+
+  describe('updateTriggerByPromptId', () => {
+    it('should update trigger by prompt ID', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId = uuidv7()
+
+      await createPrompt(promptId)
+
+      await db.insert(triggersTable).values({
+        id: triggerId,
+        triggerType: 'time',
+        triggerTime: '08:00',
+        promptId,
+        isEnabled: 1,
+      })
+
+      await updateTriggerByPromptId(promptId, { triggerTime: '16:00', isEnabled: 0 })
+
+      const result = await db.select().from(triggersTable).where(eq(triggersTable.id, triggerId)).get()
+      expect(result?.triggerTime).toBe('16:00')
+      expect(result?.isEnabled).toBe(0)
+    })
+
+    it('should update all triggers for a prompt ID', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId1 = uuidv7()
+      const triggerId2 = uuidv7()
+
+      await createPrompt(promptId)
+
+      await db.insert(triggersTable).values([
+        {
+          id: triggerId1,
+          triggerType: 'time',
+          triggerTime: '08:00',
+          promptId,
+          isEnabled: 1,
+        },
+        {
+          id: triggerId2,
+          triggerType: 'time',
+          triggerTime: '09:00',
+          promptId,
+          isEnabled: 1,
+        },
+      ])
+
+      await updateTriggerByPromptId(promptId, { isEnabled: 0 })
+
+      const triggers = await db.select().from(triggersTable).where(eq(triggersTable.promptId, promptId))
+      expect(triggers).toHaveLength(2)
+      expect(triggers.every((t) => t.isEnabled === 0)).toBe(true)
+    })
+  })
+
+  describe('deleteTrigger', () => {
+    it('should delete a trigger by ID', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId = uuidv7()
+
+      await createPrompt(promptId)
+
+      await db.insert(triggersTable).values({
+        id: triggerId,
+        triggerType: 'time',
+        triggerTime: '08:00',
+        promptId,
+        isEnabled: 1,
+      })
+
+      await deleteTrigger(triggerId)
+
+      const result = await db.select().from(triggersTable).where(eq(triggersTable.id, triggerId)).get()
+      expect(result).toBeUndefined()
+    })
+
+    it('should not affect other triggers when deleting', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId1 = uuidv7()
+      const triggerId2 = uuidv7()
+
+      await createPrompt(promptId)
+
+      await db.insert(triggersTable).values([
+        {
+          id: triggerId1,
+          triggerType: 'time',
+          triggerTime: '08:00',
+          promptId,
+          isEnabled: 1,
+        },
+        {
+          id: triggerId2,
+          triggerType: 'time',
+          triggerTime: '09:00',
+          promptId,
+          isEnabled: 1,
+        },
+      ])
+
+      await deleteTrigger(triggerId1)
+
+      const remainingTriggers = await db.select().from(triggersTable)
+      expect(remainingTriggers).toHaveLength(1)
+      expect(remainingTriggers[0]?.id).toBe(triggerId2)
+    })
+  })
+
+  describe('deleteTriggerByPromptId', () => {
+    it('should delete all triggers for a prompt ID', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId = uuidv7()
+      const triggerId1 = uuidv7()
+      const triggerId2 = uuidv7()
+
+      await createPrompt(promptId)
+
+      await db.insert(triggersTable).values([
+        {
+          id: triggerId1,
+          triggerType: 'time',
+          triggerTime: '08:00',
+          promptId,
+          isEnabled: 1,
+        },
+        {
+          id: triggerId2,
+          triggerType: 'time',
+          triggerTime: '09:00',
+          promptId,
+          isEnabled: 1,
+        },
+      ])
+
+      await deleteTriggerByPromptId(promptId)
+
+      const result = await db.select().from(triggersTable).where(eq(triggersTable.promptId, promptId))
+      expect(result).toHaveLength(0)
+    })
+
+    it('should not affect triggers for other prompts', async () => {
+      const db = DatabaseSingleton.instance.db
+      const promptId1 = uuidv7()
+      const promptId2 = uuidv7()
+      const triggerId1 = uuidv7()
+      const triggerId2 = uuidv7()
+
+      await createPrompt(promptId1)
+      await createPrompt(promptId2)
+
+      await db.insert(triggersTable).values([
+        {
+          id: triggerId1,
+          triggerType: 'time',
+          triggerTime: '08:00',
+          promptId: promptId1,
+          isEnabled: 1,
+        },
+        {
+          id: triggerId2,
+          triggerType: 'time',
+          triggerTime: '09:00',
+          promptId: promptId2,
+          isEnabled: 1,
+        },
+      ])
+
+      await deleteTriggerByPromptId(promptId1)
+
+      const remainingTriggers = await db.select().from(triggersTable)
+      expect(remainingTriggers).toHaveLength(1)
+      expect(remainingTriggers[0]?.id).toBe(triggerId2)
+      expect(remainingTriggers[0]?.promptId).toBe(promptId2)
+    })
+  })
+})

--- a/src/dal/triggers.ts
+++ b/src/dal/triggers.ts
@@ -1,0 +1,67 @@
+import { DatabaseSingleton } from '@/db/singleton'
+import { triggersTable } from '@/db/tables'
+import { type Trigger } from '@/types'
+import { eq } from 'drizzle-orm'
+
+/**
+ * Gets all triggers
+ */
+export const getAllTriggers = async (): Promise<Trigger[]> => {
+  const db = DatabaseSingleton.instance.db
+  return await db.select().from(triggersTable).where(eq(triggersTable.isEnabled, 1))
+}
+
+/**
+ * Gets triggers by prompt ID
+ */
+export const getTriggersByPromptId = async (promptId: string): Promise<Trigger[]> => {
+  const db = DatabaseSingleton.instance.db
+  return await db.select().from(triggersTable).where(eq(triggersTable.promptId, promptId))
+}
+
+/**
+ * Create a new trigger
+ */
+export const createTrigger = async (data: Trigger): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+
+  await db.insert(triggersTable).values(data)
+}
+
+/**
+ * Updates a specific trigger by ID
+ */
+export const updateTrigger = async (
+  id: string,
+  data: Partial<Pick<Trigger, 'triggerType' | 'triggerTime' | 'isEnabled'>>,
+): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.update(triggersTable).set(data).where(eq(triggersTable.id, id))
+}
+
+/**
+ * Updates a specific trigger by prompt ID
+ */
+export const updateTriggerByPromptId = async (
+  promptId: string,
+  data: Partial<Pick<Trigger, 'triggerType' | 'triggerTime' | 'isEnabled'>>,
+): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.update(triggersTable).set(data).where(eq(triggersTable.promptId, promptId))
+}
+
+/**
+ * Deletes a specific trigger by ID
+ */
+export const deleteTrigger = async (id: string): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.delete(triggersTable).where(eq(triggersTable.id, id))
+}
+
+/**
+ * Deletes a specific trigger by prompt ID
+ */
+export const deleteTriggerByPromptId = async (promptId: string): Promise<void> => {
+  const db = DatabaseSingleton.instance.db
+  await db.delete(triggersTable).where(eq(triggersTable.promptId, promptId))
+}

--- a/src/extensions/tasks/tools.ts
+++ b/src/extensions/tasks/tools.ts
@@ -1,6 +1,6 @@
+import { deleteManyTasks } from '@/dal'
 import { DatabaseSingleton } from '@/db/singleton'
 import { tasksTable } from '@/db/tables'
-import { inArray } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import { z } from 'zod'
 
@@ -48,8 +48,7 @@ export const deleteTasks = {
     taskIds: z.array(z.string()).describe("The IDs of the tasks to delete from the user's task (to do) list."),
   }),
   execute: async (params: { taskIds: string[] }) => {
-    const db = DatabaseSingleton.instance.db
-    await db.delete(tasksTable).where(inArray(tasksTable.id, params.taskIds))
+    await deleteManyTasks(params.taskIds)
     return {
       success: true,
     }

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/ui/responsive-modal'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { getHttpMcpServers } from '@/dal'
+import { deleteMcpServer, getHttpMcpServers } from '@/dal'
 import { DatabaseSingleton } from '@/db/singleton'
 import { mcpServersTable } from '@/db/tables'
 import { useMcpSync } from '@/hooks/use-mcp-sync'
@@ -134,7 +134,7 @@ export default function McpServersPage() {
 
   const deleteServerMutation = useMutation({
     mutationFn: async (id: string) => {
-      await db.delete(mcpServersTable).where(eq(mcpServersTable.id, id))
+      await deleteMcpServer(id)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['mcp-servers'] })

--- a/src/settings/models/detail.tsx
+++ b/src/settings/models/detail.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { eq } from 'drizzle-orm'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useParams } from 'react-router'
@@ -21,8 +20,6 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { deleteModel, getModel, updateModel } from '@/dal'
-import { DatabaseSingleton } from '@/db/singleton'
-import { modelsTable } from '@/db/tables'
 import type { Model } from '@/types'
 import { Trash2 } from 'lucide-react'
 
@@ -65,7 +62,7 @@ const formSchema = z
 export default function ModelDetailPage() {
   const { modelId } = useParams()
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
-  const db = DatabaseSingleton.instance.db
+
   const queryClient = useQueryClient()
   const [showSaved, setShowSaved] = useState(false)
 

--- a/src/settings/models/detail.tsx
+++ b/src/settings/models/detail.tsx
@@ -20,7 +20,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { getModel, updateModel } from '@/dal'
+import { deleteModel, getModel, updateModel } from '@/dal'
 import { DatabaseSingleton } from '@/db/singleton'
 import { modelsTable } from '@/db/tables'
 import type { Model } from '@/types'
@@ -89,7 +89,7 @@ export default function ModelDetailPage() {
 
   const deleteModelMutation = useMutation({
     mutationFn: async (id: string) => {
-      await db.delete(modelsTable).where(eq(modelsTable.id, id))
+      await deleteModel(id)
       return true
     },
     onSuccess: () => {

--- a/src/tasks/index.tsx
+++ b/src/tasks/index.tsx
@@ -3,7 +3,7 @@ import { PageHeader } from '@/components/ui/page-header'
 import { SearchInput } from '@/components/ui/search-input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { getIncompleteTasks, getIncompleteTasksCount, updateTask } from '@/dal'
+import { deleteTask, getIncompleteTasks, getIncompleteTasksCount, updateTask } from '@/dal'
 import { DatabaseSingleton } from '@/db/singleton'
 import { tasksTable } from '@/db/tables'
 import { trackEvent } from '@/lib/posthog'
@@ -338,7 +338,7 @@ export default function TasksPage() {
 
   const deleteTaskMutation = useMutation({
     mutationFn: async (id: string) => {
-      await db.delete(tasksTable).where(eq(tasksTable.id, id))
+      await deleteTask(id)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tasks'] })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Consolidates database access behind the DAL and introduces a dedicated `triggers` module.
> 
> - New `dal/triggers.ts` with CRUD (`getAllTriggers`, `getTriggersByPromptId`, `createTrigger`, `updateTrigger`, `updateTriggerByPromptId`, `deleteTrigger`, `deleteTriggerByPromptId`) and comprehensive tests
> - UI refactors: `automations/*` now use DAL for triggers and models; toggle and form updates call `updateTrigger`, `createTrigger`, etc.; scheduler uses `getAllTriggers`
> - Added delete helpers and tests: `deleteTask`, `deleteManyTasks`, `deleteModel`, `deleteMcpServer`; exported via `dal/index.ts`
> - Replaced inline deletes/updates in `tasks`, `models/detail`, `settings/mcp-servers`, and `extensions/tasks/tools` with DAL calls
> - `prompts.deleteAutomation` now deletes associated triggers via `deleteTriggerByPromptId`
> 
> Scope touches automations, tasks, models, MCP settings, and DAL tests; lockstep query invalidations updated where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de9cd024cfcd74975ad3f54ab4a216d905a46963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->