### PR TITLE
Raivieiraadriano92/schema fix create indexes

### DIFF
--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -2,7 +2,7 @@ import type { WidgetCacheData } from '@/widgets'
 import type { UIMessage } from 'ai'
 import type { UIMessageMetadata } from '@/types'
 import { sql } from 'drizzle-orm'
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 export const settingsTable = sqliteTable('settings', {
   key: text('key').primaryKey(),
@@ -11,93 +11,149 @@ export const settingsTable = sqliteTable('settings', {
   defaultHash: text('default_hash'),
 })
 
-export const chatThreadsTable = sqliteTable('chat_threads', {
-  id: text('id').primaryKey().notNull().unique(),
-  title: text('title'),
-  isEncrypted: integer('is_encrypted').default(0),
-  triggeredBy: text('triggered_by').references(() => promptsTable.id, { onDelete: 'set null' }),
-  wasTriggeredByAutomation: integer('was_triggered_by_automation').default(0),
-  contextSize: integer('context_size'),
-  deletedAt: integer('deleted_at'),
-})
+export const chatThreadsTable = sqliteTable(
+  'chat_threads',
+  {
+    id: text('id').primaryKey().notNull().unique(),
+    title: text('title'),
+    isEncrypted: integer('is_encrypted').default(0),
+    triggeredBy: text('triggered_by').references(() => promptsTable.id, { onDelete: 'set null' }),
+    wasTriggeredByAutomation: integer('was_triggered_by_automation').default(0),
+    contextSize: integer('context_size'),
+    deletedAt: integer('deleted_at'),
+  },
+  (table) => [
+    index('idx_chat_threads_active')
+      .on(table.id)
+      .where(sql`chat_threads.${table.deletedAt} IS NULL`),
+  ],
+)
 
-export const chatMessagesTable = sqliteTable('chat_messages', {
-  id: text('id').primaryKey().notNull().unique(),
-  content: text('content'),
-  role: text('role').$type<UIMessage['role']>(),
-  parts: text('parts', { mode: 'json' }).$type<UIMessage['parts']>(),
-  chatThreadId: text('chat_thread_id')
-    .notNull()
-    .references(() => chatThreadsTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
-  modelId: text('model_id').references(() => modelsTable.id),
-  parentId: text('parent_id').references((): any => chatMessagesTable.id, { onDelete: 'cascade' }),
-  cache: text('cache', { mode: 'json' }).$type<Record<string, WidgetCacheData>>(),
-  metadata: text('metadata', { mode: 'json' }).$type<UIMessageMetadata>(),
-  deletedAt: integer('deleted_at'),
-})
+export const chatMessagesTable = sqliteTable(
+  'chat_messages',
+  {
+    id: text('id').primaryKey().notNull().unique(),
+    content: text('content'),
+    role: text('role').$type<UIMessage['role']>(),
+    parts: text('parts', { mode: 'json' }).$type<UIMessage['parts']>(),
+    chatThreadId: text('chat_thread_id')
+      .notNull()
+      .references(() => chatThreadsTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    modelId: text('model_id').references(() => modelsTable.id),
+    parentId: text('parent_id').references((): any => chatMessagesTable.id, { onDelete: 'cascade' }),
+    cache: text('cache', { mode: 'json' }).$type<Record<string, WidgetCacheData>>(),
+    metadata: text('metadata', { mode: 'json' }).$type<UIMessageMetadata>(),
+    deletedAt: integer('deleted_at'),
+  },
+  (table) => [
+    index('idx_chat_messages_active')
+      .on(table.chatThreadId)
+      .where(sql`chat_messages.${table.deletedAt} IS NULL`),
+  ],
+)
 
-export const tasksTable = sqliteTable('tasks', {
-  id: text('id').primaryKey().notNull().unique(),
-  item: text('item'),
-  order: integer('order').default(0),
-  isComplete: integer('is_complete').default(0),
-  defaultHash: text('default_hash'),
-  deletedAt: integer('deleted_at'),
-})
+export const tasksTable = sqliteTable(
+  'tasks',
+  {
+    id: text('id').primaryKey().notNull().unique(),
+    item: text('item'),
+    order: integer('order').default(0),
+    isComplete: integer('is_complete').default(0),
+    defaultHash: text('default_hash'),
+    deletedAt: integer('deleted_at'),
+  },
+  (table) => [
+    index('idx_tasks_active')
+      .on(table.id)
+      .where(sql`tasks.${table.deletedAt} IS NULL`),
+  ],
+)
 
-export const modelsTable = sqliteTable('models', {
-  id: text('id').primaryKey().notNull().unique(),
-  provider: text('provider', {
-    enum: ['openai', 'custom', 'openrouter', 'thunderbolt', 'anthropic'],
-  }),
-  name: text('name'),
-  model: text('model'),
-  url: text('url'),
-  apiKey: text('api_key'),
-  isSystem: integer('is_system').default(0),
-  enabled: integer('enabled').default(1),
-  toolUsage: integer('tool_usage').default(1),
-  isConfidential: integer('is_confidential').default(0),
-  startWithReasoning: integer('start_with_reasoning').default(0),
-  supportsParallelToolCalls: integer('supports_parallel_tool_calls').default(1),
-  contextWindow: integer('context_window'),
-  deletedAt: integer('deleted_at'),
-  defaultHash: text('default_hash'),
-  vendor: text('vendor'),
-  description: text('description'),
-})
+export const modelsTable = sqliteTable(
+  'models',
+  {
+    id: text('id').primaryKey().notNull().unique(),
+    provider: text('provider', {
+      enum: ['openai', 'custom', 'openrouter', 'thunderbolt', 'anthropic'],
+    }),
+    name: text('name'),
+    model: text('model'),
+    url: text('url'),
+    apiKey: text('api_key'),
+    isSystem: integer('is_system').default(0),
+    enabled: integer('enabled').default(1),
+    toolUsage: integer('tool_usage').default(1),
+    isConfidential: integer('is_confidential').default(0),
+    startWithReasoning: integer('start_with_reasoning').default(0),
+    supportsParallelToolCalls: integer('supports_parallel_tool_calls').default(1),
+    contextWindow: integer('context_window'),
+    deletedAt: integer('deleted_at'),
+    defaultHash: text('default_hash'),
+    vendor: text('vendor'),
+    description: text('description'),
+  },
+  (table) => [
+    index('idx_models_active')
+      .on(table.id)
+      .where(sql`models.${table.deletedAt} IS NULL`),
+  ],
+)
 
-export const mcpServersTable = sqliteTable('mcp_servers', {
-  id: text('id').primaryKey().notNull().unique(),
-  name: text('name'),
-  type: text('type', { enum: ['http', 'stdio'] }).default('http'),
-  url: text('url'),
-  command: text('command'),
-  args: text('args'),
-  enabled: integer('enabled').default(1),
-  createdAt: integer('created_at').default(sql`(unixepoch())`),
-  updatedAt: integer('updated_at').default(sql`(unixepoch())`),
-  deletedAt: integer('deleted_at'),
-})
+export const mcpServersTable = sqliteTable(
+  'mcp_servers',
+  {
+    id: text('id').primaryKey().notNull().unique(),
+    name: text('name'),
+    type: text('type', { enum: ['http', 'stdio'] }).default('http'),
+    url: text('url'),
+    command: text('command'),
+    args: text('args'),
+    enabled: integer('enabled').default(1),
+    createdAt: integer('created_at').default(sql`(unixepoch())`),
+    updatedAt: integer('updated_at').default(sql`(unixepoch())`),
+    deletedAt: integer('deleted_at'),
+  },
+  (table) => [
+    index('idx_mcp_servers_active')
+      .on(table.id)
+      .where(sql`mcp_servers.${table.deletedAt} IS NULL`),
+  ],
+)
 
-export const promptsTable = sqliteTable('prompts', {
-  id: text('id').primaryKey().notNull().unique(),
-  title: text('title'),
-  prompt: text('prompt'),
-  modelId: text('model_id')
-    .notNull()
-    .references(() => modelsTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
-  deletedAt: integer('deleted_at'),
-  defaultHash: text('default_hash'),
-})
+export const promptsTable = sqliteTable(
+  'prompts',
+  {
+    id: text('id').primaryKey().notNull().unique(),
+    title: text('title'),
+    prompt: text('prompt'),
+    modelId: text('model_id')
+      .notNull()
+      .references(() => modelsTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    deletedAt: integer('deleted_at'),
+    defaultHash: text('default_hash'),
+  },
+  (table) => [
+    index('idx_prompts_active')
+      .on(table.id)
+      .where(sql`prompts.${table.deletedAt} IS NULL`),
+  ],
+)
 
-export const triggersTable = sqliteTable('triggers', {
-  id: text('id').primaryKey().notNull().unique(),
-  triggerType: text('trigger_type', { enum: ['time'] }),
-  triggerTime: text('trigger_time'),
-  promptId: text('prompt_id')
-    .notNull()
-    .references(() => promptsTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
-  isEnabled: integer('is_enabled').default(1),
-  deletedAt: integer('deleted_at'),
-})
+export const triggersTable = sqliteTable(
+  'triggers',
+  {
+    id: text('id').primaryKey().notNull().unique(),
+    triggerType: text('trigger_type', { enum: ['time'] }),
+    triggerTime: text('trigger_time'),
+    promptId: text('prompt_id')
+      .notNull()
+      .references(() => promptsTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    isEnabled: integer('is_enabled').default(1),
+    deletedAt: integer('deleted_at'),
+  },
+  (table) => [
+    index('idx_triggers_active')
+      .on(table.promptId)
+      .where(sql`triggers.${table.deletedAt} IS NULL`),
+  ],
+)

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -25,7 +25,7 @@ export const chatThreadsTable = sqliteTable(
   (table) => [
     index('idx_chat_threads_active')
       .on(table.id)
-      .where(sql`chat_threads.${table.deletedAt} IS NULL`),
+      .where(sql`${table.deletedAt} IS NULL`),
   ],
 )
 
@@ -48,7 +48,7 @@ export const chatMessagesTable = sqliteTable(
   (table) => [
     index('idx_chat_messages_active')
       .on(table.chatThreadId)
-      .where(sql`chat_messages.${table.deletedAt} IS NULL`),
+      .where(sql`${table.deletedAt} IS NULL`),
   ],
 )
 
@@ -65,7 +65,7 @@ export const tasksTable = sqliteTable(
   (table) => [
     index('idx_tasks_active')
       .on(table.id)
-      .where(sql`tasks.${table.deletedAt} IS NULL`),
+      .where(sql`${table.deletedAt} IS NULL`),
   ],
 )
 
@@ -95,7 +95,7 @@ export const modelsTable = sqliteTable(
   (table) => [
     index('idx_models_active')
       .on(table.id)
-      .where(sql`models.${table.deletedAt} IS NULL`),
+      .where(sql`${table.deletedAt} IS NULL`),
   ],
 )
 
@@ -116,7 +116,7 @@ export const mcpServersTable = sqliteTable(
   (table) => [
     index('idx_mcp_servers_active')
       .on(table.id)
-      .where(sql`mcp_servers.${table.deletedAt} IS NULL`),
+      .where(sql`${table.deletedAt} IS NULL`),
   ],
 )
 
@@ -135,7 +135,7 @@ export const promptsTable = sqliteTable(
   (table) => [
     index('idx_prompts_active')
       .on(table.id)
-      .where(sql`prompts.${table.deletedAt} IS NULL`),
+      .where(sql`${table.deletedAt} IS NULL`),
   ],
 )
 
@@ -154,6 +154,6 @@ export const triggersTable = sqliteTable(
   (table) => [
     index('idx_triggers_active')
       .on(table.promptId)
-      .where(sql`triggers.${table.deletedAt} IS NULL`),
+      .where(sql`${table.deletedAt} IS NULL`),
   ],
 )

--- a/src/drizzle/0016_chief_hedge_knight.sql
+++ b/src/drizzle/0016_chief_hedge_knight.sql
@@ -1,7 +1,0 @@
-CREATE INDEX `idx_chat_messages_active` ON `chat_messages` (`chat_thread_id`) WHERE chat_messages."chat_messages"."deleted_at" IS NULL;--> statement-breakpoint
-CREATE INDEX `idx_chat_threads_active` ON `chat_threads` (`id`) WHERE chat_threads."chat_threads"."deleted_at" IS NULL;--> statement-breakpoint
-CREATE INDEX `idx_mcp_servers_active` ON `mcp_servers` (`id`) WHERE mcp_servers."mcp_servers"."deleted_at" IS NULL;--> statement-breakpoint
-CREATE INDEX `idx_models_active` ON `models` (`id`) WHERE models."models"."deleted_at" IS NULL;--> statement-breakpoint
-CREATE INDEX `idx_prompts_active` ON `prompts` (`id`) WHERE prompts."prompts"."deleted_at" IS NULL;--> statement-breakpoint
-CREATE INDEX `idx_tasks_active` ON `tasks` (`id`) WHERE tasks."tasks"."deleted_at" IS NULL;--> statement-breakpoint
-CREATE INDEX `idx_triggers_active` ON `triggers` (`prompt_id`) WHERE triggers."triggers"."deleted_at" IS NULL;

--- a/src/drizzle/0016_chief_hedge_knight.sql
+++ b/src/drizzle/0016_chief_hedge_knight.sql
@@ -1,0 +1,7 @@
+CREATE INDEX `idx_chat_messages_active` ON `chat_messages` (`chat_thread_id`) WHERE chat_messages."chat_messages"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_chat_threads_active` ON `chat_threads` (`id`) WHERE chat_threads."chat_threads"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_mcp_servers_active` ON `mcp_servers` (`id`) WHERE mcp_servers."mcp_servers"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_models_active` ON `models` (`id`) WHERE models."models"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_prompts_active` ON `prompts` (`id`) WHERE prompts."prompts"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_tasks_active` ON `tasks` (`id`) WHERE tasks."tasks"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_triggers_active` ON `triggers` (`prompt_id`) WHERE triggers."triggers"."deleted_at" IS NULL;

--- a/src/drizzle/0016_fine_night_nurse.sql
+++ b/src/drizzle/0016_fine_night_nurse.sql
@@ -1,0 +1,7 @@
+CREATE INDEX `idx_chat_messages_active` ON `chat_messages` (`chat_thread_id`) WHERE "chat_messages"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_chat_threads_active` ON `chat_threads` (`id`) WHERE "chat_threads"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_mcp_servers_active` ON `mcp_servers` (`id`) WHERE "mcp_servers"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_models_active` ON `models` (`id`) WHERE "models"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_prompts_active` ON `prompts` (`id`) WHERE "prompts"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_tasks_active` ON `tasks` (`id`) WHERE "tasks"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX `idx_triggers_active` ON `triggers` (`prompt_id`) WHERE "triggers"."deleted_at" IS NULL;

--- a/src/drizzle/_migrations.ts
+++ b/src/drizzle/_migrations.ts
@@ -89,4 +89,9 @@ export const migrations: Migration[] = [
     name: '0015_grey_salo.sql',
     sql: '-- Custom SQL migration file, put your code below! ---- Drop manually created indexes so Drizzle can manage them from schema\nDROP INDEX IF EXISTS `idx_chat_messages_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_chat_threads_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_tasks_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_models_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_prompts_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_triggers_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_mcp_servers_active`;',
   },
+  {
+    hash: '0016_chief_hedge_knight',
+    name: '0016_chief_hedge_knight.sql',
+    sql: 'CREATE INDEX `idx_chat_messages_active` ON `chat_messages` (`chat_thread_id`) WHERE chat_messages."chat_messages"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_chat_threads_active` ON `chat_threads` (`id`) WHERE chat_threads."chat_threads"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_mcp_servers_active` ON `mcp_servers` (`id`) WHERE mcp_servers."mcp_servers"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_models_active` ON `models` (`id`) WHERE models."models"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_prompts_active` ON `prompts` (`id`) WHERE prompts."prompts"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_tasks_active` ON `tasks` (`id`) WHERE tasks."tasks"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_triggers_active` ON `triggers` (`prompt_id`) WHERE triggers."triggers"."deleted_at" IS NULL;',
+  },
 ]

--- a/src/drizzle/_migrations.ts
+++ b/src/drizzle/_migrations.ts
@@ -89,4 +89,9 @@ export const migrations: Migration[] = [
     name: '0015_grey_salo.sql',
     sql: '-- Custom SQL migration file, put your code below! ---- Drop manually created indexes so Drizzle can manage them from schema\nDROP INDEX IF EXISTS `idx_chat_messages_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_chat_threads_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_tasks_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_models_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_prompts_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_triggers_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_mcp_servers_active`;',
   },
+  {
+    hash: '0016_fine_night_nurse',
+    name: '0016_fine_night_nurse.sql',
+    sql: 'CREATE INDEX `idx_chat_messages_active` ON `chat_messages` (`chat_thread_id`) WHERE "chat_messages"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_chat_threads_active` ON `chat_threads` (`id`) WHERE "chat_threads"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_mcp_servers_active` ON `mcp_servers` (`id`) WHERE "mcp_servers"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_models_active` ON `models` (`id`) WHERE "models"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_prompts_active` ON `prompts` (`id`) WHERE "prompts"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_tasks_active` ON `tasks` (`id`) WHERE "tasks"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_triggers_active` ON `triggers` (`prompt_id`) WHERE "triggers"."deleted_at" IS NULL;',
+  },
 ]

--- a/src/drizzle/_migrations.ts
+++ b/src/drizzle/_migrations.ts
@@ -89,9 +89,4 @@ export const migrations: Migration[] = [
     name: '0015_grey_salo.sql',
     sql: '-- Custom SQL migration file, put your code below! ---- Drop manually created indexes so Drizzle can manage them from schema\nDROP INDEX IF EXISTS `idx_chat_messages_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_chat_threads_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_tasks_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_models_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_prompts_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_triggers_active`;--> statement-breakpoint\nDROP INDEX IF EXISTS `idx_mcp_servers_active`;',
   },
-  {
-    hash: '0016_chief_hedge_knight',
-    name: '0016_chief_hedge_knight.sql',
-    sql: 'CREATE INDEX `idx_chat_messages_active` ON `chat_messages` (`chat_thread_id`) WHERE chat_messages."chat_messages"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_chat_threads_active` ON `chat_threads` (`id`) WHERE chat_threads."chat_threads"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_mcp_servers_active` ON `mcp_servers` (`id`) WHERE mcp_servers."mcp_servers"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_models_active` ON `models` (`id`) WHERE models."models"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_prompts_active` ON `prompts` (`id`) WHERE prompts."prompts"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_tasks_active` ON `tasks` (`id`) WHERE tasks."tasks"."deleted_at" IS NULL;--> statement-breakpoint\nCREATE INDEX `idx_triggers_active` ON `triggers` (`prompt_id`) WHERE triggers."triggers"."deleted_at" IS NULL;',
-  },
 ]

--- a/src/drizzle/meta/0016_snapshot.json
+++ b/src/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,718 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e99f0c15-9afa-44a7-b944-917be3049c79",
+  "prevId": "c1bfdcbd-4c05-4c32-b18d-af73ed208ce3",
+  "tables": {
+    "chat_messages": {
+      "name": "chat_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache": {
+          "name": "cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_messages_id_unique": {
+          "name": "chat_messages_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        },
+        "idx_chat_messages_active": {
+          "name": "idx_chat_messages_active",
+          "columns": ["chat_thread_id"],
+          "isUnique": false,
+          "where": "chat_messages.\"chat_messages\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": ["chat_thread_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "chat_messages_model_id_models_id_fk": {
+          "name": "chat_messages_model_id_models_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "models",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_messages_parent_id_chat_messages_id_fk": {
+          "name": "chat_messages_parent_id_chat_messages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_messages",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_threads": {
+      "name": "chat_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "was_triggered_by_automation": {
+          "name": "was_triggered_by_automation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_threads_id_unique": {
+          "name": "chat_threads_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        },
+        "idx_chat_threads_active": {
+          "name": "idx_chat_threads_active",
+          "columns": ["id"],
+          "isUnique": false,
+          "where": "chat_threads.\"chat_threads\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_triggered_by_prompts_id_fk": {
+          "name": "chat_threads_triggered_by_prompts_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "prompts",
+          "columnsFrom": ["triggered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_id_unique": {
+          "name": "mcp_servers_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        },
+        "idx_mcp_servers_active": {
+          "name": "idx_mcp_servers_active",
+          "columns": ["id"],
+          "isUnique": false,
+          "where": "mcp_servers.\"mcp_servers\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "models": {
+      "name": "models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "tool_usage": {
+          "name": "tool_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_confidential": {
+          "name": "is_confidential",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "start_with_reasoning": {
+          "name": "start_with_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "supports_parallel_tool_calls": {
+          "name": "supports_parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "models_id_unique": {
+          "name": "models_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        },
+        "idx_models_active": {
+          "name": "idx_models_active",
+          "columns": ["id"],
+          "isUnique": false,
+          "where": "models.\"models\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompts_id_unique": {
+          "name": "prompts_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        },
+        "idx_prompts_active": {
+          "name": "idx_prompts_active",
+          "columns": ["id"],
+          "isUnique": false,
+          "where": "prompts.\"prompts\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "prompts_model_id_models_id_fk": {
+          "name": "prompts_model_id_models_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "models",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_id_unique": {
+          "name": "tasks_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        },
+        "idx_tasks_active": {
+          "name": "idx_tasks_active",
+          "columns": ["id"],
+          "isUnique": false,
+          "where": "tasks.\"tasks\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "triggers": {
+      "name": "triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_time": {
+          "name": "trigger_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "triggers_id_unique": {
+          "name": "triggers_id_unique",
+          "columns": ["id"],
+          "isUnique": true
+        },
+        "idx_triggers_active": {
+          "name": "idx_triggers_active",
+          "columns": ["prompt_id"],
+          "isUnique": false,
+          "where": "triggers.\"triggers\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "triggers_prompt_id_prompts_id_fk": {
+          "name": "triggers_prompt_id_prompts_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "prompts",
+          "columnsFrom": ["prompt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/drizzle/meta/0016_snapshot.json
+++ b/src/drizzle/meta/0016_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "e99f0c15-9afa-44a7-b944-917be3049c79",
+  "id": "265569fc-a3ba-464d-bfd0-e93cc0179172",
   "prevId": "c1bfdcbd-4c05-4c32-b18d-af73ed208ce3",
   "tables": {
     "chat_messages": {
@@ -88,7 +88,7 @@
           "name": "idx_chat_messages_active",
           "columns": ["chat_thread_id"],
           "isUnique": false,
-          "where": "chat_messages.\"chat_messages\".\"deleted_at\" IS NULL"
+          "where": "\"chat_messages\".\"deleted_at\" IS NULL"
         }
       },
       "foreignKeys": {
@@ -189,7 +189,7 @@
           "name": "idx_chat_threads_active",
           "columns": ["id"],
           "isUnique": false,
-          "where": "chat_threads.\"chat_threads\".\"deleted_at\" IS NULL"
+          "where": "\"chat_threads\".\"deleted_at\" IS NULL"
         }
       },
       "foreignKeys": {
@@ -295,7 +295,7 @@
           "name": "idx_mcp_servers_active",
           "columns": ["id"],
           "isUnique": false,
-          "where": "mcp_servers.\"mcp_servers\".\"deleted_at\" IS NULL"
+          "where": "\"mcp_servers\".\"deleted_at\" IS NULL"
         }
       },
       "foreignKeys": {},
@@ -442,7 +442,7 @@
           "name": "idx_models_active",
           "columns": ["id"],
           "isUnique": false,
-          "where": "models.\"models\".\"deleted_at\" IS NULL"
+          "where": "\"models\".\"deleted_at\" IS NULL"
         }
       },
       "foreignKeys": {},
@@ -506,7 +506,7 @@
           "name": "idx_prompts_active",
           "columns": ["id"],
           "isUnique": false,
-          "where": "prompts.\"prompts\".\"deleted_at\" IS NULL"
+          "where": "\"prompts\".\"deleted_at\" IS NULL"
         }
       },
       "foreignKeys": {
@@ -621,7 +621,7 @@
           "name": "idx_tasks_active",
           "columns": ["id"],
           "isUnique": false,
-          "where": "tasks.\"tasks\".\"deleted_at\" IS NULL"
+          "where": "\"tasks\".\"deleted_at\" IS NULL"
         }
       },
       "foreignKeys": {},
@@ -686,7 +686,7 @@
           "name": "idx_triggers_active",
           "columns": ["prompt_id"],
           "isUnique": false,
-          "where": "triggers.\"triggers\".\"deleted_at\" IS NULL"
+          "where": "\"triggers\".\"deleted_at\" IS NULL"
         }
       },
       "foreignKeys": {

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1768500906853,
       "tag": "0015_grey_salo",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1768501236699,
+      "tag": "0016_chief_hedge_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -117,8 +117,8 @@
     {
       "idx": 16,
       "version": "6",
-      "when": 1768501236699,
-      "tag": "0016_chief_hedge_knight",
+      "when": 1768509173390,
+      "tag": "0016_fine_night_nurse",
       "breakpoints": true
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces schema-level partial indexes to optimize queries that filter out soft-deleted rows.
> 
> - Defines partial indexes in `tables.ts` for `chat_threads`, `chat_messages` (by `chat_thread_id`), `tasks`, `models`, `mcp_servers`, `prompts`, and `triggers`
> - Adds migration `0016_fine_night_nurse.sql` to create these indexes and updates `_migrations.ts`, snapshot, and journal metadata
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 424d25d0c4577639664ce47517d4dbd8edf99a83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->