### PR TITLE
THU-248: Model value reset not working (hash bug)

### DIFF
--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, isNull } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
 import { modelsTable } from '../db/tables'
+import { hashModel } from '../defaults/models'
 import { clearNullableColumns } from '../lib/utils'
 import type { Model, ModelRow } from '../types'
 import { getSettings } from './settings'
@@ -133,8 +134,13 @@ export const updateModel = async (id: string, updates: Partial<Model>): Promise<
  */
 export const resetModelToDefault = async (id: string, defaultModel: Model): Promise<void> => {
   const db = DatabaseSingleton.instance.db
+  // Compute the hash for the default model so it shows as unmodified after reset
+  const computedHash = hashModel(defaultModel)
   const { defaultHash, ...defaultFields } = defaultModel
-  await db.update(modelsTable).set(defaultFields).where(eq(modelsTable.id, id))
+  await db
+    .update(modelsTable)
+    .set({ ...defaultFields, defaultHash: computedHash })
+    .where(eq(modelsTable.id, id))
 }
 
 /**

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, isNull, like } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import { DatabaseSingleton } from '../db/singleton'
 import { chatMessagesTable, chatThreadsTable, promptsTable } from '../db/tables'
+import { hashPrompt } from '../defaults/automations'
 import type { AutomationRun, Prompt } from '../types'
 import { clearNullableColumns, convertUIMessageToDbChatMessage } from '../lib/utils'
 import { getModel } from './models'
@@ -76,8 +77,13 @@ export const updateAutomation = async (id: string, updates: Partial<Prompt>): Pr
  */
 export const resetAutomationToDefault = async (id: string, defaultAutomation: Prompt): Promise<void> => {
   const db = DatabaseSingleton.instance.db
+  // Compute the hash for the default automation so it shows as unmodified after reset
+  const computedHash = hashPrompt(defaultAutomation)
   const { defaultHash, ...defaultFields } = defaultAutomation
-  await db.update(promptsTable).set(defaultFields).where(eq(promptsTable.id, id))
+  await db
+    .update(promptsTable)
+    .set({ ...defaultFields, defaultHash: computedHash })
+    .where(eq(promptsTable.id, id))
 }
 
 /**


### PR DESCRIPTION
When resetting an item to its default state, the defaultHash field wasn't being updated to match the new default values. This caused the system to still see the item as "modified" because the stored hash didn't match the computed hash of the reset values.

The reset functions now compute and store the correct defaultHash after resetting, matching the behavior already implemented for settings. After resetting, the modification indicator correctly disappears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures reset operations correctly reflect unmodified state by updating the stored hash.
> 
> - Update `resetModelToDefault` and `resetAutomationToDefault` to compute hashes via `hashModel`/`hashPrompt` and persist `defaultHash` alongside default fields
> - Add corresponding imports for hashing utilities
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a46c840a88d97c35d714f14ca89d278573750a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->