### PR TITLE
THU-244: Some locations are not showing up

### DIFF
--- a/backend/src/api/routes.test.ts
+++ b/backend/src/api/routes.test.ts
@@ -102,6 +102,46 @@ describe('Main Routes', () => {
     expect(Array.isArray(data)).toBe(true)
   })
 
+  it('should filter out country-level results without admin1', async () => {
+    // Mock fetch that returns a mix of city and country results
+    const mockFetchWithCountry = async (input: RequestInfo | URL): Promise<Response> => {
+      const url = input instanceof Request ? input.url : input.toString()
+      if (url.startsWith('https://geocoding-api.open-meteo.com')) {
+        return new Response(
+          JSON.stringify({
+            results: [
+              // Country-level result (no admin1) - should be filtered out
+              { name: 'Canada', country: 'Canada', latitude: 60.1, longitude: -113.6 },
+              // City-level result (has admin1) - should be included
+              { name: 'Canada', admin1: 'Kentucky', country: 'United States', latitude: 37.6, longitude: -82.3 },
+              // Another city with admin1 - should be included
+              { name: 'Cañada', admin1: 'Valencia', country: 'Spain', latitude: 38.7, longitude: -0.8 },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }
+
+    const testEnv = await createTestDb()
+    const testApp = await createApp({ fetchFn: mockFetchWithCountry as typeof fetch, database: testEnv.db })
+
+    const response = await testApp.handle(new Request('http://localhost/v1/locations?query=Canada'))
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(Array.isArray(data)).toBe(true)
+    expect(data).toHaveLength(2)
+    expect(data.every((loc: { region: string }) => loc.region !== '')).toBe(true)
+    expect(data).toEqual([
+      { name: 'Canada', region: 'Kentucky', country: 'United States', lat: 37.6, lon: -82.3 },
+      { name: 'Cañada', region: 'Valencia', country: 'Spain', lat: 38.7, lon: -0.8 },
+    ])
+
+    await testEnv.cleanup()
+  })
+
   describe('Units routes', () => {
     it('should require country parameter for units endpoint', async () => {
       const response = await app.handle(new Request('http://localhost/v1/units'))

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -96,19 +96,16 @@ export const createMainRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
             }>
           }
 
-          // Transform to match the frontend's expected format
-          const results: LocationResult[] = []
-          for (const location of data.results || []) {
-            results.push({
+          // Filter out country-level results (no admin1) - we only support cities
+          return (data.results || [])
+            .filter((location) => location.admin1)
+            .map((location) => ({
               name: location.name || '',
-              region: location.admin1 || '', // State/Province
+              region: location.admin1!,
               country: location.country || '',
               lat: location.latitude || 0,
-              lon: location.longitude || 0, // Frontend expects 'lon' not 'lng'
-            })
-          }
-
-          return results
+              lon: location.longitude || 0,
+            }))
         } catch (error) {
           if (error instanceof Error) {
             throw error // Re-throw with original message and status


### PR DESCRIPTION
Filter out country-level results from location search

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures location search returns only city-level results and aligns response mapping.
> 
> - In `backend/src/api/routes.ts`, filter `(results || []).filter(location => location.admin1)` and map directly to `LocationResult` to exclude country-level entries and simplify transformation
> - In `backend/src/api/routes.test.ts`, add test mocking mixed results to assert country-level entries are removed and only entries with non-empty `region` are returned
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55ee17629df9a9d4ba7156c0d5e2cf35aaad5395. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->