### PR TITLE
ci: remove Metal Toolchain to fix Swift compatibility lib errors

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -141,9 +141,14 @@ jobs:
 
       - name: Fix Xcode 26 Metal Toolchain Issue
         # Xcode 26+ adds MetalToolchain to TOOLCHAINS before XcodeDefault, causing
-        # Swift compatibility libraries to not be found. Force use of default toolchain.
-        # See: https://github.com/actions/runner-images/issues/13135
-        run: echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV
+        # Swift compatibility libraries to not be found. Since Tauri invokes xcodebuild
+        # internally (we can't pass -toolchain flag), we must remove the Metal toolchain.
+        # See: https://github.com/actions/runner-images/issues/13135#issuecomment-3397914993
+        run: |
+          echo "🔧 Removing Metal Toolchain to prevent TOOLCHAINS override..."
+          xcodebuild -deleteComponent metalToolchain || sudo rm -rf /System/Library/AssetsV2/com_apple_MobileAsset_MetalToolchain || true
+          echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV
+          echo "✅ Metal Toolchain removed"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@cf7216d52fba1017929b4d7162fabe2b30af5b49 # v1.262.0

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -139,6 +139,12 @@ jobs:
         with:
           xcode-select-version: '26.2'
 
+      - name: Fix Xcode 26 Metal Toolchain Issue
+        # Xcode 26+ adds MetalToolchain to TOOLCHAINS before XcodeDefault, causing
+        # Swift compatibility libraries to not be found. Force use of default toolchain.
+        # See: https://github.com/actions/runner-images/issues/13135
+        run: echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@cf7216d52fba1017929b4d7162fabe2b30af5b49 # v1.262.0
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it alters the CI environment by deleting the Metal toolchain, which could have unexpected side effects on builds but doesn’t touch app code or secrets handling.
> 
> **Overview**
> Updates the iOS release GitHub Actions workflow to **work around Xcode 26 toolchain ordering issues** that break Swift compatibility libraries.
> 
> Instead of only setting `TOOLCHAINS` in the environment, the workflow now attempts to **remove the Metal toolchain** (via `xcodebuild -deleteComponent metalToolchain` with a filesystem fallback) before forcing `TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c346bf8282e2323d6cb44d36db22e1983e8d9f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>c346bf8</u></sup><!-- /BUGBOT_STATUS -->