### PR TITLE
THU-253: Update iOS SDK Version

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -258,6 +258,30 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8192'
         run: |
           bun install
+
+          # Create export options plist to work around Fastlane Xcode 16 bug
+          # See: https://github.com/fastlane/fastlane/issues/29256
+          # Keeping for Xcode 26 until compatibility is confirmed
+          cd src-tauri/gen/apple
+          cat > ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store</string>
+              <key>teamID</key>
+              <string>$APPLE_TEAM_ID</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>net.thunderbird.thunderbolt</key>
+                  <string>$PROVISIONING_PROFILE_NAME</string>
+              </dict>
+          </dict>
+          </plist>
+          EOF
+          cd ../../../
+
           bun tauri ios build --export-method app-store-connect
 
       - name: Upload to TestFlight

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -51,7 +51,7 @@ concurrency:
 jobs:
   build_and_deploy_ios:
     if: ${{ !inputs.skip_build }}
-    runs-on: macos-15
+    runs-on: macos-26
     environment: thunderbolt_release
     outputs:
       build_version: ${{ steps.determine_version.outputs.build_version }}
@@ -134,7 +134,7 @@ jobs:
           rustup target add aarch64-apple-ios-sim
           rustup target add x86_64-apple-ios
 
-      - name: Xcode Select Version
+      - name: Select Xcode 26.2
         uses: mobiledevops/xcode-select-version-action@a58204ef24b6e61857940e51c0e11b0368065b94 # v1
         with:
           xcode-select-version: '26.2'

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -51,7 +51,7 @@ concurrency:
 jobs:
   build_and_deploy_ios:
     if: ${{ !inputs.skip_build }}
-    runs-on: macos-14
+    runs-on: macos-15
     environment: thunderbolt_release
     outputs:
       build_version: ${{ steps.determine_version.outputs.build_version }}
@@ -137,7 +137,7 @@ jobs:
       - name: Xcode Select Version
         uses: mobiledevops/xcode-select-version-action@a58204ef24b6e61857940e51c0e11b0368065b94 # v1
         with:
-          xcode-select-version: '16.2'
+          xcode-select-version: '26.2'
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@cf7216d52fba1017929b4d7162fabe2b30af5b49 # v1.262.0
@@ -258,29 +258,6 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8192'
         run: |
           bun install
-
-          # Create export options plist to work around Fastlane Xcode 16 bug
-          # See: https://github.com/fastlane/fastlane/issues/29256
-          cd src-tauri/gen/apple
-          cat > ExportOptions.plist << EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>method</key>
-              <string>app-store</string>
-              <key>teamID</key>
-              <string>$APPLE_TEAM_ID</string>
-              <key>provisioningProfiles</key>
-              <dict>
-                  <key>net.thunderbird.thunderbolt</key>
-                  <string>$PROVISIONING_PROFILE_NAME</string>
-              </dict>
-          </dict>
-          </plist>
-          EOF
-          cd ../../../
-
           bun tauri ios build --export-method app-store-connect
 
       - name: Upload to TestFlight

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -346,7 +346,7 @@ Common issues:
 
 - **Signing certificates expired**: Update secrets in GitHub repository settings
 - **Provisioning profile issues**: Regenerate and update `APP_STORE_PROVISIONING_PROFILE` secret
-- **Xcode version**: Workflow uses Xcode 16.2
+- **Xcode version**: Workflow uses Xcode 26.2 (iOS 26 SDK)
 
 ### Manual Workflow Trigger
 


### PR DESCRIPTION
Deployment target remains iOS 14.0 (backward compatible).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions macOS runner and Xcode version used for iOS builds, which can break CI/TestFlight releases due to toolchain and SDK compatibility issues.
> 
> **Overview**
> Updates the iOS TestFlight release workflow to build on `macos-26` and explicitly select **Xcode `26.2`** (iOS 26 SDK).
> 
> Keeps the existing Fastlane export-options workaround in place (with an updated note for Xcode 26), and updates `RELEASE.md` to reflect the new Xcode version used by CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11629c7ec451d9b798f8164046445455233e99f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->