### PR TITLE
THU-247: Not Found w/ Redirect to /not-found 

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -92,7 +92,7 @@ function AppRoutes(_: { initData: InitData }) {
 
       {/* 404 catch-all */}
       <Route path="/not-found" element={<NotFound />} />
-      <Route path="*" element={<NotFound />} />
+      <Route path="*" element={<Navigate to="/not-found" replace />} />
     </Routes>
   )
 }

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -8,10 +8,11 @@ import { useHandleIntegrationCompletion } from '@/hooks/use-handle-integration-c
 
 type ChatHydrateHandlerProps = PropsWithChildren<{
   id: string
+  isNew: boolean
 }>
 
-const ChatHydrateHandler = ({ children, id }: ChatHydrateHandlerProps) => {
-  const { hydrateChatStore, isReady, saveMessages } = useHydrateChatStore({ id })
+const ChatHydrateHandler = ({ children, id, isNew }: ChatHydrateHandlerProps) => {
+  const { hydrateChatStore, isReady, saveMessages } = useHydrateChatStore({ id, isNew })
 
   useHandleIntegrationCompletion({ saveMessages })
 
@@ -32,17 +33,16 @@ const ChatHydrateHandler = ({ children, id }: ChatHydrateHandlerProps) => {
 export default function ChatDetailPage() {
   const params = useParams()
 
-  const id = useMemo(
-    () => (params.chatThreadId === 'new' ? uuidv7() : params.chatThreadId || null),
-    [params.chatThreadId],
-  )
+  const isNew = params.chatThreadId === 'new'
+
+  const id = useMemo(() => (isNew ? uuidv7() : params.chatThreadId || null), [params.chatThreadId])
 
   if (!id) {
     return null
   }
 
   return (
-    <ChatHydrateHandler key={id} id={id}>
+    <ChatHydrateHandler key={id} id={id} isNew={isNew}>
       <ChatUI />
     </ChatHydrateHandler>
   )

--- a/src/chats/use-hydrate-chat-store.test.tsx
+++ b/src/chats/use-hydrate-chat-store.test.tsx
@@ -137,7 +137,7 @@ describe('useHydrateChatStore', () => {
       const modelId = await createTestModel()
       const threadId = await createTestThread(modelId)
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -148,7 +148,7 @@ describe('useHydrateChatStore', () => {
       const modelId = await createTestModel()
       const threadId = await createTestThread(modelId)
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -167,7 +167,7 @@ describe('useHydrateChatStore', () => {
       const systemModelId = await createSystemModel()
       const threadId = await createTestThread(systemModelId, 'My Test Thread')
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -198,7 +198,7 @@ describe('useHydrateChatStore', () => {
       const threadId1 = await createTestThread(systemModelId, 'Thread 1')
       const threadId2 = await createTestThread(systemModelId, 'Thread 2')
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId1 }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId1, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -211,7 +211,7 @@ describe('useHydrateChatStore', () => {
       expect(firstState.currentSessionId).toBe(threadId1)
 
       // Second hydration with different thread
-      const { result: result2 } = renderHook(() => useHydrateChatStore({ id: threadId2 }), {
+      const { result: result2 } = renderHook(() => useHydrateChatStore({ id: threadId2, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -237,7 +237,7 @@ describe('useHydrateChatStore', () => {
 
       await saveMessagesWithContextUpdate(threadId, messages)
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -255,7 +255,7 @@ describe('useHydrateChatStore', () => {
       const systemModelId = await createSystemModel()
       const threadId = await createTestThread(systemModelId)
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -275,7 +275,7 @@ describe('useHydrateChatStore', () => {
       const systemModelId = await createSystemModel()
       const threadId = await createTestThread(systemModelId)
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -304,7 +304,7 @@ describe('useHydrateChatStore', () => {
     it('should throw error if no session is found when saving messages', async () => {
       const threadId = uuidv7()
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
         wrapper: TestWrapper,
       })
 
@@ -330,7 +330,7 @@ describe('useHydrateChatStore', () => {
       const systemModelId = await createSystemModel()
       const threadId = await createTestThread(systemModelId)
 
-      const { result } = renderHook(() => useHydrateChatStore({ id: threadId }), {
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
         wrapper: TestWrapper,
       })
 

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -21,9 +21,10 @@ import { createChatInstance } from './chat-instance'
 
 type UseHydrateChatStoreParams = {
   id: string
+  isNew: boolean
 }
 
-export const useHydrateChatStore = ({ id }: UseHydrateChatStoreParams) => {
+export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) => {
   const navigate = useNavigate()
 
   const [isReady, setIsReady] = useState(false)
@@ -112,6 +113,12 @@ export const useHydrateChatStore = ({ id }: UseHydrateChatStoreParams) => {
       getTriggerPromptForThread(id),
       getEnabledClients(),
     ])
+
+    // If chat doesn't exist and this isn't a new chat, redirect to 404
+    if (!chatThread && !isNew) {
+      navigate('/not-found', { replace: true })
+      return
+    }
 
     const chatInstance = createChatInstance(
       id,

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -1,31 +1,23 @@
+import { AppLogo } from '@/components/app-logo'
 import { Button } from '@/components/ui/button'
-import { FileQuestion } from 'lucide-react'
 import { useNavigate } from 'react-router'
 
-type NotFoundProps = {
-  title?: string
-  description?: string
-}
-
-export const NotFound = ({
-  title = 'Page not found',
-  description = "The page you're looking for doesn't exist or has been removed.",
-}: NotFoundProps) => {
+export const NotFound = () => {
   const navigate = useNavigate()
 
   return (
-    <div className="flex flex-col items-center justify-center w-full h-[100vh] p-4">
-      <div className="flex flex-col items-center gap-6 max-w-md text-center">
-        <div className="rounded-full bg-muted p-4">
-          <FileQuestion className="h-12 w-12 text-muted-foreground" />
+    <div className="flex flex-col items-center justify-center w-full h-dvh">
+      <div className="flex flex-col items-center gap-8 text-center">
+        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+          <AppLogo size={16} />
+          <span>Thunderbolt</span>
         </div>
 
-        <div className="space-y-2">
-          <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
-          <p className="text-muted-foreground">{description}</p>
-        </div>
+        <h1 className="text-4xl font-semibold tracking-tight">Not Found</h1>
 
-        <Button onClick={() => navigate('/chats/new', { replace: true })}>Start a new chat</Button>
+        <Button variant="secondary" onClick={() => navigate('/chats/new', { replace: true })}>
+          Back to App
+        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves 404 handling and chat hydration behavior.
> 
> - Catch-all route now navigates to `/not-found` instead of rendering the component directly
> - Redesigns `NotFound` screen with app branding and a “Back to App” button
> - `ChatDetailPage` detects `new` threads, generates an id, and passes `isNew` to hydration
> - `useHydrateChatStore` accepts `isNew` and redirects to `/not-found` if a thread is missing or deleted; otherwise hydrates session/models/MCP clients
> - Updates tests to use the new `isNew` parameter
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85b7d1104f379e81e28acfc27d59c431a9231d01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->