### PR TITLE
[DO NOT MERGE]: THU-191: Devices management for PowerSync POC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,9 @@
 - Consider refactoring into standalone functions for clarity
 - Remove unused variables and imports
 - Verify tests pass and no TypeScript errors exist
+
+## PowerSync and synced tables
+
+- **Requirements for PowerSync tables:** New synced tables must have a `user_id` column (sync rules and backend scope by `user_id`). Define the table in **both** frontend ([src/db/tables.ts](src/db/tables.ts), SQLite) and backend ([backend/src/db/powersync-schema.ts](backend/src/db/powersync-schema.ts), PostgreSQL).
+- **Adding a new synced table:** (1) Create the table in both `src/db/tables.ts` and `backend/src/db/powersync-schema.ts` with `user_id`. (2) Register in [src/db/powersync/schema.ts](src/db/powersync/schema.ts) (`drizzleSchema`). (3) Add table name and query keys in [shared/powersync-tables.ts](shared/powersync-tables.ts). (4) Update [powersync-service/config/config.yaml](powersync-service/config/config.yaml) sync rules `data:` list. (5) Run migrations for frontend and backend as needed.
+- **Before merging to production:** Deploy the new sync rules in the PowerSync Cloud dashboard (production uses PowerSync Cloud; local uses powersync-service config).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -64,4 +64,3 @@ POWERSYNC_URL=http://localhost:8080
 POWERSYNC_JWT_SECRET=powersync-dev-secret-change-in-production
 POWERSYNC_JWT_KID=powersync-dev
 POWERSYNC_TOKEN_EXPIRY_SECONDS=3600
-

--- a/backend/drizzle/0004_living_fixer.sql
+++ b/backend/drizzle/0004_living_fixer.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "devices" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"name" text,
+	"last_seen" integer DEFAULT extract(epoch from now())::integer,
+	"created_at" integer DEFAULT extract(epoch from now())::integer,
+	"revoked_at" integer
+);

--- a/backend/drizzle/meta/0004_snapshot.json
+++ b/backend/drizzle/meta/0004_snapshot.json
@@ -826,9 +826,7 @@
         "users_email_unique": {
           "name": "users_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       },
       "policies": {},
@@ -941,12 +939,8 @@
           "name": "account_user_id_user_id_fk",
           "tableFrom": "account",
           "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1033,12 +1027,8 @@
           "name": "session_user_id_user_id_fk",
           "tableFrom": "session",
           "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1048,9 +1038,7 @@
         "session_token_unique": {
           "name": "session_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -1114,9 +1102,7 @@
         "user_email_unique": {
           "name": "user_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       },
       "policies": {},
@@ -1272,9 +1258,7 @@
         "waitlist_email_unique": {
           "name": "waitlist_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       },
       "policies": {},

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1770214255014,
       "tag": "0004_equal_red_skull",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1769803996373,
+      "tag": "0004_living_fixer",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -1,17 +1,8 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import type { db as DbType } from '@/db/client'
 import { user } from '@/db/auth-schema'
-import {
-  chatMessagesTable,
-  chatThreadsTable,
-  devicesTable,
-  modelsTable,
-  mcpServersTable,
-  promptsTable,
-  settingsTable,
-  tasksTable,
-  triggersTable,
-} from '@/db/schema'
+import { devicesTable, POWERSYNC_TABLES_BY_NAME } from '@/db/schema'
+import { POWERSYNC_TABLE_NAMES } from '@shared/powersync-tables'
 import { and, eq } from 'drizzle-orm'
 import { Elysia } from 'elysia'
 
@@ -51,15 +42,10 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
       const userId = sessionUser!.id
 
       await database.transaction(async (tx) => {
-        await tx.delete(settingsTable).where(eq(settingsTable.userId, userId))
-        await tx.delete(chatMessagesTable).where(eq(chatMessagesTable.userId, userId))
-        await tx.delete(chatThreadsTable).where(eq(chatThreadsTable.userId, userId))
-        await tx.delete(tasksTable).where(eq(tasksTable.userId, userId))
-        await tx.delete(triggersTable).where(eq(triggersTable.userId, userId))
-        await tx.delete(promptsTable).where(eq(promptsTable.userId, userId))
-        await tx.delete(mcpServersTable).where(eq(mcpServersTable.userId, userId))
-        await tx.delete(modelsTable).where(eq(modelsTable.userId, userId))
-        await tx.delete(devicesTable).where(eq(devicesTable.userId, userId))
+        for (const name of POWERSYNC_TABLE_NAMES) {
+          const table = POWERSYNC_TABLES_BY_NAME[name]
+          await tx.delete(table).where(eq(table.userId, userId))
+        }
         await tx.delete(user).where(eq(user.id, userId))
       })
 

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -4,6 +4,7 @@ import { user } from '@/db/auth-schema'
 import {
   chatMessagesTable,
   chatThreadsTable,
+  devicesTable,
   modelsTable,
   mcpServersTable,
   promptsTable,
@@ -11,7 +12,7 @@ import {
   tasksTable,
   triggersTable,
 } from '@/db/schema'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { Elysia } from 'elysia'
 
 /**
@@ -35,6 +36,16 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
         set.status = 401
         return { error: 'Unauthorized' }
       }
+    })
+    .post('/devices/:id/revoke', async ({ params, set, user: sessionUser }) => {
+      const userId = sessionUser!.id
+      const deviceId = params.id
+      const now = Math.floor(Date.now() / 1000)
+      await database
+        .update(devicesTable)
+        .set({ revokedAt: now })
+        .where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId)))
+      set.status = 204
     })
     .delete('/', async ({ set, user: sessionUser }) => {
       const userId = sessionUser!.id

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -59,6 +59,7 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
         await tx.delete(promptsTable).where(eq(promptsTable.userId, userId))
         await tx.delete(mcpServersTable).where(eq(mcpServersTable.userId, userId))
         await tx.delete(modelsTable).where(eq(modelsTable.userId, userId))
+        await tx.delete(devicesTable).where(eq(devicesTable.userId, userId))
         await tx.delete(user).where(eq(user.id, userId))
       })
 

--- a/backend/src/api/powersync.ts
+++ b/backend/src/api/powersync.ts
@@ -3,25 +3,12 @@ import type { Settings } from '@/config/settings'
 import { session as sessionTable, user as userTable } from '@/db/auth-schema'
 import { db } from '@/db/client'
 import { devicesTable } from '@/db/schema'
+import { POWERSYNC_TABLE_NAMES } from '@shared/powersync-tables'
 import { jwt } from '@elysiajs/jwt'
 import { eq, sql } from 'drizzle-orm'
 import { Elysia, t } from 'elysia'
 
-/**
- * Valid table names for PowerSync sync
- */
-const VALID_TABLES = new Set([
-  'settings',
-  'chat_threads',
-  'chat_messages',
-  'tasks',
-  'models',
-  'mcp_servers',
-  'prompts',
-  'triggers',
-  'modes',
-  'devices',
-])
+const VALID_TABLES = new Set<string>(POWERSYNC_TABLE_NAMES)
 
 /**
  * PowerSync operation types from the upload queue

--- a/backend/src/api/powersync.ts
+++ b/backend/src/api/powersync.ts
@@ -1,8 +1,10 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import type { Settings } from '@/config/settings'
+import { session as sessionTable, user as userTable } from '@/db/auth-schema'
 import { db } from '@/db/client'
+import { devicesTable } from '@/db/schema'
 import { jwt } from '@elysiajs/jwt'
-import { sql } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { Elysia, t } from 'elysia'
 
 /**
@@ -18,6 +20,7 @@ const VALID_TABLES = new Set([
   'prompts',
   'triggers',
   'modes',
+  'devices',
 ])
 
 /**
@@ -114,11 +117,17 @@ const applyOperation = async (op: PowerSyncOperation, userId: string): Promise<v
 
 /**
  * PowerSync API routes for JWT token generation and data sync.
- * All routes require authentication.
+ *
+ * GET /token: Issues a PowerSync JWT so the client can connect. Two auth paths:
+ * - Session (cookie/header): user from derive; we check device revoked, upsert device, then issue token.
+ * - Bearer token only (e.g. PowerSync credential refresh): resolve session → user; 410 if user deleted, else 401.
+ * Status codes: 410 = account deleted, 403 = device revoked (client should reset); 401 = generic auth failure (future: token refresh).
+ *
+ * PUT /upload: Applies batched CRUD from PowerSync; requires authenticated user.
+ *
  * Returns an empty Elysia instance if PowerSync is not configured.
  */
-export const createPowerSyncRoutes = (auth: Auth, settings: Settings) => {
-  // Skip PowerSync routes if not configured
+export const createPowerSyncRoutes = (auth: Auth, settings: Settings): Elysia => {
   if (!settings.powersyncJwtSecret) {
     console.warn('PowerSync is not configured, skipping PowerSync routes')
     return new Elysia({ prefix: '/powersync' })
@@ -134,47 +143,101 @@ export const createPowerSyncRoutes = (auth: Auth, settings: Settings) => {
         kid: settings.powersyncJwtKid,
       }),
     )
-    .derive(async ({ request, set }) => {
+    .derive(async ({ request }) => {
       const session = await auth.api.getSession({ headers: request.headers })
-
-      if (!session) {
-        set.status = 401
-        return { user: null }
-      }
-
-      return { user: session.user }
+      return { user: session?.user ?? null }
     })
-    .onBeforeHandle(({ user, set }) => {
-      if (!user) {
-        set.status = 401
-        return { error: 'Unauthorized' }
-      }
-    })
-    .get('/token', async ({ powersyncJwt, set, user }) => {
-      // Check if PowerSync is configured
+    .get('/token', async ({ powersyncJwt, request, set, user }) => {
       if (!settings.powersyncUrl || !settings.powersyncJwtSecret) {
         set.status = 503
         return { error: 'PowerSync is not configured' }
       }
 
-      // Generate JWT token for PowerSync with the authenticated user's ID
-      const token = await powersyncJwt.sign({
-        sub: user!.id,
-        user_id: user!.id,
-      })
+      // Path 1: Authenticated via session. Issue PowerSync JWT; check device revoked, then upsert device.
+      if (user) {
+        const deviceId = request.headers.get('x-device-id')
+        if (deviceId) {
+          const deviceRow = await db
+            .select({ revokedAt: devicesTable.revokedAt })
+            .from(devicesTable)
+            .where(eq(devicesTable.id, deviceId))
+            .limit(1)
+            .then((rows) => rows[0])
+          if (deviceRow?.revokedAt != null) {
+            set.status = 403
+            return { code: 'DEVICE_DISCONNECTED' }
+          }
+        }
 
-      const expiresAt = new Date(Date.now() + settings.powersyncTokenExpirySeconds * 1000).toISOString()
+        const token = await powersyncJwt.sign({
+          sub: user.id,
+          user_id: user.id,
+        })
+        const expiresAt = new Date(Date.now() + settings.powersyncTokenExpirySeconds * 1000).toISOString()
 
-      return {
-        token,
-        expiresAt,
-        powerSyncUrl: settings.powersyncUrl,
+        const deviceName = request.headers.get('x-device-name')
+        if (deviceId && deviceName) {
+          const now = Math.floor(Date.now() / 1000)
+          await db
+            .insert(devicesTable)
+            // Upsert device for Settings > Devices list and last-seen; synced via PowerSync.
+            .values({
+              id: deviceId,
+              userId: user.id,
+              name: deviceName,
+              lastSeen: now,
+              createdAt: now,
+            })
+            .onConflictDoUpdate({
+              target: devicesTable.id,
+              set: { lastSeen: now, name: deviceName },
+            })
+        }
+
+        return { token, expiresAt, powerSyncUrl: settings.powersyncUrl }
       }
+
+      // Path 2: No session; Bearer token only. Resolve session → user; 410 if user deleted (e.g. account deleted elsewhere).
+      const authHeader = request.headers.get('authorization')
+      const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : null
+      if (!bearerToken) {
+        set.status = 401
+        return { error: 'Unauthorized' }
+      }
+
+      const sessionRow = await db
+        .select({ userId: sessionTable.userId })
+        .from(sessionTable)
+        .where(eq(sessionTable.token, bearerToken))
+        .limit(1)
+        .then((rows) => rows[0])
+      if (!sessionRow) {
+        set.status = 401
+        return { error: 'Unauthorized' }
+      }
+
+      const userRow = await db
+        .select({ id: userTable.id })
+        .from(userTable)
+        .where(eq(userTable.id, sessionRow.userId))
+        .limit(1)
+        .then((rows) => rows[0])
+      if (!userRow) {
+        set.status = 410
+        return { code: 'ACCOUNT_DELETED' }
+      }
+
+      set.status = 401
+      return { error: 'Unauthorized' }
     })
     .put(
       '/upload',
       async ({ body, set, user }) => {
-        // Process batch of operations from PowerSync client
+        // Requires authenticated user; applies batched CRUD from PowerSync.
+        if (!user) {
+          set.status = 401
+          return { error: 'Unauthorized' }
+        }
         const operations = body.operations as PowerSyncOperation[]
 
         if (!Array.isArray(operations)) {
@@ -182,12 +245,12 @@ export const createPowerSyncRoutes = (auth: Auth, settings: Settings) => {
           return { error: 'Invalid request: operations must be an array' }
         }
 
-        console.info(`Processing ${operations.length} PowerSync operations for user=${user!.id}`)
+        console.info(`Processing ${operations.length} PowerSync operations for user=${user.id}`)
 
         // Process operations sequentially to maintain order
         for (const op of operations) {
           try {
-            await applyOperation(op, user!.id)
+            await applyOperation(op, user.id)
           } catch (error) {
             console.error(`Failed to apply operation:`, op, error)
             // Continue processing other operations

--- a/backend/src/db/powersync-schema.ts
+++ b/backend/src/db/powersync-schema.ts
@@ -183,3 +183,13 @@ export const modesTable = pgTable(
       .where(sql`${table.deletedAt} IS NULL`),
   ],
 )
+
+/** Synced via PowerSync. Device list and revoke access. No token. */
+export const devicesTable = pgTable('devices', {
+  id: text('id').primaryKey(),
+  userId: text('user_id'),
+  name: text('name'),
+  lastSeen: integer('last_seen').default(sql`extract(epoch from now())::integer`),
+  createdAt: integer('created_at').default(sql`extract(epoch from now())::integer`),
+  revokedAt: integer('revoked_at'),
+})

--- a/backend/src/db/powersync-schema.ts
+++ b/backend/src/db/powersync-schema.ts
@@ -1,3 +1,4 @@
+import type { PowerSyncTableName } from '@shared/powersync-tables'
 import { index, integer, pgTable, text } from 'drizzle-orm/pg-core'
 import { sql } from 'drizzle-orm'
 
@@ -193,3 +194,20 @@ export const devicesTable = pgTable('devices', {
   createdAt: integer('created_at').default(sql`extract(epoch from now())::integer`),
   revokedAt: integer('revoked_at'),
 })
+
+/**
+ * Map of PowerSync table names to Drizzle tables for account delete.
+ * Must have an entry for every PowerSyncTableName (type-checked).
+ */
+export const POWERSYNC_TABLES_BY_NAME = {
+  settings: settingsTable,
+  chat_threads: chatThreadsTable,
+  chat_messages: chatMessagesTable,
+  tasks: tasksTable,
+  models: modelsTable,
+  mcp_servers: mcpServersTable,
+  prompts: promptsTable,
+  triggers: triggersTable,
+  modes: modesTable,
+  devices: devicesTable,
+} satisfies Record<PowerSyncTableName, unknown>

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,9 +13,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
-    "types": [
-      "bun-types"
-    ],
+    "types": ["bun-types"],
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -26,18 +24,10 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"],
+      "@shared/*": ["../shared/*"]
     }
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts",
-    "test/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "test/**/*.ts", "../shared/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/docs/delete-account-and-revoke-device.md
+++ b/docs/delete-account-and-revoke-device.md
@@ -1,0 +1,104 @@
+# Delete Account and Revoke Device Access
+
+This document describes how account deletion and device revoke work, and how other devices are reset gracefully when the user deletes their account or revokes a device from elsewhere.
+
+## Overview
+
+- **Delete account**: The user can permanently delete their account from **Settings > Preferences**. All data is removed on the backend. Other signed-in devices must reset locally so they don’t crash when PowerSync syncs empty data.
+- **Revoke device**: In **Settings > Devices**, the user sees a list of devices that have signed in. They can revoke a device; that device is then signed out and its local data is cleared on next sync (or as soon as it sees the revoked state).
+
+Both flows rely on the same **graceful reset**: disable sync, clear localStorage, reset the app directory (DB and related files), and reload. The user lands on a clean, signed-out state.
+
+## User flows
+
+### Delete account
+
+1. User goes to **Settings > Preferences** and chooses “Delete my account” (with confirmation).
+2. Frontend calls `DELETE /v1/account` with the current auth token. Backend deletes the user and all related data (settings, chats, models, devices, etc.).
+3. On **other devices** that were signed in:
+   - When PowerSync tries to refresh the token, the backend returns **410 Gone** with `code: 'ACCOUNT_DELETED'`.
+   - The frontend treats this as “credentials invalid” and runs the reset flow (see below).
+   - Alternatively, PowerSync may sync DELETE operations and empty the local DB; without the 410 path, that could cause crashes. The 410 path triggers a full reset before or when that happens.
+
+### Revoke device
+
+1. User goes to **Settings > Devices**, sees a list of devices (name, last seen, “This device”, “Revoked”).
+2. User chooses “Revoke” on another device (with confirmation). Frontend calls `POST /v1/account/devices/:id/revoke`.
+3. Backend sets `revoked_at` on that device row (soft revoke). PowerSync syncs the updated `devices` table to all clients.
+4. On the **revoked device**:
+   - **Immediate**: The app watches the current device’s row via React Query (`getDevice(deviceId)`). When the synced row has `revoked_at` set, the app runs the same reset flow.
+   - **On token refresh**: When PowerSync refreshes the token, the backend returns **403 Forbidden** with `code: 'DEVICE_DISCONNECTED'`. The connector dispatches the same “credentials invalid” event and the app resets.
+
+So revoke is visible either as soon as the `devices` row syncs or when the next token refresh returns 403.
+
+## Backend
+
+### PowerSync token endpoint (`GET /powersync/token`)
+
+- **Authenticated (session)**  
+  If the request includes `X-Device-ID`:
+  - The backend checks the `devices` row for that id. If `revoked_at` is set, it returns **403** with `{ code: 'DEVICE_DISCONNECTED' }` and does not issue a token.
+  - Otherwise it issues a PowerSync JWT and upserts the device (id, user_id, name, last_seen, created_at).
+- **Bearer token only (e.g. PowerSync credential refresh)**  
+  Backend resolves the session from the Bearer token, then looks up the user:
+  - If the user no longer exists (account deleted), it returns **410 Gone** with `{ code: 'ACCOUNT_DELETED' }`.
+  - Otherwise it returns **401** (e.g. invalid/expired token).
+
+So:
+
+- **410** = account deleted (client should reset).
+- **403** with `DEVICE_DISCONNECTED` = this device was revoked (client should reset).
+- **401** = generic auth failure (e.g. token refresh in the future, not necessarily a full reset).
+
+### Revoke device endpoint (`POST /v1/account/devices/:id/revoke`)
+
+- Requires an authenticated user (session).
+- Sets `revoked_at` to the current timestamp for the device `id` that belongs to the current user.
+- Returns **204** on success (idempotent for already-revoked devices).
+
+### Devices table
+
+- **Backend**: `devices` table with `id`, `user_id`, `name`, `last_seen`, `created_at`, `revoked_at`. Synced via PowerSync.
+- **Frontend**: Same schema in the local DB; `devices` is in the PowerSync schema so it syncs. Used for the Settings > Devices list and for “current device revoked?” checks.
+
+## Frontend
+
+### Credentials-invalid handling
+
+When the app should reset (account deleted or device revoked), it runs a single flow:
+
+1. `setSyncEnabled(false)` – disconnect from PowerSync.
+2. `localStorage.clear()` – remove auth token and device id (and any other local state).
+3. `resetAppDir()` – clear the app directory (DB and related files).
+4. `window.location.reload()` – reload so the app starts from a clean, signed-out state.
+
+This is triggered in two ways:
+
+1. **Event `POWERSYNC_CREDENTIALS_INVALID`**  
+   The PowerSync connector dispatches this when:
+   - The token request returns **410** (account deleted), or
+   - The token request returns **403** with body `code: 'DEVICE_DISCONNECTED'` (and a token was sent).  
+     So any token refresh that gets 410 or 403 (revoked) leads to reset.
+
+2. **Devices table (current device revoked)**  
+   `usePowerSyncCredentialsInvalidListener` uses React Query with `getDevice(deviceId)` and query key `['devices', deviceId]`. When the `devices` table is invalidated (e.g. by PowerSync sync), the query refetches. If the current device’s row has `revoked_at` set, the hook runs the same reset flow. That gives an immediate reset as soon as the revoked state syncs, without waiting for the next token refresh.
+
+### Auth token and device id
+
+- **Auth token**: Stored in `localStorage` under a fixed key. Not synced. Cleared on reset via `localStorage.clear()`.
+- **Device id**: Stored in `localStorage` to identify this device. Sent as `X-Device-ID` (and optional `X-Device-Name`) on PowerSync token requests so the backend can register/update the device and enforce revoke.
+
+### Settings > Devices page
+
+- Lists devices from the local DB (synced `devices` table) via `getAllDevices()` and React Query key `['devices']`.
+- Shows name, last seen, “This device” for the current device, and “Revoked” when `revoked_at` is set.
+- “Revoke” is shown only for other, non-revoked devices; it calls `POST /v1/account/devices/:id/revoke` and then invalidates `['devices']` so the list updates after sync.
+
+## Summary
+
+| Action         | Where       | Backend / sync behavior                              | Other device behavior                                                             |
+| -------------- | ----------- | ---------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Delete account | Preferences | User and data deleted; 410 on token refresh          | Reset when 410 received or when devices table / sync reflects deletion            |
+| Revoke device  | Devices     | Set `revoked_at`; 403 on that device’s token refresh | Revoked device resets when it sees `revoked_at` (useQuery) or gets 403 on refresh |
+
+Both paths trigger the same reset: disable sync, clear localStorage, reset app dir, reload.

--- a/powersync-service/config/config.yaml
+++ b/powersync-service/config/config.yaml
@@ -25,6 +25,7 @@ sync_rules:
           - SELECT * FROM prompts WHERE prompts.user_id = bucket.user_id
           - SELECT * FROM triggers WHERE triggers.user_id = bucket.user_id
           - SELECT * FROM modes WHERE modes.user_id = bucket.user_id
+          - SELECT * FROM devices WHERE devices.user_id = bucket.user_id
 
 client_auth:
   supabase: false

--- a/shared/powersync-tables.ts
+++ b/shared/powersync-tables.ts
@@ -1,0 +1,41 @@
+/**
+ * Single source of truth for PowerSync-synced table names and React Query invalidation.
+ * Used by backend (VALID_TABLES), frontend (use-powersync-invalidation), and sync rules (config.yaml).
+ * When adding a table: add here, then to src/db/tables.ts, backend/src/db/powersync-schema.ts,
+ * src/db/powersync/schema.ts, and powersync-service/config/config.yaml.
+ */
+
+export const POWERSYNC_TABLE_NAMES = [
+  'settings',
+  'chat_threads',
+  'chat_messages',
+  'tasks',
+  'models',
+  'mcp_servers',
+  'prompts',
+  'triggers',
+  'modes',
+  'devices',
+] as const
+
+export type PowerSyncTableName = (typeof POWERSYNC_TABLE_NAMES)[number]
+
+/**
+ * Map of PowerSync table names to React Query keys to invalidate when the table changes.
+ * Keys are type-checked against POWERSYNC_TABLE_NAMES; every table must have an entry.
+ * Prefix keys (e.g. ['settings']) invalidate all queries starting with that prefix.
+ */
+export const POWERSYNC_TABLE_TO_QUERY_KEYS: {
+  [K in PowerSyncTableName]: string[][]
+} = {
+  settings: [['settings']],
+  chat_threads: [['chatThreads']],
+  chat_messages: [['messages'], ['messageCache']],
+  tasks: [['tasks']],
+  models: [['models']],
+  mcp_servers: [['mcp-servers']],
+  prompts: [['prompts']],
+  triggers: [['triggers']],
+  modes: [['modes']],
+  devices: [['devices']],
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,6 +14,7 @@ import ChatLayout from '@/layout/main-layout'
 import { PostHogProvider } from '@/lib/posthog'
 import { ThemeProvider } from '@/lib/theme-provider'
 import DevSettingsPage from '@/settings/dev-settings'
+import DevicesSettingsPage from '@/settings/devices'
 import { default as Settings } from '@/settings/index'
 import IntegrationsPage from '@/settings/integrations'
 import McpServersPage from '@/settings/mcp-servers'
@@ -31,6 +32,7 @@ import { UpdateNotification } from './components/update-notification'
 import { ContentViewProvider } from './content-view/context'
 import MessageSimulatorPage from './devtools/message-simulator'
 import { useAppInitialization } from './hooks/use-app-initialization'
+import { usePowerSyncCredentialsInvalidListener } from './hooks/use-powersync-credentials-invalid-listener'
 import { usePowerSyncInvalidation } from './hooks/use-powersync-invalidation'
 import { useSafeAreaInset } from './hooks/use-safe-area-inset'
 import Layout from './layout'
@@ -48,7 +50,8 @@ function AppContent({ initData }: { initData: InitData }) {
   useTriggerScheduler()
   useKeyboardInset()
   useSafeAreaInset()
-  usePowerSyncInvalidation() // Watch all tables for changes and invalidate React Query cache
+  usePowerSyncCredentialsInvalidListener()
+  usePowerSyncInvalidation()
 
   return (
     <BrowserRouter>
@@ -109,6 +112,7 @@ function AppRoutes({ initData }: { initData: InitData }) {
             <Route index element={<Settings />} />
             <Route path="preferences" element={<PreferencesSettingsPage />} />
             <Route path="models" element={<ModelsPage />} />
+            <Route path="devices" element={<DevicesSettingsPage />} />
             <Route path="mcp-servers" element={<McpServersPage />} />
             <Route path="integrations" element={<IntegrationsPage />} />
             <Route path="dev-settings" element={<DevSettingsPage />} />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,8 +32,6 @@ import { UpdateNotification } from './components/update-notification'
 import { ContentViewProvider } from './content-view/context'
 import MessageSimulatorPage from './devtools/message-simulator'
 import { useAppInitialization } from './hooks/use-app-initialization'
-import { usePowerSyncCredentialsInvalidListener } from './hooks/use-powersync-credentials-invalid-listener'
-import { usePowerSyncInvalidation } from './hooks/use-powersync-invalidation'
 import { useSafeAreaInset } from './hooks/use-safe-area-inset'
 import Layout from './layout'
 import { MCPProvider } from './lib/mcp-provider'
@@ -50,8 +48,6 @@ function AppContent({ initData }: { initData: InitData }) {
   useTriggerScheduler()
   useKeyboardInset()
   useSafeAreaInset()
-  usePowerSyncCredentialsInvalidListener()
-  usePowerSyncInvalidation()
 
   return (
     <BrowserRouter>

--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -1,5 +1,4 @@
 import type { AuthClient } from '@/contexts'
-import { setSyncEnabled } from '@/db/powersync'
 import { DatabaseSingleton } from '@/db/singleton'
 import { setAuthToken } from '@/lib/auth-token'
 import { isValidEmailFormat } from '@/lib/utils'
@@ -74,23 +73,20 @@ type UseSignInFormStateOptions = {
 }
 
 /**
- * Enable sync after sign-in for both new and returning users.
- * Sync is enabled by default for all users.
- * For returning users, clears pending CRUD operations to avoid conflicts with cloud data.
+ * Sync is disabled by default after sign-in/sign-up; user can enable it in Preferences.
+ * For returning users only: reset pending CRUD operations so that when they later enable
+ * sync, local ops do not conflict with cloud data.
  */
-const enableSyncAfterSignIn = async (isNewUser: boolean): Promise<void> => {
+const onSignInSuccess = async (isNewUser: boolean): Promise<void> => {
+  if (isNewUser) return
+
   try {
     const database = DatabaseSingleton.instance.database
-
-    // For returning users only: clear pending CRUD operations to avoid conflicts with cloud data
-    if (!isNewUser && 'clearPendingCrudOperations' in database) {
+    if ('clearPendingCrudOperations' in database) {
       await (database as { clearPendingCrudOperations: () => Promise<void> }).clearPendingCrudOperations()
     }
-
-    // Enable sync preference and connect (for both new and returning users)
-    await setSyncEnabled(true)
   } catch (error) {
-    console.error('Failed to enable sync after sign-in:', error)
+    console.error('Failed to clear pending CRUD after sign-in:', error)
   }
 }
 
@@ -167,9 +163,8 @@ export const useSignInFormState = ({
         await setAuthToken(result.data.token)
       }
 
-      // Enable sync for all users (new and returning)
       const isNewUser = (result.data as { isNewUser?: boolean })?.isNewUser ?? false
-      await enableSyncAfterSignIn(isNewUser)
+      await onSignInSuccess(isNewUser)
 
       // Sign-in successful - show success state
       dispatch({ type: 'VERIFY_SUCCESS' })

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { usePowerSyncCredentialsInvalidListener } from '@/hooks/use-powersync-credentials-invalid-listener'
+import { usePowerSyncInvalidation } from '@/hooks/use-powersync-invalidation'
 import { useSettings } from '@/hooks/use-settings'
 import { getAuthToken, setAuthToken } from '@/lib/auth-token'
 import { getPlatform } from '@/lib/platform'
@@ -57,6 +59,23 @@ type AuthProviderProps = {
 }
 
 export const AuthProvider = ({ children, authClient: overrideClient }: AuthProviderProps) => {
+  // Run the credentials-invalid listener here, before the early return below. When the user
+  // deletes their account elsewhere, PowerSync syncs and wipes local data (including
+  // settings). Then cloudUrl is gone, value becomes null, and we return null so children
+  // (and any hook that lived inside them) never mount. If the listener were only in
+  // AppContent, it would never run and we’d be stuck on a blank screen. By calling it at the
+  // top of AuthProvider, it runs as soon as this provider mounts (we have initData and DB)
+  // and keeps running so that when the device row disappears or is revoked, we trigger a
+  // full reset and reload.
+  usePowerSyncCredentialsInvalidListener()
+
+  // Watch PowerSync tables and invalidate React Query when they change (local writes or sync).
+  // Must run here (before the early return) so that when we return null, the devices table
+  // is still watched. Otherwise the useQuery(['devices', deviceId]) in the credentials
+  // listener would never be invalidated when PowerSync syncs (e.g. device revoked or removed),
+  // and we wouldn't detect the change.
+  usePowerSyncInvalidation()
+
   const { cloudUrl } = useSettings({ cloud_url: String })
 
   const value = useMemo(() => {

--- a/src/dal/devices.test.ts
+++ b/src/dal/devices.test.ts
@@ -1,0 +1,110 @@
+import { DatabaseSingleton } from '@/db/singleton'
+import { devicesTable } from '@/db/tables'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { getAllDevices, getDevice } from './devices'
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
+
+beforeAll(async () => {
+  await setupTestDatabase()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+describe('Devices DAL', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  describe('getDevice', () => {
+    it('returns null when no device with that id', async () => {
+      const device = await getDevice('non-existent-id')
+      expect(device).toBeNull()
+    })
+
+    it('returns device when it exists', async () => {
+      const db = DatabaseSingleton.instance.db
+      const deviceId = 'device-1'
+      const now = Math.floor(Date.now() / 1000)
+
+      await db.insert(devicesTable).values({
+        id: deviceId,
+        userId: 'user-1',
+        name: 'Chrome on macOS',
+        lastSeen: now,
+        createdAt: now,
+      })
+
+      const device = await getDevice(deviceId)
+      expect(device).not.toBeNull()
+      expect(device?.id).toBe(deviceId)
+      expect(device?.userId).toBe('user-1')
+      expect(device?.name).toBe('Chrome on macOS')
+      expect(device?.lastSeen).toBe(now)
+      expect(device?.createdAt).toBe(now)
+      expect(device?.revokedAt).toBeNull()
+    })
+
+    it('returns device with revokedAt when set', async () => {
+      const db = DatabaseSingleton.instance.db
+      const deviceId = 'device-revoked'
+      const now = Math.floor(Date.now() / 1000)
+      const revokedAt = now + 60
+
+      await db.insert(devicesTable).values({
+        id: deviceId,
+        userId: 'user-1',
+        name: 'Revoked device',
+        lastSeen: now,
+        createdAt: now,
+        revokedAt,
+      })
+
+      const device = await getDevice(deviceId)
+      expect(device?.revokedAt).toBe(revokedAt)
+    })
+  })
+
+  describe('getAllDevices', () => {
+    it('returns empty array when no devices', async () => {
+      const devices = await getAllDevices()
+      expect(devices).toEqual([])
+    })
+
+    it('returns all devices ordered by lastSeen desc', async () => {
+      const db = DatabaseSingleton.instance.db
+      const base = Math.floor(Date.now() / 1000)
+
+      await db.insert(devicesTable).values([
+        {
+          id: 'device-old',
+          userId: 'user-1',
+          name: 'Old device',
+          lastSeen: base,
+          createdAt: base,
+        },
+        {
+          id: 'device-new',
+          userId: 'user-1',
+          name: 'New device',
+          lastSeen: base + 100,
+          createdAt: base,
+        },
+        {
+          id: 'device-mid',
+          userId: 'user-1',
+          name: 'Mid device',
+          lastSeen: base + 50,
+          createdAt: base,
+        },
+      ])
+
+      const devices = await getAllDevices()
+      expect(devices).toHaveLength(3)
+      expect(devices[0]?.id).toBe('device-new')
+      expect(devices[1]?.id).toBe('device-mid')
+      expect(devices[2]?.id).toBe('device-old')
+    })
+  })
+})

--- a/src/dal/devices.ts
+++ b/src/dal/devices.ts
@@ -1,0 +1,30 @@
+import { desc, eq } from 'drizzle-orm'
+import { DatabaseSingleton } from '@/db/singleton'
+import { devicesTable } from '@/db/tables'
+
+export type Device = {
+  id: string
+  userId: string
+  name: string
+  lastSeen: number | null
+  createdAt: number | null
+  revokedAt: number | null
+}
+
+/**
+ * Gets a single device by id from the local DB (synced via PowerSync).
+ */
+export const getDevice = async (deviceId: string): Promise<Device | null> => {
+  const db = DatabaseSingleton.instance.db
+  const row = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId)).get()
+  return (row ?? null) as Device | null
+}
+
+/**
+ * Gets all devices for the current user from the local DB (synced via PowerSync).
+ */
+export const getAllDevices = async (): Promise<Device[]> => {
+  const db = DatabaseSingleton.instance.db
+  const rows = await db.select().from(devicesTable).orderBy(desc(devicesTable.lastSeen))
+  return rows as Device[]
+}

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -83,3 +83,6 @@ export {
 
 // Modes
 export { getAllModes, getDefaultMode, getMode, getSelectedMode } from './modes'
+
+// Devices
+export { getAllDevices, getDevice, type Device } from './devices'

--- a/src/db/powersync/connector.ts
+++ b/src/db/powersync/connector.ts
@@ -1,5 +1,9 @@
-import { getAuthToken } from '@/lib/auth-token'
+import { getDeviceId, getAuthToken } from '@/lib/auth-token'
+import { getDeviceDisplayName } from '@/lib/platform'
 import type { AbstractPowerSyncDatabase, PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web'
+
+/** Dispatched when backend returns 410 (account deleted) or 403 + DEVICE_DISCONNECTED. App should reset and reload. */
+export const POWERSYNC_CREDENTIALS_INVALID = 'powersync_credentials_invalid'
 
 type TokenResponse = {
   token: string
@@ -7,17 +11,22 @@ type TokenResponse = {
   powerSyncUrl: string
 }
 
+type ErrorBody = { code?: string; error?: string }
+
 /**
- * Build headers with Authorization Bearer token if available.
+ * Build headers with Authorization Bearer token and device id/name if available.
  */
 const buildHeaders = (additionalHeaders?: Record<string, string>): Record<string, string> => {
   const headers: Record<string, string> = { ...additionalHeaders }
   const token = getAuthToken()
-
   if (token) {
     headers['Authorization'] = `Bearer ${token}`
   }
-
+  const deviceId = getDeviceId()
+  if (deviceId) {
+    headers['X-Device-ID'] = deviceId
+    headers['X-Device-Name'] = getDeviceDisplayName()
+  }
   return headers
 }
 
@@ -34,18 +43,31 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
    * Returns null if unable to get credentials (e.g., not authenticated or PowerSync not configured).
    */
   async fetchCredentials(): Promise<PowerSyncCredentials | null> {
+    const hadToken = Boolean(getAuthToken())
     try {
       const response = await fetch(`${this.backendUrl}/powersync/token`, {
         headers: buildHeaders(),
       })
 
       if (!response.ok) {
-        console.error('Failed to fetch PowerSync credentials:', response.status)
+        const status = response.status
+        let body: ErrorBody = {}
+        try {
+          body = (await response.json()) as ErrorBody
+        } catch {
+          // ignore
+        }
+        const isResetSignal = status === 410 || (status === 403 && body.code === 'DEVICE_DISCONNECTED')
+        if (isResetSignal && hadToken) {
+          window.dispatchEvent(new CustomEvent(POWERSYNC_CREDENTIALS_INVALID))
+        }
+        if (status !== 401) {
+          console.error('Failed to fetch PowerSync credentials:', status, body)
+        }
         return null
       }
 
-      const data: TokenResponse = await response.json()
-
+      const data: TokenResponse = (await response.json()) as TokenResponse
       return {
         endpoint: data.powerSyncUrl,
         token: data.token,

--- a/src/db/powersync/schema.ts
+++ b/src/db/powersync/schema.ts
@@ -1,25 +1,26 @@
+import type { PowerSyncTableName } from '@shared/powersync-tables'
 import { DrizzleAppSchema } from '@powersync/drizzle-driver'
 import * as tables from '../tables'
 
 /**
- * Drizzle schema for PowerSync - uses existing table definitions.
- * This maps directly to the Drizzle tables for seamless integration.
+ * Drizzle schema for PowerSync - keys are snake_case (table names).
+ * Type-checked: every PowerSyncTableName must have an entry.
+ * The driver uses the table's config name, not our keys; snake_case keeps types in sync with shared.
  */
 export const drizzleSchema = {
   settings: tables.settingsTable,
-  chatThreads: tables.chatThreadsTable,
-  chatMessages: tables.chatMessagesTable,
+  chat_threads: tables.chatThreadsTable,
+  chat_messages: tables.chatMessagesTable,
   tasks: tables.tasksTable,
   models: tables.modelsTable,
-  mcpServers: tables.mcpServersTable,
+  mcp_servers: tables.mcpServersTable,
   prompts: tables.promptsTable,
   triggers: tables.triggersTable,
   modes: tables.modesTable,
   devices: tables.devicesTable,
-}
+} satisfies Record<PowerSyncTableName, unknown>
 
 /**
  * PowerSync AppSchema derived from Drizzle table definitions.
- * This automatically creates the PowerSync schema from Drizzle.
  */
 export const AppSchema = new DrizzleAppSchema(drizzleSchema)

--- a/src/db/powersync/schema.ts
+++ b/src/db/powersync/schema.ts
@@ -15,6 +15,7 @@ export const drizzleSchema = {
   prompts: tables.promptsTable,
   triggers: tables.triggersTable,
   modes: tables.modesTable,
+  devices: tables.devicesTable,
 }
 
 /**

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -182,3 +182,13 @@ export const modesTable = sqliteTable(
       .where(sql`${table.deletedAt} IS NULL`),
   ],
 )
+
+/** Synced via PowerSync. No token. Used for device list and revoke access. */
+export const devicesTable = sqliteTable('devices', {
+  id: text('id').primaryKey(),
+  userId: text('user_id'),
+  name: text('name'),
+  lastSeen: integer('last_seen').default(sql`(unixepoch())`),
+  createdAt: integer('created_at').default(sql`(unixepoch())`),
+  revokedAt: integer('revoked_at'),
+})

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -2,7 +2,6 @@ import type { HttpClient } from '@/contexts'
 import { getSettings } from '@/dal'
 import type { AnyDrizzleDatabase } from '@/db/database-interface'
 import { DatabaseSingleton } from '@/db/singleton'
-import { loadAuthToken } from '@/lib/auth-token'
 import { createHandleError } from '@/lib/error-utils'
 import { createAppDir, resetAppDir } from '@/lib/fs'
 import { getDatabasePath, getDatabaseType } from '@/lib/platform'
@@ -94,13 +93,6 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
       success: false,
       error: reconcileError,
     }
-  }
-
-  // Step 4.5: Load auth token for mobile (non-critical)
-  try {
-    await loadAuthToken()
-  } catch (error) {
-    console.warn('Failed to load auth token, continuing:', error)
   }
 
   // Step 5: HTTP client initialization (use provided client or create one)

--- a/src/hooks/use-powersync-credentials-invalid-listener.ts
+++ b/src/hooks/use-powersync-credentials-invalid-listener.ts
@@ -1,0 +1,50 @@
+import { getDevice } from '@/dal'
+import { setSyncEnabled } from '@/db/powersync'
+import { POWERSYNC_CREDENTIALS_INVALID } from '@/db/powersync/connector'
+import { getDeviceId } from '@/lib/auth-token'
+import { resetAppDir } from '@/lib/fs'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useRef } from 'react'
+
+/**
+ * Performs a full app reset: disable sync, clear localStorage, reset app dir, then reload.
+ * Used when account deleted (410), device revoked (403), or devices table shows revoked.
+ */
+const performCredentialsInvalidReset = async (): Promise<void> => {
+  await setSyncEnabled(false)
+  localStorage.clear()
+  await resetAppDir()
+  window.location.reload()
+}
+
+/**
+ * Listens for credentials-invalid (410/403 on token refresh) and for devices table: when the
+ * current device's row has revoked_at set (synced from another device), triggers reset.
+ * Uses useQuery so device data refetches when PowerSync invalidates ['devices'].
+ */
+export const usePowerSyncCredentialsInvalidListener = (): void => {
+  const hasTriggeredRef = useRef(false)
+  const deviceId = getDeviceId()
+
+  const { data: device } = useQuery({
+    queryKey: ['devices', deviceId],
+    queryFn: () => getDevice(deviceId),
+  })
+
+  useEffect(() => {
+    const handler = () => {
+      if (hasTriggeredRef.current) return
+      hasTriggeredRef.current = true
+      void performCredentialsInvalidReset()
+    }
+
+    window.addEventListener(POWERSYNC_CREDENTIALS_INVALID, handler)
+    return () => window.removeEventListener(POWERSYNC_CREDENTIALS_INVALID, handler)
+  }, [])
+
+  useEffect(() => {
+    if (!device?.revokedAt || hasTriggeredRef.current) return
+    hasTriggeredRef.current = true
+    void performCredentialsInvalidReset()
+  }, [device?.revokedAt])
+}

--- a/src/hooks/use-powersync-credentials-invalid-listener.ts
+++ b/src/hooks/use-powersync-credentials-invalid-listener.ts
@@ -1,14 +1,15 @@
 import { getDevice } from '@/dal'
 import { setSyncEnabled } from '@/db/powersync'
 import { POWERSYNC_CREDENTIALS_INVALID } from '@/db/powersync/connector'
-import { getDeviceId } from '@/lib/auth-token'
+import { getAuthToken, getDeviceId } from '@/lib/auth-token'
 import { resetAppDir } from '@/lib/fs'
 import { useQuery } from '@tanstack/react-query'
 import { useEffect, useRef } from 'react'
 
 /**
- * Performs a full app reset: disable sync, clear localStorage, reset app dir, then reload.
- * Used when account deleted (410), device revoked (403), or devices table shows revoked.
+ * Full app reset when credentials are no longer valid: disable PowerSync sync, clear
+ * localStorage (token + device id), reset app directory (DB), then reload. Leaves the user
+ * in a clean signed-out state so they can sign in again or use the app offline.
  */
 const performCredentialsInvalidReset = async (): Promise<void> => {
   await setSyncEnabled(false)
@@ -18,19 +19,37 @@ const performCredentialsInvalidReset = async (): Promise<void> => {
 }
 
 /**
- * Listens for credentials-invalid (410/403 on token refresh) and for devices table: when the
- * current device's row has revoked_at set (synced from another device), triggers reset.
- * Uses useQuery so device data refetches when PowerSync invalidates ['devices'].
+ * Listens for "credentials invalid" and triggers a full app reset in two cases:
+ *
+ * 1. **Event (POWERSYNC_CREDENTIALS_INVALID)** – Fired when the backend returns 410 (account
+ *    deleted) or 403 (device revoked) e.g. from the account-verify endpoint during app init
+ *    or from PowerSync token refresh. We just run the reset handler.
+ *
+ * 2. **Devices table (synced via PowerSync)** – We have a token and a device id (we consider
+ *    ourselves a logged-in device). We watch the current device row:
+ *    - **revokedAt set** – User revoked this device from another device; reset.
+ *    - **Device row missing** – Account was deleted elsewhere; PowerSync synced and wiped
+ *      user data (including devices). We only treat "missing" after the first fetch
+ *      (isFetched) and when we have a token, so we don’t reset during initial load or for
+ *      users who never signed in.
+ *
+ * This hook must be called from AuthProvider (at the top, before the early return). When
+ * the account is deleted, sync wipes the DB so settings/cloudUrl disappear, AuthProvider
+ * returns null and never renders children. If the listener lived under those children, it
+ * would never run. By running it inside AuthProvider before the `if (!value) return null`,
+ * the listener stays active and can trigger reset even when the rest of the app doesn’t
+ * render.
  */
 export const usePowerSyncCredentialsInvalidListener = (): void => {
   const hasTriggeredRef = useRef(false)
   const deviceId = getDeviceId()
 
-  const { data: device } = useQuery({
+  const { data: device, isFetched } = useQuery({
     queryKey: ['devices', deviceId],
     queryFn: () => getDevice(deviceId),
   })
 
+  // Handle 410/403 from verify endpoint or PowerSync token refresh (event-driven).
   useEffect(() => {
     const handler = () => {
       if (hasTriggeredRef.current) return
@@ -42,9 +61,15 @@ export const usePowerSyncCredentialsInvalidListener = (): void => {
     return () => window.removeEventListener(POWERSYNC_CREDENTIALS_INVALID, handler)
   }, [])
 
+  // Handle device revoked or device row missing (account deleted) from synced devices table.
   useEffect(() => {
-    if (!device?.revokedAt || hasTriggeredRef.current) return
+    const hasToken = Boolean(getAuthToken())
+    console.log('DEBUG: usePowerSyncCredentialsInvalidListener', { isFetched, hasToken, deviceId, device })
+    if (hasTriggeredRef.current) return
+    if (!isFetched || !hasToken || !deviceId) return
+    const shouldReset = !device || device?.revokedAt
+    if (!shouldReset) return
     hasTriggeredRef.current = true
     void performCredentialsInvalidReset()
-  }, [device?.revokedAt])
+  }, [isFetched, deviceId, device])
 }

--- a/src/hooks/use-powersync-invalidation.ts
+++ b/src/hooks/use-powersync-invalidation.ts
@@ -1,25 +1,8 @@
 import { DatabaseSingleton } from '@/db/singleton'
+import { type PowerSyncTableName, POWERSYNC_TABLE_TO_QUERY_KEYS } from '@shared/powersync-tables'
 import type { PowerSyncDatabase } from '@powersync/web'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
-
-/**
- * Map of table names to their React Query keys that should be invalidated.
- * When a table changes (local write or sync), all associated query keys are invalidated.
- * Using prefix keys (e.g., ['settings']) will invalidate all queries starting with that prefix.
- */
-const TABLE_TO_QUERY_KEYS: Record<string, string[][]> = {
-  settings: [['settings']],
-  chat_threads: [['chatThreads']],
-  chat_messages: [['messages'], ['messageCache']],
-  tasks: [['tasks']],
-  models: [['models']],
-  mcp_servers: [['mcp-servers']],
-  prompts: [['prompts']],
-  triggers: [['triggers']],
-  modes: [['modes']],
-  devices: [['devices']],
-}
 
 /**
  * Get PowerSync instance from singleton if available.
@@ -65,12 +48,12 @@ export const usePowerSyncInvalidation = (tables?: string[]) => {
       return
     }
 
-    const tablesToWatch = tables ?? Object.keys(TABLE_TO_QUERY_KEYS)
+    const tablesToWatch = tables ?? Object.keys(POWERSYNC_TABLE_TO_QUERY_KEYS)
     const unsubscribes: (() => void)[] = []
 
     for (const tableName of tablesToWatch) {
-      const queryKeys = TABLE_TO_QUERY_KEYS[tableName]
-      if (!queryKeys) continue
+      if (!(tableName in POWERSYNC_TABLE_TO_QUERY_KEYS)) continue
+      const queryKeys = POWERSYNC_TABLE_TO_QUERY_KEYS[tableName as PowerSyncTableName]
 
       // Watch the table for any changes
       const abortController = new AbortController()

--- a/src/hooks/use-powersync-invalidation.ts
+++ b/src/hooks/use-powersync-invalidation.ts
@@ -18,6 +18,7 @@ const TABLE_TO_QUERY_KEYS: Record<string, string[][]> = {
   prompts: [['prompts']],
   triggers: [['triggers']],
   modes: [['modes']],
+  devices: [['devices']],
 }
 
 /**

--- a/src/layout/sidebar/settings-sidebar.tsx
+++ b/src/layout/sidebar/settings-sidebar.tsx
@@ -10,7 +10,7 @@ import {
   SidebarSeparator,
   useSidebar,
 } from '@/components/ui/sidebar'
-import { ArrowLeft, Cpu, Plug, Server, SlidersHorizontal } from 'lucide-react'
+import { ArrowLeft, Cpu, Plug, Server, SlidersHorizontal, Smartphone } from 'lucide-react'
 import { useLocation } from 'react-router'
 import { SidebarHeader } from './sidebar-header'
 
@@ -66,6 +66,17 @@ export const SettingsSidebarContent = ({ onBackClick, onSettingsNavigate }: Sett
               >
                 <Plug className="size-4" />
                 <span>Integrations</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                onClick={() => onSettingsNavigate('/settings/devices')}
+                tooltip="Devices"
+                className="cursor-pointer"
+                isActive={location.pathname === '/settings/devices'}
+              >
+                <Smartphone className="size-4" />
+                <span>Devices</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
             <SidebarMenuItem>

--- a/src/lib/auth-token.test.ts
+++ b/src/lib/auth-token.test.ts
@@ -1,103 +1,68 @@
-import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
-import { _resetCacheForTesting, clearAuthToken, getAuthToken, loadAuthToken, setAuthToken } from './auth-token'
+import { beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { clearAuthToken, getAuthToken, setAuthToken } from './auth-token'
 
-beforeAll(async () => {
-  await setupTestDatabase()
+beforeAll(() => {
+  if (typeof localStorage === 'undefined') {
+    const store: Record<string, string> = {}
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: (k: string) => store[k] ?? null,
+        setItem: (k: string, v: string) => {
+          store[k] = v
+        },
+        removeItem: (k: string) => {
+          delete store[k]
+        },
+      },
+      writable: true,
+    })
+  }
 })
 
-afterAll(async () => {
-  await teardownTestDatabase()
-})
-
-beforeEach(async () => {
-  await resetTestDatabase()
-  _resetCacheForTesting()
+beforeEach(() => {
+  clearAuthToken()
 })
 
 describe('auth-token', () => {
   describe('getAuthToken', () => {
-    it('returns null when no token is cached', () => {
+    it('returns null when no token is stored', () => {
       expect(getAuthToken()).toBeNull()
     })
 
-    it('returns cached token after setAuthToken', async () => {
-      await setAuthToken('test-token-123')
+    it('returns token after setAuthToken', () => {
+      setAuthToken('test-token-123')
       expect(getAuthToken()).toBe('test-token-123')
     })
   })
 
   describe('setAuthToken', () => {
-    it('stores token in memory cache', async () => {
-      await setAuthToken('cached-token')
+    it('stores token in localStorage', () => {
+      setAuthToken('cached-token')
       expect(getAuthToken()).toBe('cached-token')
     })
 
-    it('persists token to settings database', async () => {
-      await setAuthToken('persisted-token')
-
-      // Reset cache to simulate app restart
-      _resetCacheForTesting()
-      expect(getAuthToken()).toBeNull()
-
-      // Load from database should restore the token
-      await loadAuthToken()
+    it('persists token until cleared', () => {
+      setAuthToken('persisted-token')
       expect(getAuthToken()).toBe('persisted-token')
-    })
-
-    it('removes token from database when set to null', async () => {
-      await setAuthToken('token-to-remove')
-      expect(getAuthToken()).toBe('token-to-remove')
-
-      await setAuthToken(null)
-      expect(getAuthToken()).toBeNull()
-
-      // Verify it's also removed from database
-      _resetCacheForTesting()
-      await loadAuthToken()
-      expect(getAuthToken()).toBeNull()
-    })
-  })
-
-  describe('loadAuthToken', () => {
-    it('loads token from database into cache', async () => {
-      // Store token and reset cache
-      await setAuthToken('db-token')
-      _resetCacheForTesting()
-
-      expect(getAuthToken()).toBeNull()
-
-      await loadAuthToken()
-      expect(getAuthToken()).toBe('db-token')
-    })
-
-    it('sets cache to null when no token in database', async () => {
-      await loadAuthToken()
+      clearAuthToken()
       expect(getAuthToken()).toBeNull()
     })
   })
 
   describe('clearAuthToken', () => {
-    it('clears token from cache', async () => {
-      await setAuthToken('token-to-clear')
+    it('clears token', () => {
+      setAuthToken('token-to-clear')
       expect(getAuthToken()).toBe('token-to-clear')
-
-      await clearAuthToken()
+      clearAuthToken()
       expect(getAuthToken()).toBeNull()
     })
 
-    it('clears token from database', async () => {
-      await setAuthToken('persistent-token')
-
-      await clearAuthToken()
-
-      // Verify cache is cleared
+    it('clears token from localStorage', () => {
+      setAuthToken('persistent-token')
+      clearAuthToken()
       expect(getAuthToken()).toBeNull()
-
-      // Verify database is cleared
-      _resetCacheForTesting()
-      await loadAuthToken()
-      expect(getAuthToken()).toBeNull()
+      setAuthToken('other')
+      expect(getAuthToken()).toBe('other')
     })
   })
 })

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,48 +1,32 @@
 /**
- * Auth token storage for bearer authentication
+ * Auth token storage for bearer authentication.
  *
- * Stores the session token in the settings database and sends it via
- * Authorization: Bearer header. Used universally across all platforms
- * for consistent authentication behavior.
- *
- * Provides sync access (required by Better Auth's fetchOptions.auth.token)
- * while persisting to settings database for durability across app restarts.
+ * Token is stored in localStorage so getAuthToken() is sync (required by Better Auth).
+ * device_id is also in localStorage to identify this device (e.g. for PowerSync / devices list).
  */
 
-import { deleteSetting, getSettings, updateSettings } from '@/dal/settings'
+const DEVICE_ID_KEY = 'thunderbolt_device_id'
+const AUTH_TOKEN_KEY = 'thunderbolt_auth_token'
 
-const AUTH_TOKEN_SETTING_KEY = 'auth_bearer_token'
-
-let cachedToken: string | null = null
-
-/** Get the current auth token (sync) */
-export const getAuthToken = (): string | null => {
-  return cachedToken
-}
-
-/** Store the auth token (cache + persist to settings) */
-export const setAuthToken = async (token: string | null): Promise<void> => {
-  cachedToken = token
-
-  if (token) {
-    await updateSettings({ [AUTH_TOKEN_SETTING_KEY]: token })
-  } else {
-    await deleteSetting(AUTH_TOKEN_SETTING_KEY)
+/** Get or create device_id (from localStorage). */
+export const getDeviceId = (): string => {
+  let id = localStorage.getItem(DEVICE_ID_KEY)
+  if (!id) {
+    id = crypto.randomUUID()
+    localStorage.setItem(DEVICE_ID_KEY, id)
   }
+  return id
 }
 
-/** Load auth token from settings into cache (call on app init) */
-export const loadAuthToken = async (): Promise<void> => {
-  const settings = await getSettings({ [AUTH_TOKEN_SETTING_KEY]: String })
-  cachedToken = settings.authBearerToken
+/** Get the current auth token (sync, from localStorage). */
+export const getAuthToken = (): string | null => localStorage.getItem(AUTH_TOKEN_KEY)
+
+/** Store the auth token in localStorage. Use clearAuthToken() to remove. */
+export const setAuthToken = (token: string): void => {
+  localStorage.setItem(AUTH_TOKEN_KEY, token)
 }
 
-/** Clear the auth token (for sign-out) */
-export const clearAuthToken = async (): Promise<void> => {
-  await setAuthToken(null)
-}
-
-/** Reset the in-memory cache (for testing only) */
-export const _resetCacheForTesting = (): void => {
-  cachedToken = null
+/** Clear the auth token (for sign-out). Keeps device_id in localStorage. */
+export const clearAuthToken = (): void => {
+  localStorage.removeItem(AUTH_TOKEN_KEY)
 }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -131,3 +131,28 @@ export const getDatabasePath = async (databaseType: DatabaseType, appDataDirPath
   console.warn('OPFS not available (likely private browsing), using in-memory database')
   return ':memory:'
 }
+
+/**
+ * Returns an auto-filled device display name (e.g. "Chrome on macOS", "Safari on iOS").
+ * Used for the synced devices table; not editable by the user.
+ */
+export const getDeviceDisplayName = (): string => {
+  if (isTauri()) {
+    const p = getPlatform()
+    const name = p.charAt(0).toUpperCase() + p.slice(1)
+    return `Thunderbolt on ${name}`
+  }
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : ''
+  let browser = 'Browser'
+  if (ua.includes('Chrome') && !ua.includes('Edg')) browser = 'Chrome'
+  else if (ua.includes('Safari') && !ua.includes('Chrome')) browser = 'Safari'
+  else if (ua.includes('Firefox')) browser = 'Firefox'
+  else if (ua.includes('Edg')) browser = 'Edge'
+  let os = 'Unknown'
+  if (ua.includes('Mac')) os = 'macOS'
+  else if (ua.includes('Win')) os = 'Windows'
+  else if (ua.includes('Linux')) os = 'Linux'
+  else if (ua.includes('iPhone') || ua.includes('iPad')) os = 'iOS'
+  else if (ua.includes('Android')) os = 'Android'
+  return `${browser} on ${os}`
+}

--- a/src/settings/devices.tsx
+++ b/src/settings/devices.tsx
@@ -1,0 +1,151 @@
+import { getAllDevices } from '@/dal'
+import { getDeviceId, getAuthToken } from '@/lib/auth-token'
+import { useSettings } from '@/hooks/use-settings'
+import { PageHeader } from '@/components/ui/page-header'
+import { Button } from '@/components/ui/button'
+import { SectionCard } from '@/components/ui/section-card'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import ky from 'ky'
+import { Smartphone, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+const formatLastSeen = (ts: number | null): string => {
+  if (ts == null) return '—'
+  const date = new Date(ts * 1000)
+  const now = Date.now()
+  const diffMs = now - date.getTime()
+  const diffMins = Math.floor(diffMs / 60_000)
+  if (diffMins < 1) return 'Just now'
+  if (diffMins < 60) return `${diffMins}m ago`
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `${diffHours}h ago`
+  const diffDays = Math.floor(diffHours / 24)
+  if (diffDays < 7) return `${diffDays}d ago`
+  return date.toLocaleDateString()
+}
+
+const revokeDevice = async (deviceId: string, baseUrl: string, token: string): Promise<void> => {
+  await ky.post(`account/devices/${encodeURIComponent(deviceId)}/revoke`, {
+    prefixUrl: baseUrl,
+    headers: { Authorization: `Bearer ${token}` },
+    credentials: 'omit',
+  })
+}
+
+export default function DevicesSettingsPage() {
+  const queryClient = useQueryClient()
+  const currentDeviceId = getDeviceId()
+  const { data: devices = [], isLoading } = useQuery({
+    queryKey: ['devices'],
+    queryFn: getAllDevices,
+  })
+  const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
+  const baseUrl = cloudUrl.value ?? 'http://localhost:8000/v1'
+  const [revokeTarget, setRevokeTarget] = useState<string | null>(null)
+
+  const revokeMutation = useMutation({
+    mutationFn: (deviceId: string) => {
+      const token = getAuthToken()
+      if (!token) throw new Error('Not signed in')
+      return revokeDevice(deviceId, baseUrl, token)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['devices'] })
+      setRevokeTarget(null)
+    },
+  })
+
+  const handleRevoke = (deviceId: string) => {
+    setRevokeTarget(deviceId)
+  }
+
+  const confirmRevoke = () => {
+    if (revokeTarget) revokeMutation.mutate(revokeTarget)
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4 pb-12 w-full max-w-[760px] mx-auto">
+      <PageHeader title="Devices" />
+      <p className="text-sm text-muted-foreground">
+        Devices that have signed in to your account. Revoking a device signs it out and clears its local data on next
+        sync.
+      </p>
+      <SectionCard title="Connected devices">
+        {isLoading ? (
+          <p className="text-muted-foreground py-4">Loading devices…</p>
+        ) : devices.length === 0 ? (
+          <p className="text-muted-foreground py-4">No devices yet. Sign in with sync to see devices here.</p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {devices.map((device) => {
+              const isCurrent = device.id === currentDeviceId
+              const isRevoked = device.revokedAt != null
+              return (
+                <li key={device.id} className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
+                  <div className="flex min-w-0 flex-1 items-center gap-3">
+                    <Smartphone className="size-5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium truncate">{device.name}</span>
+                        {isCurrent && (
+                          <span className="shrink-0 rounded-md bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+                            This device
+                          </span>
+                        )}
+                        {isRevoked && (
+                          <span className="shrink-0 rounded-md border border-border px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                            Revoked
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-sm text-muted-foreground">Last seen: {formatLastSeen(device.lastSeen)}</p>
+                    </div>
+                  </div>
+                  {!isRevoked && !isCurrent && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleRevoke(device.id)}
+                      disabled={revokeMutation.isPending}
+                    >
+                      <Trash2 className="size-4 mr-1" />
+                      Revoke
+                    </Button>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </SectionCard>
+
+      <AlertDialog open={revokeTarget !== null} onOpenChange={(open) => !open && setRevokeTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke this device?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The device will be signed out and its local data will be cleared on next sync. This device will need to
+              sign in again to use sync.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmRevoke} disabled={revokeMutation.isPending}>
+              {revokeMutation.isPending ? 'Revoking…' : 'Revoke'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -112,6 +112,7 @@ export default function PreferencesSettingsPage() {
 
   // Local state for sync enabled (PowerSync)
   const [syncEnabled, setSyncEnabledState] = useState(isSyncEnabled())
+  const [syncEnableWarningOpen, setSyncEnableWarningOpen] = useState(false)
 
   // Use our useSettings hook for all settings
   const {
@@ -348,8 +349,20 @@ export default function PreferencesSettingsPage() {
   }
 
   const handleSyncToggle = async (enabled: boolean) => {
-    await setSyncEnabled(enabled)
-    trackEvent(enabled ? 'settings_sync_enabled' : 'settings_sync_disabled')
+    if (!enabled) {
+      await setSyncEnabled(false)
+      setSyncEnabledState(false)
+      trackEvent('settings_sync_disabled')
+      return
+    }
+    setSyncEnableWarningOpen(true)
+  }
+
+  const handleConfirmEnableSync = async () => {
+    await setSyncEnabled(true)
+    setSyncEnabledState(true)
+    trackEvent('settings_sync_enabled')
+    setSyncEnableWarningOpen(false)
   }
 
   return (
@@ -804,6 +817,22 @@ export default function PreferencesSettingsPage() {
           <Switch checked={syncEnabled} onCheckedChange={handleSyncToggle} />
         </div>
       </SectionCard>
+
+      <AlertDialog open={syncEnableWarningOpen} onOpenChange={(open) => !open && setSyncEnableWarningOpen(false)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Enable sync?</AlertDialogTitle>
+            <AlertDialogDescription>
+              At this time, synced data is not encrypted. Enabling sync will store your data on our servers without
+              encryption. Do you want to continue?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmEnableSync}>Enable sync</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <div className="h-6" />
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,12 +21,13 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@/src/*": ["./src/*"]
+      "@/src/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
     },
     /* Types */
     "typeRoots": ["./node_modules/@types", "./src/types"]
   },
-  "include": ["src"],
+  "include": ["src", "shared"],
   "exclude": ["src/db/bundle-migrations.ts", "src/drizzle/_migrations.ts"],
   "references": [
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@shared': path.resolve(__dirname, './shared'),
     },
     conditions: ['browser'],
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches auth/session-adjacent flows (token issuance/refresh, localStorage token storage) and destructive operations (account delete cascading across synced tables), so regressions could sign users out or fail to clean up data across devices.
> 
> **Overview**
> Adds **device management** for the PowerSync POC via a new synced `devices` table (frontend SQLite + backend Postgres migration) and sync-rule updates so device metadata (name/last-seen/revoked) replicates per `user_id`.
> 
> Backend now upserts devices on `GET /powersync/token` (using `X-Device-ID`/`X-Device-Name`), blocks revoked devices with `403 {code:'DEVICE_DISCONNECTED'}`, and signals deleted accounts during credential refresh with `410 {code:'ACCOUNT_DELETED'}`; a new `POST /account/devices/:id/revoke` endpoint soft-revokes a device. Account deletion was refactored to delete all PowerSync-synced tables via shared `POWERSYNC_TABLE_NAMES`.
> 
> Frontend adds a **Settings > Devices** page to list/revoke devices, moves PowerSync table invalidation + a new credentials-invalid reset listener into `AuthProvider`, and changes auth token handling to `localStorage` (plus a persistent per-device UUID) so token/device headers are always available; sign-in no longer auto-enables sync and Preferences now shows a warning confirmation before enabling sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33d9d869d6d7eb8b650d6e03bd09249c0edfc100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->