### PR TITLE
THU-243: Build CR-SQLite Sync POC [BE]

### DIFF
--- a/backend/drizzle/0002_cheerful_ted_forrester.sql
+++ b/backend/drizzle/0002_cheerful_ted_forrester.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "sync_changes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"site_id" text NOT NULL,
+	"table_name" text NOT NULL,
+	"pk" text NOT NULL,
+	"cid" text NOT NULL,
+	"val" text,
+	"col_version" bigint NOT NULL,
+	"db_version" bigint NOT NULL,
+	"cl" integer NOT NULL,
+	"seq" integer NOT NULL,
+	"site_id_raw" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sync_devices" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"site_id" text NOT NULL,
+	"migration_version" text,
+	"last_seen_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "sync_migration_version" text;--> statement-breakpoint
+ALTER TABLE "sync_changes" ADD CONSTRAINT "sync_changes_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_devices" ADD CONSTRAINT "sync_devices_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "sync_changes_user_id_idx" ON "sync_changes" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "sync_changes_user_site_idx" ON "sync_changes" USING btree ("user_id","site_id");--> statement-breakpoint
+CREATE INDEX "sync_changes_created_at_idx" ON "sync_changes" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "sync_devices_user_id_idx" ON "sync_devices" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "sync_devices_site_id_idx" ON "sync_devices" USING btree ("site_id");

--- a/backend/drizzle/0003_gray_emma_frost.sql
+++ b/backend/drizzle/0003_gray_emma_frost.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sync_devices" ADD CONSTRAINT "sync_devices_user_site_unique" UNIQUE("user_id","site_id");

--- a/backend/drizzle/meta/0002_snapshot.json
+++ b/backend/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,690 @@
+{
+  "id": "3f3e6e16-d9b6-4c8b-8b11-071eae549623",
+  "prevId": "5c9dd586-952e-4419-a24e-25de745009f9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_migration_version": {
+          "name": "sync_migration_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_changes": {
+      "name": "sync_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pk": {
+          "name": "pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "col_version": {
+          "name": "col_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_version": {
+          "name": "db_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cl": {
+          "name": "cl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id_raw": {
+          "name": "site_id_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_changes_user_id_idx": {
+          "name": "sync_changes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_changes_user_site_idx": {
+          "name": "sync_changes_user_site_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_changes_created_at_idx": {
+          "name": "sync_changes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_changes_user_id_user_id_fk": {
+          "name": "sync_changes_user_id_user_id_fk",
+          "tableFrom": "sync_changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_version": {
+          "name": "migration_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_devices_site_id_idx": {
+          "name": "sync_devices_site_id_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0003_snapshot.json
+++ b/backend/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,699 @@
+{
+  "id": "c42a58fe-439f-4af2-9855-5384b1106163",
+  "prevId": "3f3e6e16-d9b6-4c8b-8b11-071eae549623",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_migration_version": {
+          "name": "sync_migration_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_changes": {
+      "name": "sync_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pk": {
+          "name": "pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "col_version": {
+          "name": "col_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_version": {
+          "name": "db_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cl": {
+          "name": "cl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id_raw": {
+          "name": "site_id_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_changes_user_id_idx": {
+          "name": "sync_changes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_changes_user_site_idx": {
+          "name": "sync_changes_user_site_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_changes_created_at_idx": {
+          "name": "sync_changes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_changes_user_id_user_id_fk": {
+          "name": "sync_changes_user_id_user_id_fk",
+          "tableFrom": "sync_changes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_version": {
+          "name": "migration_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_devices_site_id_idx": {
+          "name": "sync_devices_site_id_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sync_devices_user_site_unique": {
+          "name": "sync_devices_user_site_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "site_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1768312389891,
       "tag": "0002_cheerful_ted_forrester",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1768325071528,
+      "tag": "0003_gray_emma_frost",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1764105849340,
       "tag": "0001_gifted_ben_grimm",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1768312389891,
+      "tag": "0002_cheerful_ted_forrester",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/auth-schema.ts
+++ b/backend/src/db/auth-schema.ts
@@ -7,6 +7,7 @@ export const user = pgTable('user', {
   email: text('email').notNull().unique(),
   emailVerified: boolean('email_verified').default(false).notNull(),
   image: text('image'),
+  syncMigrationVersion: text('sync_migration_version'), // Minimum migration version required for sync
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at')
     .defaultNow()

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -3,6 +3,9 @@ import { integer, pgTable, varchar } from 'drizzle-orm/pg-core'
 // Re-export Better Auth schema tables
 export * from './auth-schema'
 
+// Re-export sync schema tables
+export * from './sync-schema'
+
 export const usersTable = pgTable('users', {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   name: varchar({ length: 255 }).notNull(),

--- a/backend/src/db/sync-schema.ts
+++ b/backend/src/db/sync-schema.ts
@@ -1,0 +1,65 @@
+import { relations } from 'drizzle-orm'
+import { bigint, index, integer, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core'
+import { user } from '../db/auth-schema'
+
+/**
+ * Store change events per user for multi-device sync
+ * This table acts as a relay for cr-sqlite changes between devices
+ */
+export const syncChanges = pgTable(
+  'sync_changes',
+  {
+    id: serial('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    siteId: text('site_id').notNull(), // Device that made the change
+    tableName: text('table_name').notNull(),
+    pk: text('pk').notNull(), // Primary key (base64 encoded)
+    cid: text('cid').notNull(), // Column ID
+    val: text('val'), // Value (JSON stringified)
+    colVersion: bigint('col_version', { mode: 'bigint' }).notNull(),
+    dbVersion: bigint('db_version', { mode: 'bigint' }).notNull(),
+    cl: integer('cl').notNull(), // Causal length
+    seq: integer('seq').notNull(), // Sequence number
+    siteIdRaw: text('site_id_raw').notNull(), // Site ID (base64 encoded)
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    index('sync_changes_user_id_idx').on(table.userId),
+    index('sync_changes_user_site_idx').on(table.userId, table.siteId),
+    index('sync_changes_created_at_idx').on(table.createdAt),
+  ],
+)
+
+/**
+ * Track the last sync version for each user's device
+ */
+export const syncDevices = pgTable(
+  'sync_devices',
+  {
+    id: serial('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    siteId: text('site_id').notNull(), // Device site ID
+    migrationVersion: text('migration_version'), // Last migration hash this device synced with
+    lastSeenAt: timestamp('last_seen_at').defaultNow().notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [index('sync_devices_user_id_idx').on(table.userId), index('sync_devices_site_id_idx').on(table.siteId)],
+)
+
+export const syncChangesRelations = relations(syncChanges, ({ one }) => ({
+  user: one(user, {
+    fields: [syncChanges.userId],
+    references: [user.id],
+  }),
+}))
+
+export const syncDevicesRelations = relations(syncDevices, ({ one }) => ({
+  user: one(user, {
+    fields: [syncDevices.userId],
+    references: [user.id],
+  }),
+}))

--- a/backend/src/db/sync-schema.ts
+++ b/backend/src/db/sync-schema.ts
@@ -1,5 +1,5 @@
 import { relations } from 'drizzle-orm'
-import { bigint, index, integer, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core'
+import { bigint, index, integer, pgTable, serial, text, timestamp, unique } from 'drizzle-orm/pg-core'
 import { user } from '../db/auth-schema'
 
 /**
@@ -47,7 +47,11 @@ export const syncDevices = pgTable(
     lastSeenAt: timestamp('last_seen_at').defaultNow().notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
   },
-  (table) => [index('sync_devices_user_id_idx').on(table.userId), index('sync_devices_site_id_idx').on(table.siteId)],
+  (table) => [
+    unique('sync_devices_user_site_unique').on(table.userId, table.siteId),
+    index('sync_devices_user_id_idx').on(table.userId),
+    index('sync_devices_site_id_idx').on(table.siteId),
+  ],
 )
 
 export const syncChangesRelations = relations(syncChanges, ({ one }) => ({

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,8 @@ import { createErrorHandlingMiddleware } from '@/middleware/error-handling'
 import { createHttpLoggingMiddleware } from '@/middleware/http-logging'
 import { createPostHogRoutes } from '@/posthog/routes'
 import { createProToolsRoutes } from '@/pro/routes'
+import { createSyncRoutes } from '@/sync/routes'
+import { createSyncWebSocketRoutes } from '@/sync/websocket'
 import type { AppDeps } from '@/types'
 import { cors } from '@elysiajs/cors'
 import { Elysia } from 'elysia'
@@ -52,7 +54,7 @@ export const createApp = async (deps?: AppDeps) => {
   const configuredApp = instrumentation ? app.use(instrumentation) : app
 
   // Create auth plugin with the database instance
-  const { plugin: betterAuthPlugin } = createBetterAuthPlugin(database)
+  const { plugin: betterAuthPlugin, auth } = createBetterAuthPlugin(database)
 
   return (
     configuredApp
@@ -78,6 +80,8 @@ export const createApp = async (deps?: AppDeps) => {
       .use(createProToolsRoutes(fetchFn))
       .use(createInferenceRoutes())
       .use(createPostHogRoutes(fetchFn))
+      .use(createSyncRoutes(database, auth))
+      .use(createSyncWebSocketRoutes(database, auth))
   )
 }
 

--- a/backend/src/sync/routes.test.ts
+++ b/backend/src/sync/routes.test.ts
@@ -100,7 +100,7 @@ describe('Sync Routes', () => {
 
     it('returns needsUpgrade when client version is outdated', async () => {
       // Set a required migration version
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0005_required', null)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0005_required')
 
       const response = await app.handle(
         new Request('http://localhost/v1/sync/push', {
@@ -195,7 +195,7 @@ describe('Sync Routes', () => {
     })
 
     it('returns needsUpgrade when client version is outdated', async () => {
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0005_required', null)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0005_required')
 
       const response = await app.handle(new Request('http://localhost/v1/sync/pull?since=0&migrationVersion=0001_old'))
 

--- a/backend/src/sync/routes.test.ts
+++ b/backend/src/sync/routes.test.ts
@@ -1,0 +1,287 @@
+import { createTestDb } from '@/test-utils/db'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Elysia } from 'elysia'
+import { createSyncRoutes } from './routes'
+import { ensureMockUserExists, insertChanges, MOCK_USER, updateMigrationVersionIfNewer } from './shared'
+
+/**
+ * Create a minimal test app with just sync routes
+ * This avoids initializing better-auth which has module issues in tests
+ */
+const createTestApp = (database: Awaited<ReturnType<typeof createTestDb>>['db']) => {
+  // Create a minimal mock auth object
+  const mockAuth = {} as Parameters<typeof createSyncRoutes>[1]
+
+  return new Elysia({ prefix: '/v1' }).use(createSyncRoutes(database, mockAuth))
+}
+
+describe('Sync Routes', () => {
+  let app: ReturnType<typeof createTestApp>
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+    app = createTestApp(db)
+
+    // Ensure mock user exists for all tests
+    await ensureMockUserExists(db)
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('POST /sync/push', () => {
+    it('returns success with empty changes', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/v1/sync/push', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            siteId: 'site-123',
+            changes: [],
+            dbVersion: '1',
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.success).toBe(true)
+      expect(data.serverVersion).toBeDefined()
+    })
+
+    it('pushes changes successfully', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/v1/sync/push', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            siteId: 'site-123',
+            changes: [
+              {
+                table: 'test_table',
+                pk: 'pk1',
+                cid: 'col1',
+                val: 'value1',
+                col_version: '1',
+                db_version: '1',
+                site_id: 'site-123',
+                cl: 1,
+                seq: 0,
+              },
+            ],
+            dbVersion: '1',
+            migrationVersion: '0001_test',
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.success).toBe(true)
+      expect(parseInt(data.serverVersion)).toBeGreaterThan(0)
+    })
+
+    it('returns validation error for missing required fields', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/v1/sync/push', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      )
+
+      expect(response.status).toBe(400)
+    })
+
+    it('returns needsUpgrade when client version is outdated', async () => {
+      // Set a required migration version
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0005_required', null)
+
+      const response = await app.handle(
+        new Request('http://localhost/v1/sync/push', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            siteId: 'site-123',
+            changes: [],
+            dbVersion: '1',
+            migrationVersion: '0001_old',
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.success).toBe(false)
+      expect(data.needsUpgrade).toBe(true)
+      expect(data.requiredVersion).toBe('0005_required')
+    })
+  })
+
+  describe('GET /sync/pull', () => {
+    it('returns empty changes when none exist', async () => {
+      const response = await app.handle(new Request('http://localhost/v1/sync/pull?since=0'))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.changes).toEqual([])
+      expect(data.serverVersion).toBe('0')
+    })
+
+    it('returns changes since given version', async () => {
+      // Insert some changes
+      await insertChanges(db, MOCK_USER.id, 'site-123', [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ])
+
+      const response = await app.handle(new Request('http://localhost/v1/sync/pull?since=0'))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.changes).toHaveLength(1)
+      expect(data.changes[0].table).toBe('test_table')
+      expect(parseInt(data.serverVersion)).toBeGreaterThan(0)
+    })
+
+    it('filters changes by since parameter', async () => {
+      // Insert two changes
+      const inserted = await insertChanges(db, MOCK_USER.id, 'site-123', [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+        {
+          table: 'test_table',
+          pk: 'pk2',
+          cid: 'col1',
+          val: 'value2',
+          col_version: '2',
+          db_version: '2',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 1,
+        },
+      ])
+
+      // Pull only changes after the first one
+      const response = await app.handle(new Request(`http://localhost/v1/sync/pull?since=${inserted[0].id}`))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.changes).toHaveLength(1)
+      expect(data.changes[0].pk).toBe('pk2')
+    })
+
+    it('returns needsUpgrade when client version is outdated', async () => {
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0005_required', null)
+
+      const response = await app.handle(new Request('http://localhost/v1/sync/pull?since=0&migrationVersion=0001_old'))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.changes).toEqual([])
+      expect(data.needsUpgrade).toBe(true)
+      expect(data.requiredVersion).toBe('0005_required')
+    })
+
+    it('requires since parameter', async () => {
+      const response = await app.handle(new Request('http://localhost/v1/sync/pull'))
+
+      expect(response.status).toBe(422)
+    })
+  })
+
+  describe('GET /sync/version', () => {
+    it('returns 0 when no changes exist', async () => {
+      const response = await app.handle(new Request('http://localhost/v1/sync/version'))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.serverVersion).toBe('0')
+    })
+
+    it('returns latest version after changes', async () => {
+      await insertChanges(db, MOCK_USER.id, 'site-123', [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ])
+
+      const response = await app.handle(new Request('http://localhost/v1/sync/version'))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(parseInt(data.serverVersion)).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Push/Pull Integration', () => {
+    it('changes pushed are available for pull', async () => {
+      // Push a change
+      const pushResponse = await app.handle(
+        new Request('http://localhost/v1/sync/push', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            siteId: 'device-1',
+            changes: [
+              {
+                table: 'notes',
+                pk: 'note-1',
+                cid: 'content',
+                val: 'Hello World',
+                col_version: '1',
+                db_version: '1',
+                site_id: 'device-1',
+                cl: 1,
+                seq: 0,
+              },
+            ],
+            dbVersion: '1',
+          }),
+        }),
+      )
+
+      expect(pushResponse.status).toBe(200)
+
+      // Pull from another device
+      const pullResponse = await app.handle(new Request('http://localhost/v1/sync/pull?since=0&siteId=device-2'))
+
+      expect(pullResponse.status).toBe(200)
+      const data = await pullResponse.json()
+      expect(data.changes).toHaveLength(1)
+      expect(data.changes[0].table).toBe('notes')
+      expect(data.changes[0].val).toBe('Hello World')
+    })
+  })
+})

--- a/backend/src/sync/routes.ts
+++ b/backend/src/sync/routes.ts
@@ -59,6 +59,11 @@ export const createSyncRoutes = (database: typeof DbType, auth: Auth) => {
             }
           }
 
+          // Always update migration version and device record, even with empty changes
+          // This ensures the server learns about schema upgrades from clients without local changes
+          await updateMigrationVersionIfNewer(database, authUser.id, migrationVersion)
+          await upsertSyncDevice(database, authUser.id, siteId, migrationVersion)
+
           if (changes.length === 0) {
             const serverVersion = await getLatestServerVersion(database, authUser.id)
             return {
@@ -67,15 +72,9 @@ export const createSyncRoutes = (database: typeof DbType, auth: Auth) => {
             }
           }
 
-          // Atomically update migration version BEFORE inserting changes
-          await updateMigrationVersionIfNewer(database, authUser.id, migrationVersion)
-
           // Insert all changes
           const insertedChanges = await insertChanges(database, authUser.id, siteId, changes)
           const maxServerVersion = getMaxServerVersion(insertedChanges, 0)
-
-          // Update device record
-          await upsertSyncDevice(database, authUser.id, siteId, migrationVersion)
 
           return {
             success: true,

--- a/backend/src/sync/routes.ts
+++ b/backend/src/sync/routes.ts
@@ -67,8 +67,8 @@ export const createSyncRoutes = (database: typeof DbType, auth: Auth) => {
             }
           }
 
-          // Update migration version BEFORE inserting changes to prevent race conditions
-          await updateMigrationVersionIfNewer(database, authUser.id, migrationVersion, requiredVersion)
+          // Atomically update migration version BEFORE inserting changes
+          await updateMigrationVersionIfNewer(database, authUser.id, migrationVersion)
 
           // Insert all changes
           const insertedChanges = await insertChanges(database, authUser.id, siteId, changes)

--- a/backend/src/sync/routes.ts
+++ b/backend/src/sync/routes.ts
@@ -1,0 +1,167 @@
+import type { Auth } from '@/auth/elysia-plugin'
+import type { db as DbType } from '@/db/client'
+import { Elysia, t } from 'elysia'
+import {
+  checkMigrationVersionRequirement,
+  fetchChangesSince,
+  getAuthenticatedUser,
+  getLatestServerVersion,
+  getMaxServerVersion,
+  insertChanges,
+  serializedChangeSchema,
+  serializeChanges,
+  updateMigrationVersionIfNewer,
+  upsertSyncDevice,
+} from './shared'
+
+/**
+ * Create sync routes for multi-device database synchronization
+ */
+export const createSyncRoutes = (database: typeof DbType, auth: Auth) => {
+  return (
+    new Elysia({ prefix: '/sync' })
+      .onError(({ code, error, set }) => {
+        set.status = code === 'VALIDATION' ? 400 : 500
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      })
+
+      /**
+       * Push local changes to the server
+       * Requires authentication
+       */
+      .post(
+        '/push',
+        async ({ body, request, set }) => {
+          const authUser = await getAuthenticatedUser(database, auth, request.headers)
+          if (!authUser) {
+            set.status = 401
+            return { success: false, error: 'Unauthorized' }
+          }
+
+          const { siteId, changes, migrationVersion } = body
+
+          // Check if client's migration version meets the minimum required version
+          const { needsUpgrade, requiredVersion } = await checkMigrationVersionRequirement(
+            database,
+            authUser.id,
+            migrationVersion,
+          )
+
+          if (needsUpgrade) {
+            return {
+              success: false,
+              needsUpgrade: true,
+              requiredVersion,
+              serverVersion: '0',
+            }
+          }
+
+          if (changes.length === 0) {
+            const serverVersion = await getLatestServerVersion(database, authUser.id)
+            return {
+              success: true,
+              serverVersion: serverVersion.toString(),
+            }
+          }
+
+          // Update migration version BEFORE inserting changes to prevent race conditions
+          await updateMigrationVersionIfNewer(database, authUser.id, migrationVersion, requiredVersion)
+
+          // Insert all changes
+          const insertedChanges = await insertChanges(database, authUser.id, siteId, changes)
+          const maxServerVersion = getMaxServerVersion(insertedChanges, 0)
+
+          // Update device record
+          await upsertSyncDevice(database, authUser.id, siteId, migrationVersion)
+
+          return {
+            success: true,
+            serverVersion: maxServerVersion.toString(),
+          }
+        },
+        {
+          body: t.Object({
+            siteId: t.String(),
+            changes: t.Array(serializedChangeSchema),
+            dbVersion: t.String(),
+            migrationVersion: t.Optional(t.String()),
+          }),
+        },
+      )
+
+      /**
+       * Pull changes from the server since a given version
+       * Requires authentication
+       */
+      .get(
+        '/pull',
+        async ({ query, request, set }) => {
+          const authUser = await getAuthenticatedUser(database, auth, request.headers)
+          if (!authUser) {
+            set.status = 401
+            return { changes: [], serverVersion: '0', error: 'Unauthorized' }
+          }
+
+          const { since, siteId, migrationVersion } = query
+          const sinceVersion = parseInt(since, 10) || 0
+
+          // Check if client's migration version meets the minimum required version
+          const { needsUpgrade, requiredVersion } = await checkMigrationVersionRequirement(
+            database,
+            authUser.id,
+            migrationVersion,
+          )
+
+          if (needsUpgrade) {
+            return {
+              changes: [],
+              serverVersion: sinceVersion.toString(),
+              needsUpgrade: true,
+              requiredVersion,
+            }
+          }
+
+          // Fetch changes since the given version
+          const changes = await fetchChangesSince(database, authUser.id, sinceVersion)
+          const maxServerVersion = getMaxServerVersion(changes, sinceVersion)
+
+          // Update device record if siteId is provided
+          if (siteId) {
+            await upsertSyncDevice(database, authUser.id, siteId, migrationVersion)
+          }
+
+          return {
+            changes: serializeChanges(changes),
+            serverVersion: maxServerVersion.toString(),
+          }
+        },
+        {
+          query: t.Object({
+            since: t.String(),
+            siteId: t.Optional(t.String()),
+            migrationVersion: t.Optional(t.String()),
+          }),
+        },
+      )
+
+      /**
+       * Get the current server version for the user
+       * Useful for initial sync setup
+       */
+      .get('/version', async ({ request, set }) => {
+        const authUser = await getAuthenticatedUser(database, auth, request.headers)
+        if (!authUser) {
+          set.status = 401
+          return { serverVersion: '0', error: 'Unauthorized' }
+        }
+
+        const serverVersion = await getLatestServerVersion(database, authUser.id)
+        return {
+          serverVersion: serverVersion.toString(),
+        }
+      })
+  )
+}

--- a/backend/src/sync/shared.test.ts
+++ b/backend/src/sync/shared.test.ts
@@ -88,7 +88,7 @@ describe('Sync Shared Utilities', () => {
 
     it('returns set version after update', async () => {
       await ensureMockUserExists(db)
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_test', null)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_test')
 
       const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
       expect(version).toBe('0002_test')
@@ -107,14 +107,14 @@ describe('Sync Shared Utilities', () => {
     })
 
     it('returns needsUpgrade false when client version meets requirement', async () => {
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_test', null)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_test')
 
       const result = await checkMigrationVersionRequirement(db, MOCK_USER.id, '0003_newer')
       expect(result.needsUpgrade).toBe(false)
     })
 
     it('returns needsUpgrade true when client version is older', async () => {
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0003_newer', null)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0003_newer')
 
       const result = await checkMigrationVersionRequirement(db, MOCK_USER.id, '0001_old')
       expect(result.needsUpgrade).toBe(true)
@@ -128,23 +128,31 @@ describe('Sync Shared Utilities', () => {
     })
 
     it('updates version when new version is provided', async () => {
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first', null)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first')
 
       const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
       expect(version).toBe('0001_first')
     })
 
     it('updates version when new version is newer', async () => {
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first', null)
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_second', '0001_first')
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first')
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_second')
 
       const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
       expect(version).toBe('0002_second')
     })
 
-    it('does not update when new version is older', async () => {
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_second', null)
-      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first', '0002_second')
+    it('does not update when new version is older (atomic compare-and-set)', async () => {
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_second')
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first')
+
+      const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
+      expect(version).toBe('0002_second')
+    })
+
+    it('does nothing when new version is undefined', async () => {
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_second')
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, undefined)
 
       const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
       expect(version).toBe('0002_second')

--- a/backend/src/sync/shared.test.ts
+++ b/backend/src/sync/shared.test.ts
@@ -11,6 +11,7 @@ import {
   getRequiredMigrationVersion,
   insertChanges,
   MOCK_USER,
+  normalizeChangesForBroadcast,
   serializeChanges,
   updateMigrationVersionIfNewer,
   upsertSyncDevice,
@@ -414,6 +415,129 @@ describe('Sync Shared Utilities', () => {
     it('works with single item', () => {
       const changes = [{ id: 10 }]
       expect(getMaxServerVersion(changes, 0)).toBe(10)
+    })
+  })
+
+  describe('normalizeChangesForBroadcast', () => {
+    it('converts number values to strings', () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 123,
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      const normalized = normalizeChangesForBroadcast(changes)
+
+      expect(normalized[0].val).toBe('123')
+      expect(typeof normalized[0].val).toBe('string')
+    })
+
+    it('converts boolean values to strings', () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test',
+          pk: 'pk1',
+          cid: 'col1',
+          val: true,
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      const normalized = normalizeChangesForBroadcast(changes)
+
+      expect(normalized[0].val).toBe('true')
+    })
+
+    it('preserves null values', () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test',
+          pk: 'pk1',
+          cid: 'col1',
+          val: null,
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      const normalized = normalizeChangesForBroadcast(changes)
+
+      expect(normalized[0].val).toBeNull()
+    })
+
+    it('preserves undefined as null', () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test',
+          pk: 'pk1',
+          cid: 'col1',
+          val: undefined,
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      const normalized = normalizeChangesForBroadcast(changes)
+
+      expect(normalized[0].val).toBeNull()
+    })
+
+    it('keeps string values unchanged', () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'already a string',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      const normalized = normalizeChangesForBroadcast(changes)
+
+      expect(normalized[0].val).toBe('already a string')
+    })
+
+    it('does not mutate original array', () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 123,
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      normalizeChangesForBroadcast(changes)
+
+      expect(changes[0].val).toBe(123)
     })
   })
 })

--- a/backend/src/sync/shared.test.ts
+++ b/backend/src/sync/shared.test.ts
@@ -1,0 +1,411 @@
+import { createTestDb } from '@/test-utils/db'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  type SerializedChange,
+  checkMigrationVersionRequirement,
+  compareMigrationVersions,
+  ensureMockUserExists,
+  fetchChangesSince,
+  getLatestServerVersion,
+  getMaxServerVersion,
+  getRequiredMigrationVersion,
+  insertChanges,
+  MOCK_USER,
+  serializeChanges,
+  updateMigrationVersionIfNewer,
+  upsertSyncDevice,
+} from './shared'
+
+describe('Sync Shared Utilities', () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('compareMigrationVersions', () => {
+    it('returns 0 when both are null', () => {
+      expect(compareMigrationVersions(null, null)).toBe(0)
+    })
+
+    it('returns -1 when first is null', () => {
+      expect(compareMigrationVersions(null, '0001_migration')).toBe(-1)
+    })
+
+    it('returns 1 when second is null', () => {
+      expect(compareMigrationVersions('0001_migration', null)).toBe(1)
+    })
+
+    it('compares version numbers correctly', () => {
+      expect(compareMigrationVersions('0001_first', '0002_second')).toBeLessThan(0)
+      expect(compareMigrationVersions('0002_second', '0001_first')).toBeGreaterThan(0)
+      expect(compareMigrationVersions('0001_first', '0001_other')).toBe(0)
+    })
+
+    it('handles multi-digit version numbers', () => {
+      expect(compareMigrationVersions('0099_old', '0100_new')).toBeLessThan(0)
+      expect(compareMigrationVersions('0100_new', '0099_old')).toBeGreaterThan(0)
+    })
+
+    it('handles versions without underscore', () => {
+      expect(compareMigrationVersions('0001', '0002')).toBeLessThan(0)
+    })
+  })
+
+  describe('ensureMockUserExists', () => {
+    it('creates mock user when not exists', async () => {
+      await ensureMockUserExists(db)
+
+      const requiredVersion = await getRequiredMigrationVersion(db, MOCK_USER.id)
+      // If we can fetch the required version, the user exists
+      expect(requiredVersion).toBeNull()
+    })
+
+    it('does not duplicate mock user on second call', async () => {
+      await ensureMockUserExists(db)
+      await ensureMockUserExists(db)
+
+      // No error means it worked
+      const requiredVersion = await getRequiredMigrationVersion(db, MOCK_USER.id)
+      expect(requiredVersion).toBeNull()
+    })
+  })
+
+  describe('getRequiredMigrationVersion', () => {
+    it('returns null for new user', async () => {
+      await ensureMockUserExists(db)
+
+      const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
+      expect(version).toBeNull()
+    })
+
+    it('returns set version after update', async () => {
+      await ensureMockUserExists(db)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_test', null)
+
+      const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
+      expect(version).toBe('0002_test')
+    })
+  })
+
+  describe('checkMigrationVersionRequirement', () => {
+    beforeEach(async () => {
+      await ensureMockUserExists(db)
+    })
+
+    it('returns needsUpgrade false when no required version', async () => {
+      const result = await checkMigrationVersionRequirement(db, MOCK_USER.id, undefined)
+      expect(result.needsUpgrade).toBe(false)
+      expect(result.requiredVersion).toBeNull()
+    })
+
+    it('returns needsUpgrade false when client version meets requirement', async () => {
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_test', null)
+
+      const result = await checkMigrationVersionRequirement(db, MOCK_USER.id, '0003_newer')
+      expect(result.needsUpgrade).toBe(false)
+    })
+
+    it('returns needsUpgrade true when client version is older', async () => {
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0003_newer', null)
+
+      const result = await checkMigrationVersionRequirement(db, MOCK_USER.id, '0001_old')
+      expect(result.needsUpgrade).toBe(true)
+      expect(result.requiredVersion).toBe('0003_newer')
+    })
+  })
+
+  describe('updateMigrationVersionIfNewer', () => {
+    beforeEach(async () => {
+      await ensureMockUserExists(db)
+    })
+
+    it('updates version when new version is provided', async () => {
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first', null)
+
+      const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
+      expect(version).toBe('0001_first')
+    })
+
+    it('updates version when new version is newer', async () => {
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first', null)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_second', '0001_first')
+
+      const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
+      expect(version).toBe('0002_second')
+    })
+
+    it('does not update when new version is older', async () => {
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0002_second', null)
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0001_first', '0002_second')
+
+      const version = await getRequiredMigrationVersion(db, MOCK_USER.id)
+      expect(version).toBe('0002_second')
+    })
+  })
+
+  describe('upsertSyncDevice', () => {
+    beforeEach(async () => {
+      await ensureMockUserExists(db)
+    })
+
+    it('creates new device record', async () => {
+      await upsertSyncDevice(db, MOCK_USER.id, 'site-123', '0001_first')
+      // No error means it worked
+    })
+
+    it('updates existing device record', async () => {
+      await upsertSyncDevice(db, MOCK_USER.id, 'site-123', '0001_first')
+      await upsertSyncDevice(db, MOCK_USER.id, 'site-123', '0002_second')
+      // No error means it worked
+    })
+  })
+
+  describe('getLatestServerVersion', () => {
+    beforeEach(async () => {
+      await ensureMockUserExists(db)
+    })
+
+    it('returns 0 when no changes exist', async () => {
+      const version = await getLatestServerVersion(db, MOCK_USER.id)
+      expect(version).toBe(0)
+    })
+
+    it('returns latest version after inserting changes', async () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      const inserted = await insertChanges(db, MOCK_USER.id, 'site-123', changes)
+      const version = await getLatestServerVersion(db, MOCK_USER.id)
+
+      expect(version).toBe(inserted[0].id)
+    })
+  })
+
+  describe('insertChanges', () => {
+    beforeEach(async () => {
+      await ensureMockUserExists(db)
+    })
+
+    it('inserts single change', async () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      const result = await insertChanges(db, MOCK_USER.id, 'site-123', changes)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].tableName).toBe('test_table')
+      expect(result[0].pk).toBe('pk1')
+    })
+
+    it('inserts multiple changes', async () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+        {
+          table: 'test_table',
+          pk: 'pk2',
+          cid: 'col2',
+          val: 'value2',
+          col_version: '2',
+          db_version: '2',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 1,
+        },
+      ]
+
+      const result = await insertChanges(db, MOCK_USER.id, 'site-123', changes)
+
+      expect(result).toHaveLength(2)
+    })
+
+    it('handles null values', async () => {
+      const changes: SerializedChange[] = [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: null,
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ]
+
+      const result = await insertChanges(db, MOCK_USER.id, 'site-123', changes)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].val).toBeNull()
+    })
+  })
+
+  describe('fetchChangesSince', () => {
+    beforeEach(async () => {
+      await ensureMockUserExists(db)
+    })
+
+    it('returns empty array when no changes', async () => {
+      const changes = await fetchChangesSince(db, MOCK_USER.id, 0)
+      expect(changes).toHaveLength(0)
+    })
+
+    it('returns changes after given version', async () => {
+      const inserted = await insertChanges(db, MOCK_USER.id, 'site-123', [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+        {
+          table: 'test_table',
+          pk: 'pk2',
+          cid: 'col2',
+          val: 'value2',
+          col_version: '2',
+          db_version: '2',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 1,
+        },
+      ])
+
+      const changes = await fetchChangesSince(db, MOCK_USER.id, inserted[0].id)
+
+      expect(changes).toHaveLength(1)
+      expect(changes[0].pk).toBe('pk2')
+    })
+
+    it('respects limit parameter', async () => {
+      await insertChanges(
+        db,
+        MOCK_USER.id,
+        'site-123',
+        Array.from({ length: 10 }, (_, i) => ({
+          table: 'test_table',
+          pk: `pk${i}`,
+          cid: 'col1',
+          val: `value${i}`,
+          col_version: String(i + 1),
+          db_version: String(i + 1),
+          site_id: 'site-123',
+          cl: 1,
+          seq: i,
+        })),
+      )
+
+      const changes = await fetchChangesSince(db, MOCK_USER.id, 0, 5)
+
+      expect(changes).toHaveLength(5)
+    })
+  })
+
+  describe('serializeChanges', () => {
+    it('serializes raw changes to network format', () => {
+      const rawChanges = [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: BigInt(1),
+          db_version: BigInt(1),
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+          id: 1,
+        },
+      ]
+
+      const serialized = serializeChanges(rawChanges)
+
+      expect(serialized).toHaveLength(1)
+      expect(serialized[0].col_version).toBe('1')
+      expect(serialized[0].db_version).toBe('1')
+      expect(typeof serialized[0].col_version).toBe('string')
+    })
+
+    it('handles null values', () => {
+      const rawChanges = [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: null,
+          col_version: BigInt(1),
+          db_version: BigInt(1),
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+          id: 1,
+        },
+      ]
+
+      const serialized = serializeChanges(rawChanges)
+
+      expect(serialized[0].val).toBeNull()
+    })
+  })
+
+  describe('getMaxServerVersion', () => {
+    it('returns fallback when array is empty', () => {
+      expect(getMaxServerVersion([], 42)).toBe(42)
+    })
+
+    it('returns max id from array', () => {
+      const changes = [{ id: 1 }, { id: 5 }, { id: 3 }]
+      expect(getMaxServerVersion(changes, 0)).toBe(5)
+    })
+
+    it('works with single item', () => {
+      const changes = [{ id: 10 }]
+      expect(getMaxServerVersion(changes, 0)).toBe(10)
+    })
+  })
+})

--- a/backend/src/sync/shared.ts
+++ b/backend/src/sync/shared.ts
@@ -6,7 +6,7 @@ import type { Auth } from '@/auth/elysia-plugin'
 import { user } from '@/db/auth-schema'
 import type { db as DbType } from '@/db/client'
 import { syncChanges, syncDevices } from '@/db/sync-schema'
-import { and, eq, gt } from 'drizzle-orm'
+import { and, eq, gt, isNull, lt, or } from 'drizzle-orm'
 import { t } from 'elysia'
 
 /**
@@ -141,17 +141,23 @@ export const checkMigrationVersionRequirement = async (
 }
 
 /**
- * Update migration version if the new version is newer
+ * Atomically update migration version if the new version is newer than the current database value.
+ * Uses compare-and-set in the WHERE clause to prevent TOCTOU race conditions.
+ * Since migration versions are zero-padded (e.g., 0001_name, 0002_name),
+ * lexicographic string comparison in SQL works correctly.
  */
 export const updateMigrationVersionIfNewer = async (
   database: typeof DbType,
   userId: string,
   newVersion: string | undefined,
-  currentVersion: string | null,
 ) => {
-  if (newVersion && compareMigrationVersions(newVersion, currentVersion) > 0) {
-    await database.update(user).set({ syncMigrationVersion: newVersion }).where(eq(user.id, userId))
-  }
+  if (!newVersion) return
+
+  // Atomic compare-and-set: only update if new version is actually newer than current DB value
+  await database
+    .update(user)
+    .set({ syncMigrationVersion: newVersion })
+    .where(and(eq(user.id, userId), or(isNull(user.syncMigrationVersion), lt(user.syncMigrationVersion, newVersion))))
 }
 
 /**

--- a/backend/src/sync/shared.ts
+++ b/backend/src/sync/shared.ts
@@ -291,6 +291,18 @@ export const serializeChanges = (changes: RawChange[]): SerializedChange[] => {
 }
 
 /**
+ * Normalize val field in changes to match database storage format.
+ * This ensures consistency between real-time broadcasts and pull responses.
+ * Database stores val as string (via String()), so we apply the same transformation.
+ */
+export const normalizeChangesForBroadcast = (changes: SerializedChange[]): SerializedChange[] => {
+  return changes.map((change) => ({
+    ...change,
+    val: change.val !== null && change.val !== undefined ? String(change.val) : null,
+  }))
+}
+
+/**
  * Get max server version from a list of changes
  */
 export const getMaxServerVersion = (changes: { id: number }[], fallback: number): number => {

--- a/backend/src/sync/shared.ts
+++ b/backend/src/sync/shared.ts
@@ -6,7 +6,7 @@ import type { Auth } from '@/auth/elysia-plugin'
 import { user } from '@/db/auth-schema'
 import type { db as DbType } from '@/db/client'
 import { syncChanges, syncDevices } from '@/db/sync-schema'
-import { and, eq, gt, isNull, lt, or } from 'drizzle-orm'
+import { and, desc, eq, gt, isNull, lt, or } from 'drizzle-orm'
 import { t } from 'elysia'
 
 /**
@@ -198,7 +198,7 @@ export const getLatestServerVersion = async (database: typeof DbType, userId: st
     .select({ id: syncChanges.id })
     .from(syncChanges)
     .where(eq(syncChanges.userId, userId))
-    .orderBy(syncChanges.id)
+    .orderBy(desc(syncChanges.id))
     .limit(1)
 
   return lastChange[0]?.id ?? 0

--- a/backend/src/sync/shared.ts
+++ b/backend/src/sync/shared.ts
@@ -1,0 +1,296 @@
+/**
+ * Shared utilities for sync routes and WebSocket handlers
+ */
+
+import type { Auth } from '@/auth/elysia-plugin'
+import { user } from '@/db/auth-schema'
+import type { db as DbType } from '@/db/client'
+import { syncChanges, syncDevices } from '@/db/sync-schema'
+import { and, eq, gt } from 'drizzle-orm'
+import { t } from 'elysia'
+
+/**
+ * Serialized change format for network transport
+ */
+export type SerializedChange = {
+  table: string
+  pk: string // base64 encoded
+  cid: string
+  val: unknown
+  col_version: string // bigint as string
+  db_version: string // bigint as string
+  site_id: string // base64 encoded
+  cl: number
+  seq: number
+}
+
+/**
+ * Elysia schema for serialized change validation
+ */
+export const serializedChangeSchema = t.Object({
+  table: t.String(),
+  pk: t.String(),
+  cid: t.String(),
+  val: t.Unknown(),
+  col_version: t.String(),
+  db_version: t.String(),
+  site_id: t.String(),
+  cl: t.Number(),
+  seq: t.Number(),
+})
+
+/**
+ * Mock user for sync integration testing
+ * TODO: Replace with real authentication once CORS is resolved
+ */
+export const MOCK_USER = {
+  id: 'mock-user-00000000-0000-0000-0000-000000000001',
+  email: 'mock-user@thunderbolt.local',
+  name: 'Mock User',
+} as const
+
+export type AuthenticatedUser = {
+  id: string
+  email: string
+  name: string
+}
+
+/**
+ * Compare two migration versions
+ * Migration hashes are in format: 0000_name, 0001_name, etc.
+ * Returns: negative if a < b, 0 if equal, positive if a > b
+ */
+export const compareMigrationVersions = (a: string | null, b: string | null): number => {
+  if (!a && !b) return 0
+  if (!a) return -1
+  if (!b) return 1
+
+  const getVersionNumber = (version: string): number => {
+    const match = version.match(/^(\d+)/)
+    return match ? parseInt(match[1], 10) : 0
+  }
+
+  return getVersionNumber(a) - getVersionNumber(b)
+}
+
+/**
+ * Ensure mock user exists in database (for development/testing)
+ */
+export const ensureMockUserExists = async (database: typeof DbType) => {
+  const existing = await database.select({ id: user.id }).from(user).where(eq(user.id, MOCK_USER.id)).limit(1)
+
+  if (existing.length === 0) {
+    await database.insert(user).values({
+      id: MOCK_USER.id,
+      email: MOCK_USER.email,
+      name: MOCK_USER.name,
+      emailVerified: true,
+    })
+  }
+}
+
+/**
+ * Get authenticated user from request
+ * Currently returns mock user for testing - bypasses real auth
+ */
+export const getAuthenticatedUser = async (
+  database: typeof DbType,
+  _auth: Auth,
+  _headers: Headers,
+): Promise<AuthenticatedUser> => {
+  // TODO: Restore real authentication once CORS is resolved
+  // const session = await auth.api.getSession({ headers })
+  // if (!session) {
+  //   return null
+  // }
+  // return session.user
+
+  await ensureMockUserExists(database)
+  return MOCK_USER
+}
+
+/**
+ * Get the required migration version for a user
+ */
+export const getRequiredMigrationVersion = async (database: typeof DbType, userId: string): Promise<string | null> => {
+  const currentUser = await database
+    .select({ syncMigrationVersion: user.syncMigrationVersion })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1)
+
+  return currentUser[0]?.syncMigrationVersion ?? null
+}
+
+/**
+ * Check if client migration version is valid
+ * Returns the required version if upgrade is needed, null otherwise
+ */
+export const checkMigrationVersionRequirement = async (
+  database: typeof DbType,
+  userId: string,
+  clientVersion: string | undefined,
+): Promise<{ needsUpgrade: boolean; requiredVersion: string | null }> => {
+  const requiredVersion = await getRequiredMigrationVersion(database, userId)
+
+  if (requiredVersion && compareMigrationVersions(clientVersion ?? null, requiredVersion) < 0) {
+    return { needsUpgrade: true, requiredVersion }
+  }
+
+  return { needsUpgrade: false, requiredVersion }
+}
+
+/**
+ * Update migration version if the new version is newer
+ */
+export const updateMigrationVersionIfNewer = async (
+  database: typeof DbType,
+  userId: string,
+  newVersion: string | undefined,
+  currentVersion: string | null,
+) => {
+  if (newVersion && compareMigrationVersions(newVersion, currentVersion) > 0) {
+    await database.update(user).set({ syncMigrationVersion: newVersion }).where(eq(user.id, userId))
+  }
+}
+
+/**
+ * Upsert a sync device record
+ */
+export const upsertSyncDevice = async (
+  database: typeof DbType,
+  userId: string,
+  siteId: string,
+  migrationVersion: string | undefined,
+) => {
+  const existingDevice = await database
+    .select({ id: syncDevices.id })
+    .from(syncDevices)
+    .where(and(eq(syncDevices.userId, userId), eq(syncDevices.siteId, siteId)))
+    .limit(1)
+
+  if (existingDevice.length > 0) {
+    await database
+      .update(syncDevices)
+      .set({ lastSeenAt: new Date(), migrationVersion })
+      .where(eq(syncDevices.id, existingDevice[0].id))
+  } else {
+    await database.insert(syncDevices).values({
+      userId,
+      siteId,
+      migrationVersion,
+      lastSeenAt: new Date(),
+    })
+  }
+}
+
+/**
+ * Get the latest server version for a user
+ */
+export const getLatestServerVersion = async (database: typeof DbType, userId: string): Promise<number> => {
+  const lastChange = await database
+    .select({ id: syncChanges.id })
+    .from(syncChanges)
+    .where(eq(syncChanges.userId, userId))
+    .orderBy(syncChanges.id)
+    .limit(1)
+
+  return lastChange[0]?.id ?? 0
+}
+
+/**
+ * Insert changes into the sync_changes table
+ */
+export const insertChanges = async (
+  database: typeof DbType,
+  userId: string,
+  siteId: string,
+  changes: SerializedChange[],
+) => {
+  return database
+    .insert(syncChanges)
+    .values(
+      changes.map((change) => ({
+        userId,
+        siteId,
+        tableName: change.table,
+        pk: change.pk,
+        cid: change.cid,
+        val: change.val !== null && change.val !== undefined ? String(change.val) : null,
+        colVersion: BigInt(change.col_version),
+        dbVersion: BigInt(change.db_version),
+        cl: change.cl,
+        seq: change.seq,
+        siteIdRaw: change.site_id,
+      })),
+    )
+    .returning()
+}
+
+/**
+ * Raw change format from database query
+ */
+type RawChange = {
+  table: string
+  pk: string
+  cid: string
+  val: string | null
+  col_version: bigint
+  db_version: bigint
+  site_id: string
+  cl: number
+  seq: number
+  id: number
+}
+
+/**
+ * Fetch changes since a given version
+ */
+export const fetchChangesSince = async (
+  database: typeof DbType,
+  userId: string,
+  sinceVersion: number,
+  limit = 1000,
+): Promise<RawChange[]> => {
+  return database
+    .select({
+      table: syncChanges.tableName,
+      pk: syncChanges.pk,
+      cid: syncChanges.cid,
+      val: syncChanges.val,
+      col_version: syncChanges.colVersion,
+      db_version: syncChanges.dbVersion,
+      site_id: syncChanges.siteIdRaw,
+      cl: syncChanges.cl,
+      seq: syncChanges.seq,
+      id: syncChanges.id,
+    })
+    .from(syncChanges)
+    .where(and(eq(syncChanges.userId, userId), gt(syncChanges.id, sinceVersion)))
+    .orderBy(syncChanges.id)
+    .limit(limit)
+}
+
+/**
+ * Serialize raw changes for network transport
+ */
+export const serializeChanges = (changes: RawChange[]): SerializedChange[] => {
+  return changes.map((change) => ({
+    table: change.table,
+    pk: change.pk,
+    cid: change.cid,
+    val: change.val,
+    col_version: change.col_version.toString(),
+    db_version: change.db_version.toString(),
+    site_id: change.site_id,
+    cl: change.cl,
+    seq: change.seq,
+  }))
+}
+
+/**
+ * Get max server version from a list of changes
+ */
+export const getMaxServerVersion = (changes: { id: number }[], fallback: number): number => {
+  return changes.length > 0 ? Math.max(...changes.map((c) => c.id)) : fallback
+}

--- a/backend/src/sync/shared.ts
+++ b/backend/src/sync/shared.ts
@@ -161,7 +161,7 @@ export const updateMigrationVersionIfNewer = async (
 }
 
 /**
- * Upsert a sync device record
+ * Upsert a sync device record using atomic ON CONFLICT DO UPDATE
  */
 export const upsertSyncDevice = async (
   database: typeof DbType,
@@ -169,25 +169,21 @@ export const upsertSyncDevice = async (
   siteId: string,
   migrationVersion: string | undefined,
 ) => {
-  const existingDevice = await database
-    .select({ id: syncDevices.id })
-    .from(syncDevices)
-    .where(and(eq(syncDevices.userId, userId), eq(syncDevices.siteId, siteId)))
-    .limit(1)
-
-  if (existingDevice.length > 0) {
-    await database
-      .update(syncDevices)
-      .set({ lastSeenAt: new Date(), migrationVersion })
-      .where(eq(syncDevices.id, existingDevice[0].id))
-  } else {
-    await database.insert(syncDevices).values({
+  await database
+    .insert(syncDevices)
+    .values({
       userId,
       siteId,
       migrationVersion,
       lastSeenAt: new Date(),
     })
-  }
+    .onConflictDoUpdate({
+      target: [syncDevices.userId, syncDevices.siteId],
+      set: {
+        lastSeenAt: new Date(),
+        migrationVersion,
+      },
+    })
 }
 
 /**

--- a/backend/src/sync/websocket.test.ts
+++ b/backend/src/sync/websocket.test.ts
@@ -1,0 +1,427 @@
+import { createTestDb } from '@/test-utils/db'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Elysia } from 'elysia'
+import {
+  ensureMockUserExists,
+  fetchChangesSince,
+  insertChanges,
+  MOCK_USER,
+  serializeChanges,
+  updateMigrationVersionIfNewer,
+} from './shared'
+import { createSyncWebSocketRoutes, getConnectedClientsCount } from './websocket'
+
+/**
+ * Create a minimal test app with just WebSocket routes
+ * This avoids initializing better-auth which has module issues in tests
+ */
+const createTestApp = (database: Awaited<ReturnType<typeof createTestDb>>['db']) => {
+  const mockAuth = {} as Parameters<typeof createSyncWebSocketRoutes>[1]
+  return new Elysia({ prefix: '/v1' }).use(createSyncWebSocketRoutes(database, mockAuth))
+}
+
+describe('Sync WebSocket', () => {
+  let app: ReturnType<typeof createTestApp>
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+  let server: { stop: () => void; hostname: string; port: number } | null = null
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+    app = createTestApp(db)
+
+    await ensureMockUserExists(db)
+
+    // Start a real server for WebSocket testing
+    server = Bun.serve({
+      port: 0, // Random available port
+      fetch: app.fetch,
+      websocket: app.websocket,
+    })
+  })
+
+  afterEach(async () => {
+    server?.stop()
+    server = null
+    await cleanup()
+  })
+
+  const createWebSocket = (): WebSocket => {
+    if (!server) throw new Error('Server not started')
+    return new WebSocket(`ws://${server.hostname}:${server.port}/v1/sync/ws`)
+  }
+
+  const waitForOpen = (ws: WebSocket): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('WebSocket open timeout')), 5000)
+      ws.onopen = () => {
+        clearTimeout(timeout)
+        resolve()
+      }
+      ws.onerror = (e) => {
+        clearTimeout(timeout)
+        reject(e)
+      }
+    })
+  }
+
+  const waitForMessage = <T>(ws: WebSocket): Promise<T> => {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('WebSocket message timeout')), 5000)
+      ws.onmessage = (event) => {
+        clearTimeout(timeout)
+        resolve(JSON.parse(event.data as string) as T)
+      }
+      ws.onerror = (e) => {
+        clearTimeout(timeout)
+        reject(e)
+      }
+    })
+  }
+
+  describe('Authentication', () => {
+    it('connects and authenticates successfully', async () => {
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      ws.send(
+        JSON.stringify({
+          type: 'auth',
+          siteId: 'test-site-123',
+          migrationVersion: '0001_test',
+        }),
+      )
+
+      const response = await waitForMessage<{ type: string; serverVersion: string }>(ws)
+      expect(response.type).toBe('auth_success')
+      expect(response.serverVersion).toBeDefined()
+
+      ws.close()
+    })
+
+    it('returns auth_error for unauthenticated push', async () => {
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      // Send push without auth
+      ws.send(
+        JSON.stringify({
+          type: 'push',
+          changes: [],
+          dbVersion: '1',
+        }),
+      )
+
+      const response = await waitForMessage<{ type: string; error: string }>(ws)
+      expect(response.type).toBe('auth_error')
+      expect(response.error).toBe('Not authenticated')
+
+      ws.close()
+    })
+
+    it('closes connection on version mismatch', async () => {
+      // Set a required migration version
+      await updateMigrationVersionIfNewer(db, MOCK_USER.id, '0005_required', null)
+
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      ws.send(
+        JSON.stringify({
+          type: 'auth',
+          siteId: 'test-site-123',
+          migrationVersion: '0001_old',
+        }),
+      )
+
+      const response = await waitForMessage<{ type: string; requiredVersion: string }>(ws)
+      expect(response.type).toBe('version_mismatch')
+      expect(response.requiredVersion).toBe('0005_required')
+
+      // Wait for close
+      await new Promise<void>((resolve) => {
+        ws.onclose = () => resolve()
+        setTimeout(resolve, 100)
+      })
+    })
+  })
+
+  describe('Push', () => {
+    it('pushes changes successfully', async () => {
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      // Authenticate first
+      ws.send(JSON.stringify({ type: 'auth', siteId: 'test-site-123' }))
+      await waitForMessage(ws)
+
+      // Push changes
+      ws.send(
+        JSON.stringify({
+          type: 'push',
+          changes: [
+            {
+              table: 'test_table',
+              pk: 'pk1',
+              cid: 'col1',
+              val: 'value1',
+              col_version: '1',
+              db_version: '1',
+              site_id: 'test-site-123',
+              cl: 1,
+              seq: 0,
+            },
+          ],
+          dbVersion: '1',
+        }),
+      )
+
+      const response = await waitForMessage<{ type: string; serverVersion: string }>(ws)
+      expect(response.type).toBe('push_success')
+      expect(parseInt(response.serverVersion)).toBeGreaterThan(0)
+
+      ws.close()
+    })
+
+    it('returns push_success with empty changes', async () => {
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'auth', siteId: 'test-site-123' }))
+      await waitForMessage(ws)
+
+      ws.send(
+        JSON.stringify({
+          type: 'push',
+          changes: [],
+          dbVersion: '1',
+        }),
+      )
+
+      const response = await waitForMessage<{ type: string; serverVersion: string }>(ws)
+      expect(response.type).toBe('push_success')
+
+      ws.close()
+    })
+  })
+
+  describe('Pull', () => {
+    it('pulls changes successfully', async () => {
+      // Insert some changes first
+      await insertChanges(db, MOCK_USER.id, 'other-device', [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'value1',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'other-device',
+          cl: 1,
+          seq: 0,
+        },
+      ])
+
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'auth', siteId: 'test-site-123' }))
+      await waitForMessage(ws)
+
+      ws.send(JSON.stringify({ type: 'pull', since: '0' }))
+
+      const response = await waitForMessage<{ type: string; changes: unknown[]; serverVersion: string }>(ws)
+      expect(response.type).toBe('changes')
+      expect(response.changes).toHaveLength(1)
+      expect(parseInt(response.serverVersion)).toBeGreaterThan(0)
+
+      ws.close()
+    })
+
+    it('returns empty changes when none exist', async () => {
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'auth', siteId: 'test-site-123' }))
+      await waitForMessage(ws)
+
+      ws.send(JSON.stringify({ type: 'pull', since: '0' }))
+
+      const response = await waitForMessage<{ type: string; changes: unknown[]; serverVersion: string }>(ws)
+      expect(response.type).toBe('changes')
+      expect(response.changes).toHaveLength(0)
+
+      ws.close()
+    })
+  })
+
+  describe('Broadcasting', () => {
+    it('broadcasts changes to other connected clients', async () => {
+      // Connect two clients
+      const ws1 = createWebSocket()
+      const ws2 = createWebSocket()
+
+      await Promise.all([waitForOpen(ws1), waitForOpen(ws2)])
+
+      // Authenticate both
+      ws1.send(JSON.stringify({ type: 'auth', siteId: 'device-1' }))
+      ws2.send(JSON.stringify({ type: 'auth', siteId: 'device-2' }))
+
+      await Promise.all([waitForMessage(ws1), waitForMessage(ws2)])
+
+      // Set up listener for broadcast on ws2
+      const broadcastPromise = waitForMessage<{ type: string; changes: unknown[] }>(ws2)
+
+      // Push from ws1
+      ws1.send(
+        JSON.stringify({
+          type: 'push',
+          changes: [
+            {
+              table: 'test_table',
+              pk: 'pk1',
+              cid: 'col1',
+              val: 'broadcast-test',
+              col_version: '1',
+              db_version: '1',
+              site_id: 'device-1',
+              cl: 1,
+              seq: 0,
+            },
+          ],
+          dbVersion: '1',
+        }),
+      )
+
+      // Wait for push_success on ws1
+      const pushResponse = await waitForMessage<{ type: string }>(ws1)
+      expect(pushResponse.type).toBe('push_success')
+
+      // Wait for broadcast on ws2
+      const broadcastResponse = await broadcastPromise
+      expect(broadcastResponse.type).toBe('changes')
+      expect(broadcastResponse.changes).toHaveLength(1)
+
+      ws1.close()
+      ws2.close()
+    })
+  })
+
+  describe('Connection Management', () => {
+    it('tracks connected clients count', async () => {
+      const initialCount = getConnectedClientsCount()
+
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'auth', siteId: 'test-site-123' }))
+      await waitForMessage(ws)
+
+      expect(getConnectedClientsCount()).toBe(initialCount + 1)
+
+      ws.close()
+
+      // Wait for close to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      expect(getConnectedClientsCount()).toBe(initialCount)
+    })
+  })
+
+  describe('Integration', () => {
+    it('full sync flow: push then pull from another device', async () => {
+      // Device 1 pushes changes
+      const ws1 = createWebSocket()
+      await waitForOpen(ws1)
+
+      ws1.send(JSON.stringify({ type: 'auth', siteId: 'device-1' }))
+      const authResponse1 = await waitForMessage<{ serverVersion: string }>(ws1)
+      const initialVersion = authResponse1.serverVersion
+
+      ws1.send(
+        JSON.stringify({
+          type: 'push',
+          changes: [
+            {
+              table: 'notes',
+              pk: 'note-1',
+              cid: 'title',
+              val: 'My Note',
+              col_version: '1',
+              db_version: '1',
+              site_id: 'device-1',
+              cl: 1,
+              seq: 0,
+            },
+          ],
+          dbVersion: '1',
+        }),
+      )
+
+      const pushResponse = await waitForMessage<{ type: string; serverVersion: string }>(ws1)
+      expect(pushResponse.type).toBe('push_success')
+
+      ws1.close()
+
+      // Device 2 connects and pulls changes
+      const ws2 = createWebSocket()
+      await waitForOpen(ws2)
+
+      ws2.send(JSON.stringify({ type: 'auth', siteId: 'device-2' }))
+      await waitForMessage(ws2)
+
+      ws2.send(JSON.stringify({ type: 'pull', since: initialVersion }))
+
+      const pullResponse = await waitForMessage<{ type: string; changes: Array<{ table: string; val: unknown }> }>(ws2)
+      expect(pullResponse.type).toBe('changes')
+      expect(pullResponse.changes).toHaveLength(1)
+      expect(pullResponse.changes[0].table).toBe('notes')
+      expect(pullResponse.changes[0].val).toBe('My Note')
+
+      ws2.close()
+    })
+  })
+})
+
+describe('Sync WebSocket Utilities', () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+    await ensureMockUserExists(db)
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('serializeChanges for WebSocket', () => {
+    it('serializes changes for WebSocket transport', async () => {
+      await insertChanges(db, MOCK_USER.id, 'site-123', [
+        {
+          table: 'test_table',
+          pk: 'pk1',
+          cid: 'col1',
+          val: 'test-value',
+          col_version: '1',
+          db_version: '1',
+          site_id: 'site-123',
+          cl: 1,
+          seq: 0,
+        },
+      ])
+
+      const rawChanges = await fetchChangesSince(db, MOCK_USER.id, 0)
+      const serialized = serializeChanges(rawChanges)
+
+      expect(serialized).toHaveLength(1)
+      expect(typeof serialized[0].col_version).toBe('string')
+      expect(typeof serialized[0].db_version).toBe('string')
+    })
+  })
+})

--- a/backend/src/sync/websocket.test.ts
+++ b/backend/src/sync/websocket.test.ts
@@ -328,6 +328,33 @@ describe('Sync WebSocket', () => {
 
       expect(getConnectedClientsCount()).toBe(initialCount)
     })
+
+    it('does not leak clients when re-authenticating on same connection', async () => {
+      const initialCount = getConnectedClientsCount()
+
+      const ws = createWebSocket()
+      await waitForOpen(ws)
+
+      // Auth multiple times on the same connection
+      ws.send(JSON.stringify({ type: 'auth', siteId: 'site-v1' }))
+      await waitForMessage(ws)
+      expect(getConnectedClientsCount()).toBe(initialCount + 1)
+
+      ws.send(JSON.stringify({ type: 'auth', siteId: 'site-v2' }))
+      await waitForMessage(ws)
+      expect(getConnectedClientsCount()).toBe(initialCount + 1) // Still 1, not 2
+
+      ws.send(JSON.stringify({ type: 'auth', siteId: 'site-v3' }))
+      await waitForMessage(ws)
+      expect(getConnectedClientsCount()).toBe(initialCount + 1) // Still 1, not 3
+
+      ws.close()
+
+      // Wait for close to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      expect(getConnectedClientsCount()).toBe(initialCount) // Back to initial, no leaks
+    })
   })
 
   describe('Integration', () => {

--- a/backend/src/sync/websocket.ts
+++ b/backend/src/sync/websocket.ts
@@ -204,6 +204,10 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
           // Handle push changes
           const { changes } = message
 
+          // Always update migration version, even with empty changes
+          // This ensures the server learns about schema upgrades from clients without local changes
+          await updateMigrationVersionIfNewer(database, client.userId, client.migrationVersion)
+
           if (!changes || changes.length === 0) {
             ws.send(
               JSON.stringify({
@@ -213,9 +217,6 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
             )
             return
           }
-
-          // Atomically update migration version if this client has a newer version
-          await updateMigrationVersionIfNewer(database, client.userId, client.migrationVersion)
 
           // Insert changes
           const insertedChanges = await insertChanges(database, client.userId, client.siteId, changes)
@@ -242,7 +243,7 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
 
         if (message.type === 'pull') {
           // Handle pull changes
-          const since = message.since ? parseInt(message.since, 10) : 0
+          const since = parseInt(message.since ?? '', 10) || 0
 
           const changes = await fetchChangesSince(database, client.userId, since)
           const maxServerVersion = getMaxServerVersion(changes, since)

--- a/backend/src/sync/websocket.ts
+++ b/backend/src/sync/websocket.ts
@@ -9,12 +9,10 @@ import { Elysia, t } from 'elysia'
 import {
   type SerializedChange,
   checkMigrationVersionRequirement,
-  compareMigrationVersions,
   ensureMockUserExists,
   fetchChangesSince,
   getLatestServerVersion,
   getMaxServerVersion,
-  getRequiredMigrationVersion,
   insertChanges,
   MOCK_USER,
   serializeChanges,
@@ -216,18 +214,8 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
             return
           }
 
-          // Update migration version if newer
-          if (client.migrationVersion) {
-            const currentRequiredVersion = await getRequiredMigrationVersion(database, client.userId)
-            if (compareMigrationVersions(client.migrationVersion, currentRequiredVersion) > 0) {
-              await updateMigrationVersionIfNewer(
-                database,
-                client.userId,
-                client.migrationVersion,
-                currentRequiredVersion,
-              )
-            }
-          }
+          // Atomically update migration version if this client has a newer version
+          await updateMigrationVersionIfNewer(database, client.userId, client.migrationVersion)
 
           // Insert changes
           const insertedChanges = await insertChanges(database, client.userId, client.siteId, changes)

--- a/backend/src/sync/websocket.ts
+++ b/backend/src/sync/websocket.ts
@@ -16,10 +16,34 @@ import {
   insertChanges,
   MOCK_USER,
   normalizeChangesForBroadcast,
+  serializedChangeSchema,
   serializeChanges,
   updateMigrationVersionIfNewer,
   upsertSyncDevice,
 } from './shared'
+
+/**
+ * WebSocket message schemas for proper validation
+ * These match the HTTP route validation for consistency
+ */
+const authMessageSchema = t.Object({
+  type: t.Literal('auth'),
+  siteId: t.String(),
+  migrationVersion: t.Optional(t.String()),
+})
+
+const pushMessageSchema = t.Object({
+  type: t.Literal('push'),
+  changes: t.Array(serializedChangeSchema),
+  dbVersion: t.String(),
+})
+
+const pullMessageSchema = t.Object({
+  type: t.Literal('pull'),
+  since: t.String(),
+})
+
+const wsMessageSchema = t.Union([authMessageSchema, pushMessageSchema, pullMessageSchema])
 
 /**
  * WebSocket message types
@@ -108,14 +132,7 @@ const broadcastToUser = (userId: string, senderSiteId: string, message: WSRespon
  */
 export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) => {
   return new Elysia({ prefix: '/sync' }).ws('/ws', {
-    body: t.Object({
-      type: t.String(),
-      siteId: t.Optional(t.String()),
-      migrationVersion: t.Optional(t.String()),
-      changes: t.Optional(t.Array(t.Any())),
-      dbVersion: t.Optional(t.String()),
-      since: t.Optional(t.String()),
-    }),
+    body: wsMessageSchema,
 
     open(ws) {
       const wsData = ws as unknown as { data: { authenticated: boolean; client?: ConnectedClient } }
@@ -221,7 +238,7 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
           // This ensures the server learns about schema upgrades from clients without local changes
           await updateMigrationVersionIfNewer(database, client.userId, client.migrationVersion)
 
-          if (!changes || changes.length === 0) {
+          if (changes.length === 0) {
             // Query the database for the latest server version to avoid returning stale cached values
             // This matches the HTTP handler behavior and ensures consistency when other clients have pushed changes
             const serverVersion = await getLatestServerVersion(database, client.userId)
@@ -261,7 +278,7 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
 
         if (message.type === 'pull') {
           // Handle pull changes
-          const since = parseInt(message.since ?? '', 10) || 0
+          const since = parseInt(message.since, 10) || 0
 
           const changes = await fetchChangesSince(database, client.userId, since)
           const maxServerVersion = getMaxServerVersion(changes, since)

--- a/backend/src/sync/websocket.ts
+++ b/backend/src/sync/websocket.ts
@@ -15,6 +15,7 @@ import {
   getMaxServerVersion,
   insertChanges,
   MOCK_USER,
+  normalizeChangesForBroadcast,
   serializeChanges,
   updateMigrationVersionIfNewer,
   upsertSyncDevice,
@@ -244,9 +245,10 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
           )
 
           // Broadcast changes to other connected clients of this user
+          // Normalize changes to match database storage format for consistency
           broadcastToUser(client.userId, client.siteId, {
             type: 'changes',
-            changes,
+            changes: normalizeChangesForBroadcast(changes),
             serverVersion: maxServerVersion.toString(),
           })
 

--- a/backend/src/sync/websocket.ts
+++ b/backend/src/sync/websocket.ts
@@ -158,6 +158,18 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
           // Get current server version
           const serverVersion = await getLatestServerVersion(database, authUser.id)
 
+          // Remove existing client if re-authenticating to prevent memory leak
+          if (wsData.data.client) {
+            const existingClient = wsData.data.client
+            const userClients = connectedClients.get(existingClient.userId)
+            if (userClients) {
+              userClients.delete(existingClient)
+              if (userClients.size === 0) {
+                connectedClients.delete(existingClient.userId)
+              }
+            }
+          }
+
           // Create client record
           const client: ConnectedClient = {
             ws: ws as unknown as ConnectedClient['ws'],

--- a/backend/src/sync/websocket.ts
+++ b/backend/src/sync/websocket.ts
@@ -1,0 +1,313 @@
+/**
+ * WebSocket-based sync for real-time database synchronization
+ * Replaces polling with instant push/pull via persistent WebSocket connections
+ */
+
+import type { Auth } from '@/auth/elysia-plugin'
+import type { db as DbType } from '@/db/client'
+import { Elysia, t } from 'elysia'
+import {
+  type SerializedChange,
+  checkMigrationVersionRequirement,
+  compareMigrationVersions,
+  ensureMockUserExists,
+  fetchChangesSince,
+  getLatestServerVersion,
+  getMaxServerVersion,
+  getRequiredMigrationVersion,
+  insertChanges,
+  MOCK_USER,
+  serializeChanges,
+  updateMigrationVersionIfNewer,
+  upsertSyncDevice,
+} from './shared'
+
+/**
+ * WebSocket message types
+ */
+type WSMessage =
+  | {
+      type: 'auth'
+      siteId: string
+      migrationVersion?: string
+    }
+  | {
+      type: 'push'
+      changes: SerializedChange[]
+      dbVersion: string
+    }
+  | {
+      type: 'pull'
+      since: string
+    }
+
+type WSResponse =
+  | {
+      type: 'auth_success'
+      serverVersion: string
+    }
+  | {
+      type: 'auth_error'
+      error: string
+    }
+  | {
+      type: 'push_success'
+      serverVersion: string
+    }
+  | {
+      type: 'push_error'
+      error: string
+    }
+  | {
+      type: 'changes'
+      changes: SerializedChange[]
+      serverVersion: string
+    }
+  | {
+      type: 'version_mismatch'
+      requiredVersion: string
+    }
+
+/**
+ * Connected client info
+ */
+type ConnectedClient = {
+  ws: {
+    send: (data: string) => void
+    close: () => void
+  }
+  userId: string
+  siteId: string
+  migrationVersion?: string
+  lastServerVersion: bigint
+}
+
+// Store connected clients by userId for broadcasting
+const connectedClients = new Map<string, Set<ConnectedClient>>()
+
+/**
+ * Broadcast changes to all connected clients of a user except the sender
+ */
+const broadcastToUser = (userId: string, senderSiteId: string, message: WSResponse) => {
+  const clients = connectedClients.get(userId)
+  if (!clients) return
+
+  const messageStr = JSON.stringify(message)
+  for (const client of clients) {
+    if (client.siteId !== senderSiteId) {
+      try {
+        client.ws.send(messageStr)
+      } catch (error) {
+        console.error('Failed to send to client:', error)
+      }
+    }
+  }
+}
+
+/**
+ * Create WebSocket sync routes for real-time database synchronization
+ */
+export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) => {
+  return new Elysia({ prefix: '/sync' }).ws('/ws', {
+    body: t.Object({
+      type: t.String(),
+      siteId: t.Optional(t.String()),
+      migrationVersion: t.Optional(t.String()),
+      changes: t.Optional(t.Array(t.Any())),
+      dbVersion: t.Optional(t.String()),
+      since: t.Optional(t.String()),
+    }),
+
+    open(ws) {
+      const wsData = ws as unknown as { data: { authenticated: boolean; client?: ConnectedClient } }
+      wsData.data = { authenticated: false }
+    },
+
+    async message(ws, rawMessage) {
+      const wsData = ws as unknown as { data: { authenticated: boolean; client?: ConnectedClient } }
+      const message = rawMessage as unknown as WSMessage
+
+      try {
+        if (message.type === 'auth') {
+          // Handle authentication
+          // TODO: Use real auth from headers/cookies when available
+          await ensureMockUserExists(database)
+          const authUser = MOCK_USER
+
+          const { siteId, migrationVersion } = message
+
+          // Check migration version
+          const { needsUpgrade, requiredVersion } = await checkMigrationVersionRequirement(
+            database,
+            authUser.id,
+            migrationVersion,
+          )
+
+          if (needsUpgrade && requiredVersion) {
+            ws.send(
+              JSON.stringify({
+                type: 'version_mismatch',
+                requiredVersion,
+              } satisfies WSResponse),
+            )
+            ws.close()
+            return
+          }
+
+          // Upsert device record
+          await upsertSyncDevice(database, authUser.id, siteId, migrationVersion)
+
+          // Get current server version
+          const serverVersion = await getLatestServerVersion(database, authUser.id)
+
+          // Create client record
+          const client: ConnectedClient = {
+            ws: ws as unknown as ConnectedClient['ws'],
+            userId: authUser.id,
+            siteId,
+            migrationVersion,
+            lastServerVersion: BigInt(serverVersion),
+          }
+
+          // Store client
+          if (!connectedClients.has(authUser.id)) {
+            connectedClients.set(authUser.id, new Set())
+          }
+          connectedClients.get(authUser.id)!.add(client)
+
+          wsData.data.authenticated = true
+          wsData.data.client = client
+
+          ws.send(
+            JSON.stringify({
+              type: 'auth_success',
+              serverVersion: serverVersion.toString(),
+            } satisfies WSResponse),
+          )
+
+          console.info(`WebSocket authenticated: user=${authUser.id}, site=${siteId}`)
+          return
+        }
+
+        // All other messages require authentication
+        if (!wsData.data.authenticated || !wsData.data.client) {
+          ws.send(
+            JSON.stringify({
+              type: 'auth_error',
+              error: 'Not authenticated',
+            } satisfies WSResponse),
+          )
+          return
+        }
+
+        const client = wsData.data.client
+
+        if (message.type === 'push') {
+          // Handle push changes
+          const { changes } = message
+
+          if (!changes || changes.length === 0) {
+            ws.send(
+              JSON.stringify({
+                type: 'push_success',
+                serverVersion: client.lastServerVersion.toString(),
+              } satisfies WSResponse),
+            )
+            return
+          }
+
+          // Update migration version if newer
+          if (client.migrationVersion) {
+            const currentRequiredVersion = await getRequiredMigrationVersion(database, client.userId)
+            if (compareMigrationVersions(client.migrationVersion, currentRequiredVersion) > 0) {
+              await updateMigrationVersionIfNewer(
+                database,
+                client.userId,
+                client.migrationVersion,
+                currentRequiredVersion,
+              )
+            }
+          }
+
+          // Insert changes
+          const insertedChanges = await insertChanges(database, client.userId, client.siteId, changes)
+          const maxServerVersion = getMaxServerVersion(insertedChanges, 0)
+          client.lastServerVersion = BigInt(maxServerVersion)
+
+          // Send success to sender
+          ws.send(
+            JSON.stringify({
+              type: 'push_success',
+              serverVersion: maxServerVersion.toString(),
+            } satisfies WSResponse),
+          )
+
+          // Broadcast changes to other connected clients of this user
+          broadcastToUser(client.userId, client.siteId, {
+            type: 'changes',
+            changes,
+            serverVersion: maxServerVersion.toString(),
+          })
+
+          return
+        }
+
+        if (message.type === 'pull') {
+          // Handle pull changes
+          const since = message.since ? parseInt(message.since, 10) : 0
+
+          const changes = await fetchChangesSince(database, client.userId, since)
+          const maxServerVersion = getMaxServerVersion(changes, since)
+          client.lastServerVersion = BigInt(maxServerVersion)
+
+          ws.send(
+            JSON.stringify({
+              type: 'changes',
+              changes: serializeChanges(changes),
+              serverVersion: maxServerVersion.toString(),
+            } satisfies WSResponse),
+          )
+
+          return
+        }
+      } catch (error) {
+        console.error('WebSocket message error:', error)
+        ws.send(
+          JSON.stringify({
+            type: 'push_error',
+            error: error instanceof Error ? error.message : 'Unknown error',
+          } satisfies WSResponse),
+        )
+      }
+    },
+
+    close(ws) {
+      const wsData = ws as unknown as { data: { authenticated: boolean; client?: ConnectedClient } }
+
+      if (wsData.data.client) {
+        const client = wsData.data.client
+        const userClients = connectedClients.get(client.userId)
+        if (userClients) {
+          userClients.delete(client)
+          if (userClients.size === 0) {
+            connectedClients.delete(client.userId)
+          }
+        }
+        console.info(`WebSocket closed: user=${client.userId}, site=${client.siteId}`)
+      } else {
+        console.info('WebSocket closed (unauthenticated)')
+      }
+    },
+  })
+}
+
+/**
+ * Get count of connected clients (for monitoring)
+ */
+export const getConnectedClientsCount = (): number => {
+  let count = 0
+  for (const clients of connectedClients.values()) {
+    count += clients.size
+  }
+  return count
+}

--- a/backend/src/sync/websocket.ts
+++ b/backend/src/sync/websocket.ts
@@ -222,10 +222,14 @@ export const createSyncWebSocketRoutes = (database: typeof DbType, _auth: Auth) 
           await updateMigrationVersionIfNewer(database, client.userId, client.migrationVersion)
 
           if (!changes || changes.length === 0) {
+            // Query the database for the latest server version to avoid returning stale cached values
+            // This matches the HTTP handler behavior and ensures consistency when other clients have pushed changes
+            const serverVersion = await getLatestServerVersion(database, client.userId)
+            client.lastServerVersion = BigInt(serverVersion)
             ws.send(
               JSON.stringify({
                 type: 'push_success',
-                serverVersion: client.lastServerVersion.toString(),
+                serverVersion: serverVersion.toString(),
               } satisfies WSResponse),
             )
             return


### PR DESCRIPTION
- Add `sync_changes` and `sync_devices` tables to track changes and device states.
- Introduce sync routes for pushing and pulling changes between devices.
- Update user schema to include `sync_migration_version` for version tracking.
- Implement WebSocket support for real-time synchronization.
- Add tests for sync routes and WebSocket functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements backend support for multi-device synchronization, including storage, APIs, and real-time updates.
> 
> - Adds `sync_changes` and `sync_devices` tables with FKs, indexes, and unique (`user_id`,`site_id`) constraint; extends `user` with `sync_migration_version`
> - New Elysia routes under `/sync`: `POST /push`, `GET /pull`, `GET /version` with request validation, device upsert, and migration version enforcement
> - WebSocket endpoint `/sync/ws` for real-time push/pull and broadcasting changes to other client devices; tracks connected clients and prevents leaks on re-auth
> - New Drizzle schemas (`sync-schema.ts`) and re-exports via `db/schema.ts`; integrates routes into app startup (`index.ts`)
> - Comprehensive tests for shared utils, HTTP routes, and WebSocket behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1f9b08a1f6a77cf384f0c4080646b1d9fc4dbc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->