### PR TITLE
fix: handle pre-release suffixes in version bumping to prevent NaN

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thunderbolt",
   "private": true,
-  "version": "0.1.NaN",
+  "version": "0.1.43",
   "description": "Thunderbolt",
   "type": "module",
   "license": "MPL-2.0",

--- a/scripts/create-release.test.ts
+++ b/scripts/create-release.test.ts
@@ -618,6 +618,53 @@ describe('create-release.ts', () => {
     })
   })
 
+  describe('Pre-release Suffix Handling', () => {
+    it('should strip pre-release suffix before bumping patch', () => {
+      const current = '0.1.43-desktop-rc'
+      const cleanVersion = current.split('-')[0]
+      const [major, minor, patch] = cleanVersion.split('.').map(Number)
+      const result = `${major}.${minor}.${patch + 1}`
+
+      expect(result).toBe('0.1.44')
+    })
+
+    it('should strip iOS release candidate suffix before bumping minor', () => {
+      const current = '0.3.0-ios-rc'
+      const cleanVersion = current.split('-')[0]
+      const [major, minor, patch] = cleanVersion.split('.').map(Number)
+      const result = `${major}.${minor + 1}.0`
+
+      expect(result).toBe('0.4.0')
+    })
+
+    it('should handle version without suffix unchanged', () => {
+      const current = '1.2.3'
+      const cleanVersion = current.split('-')[0]
+      const [major, minor, patch] = cleanVersion.split('.').map(Number)
+      const result = `${major}.${minor}.${patch + 1}`
+
+      expect(result).toBe('1.2.4')
+    })
+
+    it('should detect NaN in version numbers for validation', () => {
+      const current = '0.1.NaN'
+      const cleanVersion = current.split('-')[0]
+      const parts = cleanVersion.split('.').map(Number)
+      const hasNaN = parts.some((n) => isNaN(n))
+
+      expect(hasNaN).toBe(true)
+    })
+
+    it('should handle multiple hyphens in suffix', () => {
+      const current = '0.1.43-desktop-rc-rc'
+      const cleanVersion = current.split('-')[0]
+      const [major, minor, patch] = cleanVersion.split('.').map(Number)
+      const result = `${major}.${minor}.${patch + 1}`
+
+      expect(result).toBe('0.1.44')
+    })
+  })
+
   describe('Edge Cases', () => {
     it('should handle version with leading zeros', () => {
       const version = '01.02.03'

--- a/scripts/create-release.ts
+++ b/scripts/create-release.ts
@@ -129,9 +129,22 @@ const getCurrentVersion = (): string => {
 
 /**
  * Bump version based on type
+ * Handles pre-release suffixes like '-desktop-rc', '-ios-rc' by stripping them first
  */
 const bumpVersion = (current: string, type: 'major' | 'minor' | 'patch'): string => {
-  const [major, minor, patch] = current.split('.').map(Number)
+  // Strip any pre-release suffix (e.g., '-desktop-rc', '-ios-rc') before parsing
+  const cleanVersion = current.split('-')[0]
+  const parts = cleanVersion.split('.')
+
+  if (parts.length !== 3) {
+    throw new Error(`Invalid version format: ${current}. Expected X.Y.Z format.`)
+  }
+
+  const [major, minor, patch] = parts.map(Number)
+
+  if ([major, minor, patch].some((n) => isNaN(n) || n < 0)) {
+    throw new Error(`Invalid version numbers in: ${current}`)
+  }
 
   switch (type) {
     case 'major':

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6608,7 +6608,7 @@ dependencies = [
 
 [[package]]
 name = "thunderbolt"
-version = "0.1.43-desktop-rc"
+version = "0.1.43"
 dependencies = [
  "anyhow",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thunderbolt"
-version = "0.1.NaN"
+version = "0.1.43"
 description = "Privacy-respecting AI assistant."
 authors = ["Chris Roth <chris@cjroth.com>"]
 license = "MPL-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Thunderbolt",
-  "version": "0.1.NaN",
+  "version": "0.1.43",
   "identifier": "net.thunderbird.thunderbolt",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, well-scoped changes to the release/versioning script and version metadata, with added tests to cover new parsing/validation behavior.
> 
> **Overview**
> Fixes version bumping in `scripts/create-release.ts` to **strip prerelease suffixes** (e.g. `-desktop-rc`, `-ios-rc`) before parsing, and adds **format/NaN validation** to prevent generating invalid versions.
> 
> Updates stored app versions from `0.1.NaN`/`0.1.43-desktop-rc` to `0.1.43` across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and the `thunderbolt` entry in `src-tauri/Cargo.lock`, and adds a focused test suite for prerelease-suffix handling edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdc4bd87235d41fd93ca000fd547212d991e238a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->