### PR TITLE
fix: update loading state check in useAuthGate to handle session correctly

### DIFF
--- a/src/components/auth-gate/use-auth-gate.test.ts
+++ b/src/components/auth-gate/use-auth-gate.test.ts
@@ -1,0 +1,128 @@
+import { createMockAuthClient } from '@/test-utils/auth-client'
+import { createTestProvider } from '@/test-utils/test-provider'
+import { describe, expect, it } from 'bun:test'
+import { renderHook } from '@testing-library/react'
+import { useAuthGate } from './use-auth-gate'
+
+const sessionWithUser = {
+  user: { id: '1', email: 'u@example.com', name: 'User' },
+}
+
+describe('useAuthGate', () => {
+  describe('initial load (pending, no cached result)', () => {
+    it('returns loading when session is pending and require is authenticated', () => {
+      const authClient = createMockAuthClient({ session: null, isPending: true })
+      const wrapper = createTestProvider({ authClient })
+      const { result } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+      expect(result.current).toEqual({ status: 'loading' })
+    })
+
+    it('returns loading when session is pending and require is unauthenticated', () => {
+      const authClient = createMockAuthClient({ session: null, isPending: true })
+      const wrapper = createTestProvider({ authClient })
+      const { result } = renderHook(() => useAuthGate('unauthenticated'), { wrapper })
+      expect(result.current).toEqual({ status: 'loading' })
+    })
+  })
+
+  describe('after resolve', () => {
+    it('returns allowed when require authenticated and user has session', () => {
+      const authClient = createMockAuthClient({ session: sessionWithUser, isPending: false })
+      const wrapper = createTestProvider({ authClient })
+      const { result } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+      expect(result.current).toEqual({ status: 'allowed' })
+    })
+
+    it('returns redirect when require authenticated and no session', () => {
+      const authClient = createMockAuthClient({ session: null, isPending: false })
+      const wrapper = createTestProvider({ authClient })
+      const { result } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+      expect(result.current).toEqual({ status: 'redirect' })
+    })
+
+    it('returns allowed when require unauthenticated and no session', () => {
+      const authClient = createMockAuthClient({ session: null, isPending: false })
+      const wrapper = createTestProvider({ authClient })
+      const { result } = renderHook(() => useAuthGate('unauthenticated'), { wrapper })
+      expect(result.current).toEqual({ status: 'allowed' })
+    })
+
+    it('returns redirect when require unauthenticated and user has session', () => {
+      const authClient = createMockAuthClient({ session: sessionWithUser, isPending: false })
+      const wrapper = createTestProvider({ authClient })
+      const { result } = renderHook(() => useAuthGate('unauthenticated'), { wrapper })
+      expect(result.current).toEqual({ status: 'redirect' })
+    })
+  })
+
+  describe('refetch (pending again after resolve)', () => {
+    it('returns cached allowed when require authenticated, had session, then goes pending again', () => {
+      const sessionRef = { current: sessionWithUser as typeof sessionWithUser | null }
+      const isPendingRef = { current: false }
+      const authClient = {
+        ...createMockAuthClient(),
+        useSession: () => ({
+          data: sessionRef.current,
+          isPending: isPendingRef.current,
+          isRefetching: false,
+          error: null,
+          refetch: async () => {},
+        }),
+      }
+      const wrapper = createTestProvider({ authClient })
+      const { result, rerender } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+
+      expect(result.current).toEqual({ status: 'allowed' })
+
+      isPendingRef.current = true
+      rerender()
+      expect(result.current).toEqual({ status: 'allowed' })
+    })
+
+    it('returns cached redirect when require authenticated, had no session, then goes pending again', () => {
+      const sessionRef = { current: null as typeof sessionWithUser | null }
+      const isPendingRef = { current: false }
+      const authClient = {
+        ...createMockAuthClient(),
+        useSession: () => ({
+          data: sessionRef.current,
+          isPending: isPendingRef.current,
+          isRefetching: false,
+          error: null,
+          refetch: async () => {},
+        }),
+      }
+      const wrapper = createTestProvider({ authClient })
+      const { result, rerender } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+
+      expect(result.current).toEqual({ status: 'redirect' })
+
+      isPendingRef.current = true
+      rerender()
+      expect(result.current).toEqual({ status: 'redirect' })
+    })
+
+    it('returns cached allowed when require unauthenticated, had no session, then goes pending again', () => {
+      const sessionRef = { current: null as typeof sessionWithUser | null }
+      const isPendingRef = { current: false }
+      const authClient = {
+        ...createMockAuthClient(),
+        useSession: () => ({
+          data: sessionRef.current,
+          isPending: isPendingRef.current,
+          isRefetching: false,
+          error: null,
+          refetch: async () => {},
+        }),
+      }
+      const wrapper = createTestProvider({ authClient })
+      const { result, rerender } = renderHook(() => useAuthGate('unauthenticated'), { wrapper })
+
+      expect(result.current).toEqual({ status: 'allowed' })
+
+      isPendingRef.current = true
+      rerender()
+      expect(result.current).toEqual({ status: 'allowed' })
+    })
+  })
+})

--- a/src/components/auth-gate/use-auth-gate.test.ts
+++ b/src/components/auth-gate/use-auth-gate.test.ts
@@ -126,4 +126,110 @@ describe('useAuthGate', () => {
       expect(result.current).toEqual({ status: 'allowed' })
     })
   })
+
+  describe('auth state changes after resolve', () => {
+    it('returns redirect when user logs out in another tab (session becomes null, isPending false)', () => {
+      const sessionRef = { current: sessionWithUser as typeof sessionWithUser | null }
+      const isPendingRef = { current: false }
+      const authClient = {
+        ...createMockAuthClient(),
+        useSession: () => ({
+          data: sessionRef.current,
+          isPending: isPendingRef.current,
+          isRefetching: false,
+          error: null,
+          refetch: async () => {},
+        }),
+      } as AuthClient
+      const wrapper = createTestProvider({ authClient })
+      const { result, rerender } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+
+      expect(result.current).toEqual({ status: 'allowed' })
+
+      sessionRef.current = null
+      rerender()
+      expect(result.current).toEqual({ status: 'redirect' })
+    })
+
+    it('returns allowed when user logs in in another tab (session appears, isPending false)', () => {
+      const sessionRef = { current: null as typeof sessionWithUser | null }
+      const isPendingRef = { current: false }
+      const authClient = {
+        ...createMockAuthClient(),
+        useSession: () => ({
+          data: sessionRef.current,
+          isPending: isPendingRef.current,
+          isRefetching: false,
+          error: null,
+          refetch: async () => {},
+        }),
+      } as AuthClient
+      const wrapper = createTestProvider({ authClient })
+      const { result, rerender } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+
+      expect(result.current).toEqual({ status: 'redirect' })
+
+      sessionRef.current = sessionWithUser
+      rerender()
+      expect(result.current).toEqual({ status: 'allowed' })
+    })
+  })
+
+  describe('refetch completes with different auth state', () => {
+    it('updates cache to redirect when refetch completes with session expired (was allowed)', () => {
+      const sessionRef = { current: sessionWithUser as typeof sessionWithUser | null }
+      const isPendingRef = { current: false }
+      const authClient = {
+        ...createMockAuthClient(),
+        useSession: () => ({
+          data: sessionRef.current,
+          isPending: isPendingRef.current,
+          isRefetching: false,
+          error: null,
+          refetch: async () => {},
+        }),
+      } as AuthClient
+      const wrapper = createTestProvider({ authClient })
+      const { result, rerender } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+
+      expect(result.current).toEqual({ status: 'allowed' })
+
+      isPendingRef.current = true
+      rerender()
+      expect(result.current).toEqual({ status: 'allowed' })
+
+      sessionRef.current = null
+      isPendingRef.current = false
+      rerender()
+      expect(result.current).toEqual({ status: 'redirect' })
+    })
+
+    it('updates cache to allowed when refetch completes with session (was redirect)', () => {
+      const sessionRef = { current: null as typeof sessionWithUser | null }
+      const isPendingRef = { current: false }
+      const authClient = {
+        ...createMockAuthClient(),
+        useSession: () => ({
+          data: sessionRef.current,
+          isPending: isPendingRef.current,
+          isRefetching: false,
+          error: null,
+          refetch: async () => {},
+        }),
+      } as AuthClient
+      const wrapper = createTestProvider({ authClient })
+      const { result, rerender } = renderHook(() => useAuthGate('authenticated'), { wrapper })
+
+      expect(result.current).toEqual({ status: 'redirect' })
+
+      isPendingRef.current = true
+      rerender()
+      expect(result.current).toEqual({ status: 'redirect' })
+
+      sessionRef.current = sessionWithUser
+      isPendingRef.current = false
+      rerender()
+      expect(result.current).toEqual({ status: 'allowed' })
+    })
+  })
 })

--- a/src/components/auth-gate/use-auth-gate.test.ts
+++ b/src/components/auth-gate/use-auth-gate.test.ts
@@ -1,3 +1,4 @@
+import type { AuthClient } from '@/contexts'
 import { createMockAuthClient } from '@/test-utils/auth-client'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { describe, expect, it } from 'bun:test'
@@ -68,7 +69,7 @@ describe('useAuthGate', () => {
           error: null,
           refetch: async () => {},
         }),
-      }
+      } as AuthClient
       const wrapper = createTestProvider({ authClient })
       const { result, rerender } = renderHook(() => useAuthGate('authenticated'), { wrapper })
 
@@ -91,7 +92,7 @@ describe('useAuthGate', () => {
           error: null,
           refetch: async () => {},
         }),
-      }
+      } as AuthClient
       const wrapper = createTestProvider({ authClient })
       const { result, rerender } = renderHook(() => useAuthGate('authenticated'), { wrapper })
 
@@ -114,7 +115,7 @@ describe('useAuthGate', () => {
           error: null,
           refetch: async () => {},
         }),
-      }
+      } as AuthClient
       const wrapper = createTestProvider({ authClient })
       const { result, rerender } = renderHook(() => useAuthGate('unauthenticated'), { wrapper })
 

--- a/src/components/auth-gate/use-auth-gate.ts
+++ b/src/components/auth-gate/use-auth-gate.ts
@@ -16,7 +16,7 @@ export const useAuthGate = (require: AuthRequirement): AuthGateState => {
   // Only show loading on the initial session fetch (no cached data yet).
   // Background refetches (e.g. on window focus) keep `session` populated,
   // so we skip loading to avoid unmounting child routes and losing their state.
-  if (isPending && session === undefined) return { status: 'loading' }
+  if (isPending && !session) return { status: 'loading' }
 
   if (require === 'authenticated' && !isAuthenticated) return { status: 'redirect' }
   if (require === 'unauthenticated' && isAuthenticated) return { status: 'redirect' }

--- a/src/components/auth-gate/use-auth-gate.ts
+++ b/src/components/auth-gate/use-auth-gate.ts
@@ -13,9 +13,6 @@ export const useAuthGate = (require: AuthRequirement): AuthGateState => {
   const { data: session, isPending } = authClient.useSession()
   const isAuthenticated = !!session?.user
 
-  // Only show loading on the initial session fetch (no cached data yet).
-  // Background refetches (e.g. on window focus) keep `session` populated,
-  // so we skip loading to avoid unmounting child routes and losing their state.
   if (isPending && !session) return { status: 'loading' }
 
   if (require === 'authenticated' && !isAuthenticated) return { status: 'redirect' }

--- a/src/components/auth-gate/use-auth-gate.ts
+++ b/src/components/auth-gate/use-auth-gate.ts
@@ -1,22 +1,36 @@
+import { useRef } from 'react'
 import { useAuth } from '@/contexts'
 
 export type AuthRequirement = 'authenticated' | 'unauthenticated'
 
 export type AuthGateState = { status: 'loading' } | { status: 'allowed' } | { status: 'redirect' }
 
+type ResolvedState = { status: 'allowed' } | { status: 'redirect' }
+
 /**
  * Hook that determines route access based on authentication state.
  * Returns a state object indicating whether to show loading, allow access, or redirect.
+ * Once resolved, never returns loading again for this mount so refetches (e.g. tab focus) don't unmount children.
  */
 export const useAuthGate = (require: AuthRequirement): AuthGateState => {
   const authClient = useAuth()
   const { data: session, isPending } = authClient.useSession()
   const isAuthenticated = !!session?.user
+  const resolvedRef = useRef<ResolvedState | null>(null)
 
-  if (isPending && !session) return { status: 'loading' }
+  if (isPending) {
+    if (resolvedRef.current) return resolvedRef.current
+    return { status: 'loading' }
+  }
 
-  if (require === 'authenticated' && !isAuthenticated) return { status: 'redirect' }
-  if (require === 'unauthenticated' && isAuthenticated) return { status: 'redirect' }
-
+  if (require === 'authenticated' && !isAuthenticated) {
+    resolvedRef.current = { status: 'redirect' }
+    return { status: 'redirect' }
+  }
+  if (require === 'unauthenticated' && isAuthenticated) {
+    resolvedRef.current = { status: 'redirect' }
+    return { status: 'redirect' }
+  }
+  resolvedRef.current = { status: 'allowed' }
   return { status: 'allowed' }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches route-gating/auth flow; incorrect caching could temporarily allow/redirect the wrong users during pending session refetches, though the change is small and now covered by tests.
> 
> **Overview**
> Updates `useAuthGate` to cache the first resolved decision (`allowed`/`redirect`) in a ref and, when `useSession()` becomes pending again, return the cached decision instead of re-entering `loading`.
> 
> Adds a comprehensive `useAuthGate` test suite covering initial pending, resolved states, pending-after-resolve (refetch), cross-tab login/logout changes, and refetch completion changing auth state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ce2c1b627f781ad91ca8c1e8437479d8cc6ef6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->