### PR TITLE
fix: enhance logger configuration with console method overrides

### DIFF
--- a/backend/src/config/logger.ts
+++ b/backend/src/config/logger.ts
@@ -48,19 +48,88 @@ const createPinoLogger = (settings: Settings): Logger => {
   })
 }
 
+// Track if console overrides have been set up to avoid duplicate setup
+let consoleOverridesSetup = false
+
+/**
+ * Format console arguments into a string (similar to console.log behavior)
+ */
+const formatConsoleArgs = (args: unknown[]): string => {
+  if (args.length === 0) {
+    return ''
+  }
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg
+      if (typeof arg === 'object' && arg !== null) {
+        try {
+          return JSON.stringify(arg, null, 2)
+        } catch {
+          return String(arg)
+        }
+      }
+      return String(arg)
+    })
+    .join(' ')
+}
+
+/**
+ * Create a console override function that routes to a pino logger method
+ */
+const createConsoleOverride = (logger: Logger, method: 'info' | 'error' | 'warn' | 'debug') => {
+  return (...args: unknown[]) => {
+    const message = formatConsoleArgs(args)
+    logger[method](message)
+  }
+}
+
+/**
+ * Override console methods to use pino logger
+ * This ensures all console.* calls go through pino-pretty formatting
+ * Only sets up once to avoid duplicate overrides
+ */
+const setupConsoleOverrides = (logger: Logger) => {
+  // Only set up once
+  if (consoleOverridesSetup) {
+    return
+  }
+  consoleOverridesSetup = true
+
+  // Override console methods to use pino logger
+  // eslint-disable-next-line no-console
+  console.log = createConsoleOverride(logger, 'info')
+  // eslint-disable-next-line no-console
+  console.error = createConsoleOverride(logger, 'error')
+  // eslint-disable-next-line no-console
+  console.warn = createConsoleOverride(logger, 'warn')
+  // eslint-disable-next-line no-console
+  console.info = createConsoleOverride(logger, 'info')
+  // eslint-disable-next-line no-console
+  if (console.debug) {
+    // eslint-disable-next-line no-console
+    console.debug = createConsoleOverride(logger, 'debug')
+  }
+}
+
 /**
  * Minimal logger middleware: only decorates ctx.log with pino
  */
 const createLoggerMiddleware = (settings: Settings) => {
   const logger = createPinoLogger(settings)
+  // Override console methods to use pino logger
+  setupConsoleOverrides(logger)
   return new Elysia({ name: 'logger' }).decorate('log', logger)
 }
 
 /**
  * Create a standalone logger instance for use outside request contexts
+ * Also sets up console overrides so console.* calls go through pino
  */
 const createStandaloneLogger = (settings: Settings): Logger => {
-  return createPinoLogger(settings)
+  const logger = createPinoLogger(settings)
+  // Override console methods to use pino logger
+  setupConsoleOverrides(logger)
+  return logger
 }
 
 export { createLoggerMiddleware, createPinoLogger, createStandaloneLogger }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes all `console.*` output through Pino for consistent formatting.
> 
> - Adds `formatConsoleArgs`, `createConsoleOverride`, and `setupConsoleOverrides` to map `console.log/error/warn/info/debug` to Pino methods
> - Ensures overrides are applied only once via `consoleOverridesSetup` guard
> - Hooks override setup into both `createLoggerMiddleware` and `createStandaloneLogger` so all runtime logs use Pino (pretty in dev, JSON in prod)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca7632b2e4e8d56c7f90ff3fbe63ef7854cd323f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->