### PR TITLE
fix: add Xcode 26 Metal Toolchain workaround for iOS build

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -139,6 +139,12 @@ jobs:
         with:
           xcode-select-version: '26.2'
 
+      - name: Fix Xcode 26 Metal Toolchain Issue
+        # Xcode 26+ adds MetalToolchain to TOOLCHAINS before XcodeDefault, causing
+        # Swift compatibility libraries to not be found. Force use of default toolchain.
+        # See: https://github.com/actions/runner-images/issues/13135
+        run: echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@cf7216d52fba1017929b4d7162fabe2b30af5b49 # v1.262.0
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that sets an environment variable to stabilize Xcode 26 builds; main risk is unintended toolchain selection differences affecting iOS build output.
> 
> **Overview**
> Adds a workaround to the `ios-release` GitHub Actions workflow for Xcode 26+: after selecting Xcode 26.2, it forces `TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault` via `$GITHUB_ENV` to avoid MetalToolchain taking precedence and breaking Swift compatibility library resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a3d8d427c18374c68c54b6d8e8fd3177ec1a883. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->