### PR TITLE
THU-279: Waitlist Fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - Prefer `type` over `interface`
 - Prefer arrow functions over `function` keyword
 - Prefer `const` over `let` - create helper functions with early return instead of setting `let` variables inside conditionals
+- Use camelCase for const and variable names
 - Prefer early return over long if statements and nested code
 - Use direct imports: `useEffect` not `React.useEffect`
 - Prefer async/await over .then/.catch

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -65,7 +65,7 @@ function AppRoutes({ initData }: { initData: InitData }) {
     experimental_feature_tasks: initData.experimentalFeatureTasks,
   })
 
-  const bypassWaitlist = import.meta.env.VITE_BYPASS_WAITLIST === 'true' || isPrPreview()
+  const shouldBypassWaitlist = import.meta.env.VITE_BYPASS_WAITLIST === 'true' || isPrPreview()
 
   return (
     <Routes>
@@ -74,7 +74,7 @@ function AppRoutes({ initData }: { initData: InitData }) {
       <Route path="/auth/verify" element={<MagicLinkVerify />} />
 
       {/* Waitlist routes - unauthenticated only (skip when bypass is enabled) */}
-      {!bypassWaitlist && (
+      {!shouldBypassWaitlist && (
         <Route element={<AuthGate require="unauthenticated" redirectTo="/" />}>
           <Route path="waitlist" element={<WaitlistLayout />}>
             <Route index element={<WaitlistPage />} />
@@ -84,7 +84,7 @@ function AppRoutes({ initData }: { initData: InitData }) {
       )}
 
       {/* Main app routes - authenticated only (pass-through when bypass enabled) */}
-      <Route element={bypassWaitlist ? <Outlet /> : <AuthGate require="authenticated" redirectTo="/waitlist" />}>
+      <Route element={shouldBypassWaitlist ? <Outlet /> : <AuthGate require="authenticated" redirectTo="/waitlist" />}>
         <Route
           path="/"
           element={

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -39,6 +39,7 @@ import Loading from './loading'
 import SettingsLayout from './settings/layout'
 import type { InitData } from './types'
 import { useSettings } from './hooks/use-settings'
+import { isPrPreview } from './lib/platform'
 
 const queryClient = new QueryClient()
 
@@ -64,7 +65,7 @@ function AppRoutes({ initData }: { initData: InitData }) {
     experimental_feature_tasks: initData.experimentalFeatureTasks,
   })
 
-  const bypassWaitlist = import.meta.env.VITE_BYPASS_WAITLIST === 'true'
+  const bypassWaitlist = import.meta.env.VITE_BYPASS_WAITLIST === 'true' || isPrPreview()
 
   return (
     <Routes>

--- a/src/components/sign-in-modal.test.tsx
+++ b/src/components/sign-in-modal.test.tsx
@@ -428,4 +428,31 @@ describe('SignInModal', () => {
       })
     })
   })
+
+  describe('back button on OTP step', () => {
+    it('returns to email step when back button is clicked', async () => {
+      renderModal()
+
+      const emailInput = await waitForModal()
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+      fireEvent.submit(emailInput.closest('form')!)
+
+      await act(async () => {
+        await getClock().tickAsync(100)
+      })
+
+      expect(screen.getByText('Or enter the 6-digit code')).toBeInTheDocument()
+      expect(screen.getByTestId('mock-otp-input')).toBeInTheDocument()
+
+      const backButton = screen.getByRole('button', { name: 'Go back' })
+      fireEvent.click(backButton)
+
+      await act(async () => {})
+
+      expect(screen.getByPlaceholderText('Email address')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Send Magic Link' })).toBeInTheDocument()
+      expect(screen.getByText('Unlock more features')).toBeInTheDocument()
+      expect(screen.queryByText('Or enter the 6-digit code')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/sign-in-modal.tsx
+++ b/src/components/sign-in-modal.tsx
@@ -6,7 +6,7 @@ import {
   ResponsiveModalHeader,
   ResponsiveModalTitle,
 } from '@/components/ui/responsive-modal'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { SignInForm } from './sign-in'
 
 type SignInModalProps = {
@@ -20,13 +20,16 @@ type SignInModalProps = {
  */
 export const SignInModal = ({ open, onOpenChange }: SignInModalProps) => {
   const [step, setStep] = useState<'email' | 'otp'>('email')
+  const goBackRef = useRef<(() => void) | null>(null)
 
   const handleClose = () => {
     onOpenChange(false)
     setStep('email')
   }
 
-  const handleGoBack = () => setStep('email')
+  const handleGoBack = () => {
+    goBackRef.current?.()
+  }
   const handleGoToOtp = () => setStep('otp')
 
   return (
@@ -52,8 +55,9 @@ export const SignInModal = ({ open, onOpenChange }: SignInModalProps) => {
           variant="modal"
           onSuccess={handleClose}
           onCancel={handleClose}
-          onGoBack={handleGoBack}
+          onGoBack={() => setStep('email')}
           onEmailSent={handleGoToOtp}
+          goBackRef={goBackRef}
         />
       </ResponsiveModalContent>
     </ResponsiveModal>

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { PR_PREVIEW_HOST_REGEX, isPrPreview } from './platform'
+
+describe('PR_PREVIEW_HOST_REGEX', () => {
+  it('matches thunderbolt-pr-{number}.onrender.com hostnames', () => {
+    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr-368.onrender.com')).toBe(true)
+    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr-1.onrender.com')).toBe(true)
+    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr-9999.onrender.com')).toBe(true)
+  })
+
+  it('rejects non-matching hostnames', () => {
+    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt.onrender.com')).toBe(false)
+    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr.onrender.com')).toBe(false)
+    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr-368x.onrender.com')).toBe(false)
+    expect(PR_PREVIEW_HOST_REGEX.test('localhost')).toBe(false)
+    expect(PR_PREVIEW_HOST_REGEX.test('')).toBe(false)
+  })
+})
+
+describe('isPrPreview', () => {
+  const originalLocation = window.location
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  it('returns true when hostname matches PR preview pattern', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, hostname: 'thunderbolt-pr-368.onrender.com' },
+      configurable: true,
+      writable: true,
+    })
+    expect(isPrPreview()).toBe(true)
+  })
+
+  it('returns false when hostname does not match', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, hostname: 'localhost' },
+      configurable: true,
+      writable: true,
+    })
+    expect(isPrPreview()).toBe(false)
+  })
+})

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,19 +1,19 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import { PR_PREVIEW_HOST_REGEX, isPrPreview } from './platform'
+import { isPrPreview, prPreviewHostRegex } from './platform'
 
-describe('PR_PREVIEW_HOST_REGEX', () => {
+describe('prPreviewHostRegex', () => {
   it('matches thunderbolt-pr-{number}.onrender.com hostnames', () => {
-    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr-368.onrender.com')).toBe(true)
-    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr-1.onrender.com')).toBe(true)
-    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr-9999.onrender.com')).toBe(true)
+    expect(prPreviewHostRegex.test('thunderbolt-pr-368.onrender.com')).toBe(true)
+    expect(prPreviewHostRegex.test('thunderbolt-pr-1.onrender.com')).toBe(true)
+    expect(prPreviewHostRegex.test('thunderbolt-pr-9999.onrender.com')).toBe(true)
   })
 
   it('rejects non-matching hostnames', () => {
-    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt.onrender.com')).toBe(false)
-    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr.onrender.com')).toBe(false)
-    expect(PR_PREVIEW_HOST_REGEX.test('thunderbolt-pr-368x.onrender.com')).toBe(false)
-    expect(PR_PREVIEW_HOST_REGEX.test('localhost')).toBe(false)
-    expect(PR_PREVIEW_HOST_REGEX.test('')).toBe(false)
+    expect(prPreviewHostRegex.test('thunderbolt.onrender.com')).toBe(false)
+    expect(prPreviewHostRegex.test('thunderbolt-pr.onrender.com')).toBe(false)
+    expect(prPreviewHostRegex.test('thunderbolt-pr-368x.onrender.com')).toBe(false)
+    expect(prPreviewHostRegex.test('localhost')).toBe(false)
+    expect(prPreviewHostRegex.test('')).toBe(false)
   })
 })
 

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -4,7 +4,7 @@ import type { DatabaseType } from '../db/singleton'
 import { memoize } from './memoize'
 
 /** Matches Render PR preview hostnames: thunderbolt-pr-{number}.onrender.com */
-export const PR_PREVIEW_HOST_REGEX = /^thunderbolt-pr-\d+\.onrender\.com$/
+export const prPreviewHostRegex = /^thunderbolt-pr-\d+\.onrender\.com$/
 
 /**
  * Returns true when the frontend is running on a Render PR preview deployment
@@ -12,7 +12,7 @@ export const PR_PREVIEW_HOST_REGEX = /^thunderbolt-pr-\d+\.onrender\.com$/
  */
 export const isPrPreview = (): boolean => {
   if (typeof window === 'undefined') return false
-  return PR_PREVIEW_HOST_REGEX.test(window.location.hostname)
+  return prPreviewHostRegex.test(window.location.hostname)
 }
 
 /**

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -3,6 +3,18 @@ import { platform, type Platform } from '@tauri-apps/plugin-os'
 import type { DatabaseType } from '../db/singleton'
 import { memoize } from './memoize'
 
+/** Matches Render PR preview hostnames: thunderbolt-pr-{number}.onrender.com */
+export const PR_PREVIEW_HOST_REGEX = /^thunderbolt-pr-\d+\.onrender\.com$/
+
+/**
+ * Returns true when the frontend is running on a Render PR preview deployment
+ * (e.g. https://thunderbolt-pr-368.onrender.com/).
+ */
+export const isPrPreview = (): boolean => {
+  if (typeof window === 'undefined') return false
+  return PR_PREVIEW_HOST_REGEX.test(window.location.hostname)
+}
+
 /**
  * Detects if the app is running in a Tauri environment
  * @returns true if running in Tauri, false otherwise


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes routing/auth gating behavior for web PR preview hosts and could unintentionally bypass the waitlist if hostname matching is wrong. Sign-in modal change is localized but affects auth UX flow.
> 
> **Overview**
> **Waitlist access logic is adjusted** so PR preview deployments on Render automatically bypass the waitlist, in addition to the existing `VITE_BYPASS_WAITLIST` env flag.
> 
> Adds `isPrPreview()`/`prPreviewHostRegex` to `src/lib/platform.ts` (with tests) and wires it into `src/app.tsx` routing.
> 
> Fixes sign-in modal back navigation from the OTP step by delegating the modal back button to the form’s internal `goBack` via a ref, and adds a regression test for the back button behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 094391a8c4aa293c9c9c449b32424389f085edd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->