### PR TITLE
THU-245: Changing a location alert is broken

### DIFF
--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -308,4 +308,79 @@ describe('reconcileDefaultsForTable', () => {
     // Value should be preserved
     expect(setting?.value).toBe('some_value')
   })
+
+  test('preserves user values set via recomputeHash when code default is null', async () => {
+    const db = DatabaseSingleton.instance.db
+
+    // Simulate the recomputeHash scenario:
+    // User accepts localization settings (e.g., distance_unit = "metric")
+    // Both value AND defaultHash are set to match (this is what recomputeHash does)
+    const userSetValue = 'metric'
+    const userSetting = {
+      key: 'distance_unit',
+      value: userSetValue,
+      updatedAt: null,
+      defaultHash: null,
+    }
+
+    await db.insert(settingsTable).values({
+      ...userSetting,
+      // This simulates recomputeHash: true - hash matches the user's value
+      defaultHash: hashSetting(userSetting),
+    })
+
+    // Verify the hash matches (as recomputeHash would set it)
+    const beforeReconcile = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
+    expect(beforeReconcile?.value).toBe(userSetValue)
+    expect(beforeReconcile?.defaultHash).toBe(hashSetting(userSetting))
+
+    // Code default has null value (like localization settings)
+    const nullDefault = {
+      key: 'distance_unit',
+      value: null,
+      updatedAt: null,
+      defaultHash: null,
+    }
+
+    // Run reconcile - this previously would overwrite user's "metric" with null
+    await reconcileDefaultsForTable(db, settingsTable, [nullDefault], hashSetting, 'key')
+
+    // User's value should be PRESERVED, not overwritten with null
+    const afterReconcile = await db.select().from(settingsTable).where(eq(settingsTable.key, 'distance_unit')).get()
+    expect(afterReconcile?.value).toBe(userSetValue)
+    // Hash should remain unchanged
+    expect(afterReconcile?.defaultHash).toBe(hashSetting(userSetting))
+  })
+
+  test('still updates when both existing and default values are null', async () => {
+    const db = DatabaseSingleton.instance.db
+
+    // Setting with null value and matching hash
+    const nullSetting = {
+      key: 'optional_setting',
+      value: null,
+      updatedAt: null,
+      defaultHash: null,
+    }
+
+    await db.insert(settingsTable).values({
+      ...nullSetting,
+      defaultHash: hashSetting(nullSetting),
+    })
+
+    // Code default also has null value
+    const nullDefault = {
+      key: 'optional_setting',
+      value: null,
+      updatedAt: null,
+      defaultHash: null,
+    }
+
+    // Run reconcile - should proceed (this is a no-op anyway)
+    await reconcileDefaultsForTable(db, settingsTable, [nullDefault], hashSetting, 'key')
+
+    // Value should still be null (no change, but update was allowed)
+    const afterReconcile = await db.select().from(settingsTable).where(eq(settingsTable.key, 'optional_setting')).get()
+    expect(afterReconcile?.value).toBeNull()
+  })
 })

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -43,6 +43,14 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
         // No defaultHash - set it to the default hash to enable modification tracking
         await db.update(table).set({ defaultHash: defaultHashValue }).where(eq(table[keyField], keyValue))
       } else if (currentHash === existing.defaultHash) {
+        // Protect user-set values from being overwritten by null defaults.
+        // This handles localization settings (distance_unit, etc.) where the user explicitly
+        // set a value via recomputeHash, but the code default is null.
+        // For non-settings tables, 'value' is undefined so this check is safely skipped.
+        const wouldOverwriteUserValue = (existing as any).value !== null && (defaultItem as any).value === null
+
+        if (wouldOverwriteUserValue) continue
+
         // Unmodified - safe to update to new default
         await db
           .update(table)

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -768,14 +768,7 @@ export default function PreferencesSettingsPage() {
       <TelemetryWarningModal ref={telemetryWarningModalRef} onDisableTelemetry={handleDisableTelemetry} />
 
       <AlertDialog open={localizationDialogOpen} onOpenChange={(open) => !open && handleDeclineLocalizationSettings()}>
-        <AlertDialogContent
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              handleApplyLocalizationSettings()
-            }
-          }}
-        >
+        <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Update Defaults?</AlertDialogTitle>
             <AlertDialogDescription>
@@ -784,12 +777,7 @@ export default function PreferencesSettingsPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Keep Current Units</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(e) => {
-                e.preventDefault()
-                handleApplyLocalizationSettings()
-              }}
-            >
+            <AlertDialogAction autoFocus onClick={handleApplyLocalizationSettings}>
               Update Units
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -237,18 +237,7 @@ export default function PreferencesSettingsPage() {
     trackEvent('settings_localization_update')
   }
 
-  const handleDeclineLocalizationSettings = async () => {
-    if (!pendingCountryUnits) return
-
-    // Update hash values to new country defaults without changing actual values
-    await Promise.all([
-      distanceUnit.setValue(pendingCountryUnits.unit, { updateHashOnly: true }),
-      temperatureUnit.setValue(pendingCountryUnits.temperature, { updateHashOnly: true }),
-      dateFormat.setValue(pendingCountryUnits.dateFormatExample, { updateHashOnly: true }),
-      timeFormat.setValue(pendingCountryUnits.timeFormat, { updateHashOnly: true }),
-      currency.setValue(pendingCountryUnits.currency.code, { updateHashOnly: true }),
-    ])
-
+  const handleDeclineLocalizationSettings = () => {
     dispatch({ type: 'CLOSE_LOCALIZATION_DIALOG' })
   }
 
@@ -779,7 +768,14 @@ export default function PreferencesSettingsPage() {
       <TelemetryWarningModal ref={telemetryWarningModalRef} onDisableTelemetry={handleDisableTelemetry} />
 
       <AlertDialog open={localizationDialogOpen} onOpenChange={(open) => !open && handleDeclineLocalizationSettings()}>
-        <AlertDialogContent>
+        <AlertDialogContent
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              handleApplyLocalizationSettings()
+            }
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle>Update Defaults?</AlertDialogTitle>
             <AlertDialogDescription>
@@ -787,8 +783,15 @@ export default function PreferencesSettingsPage() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel onClick={handleDeclineLocalizationSettings}>Keep Current Units</AlertDialogCancel>
-            <AlertDialogAction onClick={handleApplyLocalizationSettings}>Update Units</AlertDialogAction>
+            <AlertDialogCancel>Keep Current Units</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                handleApplyLocalizationSettings()
+              }}
+            >
+              Update Units
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fix: preserve user-set values during defaults reconciliation**
> 
> - In `reconcile-defaults.ts`, skip updating when `existing.value` is non-null and `defaultItem.value` is null (even if hashes match), protecting localization and similar settings; still sets `defaultHash` when missing and updates when both values are null.
> - Tests in `reconcile-defaults.test.ts` cover preserving recomputeHash-set values vs. null defaults and the both-null case.
> - In `preferences.tsx`, declining localization changes now only closes the dialog (no hash-only updates); dialog buttons refined (cancel without handler, action `autoFocus`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a633a83b5c286c16e04e6ab945521fdb2e86292. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->