### PR TITLE
THU-221: Authentication not working on mobile

### DIFF
--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -1,7 +1,7 @@
 import type { db as DbType } from '@/db/client'
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
-import { emailOTP } from 'better-auth/plugins'
+import { bearer, emailOTP } from 'better-auth/plugins'
 import { Resend } from 'resend'
 import { buildVerifyUrl, getValidatedOrigin, parseTrustedOrigins, sendSignInEmail } from './utils'
 
@@ -34,6 +34,7 @@ export const createAuth = (database: typeof DbType) =>
     }),
     trustedOrigins,
     plugins: [
+      bearer(), // Enables Authorization: Bearer <token> for mobile apps where cookies don't work
       emailOTP({
         otpLength: 6,
         expiresIn: 300, // 5 minutes

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -103,11 +103,12 @@ const startServer = async () => {
   try {
     const app = await createApp()
 
-    const hostname = process.env.HOST
-      ? process.env.HOST
-      : process.env.NODE_ENV === 'production'
-        ? '0.0.0.0'
-        : 'localhost'
+    // const hostname = process.env.HOST
+    //   ? process.env.HOST
+    //   : process.env.NODE_ENV === 'production'
+    //     ? '0.0.0.0'
+    //     : 'localhost'
+    const hostname = '0.0.0.0'
 
     app.listen(
       {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -103,12 +103,11 @@ const startServer = async () => {
   try {
     const app = await createApp()
 
-    // const hostname = process.env.HOST
-    //   ? process.env.HOST
-    //   : process.env.NODE_ENV === 'production'
-    //     ? '0.0.0.0'
-    //     : 'localhost'
-    const hostname = '0.0.0.0'
+    const hostname = process.env.HOST
+      ? process.env.HOST
+      : process.env.NODE_ENV === 'production'
+        ? '0.0.0.0'
+        : 'localhost'
 
     app.listen(
       {

--- a/src/components/logout-modal.test.tsx
+++ b/src/components/logout-modal.test.tsx
@@ -1,3 +1,4 @@
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import type { ConsoleSpies } from '@/test-utils/console-spies'
 import { setupConsoleSpy } from '@/test-utils/console-spies'
 import { createMockAuthClient } from '@/test-utils/auth-client'
@@ -28,15 +29,18 @@ describe('LogoutModal', () => {
   let mockOnOpenChange: ReturnType<typeof mock>
   let mockSignOut: ReturnType<typeof mock>
 
-  beforeAll(() => {
+  beforeAll(async () => {
     consoleSpies = setupConsoleSpy()
+    await setupTestDatabase()
   })
 
-  afterAll(() => {
+  afterAll(async () => {
     consoleSpies.restore()
+    await teardownTestDatabase()
   })
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await resetTestDatabase()
     mockOnOpenChange = mock()
     mockSignOut = mock(() => Promise.resolve())
     mockResetAppDir.mockClear()

--- a/src/components/logout-modal.tsx
+++ b/src/components/logout-modal.tsx
@@ -13,6 +13,7 @@ import {
   ResponsiveModalTitle,
 } from '@/components/ui/responsive-modal'
 import { useAuth } from '@/contexts'
+import { clearAuthToken } from '@/lib/auth-token'
 import { resetAppDir } from '@/lib/fs'
 import { cn } from '@/lib/utils'
 
@@ -101,6 +102,9 @@ export const LogoutModal = ({ open, onOpenChange }: LogoutModalProps) => {
     } catch (error) {
       console.error('Failed to sign out:', error)
     }
+
+    // Clear local bearer token (mobile auth)
+    await clearAuthToken()
 
     try {
       if (selectedOption === 'delete') {

--- a/src/components/use-sign-in-modal-state.ts
+++ b/src/components/use-sign-in-modal-state.ts
@@ -1,4 +1,6 @@
 import type { AuthClient } from '@/contexts'
+import { setAuthToken } from '@/lib/auth-token'
+import { isMobile } from '@/lib/platform'
 import { useReducer, type FormEvent } from 'react'
 
 type ModalStatus = 'idle' | 'sending' | 'sent' | 'verifying' | 'success' | 'error'
@@ -109,6 +111,11 @@ export const useSignInModalState = ({ authClient, onClose }: UseSignInModalState
       if (result.error) {
         dispatch({ type: 'VERIFY_ERROR', payload: result.error.message || 'Invalid code. Please try again.' })
         return
+      }
+
+      // On mobile, store the token for bearer auth (cookies don't persist)
+      if (isMobile() && result.data?.token) {
+        await setAuthToken(result.data.token)
       }
 
       // Sign-in successful - show success state

--- a/src/components/use-sign-in-modal-state.ts
+++ b/src/components/use-sign-in-modal-state.ts
@@ -1,6 +1,5 @@
 import type { AuthClient } from '@/contexts'
 import { setAuthToken } from '@/lib/auth-token'
-import { isMobile } from '@/lib/platform'
 import { useReducer, type FormEvent } from 'react'
 
 type ModalStatus = 'idle' | 'sending' | 'sent' | 'verifying' | 'success' | 'error'
@@ -113,8 +112,8 @@ export const useSignInModalState = ({ authClient, onClose }: UseSignInModalState
         return
       }
 
-      // On mobile, store the token for bearer auth (cookies don't persist)
-      if (isMobile() && result.data?.token) {
+      // Store the token for bearer auth
+      if (result.data?.token) {
         await setAuthToken(result.data.token)
       }
 

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -2,7 +2,7 @@
 
 import { useSettings } from '@/hooks/use-settings'
 import { getAuthToken, setAuthToken } from '@/lib/auth-token'
-import { getPlatform, isMobile } from '@/lib/platform'
+import { getPlatform } from '@/lib/platform'
 import { emailOTPClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/react'
 import { createContext, useContext, useMemo, type ReactNode } from 'react'
@@ -10,47 +10,35 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react'
 /**
  * Create an auth client instance with the given base URL
  *
- * On mobile (iOS/Android), uses Bearer token auth since cookies don't persist
- * for the tauri://localhost origin in WKWebView.
+ * Uses Bearer token authentication for all platforms, storing tokens
+ * in the settings database for persistence across app restarts.
  */
 const createAuthClientInstance = (cloudUrl: string) => {
   const baseURL = cloudUrl.replace(/\/v1$/, '') // Better Auth adds /api/auth
   const platform = getPlatform()
-  const mobile = isMobile()
 
   return createAuthClient({
     baseURL,
     basePath: '/v1/api/auth',
     plugins: [emailOTPClient()],
-    fetchOptions: buildFetchOptions(platform, mobile),
+    fetchOptions: buildFetchOptions(platform),
   })
 }
 
-const buildFetchOptions = (platform: string, mobile: boolean) => {
-  const baseOptions = {
-    credentials: (mobile ? 'omit' : 'include') as RequestCredentials,
-    headers: { 'X-Client-Platform': platform },
-  }
-
-  if (!mobile) {
-    return baseOptions
-  }
-
-  // Mobile: Use bearer token instead of cookies
-  return {
-    ...baseOptions,
-    auth: {
-      type: 'Bearer' as const,
-      token: () => getAuthToken() ?? '',
-    },
-    onSuccess: (ctx: { response: Response }) => {
-      const token = ctx.response.headers.get('set-auth-token')
-      if (token) {
-        setAuthToken(token)
-      }
-    },
-  }
-}
+const buildFetchOptions = (platform: string) => ({
+  credentials: 'omit' as RequestCredentials,
+  headers: { 'X-Client-Platform': platform },
+  auth: {
+    type: 'Bearer' as const,
+    token: () => getAuthToken() ?? '',
+  },
+  onSuccess: (ctx: { response: Response }) => {
+    const token = ctx.response.headers.get('set-auth-token')
+    if (token) {
+      setAuthToken(token)
+    }
+  },
+})
 
 export type AuthClient = ReturnType<typeof createAuthClientInstance>
 export type Session = AuthClient['$Infer']['Session']

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -1,31 +1,55 @@
 'use client'
 
 import { useSettings } from '@/hooks/use-settings'
-import { getPlatform } from '@/lib/platform'
+import { getAuthToken, setAuthToken } from '@/lib/auth-token'
+import { getPlatform, isMobile } from '@/lib/platform'
 import { emailOTPClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/react'
 import { createContext, useContext, useMemo, type ReactNode } from 'react'
 
 /**
  * Create an auth client instance with the given base URL
- * Includes platform header so backend can use deep links for mobile
+ *
+ * On mobile (iOS/Android), uses Bearer token auth since cookies don't persist
+ * for the tauri://localhost origin in WKWebView.
  */
 const createAuthClientInstance = (cloudUrl: string) => {
-  // Remove trailing /v1 if present since Better Auth adds /api/auth
-  const baseURL = cloudUrl.replace(/\/v1$/, '')
+  const baseURL = cloudUrl.replace(/\/v1$/, '') // Better Auth adds /api/auth
   const platform = getPlatform()
+  const mobile = isMobile()
 
   return createAuthClient({
     baseURL,
     basePath: '/v1/api/auth',
     plugins: [emailOTPClient()],
-    fetchOptions: {
-      credentials: 'include', // Required for cookies to be sent/received
-      headers: {
-        'X-Client-Platform': platform,
-      },
-    },
+    fetchOptions: buildFetchOptions(platform, mobile),
   })
+}
+
+const buildFetchOptions = (platform: string, mobile: boolean) => {
+  const baseOptions = {
+    credentials: (mobile ? 'omit' : 'include') as RequestCredentials,
+    headers: { 'X-Client-Platform': platform },
+  }
+
+  if (!mobile) {
+    return baseOptions
+  }
+
+  // Mobile: Use bearer token instead of cookies
+  return {
+    ...baseOptions,
+    auth: {
+      type: 'Bearer' as const,
+      token: () => getAuthToken() ?? '',
+    },
+    onSuccess: (ctx: { response: Response }) => {
+      const token = ctx.response.headers.get('set-auth-token')
+      if (token) {
+        setAuthToken(token)
+      }
+    },
+  }
 }
 
 export type AuthClient = ReturnType<typeof createAuthClientInstance>

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -3,6 +3,7 @@ import { getSettings } from '@/dal'
 import type { AnyDrizzleDatabase } from '@/db/database-interface'
 import { migrate } from '@/db/migrate'
 import { DatabaseSingleton } from '@/db/singleton'
+import { loadAuthToken } from '@/lib/auth-token'
 import { createHandleError } from '@/lib/error-utils'
 import { createAppDir, resetAppDir } from '@/lib/fs'
 import { getDatabasePath, getDatabaseType } from '@/lib/platform'
@@ -102,6 +103,13 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
       success: false,
       error: reconcileError,
     }
+  }
+
+  // Step 4.5: Load auth token for mobile (non-critical)
+  try {
+    await loadAuthToken()
+  } catch (error) {
+    console.warn('Failed to load auth token, continuing:', error)
   }
 
   // Step 5: HTTP client initialization (use provided client or create one)

--- a/src/lib/auth-token.test.ts
+++ b/src/lib/auth-token.test.ts
@@ -1,0 +1,103 @@
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { _resetCacheForTesting, clearAuthToken, getAuthToken, loadAuthToken, setAuthToken } from './auth-token'
+
+beforeAll(async () => {
+  await setupTestDatabase()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+beforeEach(async () => {
+  await resetTestDatabase()
+  _resetCacheForTesting()
+})
+
+describe('auth-token', () => {
+  describe('getAuthToken', () => {
+    it('returns null when no token is cached', () => {
+      expect(getAuthToken()).toBeNull()
+    })
+
+    it('returns cached token after setAuthToken', async () => {
+      await setAuthToken('test-token-123')
+      expect(getAuthToken()).toBe('test-token-123')
+    })
+  })
+
+  describe('setAuthToken', () => {
+    it('stores token in memory cache', async () => {
+      await setAuthToken('cached-token')
+      expect(getAuthToken()).toBe('cached-token')
+    })
+
+    it('persists token to settings database', async () => {
+      await setAuthToken('persisted-token')
+
+      // Reset cache to simulate app restart
+      _resetCacheForTesting()
+      expect(getAuthToken()).toBeNull()
+
+      // Load from database should restore the token
+      await loadAuthToken()
+      expect(getAuthToken()).toBe('persisted-token')
+    })
+
+    it('removes token from database when set to null', async () => {
+      await setAuthToken('token-to-remove')
+      expect(getAuthToken()).toBe('token-to-remove')
+
+      await setAuthToken(null)
+      expect(getAuthToken()).toBeNull()
+
+      // Verify it's also removed from database
+      _resetCacheForTesting()
+      await loadAuthToken()
+      expect(getAuthToken()).toBeNull()
+    })
+  })
+
+  describe('loadAuthToken', () => {
+    it('loads token from database into cache', async () => {
+      // Store token and reset cache
+      await setAuthToken('db-token')
+      _resetCacheForTesting()
+
+      expect(getAuthToken()).toBeNull()
+
+      await loadAuthToken()
+      expect(getAuthToken()).toBe('db-token')
+    })
+
+    it('sets cache to null when no token in database', async () => {
+      await loadAuthToken()
+      expect(getAuthToken()).toBeNull()
+    })
+  })
+
+  describe('clearAuthToken', () => {
+    it('clears token from cache', async () => {
+      await setAuthToken('token-to-clear')
+      expect(getAuthToken()).toBe('token-to-clear')
+
+      await clearAuthToken()
+      expect(getAuthToken()).toBeNull()
+    })
+
+    it('clears token from database', async () => {
+      await setAuthToken('persistent-token')
+
+      await clearAuthToken()
+
+      // Verify cache is cleared
+      expect(getAuthToken()).toBeNull()
+
+      // Verify database is cleared
+      _resetCacheForTesting()
+      await loadAuthToken()
+      expect(getAuthToken()).toBeNull()
+    })
+  })
+})

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -8,6 +8,7 @@
  * while persisting to settings database for durability across app restarts.
  */
 
+import { deleteSetting, getSettings, updateSettings } from '@/dal/settings'
 import { isMobile } from './platform'
 
 const AUTH_TOKEN_SETTING_KEY = 'auth_bearer_token'
@@ -24,7 +25,6 @@ export const getAuthToken = (): string | null => {
 export const setAuthToken = async (token: string | null): Promise<void> => {
   cachedToken = token
 
-  const { updateSettings, deleteSetting } = await import('@/dal/settings')
   if (token) {
     await updateSettings({ [AUTH_TOKEN_SETTING_KEY]: token })
   } else {
@@ -36,7 +36,6 @@ export const setAuthToken = async (token: string | null): Promise<void> => {
 export const loadAuthToken = async (): Promise<void> => {
   if (!isMobile()) return
 
-  const { getSettings } = await import('@/dal/settings')
   const settings = await getSettings({ [AUTH_TOKEN_SETTING_KEY]: String })
   cachedToken = settings.authBearerToken
 }

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,0 +1,47 @@
+/**
+ * Auth token storage for mobile platforms (iOS/Android)
+ *
+ * Cookies don't persist for the tauri://localhost origin in WKWebView.
+ * This module stores the session token and sends it as Authorization: Bearer header.
+ *
+ * Provides sync access (required by Better Auth's fetchOptions.auth.token)
+ * while persisting to settings database for durability across app restarts.
+ */
+
+import { isMobile } from './platform'
+
+const AUTH_TOKEN_SETTING_KEY = 'auth_bearer_token'
+
+let cachedToken: string | null = null
+
+/** Get the current auth token (sync, for mobile only) */
+export const getAuthToken = (): string | null => {
+  if (!isMobile()) return null
+  return cachedToken
+}
+
+/** Store the auth token (cache + persist to settings) */
+export const setAuthToken = async (token: string | null): Promise<void> => {
+  cachedToken = token
+
+  const { updateSettings, deleteSetting } = await import('@/dal/settings')
+  if (token) {
+    await updateSettings({ [AUTH_TOKEN_SETTING_KEY]: token })
+  } else {
+    await deleteSetting(AUTH_TOKEN_SETTING_KEY)
+  }
+}
+
+/** Load auth token from settings into cache (call on app init) */
+export const loadAuthToken = async (): Promise<void> => {
+  if (!isMobile()) return
+
+  const { getSettings } = await import('@/dal/settings')
+  const settings = await getSettings({ [AUTH_TOKEN_SETTING_KEY]: String })
+  cachedToken = settings.authBearerToken
+}
+
+/** Clear the auth token (for sign-out) */
+export const clearAuthToken = async (): Promise<void> => {
+  await setAuthToken(null)
+}

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,23 +1,22 @@
 /**
- * Auth token storage for mobile platforms (iOS/Android)
+ * Auth token storage for bearer authentication
  *
- * Cookies don't persist for the tauri://localhost origin in WKWebView.
- * This module stores the session token and sends it as Authorization: Bearer header.
+ * Stores the session token in the settings database and sends it via
+ * Authorization: Bearer header. Used universally across all platforms
+ * for consistent authentication behavior.
  *
  * Provides sync access (required by Better Auth's fetchOptions.auth.token)
  * while persisting to settings database for durability across app restarts.
  */
 
 import { deleteSetting, getSettings, updateSettings } from '@/dal/settings'
-import { isMobile } from './platform'
 
 const AUTH_TOKEN_SETTING_KEY = 'auth_bearer_token'
 
 let cachedToken: string | null = null
 
-/** Get the current auth token (sync, for mobile only) */
+/** Get the current auth token (sync) */
 export const getAuthToken = (): string | null => {
-  if (!isMobile()) return null
   return cachedToken
 }
 
@@ -34,14 +33,16 @@ export const setAuthToken = async (token: string | null): Promise<void> => {
 
 /** Load auth token from settings into cache (call on app init) */
 export const loadAuthToken = async (): Promise<void> => {
-  if (!isMobile()) return
-
   const settings = await getSettings({ [AUTH_TOKEN_SETTING_KEY]: String })
   cachedToken = settings.authBearerToken
 }
 
-/** Clear the auth token (for sign-out) - mobile only */
+/** Clear the auth token (for sign-out) */
 export const clearAuthToken = async (): Promise<void> => {
-  if (!isMobile()) return
   await setAuthToken(null)
+}
+
+/** Reset the in-memory cache (for testing only) */
+export const _resetCacheForTesting = (): void => {
+  cachedToken = null
 }

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -40,7 +40,8 @@ export const loadAuthToken = async (): Promise<void> => {
   cachedToken = settings.authBearerToken
 }
 
-/** Clear the auth token (for sign-out) */
+/** Clear the auth token (for sign-out) - mobile only */
 export const clearAuthToken = async (): Promise<void> => {
+  if (!isMobile()) return
   await setAuthToken(null)
 }


### PR DESCRIPTION
### Problem

On iOS, users could complete the sign-in flow successfully but weren't actually logged in after closing the modal. This happened because iOS WKWebView doesn't persist cookies for the `tauri://localhost` origin used by Tauri apps.

### Solution

Implemented bearer token authentication for mobile platforms. Instead of relying on cookies (which work on desktop), the app now:

- Stores the session token locally after successful sign-in
- Sends it via `Authorization: Bearer` header on subsequent requests
- Restores the token on app startup for persistent sessions

This approach follows Better Auth's recommended pattern for mobile apps where cookie-based sessions aren't reliable.

### Impact

iOS and Android users can now sign in and stay authenticated across app sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces bearer-token–based auth for reliable mobile sessions and unifies auth across platforms.
> 
> - Backend: enables `bearer()` plugin in `backend/src/auth/auth.ts` alongside `emailOTP`
> - Client: routes all requests with `Authorization: Bearer <token>` via `fetchOptions.auth` in `src/contexts/auth-context.tsx`; captures `set-auth-token` response header to persist
> - New token store: adds `src/lib/auth-token.ts` to cache/persist tokens in settings; supports `get/set/load/clear`
> - App init: loads stored token during startup in `src/hooks/use-app-initialization.ts`
> - Sign-in: saves returned token after OTP verification in `src/components/use-sign-in-modal-state.ts`
> - Logout: clears persisted token in `src/components/logout-modal.tsx`
> - Tests: adds `src/lib/auth-token.test.ts` and updates `logout-modal.test.tsx` for DB setup/reset
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d385dbb4106b01bb4108c47b4b8e2e6cf1023aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->