### PR TITLE
THU-180: Improve the link preview feature

### DIFF
--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -606,6 +606,47 @@ describe('Link Preview Routes', () => {
       expect(response.headers.get('content-type')).toBe('image/png')
     })
 
+    it('should reject HTML page response exceeding 2MB (Content-Length check)', async () => {
+      const pageUrl = 'https://example.com/page'
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response('small body', {
+            status: 200,
+            headers: { 'Content-Type': 'text/html', 'Content-Length': String(5 * 1024 * 1024) },
+          }),
+        ),
+      )
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(413)
+      expect(await response.text()).toBe('Page response too large')
+    })
+
+    it('should reject HTML page response exceeding 2MB (actual size check)', async () => {
+      const pageUrl = 'https://example.com/page'
+      const largeHtml = 'x'.repeat(3 * 1024 * 1024) // 3MB — exceeds 2MB limit
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(largeHtml, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+        ),
+      )
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(413)
+      expect(await response.text()).toBe('Page response too large')
+    })
+
     it('should reject images larger than 2MB (Content-Length check)', async () => {
       const pageUrl = 'https://example.com/page'
       const imageUrl = 'https://example.com/huge.jpg'

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -414,7 +414,7 @@ describe('Link Preview Routes', () => {
 
       const body = (await response.json()) as LinkPreviewResponse
       expect(body.success).toBe(false)
-      expect(body.error).toBe('Network connection failed')
+      expect(body.error).toBe('Link preview request failed')
     })
 
     it('should return all nulls when page has no social tags (e.g. captcha page)', async () => {

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -1067,6 +1067,45 @@ describe('Link Preview Routes', () => {
       expect(await response.text()).toBe('Internal URLs are not allowed')
     })
 
+    it('should reject IPv4-mapped IPv6 private addresses (::ffff:10.0.0.1)', async () => {
+      const imageUrl = 'http://[::ffff:10.0.0.1]/admin'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${encodeURIComponent(imageUrl)}`, {
+          method: 'GET',
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Internal URLs are not allowed')
+    })
+
+    it('should reject IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)', async () => {
+      const imageUrl = 'http://[::ffff:127.0.0.1]/admin'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${encodeURIComponent(imageUrl)}`, {
+          method: 'GET',
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Internal URLs are not allowed')
+    })
+
+    it('should reject IPv4-mapped IPv6 metadata endpoint (::ffff:169.254.169.254)', async () => {
+      const imageUrl = 'http://[::ffff:169.254.169.254]/latest/meta-data/'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${encodeURIComponent(imageUrl)}`, {
+          method: 'GET',
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Internal URLs are not allowed')
+    })
+
     it('should handle URLs with query strings', async () => {
       const imageUrl = 'https://example.com/image.jpg?w=800&h=600'
 

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -96,11 +96,9 @@ describe('Link Preview Routes', () => {
 
       const body = (await response.json()) as LinkPreviewResponse
       expect(body.success).toBe(true)
-      expect(body.data).toEqual({
-        title: 'Test Article',
-        description: 'This is a test article',
-        image: 'https://example.com/image.jpg',
-      })
+      expect(body.data?.title).toBe('Test Article')
+      expect(body.data?.description).toBe('This is a test article')
+      expect(body.data?.image).toBe('https://example.com/image.jpg')
     })
 
     it('should fallback to title tag if og:title is missing', async () => {
@@ -125,12 +123,12 @@ describe('Link Preview Routes', () => {
       expect(body.data?.title).toBe('Page Title')
     })
 
-    it('should fallback to meta description if og:description is missing', async () => {
+    it('should fallback to meta description when social tags are present', async () => {
       const targetUrl = 'https://example.com/page'
       const html = `
         <html>
           <head>
-            <title>Page Title</title>
+            <meta property="og:title" content="OG Title" />
             <meta name="description" content="Regular meta description" />
           </head>
         </html>
@@ -144,29 +142,8 @@ describe('Link Preview Routes', () => {
 
       const body = (await response.json()) as LinkPreviewResponse
       expect(body.success).toBe(true)
+      expect(body.data?.title).toBe('OG Title')
       expect(body.data?.description).toBe('Regular meta description')
-    })
-
-    it('should handle twitter:image fallback', async () => {
-      const targetUrl = 'https://example.com/page'
-      const html = `
-        <html>
-          <head>
-            <title>Page Title</title>
-            <meta name="twitter:image" content="https://example.com/twitter-image.jpg" />
-          </head>
-        </html>
-      `
-
-      mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
-
-      const response = await app.handle(new Request(`http://localhost/link-preview/${targetUrl}`, { method: 'GET' }))
-
-      expect(response.status).toBe(200)
-
-      const body = (await response.json()) as LinkPreviewResponse
-      expect(body.success).toBe(true)
-      expect(body.data?.image).toBe('https://example.com/twitter-image.jpg')
     })
 
     it('should convert relative image URLs to absolute URLs', async () => {
@@ -229,6 +206,7 @@ describe('Link Preview Routes', () => {
         title: null,
         description: null,
         image: null,
+        siteName: null,
       })
     })
 
@@ -296,7 +274,7 @@ describe('Link Preview Routes', () => {
     it('should handle URL-encoded target URLs', async () => {
       const targetUrl = 'https://example.com/page?v=2'
       const encodedTargetUrl = encodeURIComponent(targetUrl)
-      const html = '<html><head><title>Test</title></head></html>'
+      const html = '<html><head><meta property="og:title" content="Test" /></head></html>'
 
       mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
 
@@ -374,9 +352,104 @@ describe('Link Preview Routes', () => {
       expect(body.error).toBe('Network connection failed')
     })
 
+    it('should return all nulls when page has no social tags (e.g. captcha page)', async () => {
+      const targetUrl = 'https://example.com/blocked'
+      const html = `
+        <html>
+          <head>
+            <title>Please verify you are human</title>
+            <meta name="description" content="Complete the captcha to continue" />
+          </head>
+        </html>
+      `
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+      const response = await app.handle(new Request(`http://localhost/link-preview/${targetUrl}`, { method: 'GET' }))
+
+      expect(response.status).toBe(200)
+
+      const body = (await response.json()) as LinkPreviewResponse
+      expect(body.success).toBe(true)
+      expect(body.data).toEqual({
+        title: null,
+        description: null,
+        image: null,
+        siteName: null,
+      })
+    })
+
+    it('should use title tag fallback when at least one social tag is present', async () => {
+      const targetUrl = 'https://example.com/page'
+      const html = `
+        <html>
+          <head>
+            <title>Page Title</title>
+            <meta property="og:image" content="https://example.com/img.jpg" />
+          </head>
+        </html>
+      `
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+      const response = await app.handle(new Request(`http://localhost/link-preview/${targetUrl}`, { method: 'GET' }))
+
+      expect(response.status).toBe(200)
+
+      const body = (await response.json()) as LinkPreviewResponse
+      expect(body.success).toBe(true)
+      expect(body.data?.title).toBe('Page Title')
+      expect(body.data?.image).toBe('https://example.com/img.jpg')
+    })
+
+    it('should extract og:site_name', async () => {
+      const targetUrl = 'https://example.com/page'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:title" content="Article Title" />
+            <meta property="og:site_name" content="The Example Times" />
+            <meta property="og:description" content="An article" />
+          </head>
+        </html>
+      `
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+      const response = await app.handle(new Request(`http://localhost/link-preview/${targetUrl}`, { method: 'GET' }))
+
+      expect(response.status).toBe(200)
+
+      const body = (await response.json()) as LinkPreviewResponse
+      expect(body.success).toBe(true)
+      expect(body.data?.siteName).toBe('The Example Times')
+      expect(body.data?.title).toBe('Article Title')
+    })
+
+    it('should return null siteName when og:site_name is not present', async () => {
+      const targetUrl = 'https://example.com/page'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:title" content="Article Title" />
+          </head>
+        </html>
+      `
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+      const response = await app.handle(new Request(`http://localhost/link-preview/${targetUrl}`, { method: 'GET' }))
+
+      expect(response.status).toBe(200)
+
+      const body = (await response.json()) as LinkPreviewResponse
+      expect(body.success).toBe(true)
+      expect(body.data?.siteName).toBeNull()
+    })
+
     it('should send User-Agent header', async () => {
       const targetUrl = 'https://example.com/page'
-      const html = '<html><head><title>Test</title></head></html>'
+      const html = '<html><head><meta property="og:title" content="Test" /></head></html>'
 
       mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
 
@@ -394,6 +467,659 @@ describe('Link Preview Routes', () => {
           }),
         }),
       )
+    })
+  })
+
+  describe('GET /link-preview/image/*', () => {
+    const createMockImageResponse = (contentType = 'image/png', size = 100) =>
+      new Response(new Uint8Array(size), {
+        status: 200,
+        headers: { 'content-type': contentType },
+      })
+
+    it('should fetch page, extract image URL, and return image with proper content type', async () => {
+      const pageUrl = 'https://example.com/page'
+      const imageUrl = 'https://example.com/image.jpg'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:image" content="${imageUrl}" />
+          </head>
+        </html>
+      `
+
+      // Mock: first call fetches page, second call fetches image
+      let callCount = 0
+      mockFetch.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve(createMockHtmlResponse(html))
+        }
+        return Promise.resolve(createMockImageResponse('image/jpeg'))
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('image/jpeg')
+      const buffer = await response.arrayBuffer()
+      expect(buffer.byteLength).toBe(100)
+    })
+
+    it('should infer content type from URL extension when header is missing', async () => {
+      const pageUrl = 'https://example.com/page'
+      const imageUrl = 'https://example.com/image.png'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:image" content="${imageUrl}" />
+          </head>
+        </html>
+      `
+
+      let callCount = 0
+      mockFetch.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve(createMockHtmlResponse(html))
+        }
+        return Promise.resolve(
+          new Response(new Uint8Array(100), {
+            status: 200,
+            headers: {}, // No content-type header
+          }),
+        )
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('image/png')
+    })
+
+    it('should reject images larger than 2MB (Content-Length check)', async () => {
+      const pageUrl = 'https://example.com/page'
+      const imageUrl = 'https://example.com/huge.jpg'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:image" content="${imageUrl}" />
+          </head>
+        </html>
+      `
+
+      let callCount = 0
+      mockFetch.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve(createMockHtmlResponse(html))
+        }
+        return Promise.resolve(
+          new Response(new Uint8Array(100), {
+            status: 200,
+            headers: { 'content-type': 'image/jpeg', 'content-length': '3000000' }, // 3MB
+          }),
+        )
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(413)
+      expect(await response.text()).toBe('Image too large')
+    })
+
+    it('should reject images larger than 2MB (actual size check)', async () => {
+      const pageUrl = 'https://example.com/page'
+      const imageUrl = 'https://example.com/huge.jpg'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:image" content="${imageUrl}" />
+          </head>
+        </html>
+      `
+      const largeBuffer = new Uint8Array(2 * 1024 * 1024 + 1024) // 2MB + 1KB
+
+      let callCount = 0
+      mockFetch.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve(createMockHtmlResponse(html))
+        }
+        return Promise.resolve(
+          new Response(largeBuffer, {
+            status: 200,
+            headers: { 'content-type': 'image/jpeg' },
+          }),
+        )
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(413)
+      expect(await response.text()).toBe('Image too large')
+    })
+
+    it('should timeout after 2 seconds when image fetch is slow', async () => {
+      const pageUrl = 'https://example.com/page'
+      const imageUrl = 'https://example.com/slow.jpg'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:image" content="${imageUrl}" />
+          </head>
+        </html>
+      `
+
+      let callCount = 0
+      mockFetch.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve(createMockHtmlResponse(html))
+        }
+        // Simulate abort - when the abort controller fires after 2s, fetch rejects with AbortError
+        const abortError = new Error('The operation was aborted')
+        abortError.name = 'AbortError'
+        return Promise.reject(abortError)
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(408)
+      expect(await response.text()).toBe('Image fetch timeout')
+    })
+
+    it('should return 400 for invalid URL encoding', async () => {
+      const response = await app.handle(new Request('http://localhost/link-preview/image/%E0%A4%A', { method: 'GET' }))
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Invalid URL encoding')
+    })
+
+    it('should return 400 for non-HTTP(S) URLs', async () => {
+      const pageUrl = 'file:///etc/passwd'
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Only HTTP and HTTPS URLs are supported')
+    })
+
+    it('should return 500 on image fetch failure', async () => {
+      const pageUrl = 'https://example.com/page'
+      const imageUrl = 'https://example.com/broken.jpg'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:image" content="${imageUrl}" />
+          </head>
+        </html>
+      `
+
+      let callCount = 0
+      mockFetch.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve(createMockHtmlResponse(html))
+        }
+        return Promise.reject(new Error('Connection refused'))
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(500)
+      expect(await response.text()).toBe('Image fetch failed')
+    })
+
+    it('should return error status when image fetch returns non-200', async () => {
+      const pageUrl = 'https://example.com/page'
+      const imageUrl = 'https://example.com/forbidden.jpg'
+      const html = `
+        <html>
+          <head>
+            <meta property="og:image" content="${imageUrl}" />
+          </head>
+        </html>
+      `
+
+      let callCount = 0
+      mockFetch.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve(createMockHtmlResponse(html))
+        }
+        return Promise.resolve(new Response('Forbidden', { status: 403, statusText: 'Forbidden' }))
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(403)
+      expect(await response.text()).toBe('Failed to fetch image: Forbidden')
+    })
+
+    it('should return 404 when page has no image', async () => {
+      const pageUrl = 'https://example.com/page'
+      const html = `
+        <html>
+          <head>
+            <title>Page without image</title>
+          </head>
+        </html>
+      `
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(404)
+      expect(await response.text()).toBe('No image found in page metadata')
+    })
+
+    it('should return 408 when page fetch times out', async () => {
+      const pageUrl = 'https://example.com/slow-page'
+      const abortError = new Error('The operation was aborted')
+      abortError.name = 'AbortError'
+      mockFetch.mockImplementation(() => Promise.reject(abortError))
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(408)
+      expect(await response.text()).toBe('Request timeout exceeded')
+    })
+
+    describe('SSRF protection', () => {
+      it('should reject file:// protocol in image URL', async () => {
+        const pageUrl = 'https://example.com/page'
+        const html = `
+          <html>
+            <head>
+              <meta property="og:image" content="file:///etc/passwd" />
+            </head>
+          </html>
+        `
+
+        mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+        const response = await app.handle(
+          new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe('Only HTTP and HTTPS URLs are supported')
+      })
+
+      it('should reject localhost in image URL', async () => {
+        const pageUrl = 'https://example.com/page'
+        const html = `
+          <html>
+            <head>
+              <meta property="og:image" content="http://localhost/admin" />
+            </head>
+          </html>
+        `
+
+        mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+        const response = await app.handle(
+          new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe('Internal URLs are not allowed')
+      })
+
+      it('should reject 127.0.0.1 in image URL', async () => {
+        const pageUrl = 'https://example.com/page'
+        const html = `
+          <html>
+            <head>
+              <meta property="og:image" content="http://127.0.0.1/admin" />
+            </head>
+          </html>
+        `
+
+        mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+        const response = await app.handle(
+          new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe('Internal URLs are not allowed')
+      })
+
+      it('should reject private IP ranges (10.x.x.x) in image URL', async () => {
+        const pageUrl = 'https://example.com/page'
+        const html = `
+          <html>
+            <head>
+              <meta property="og:image" content="http://10.0.0.1/admin" />
+            </head>
+          </html>
+        `
+
+        mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+        const response = await app.handle(
+          new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe('Internal URLs are not allowed')
+      })
+
+      it('should reject private IP ranges (172.16.x.x) in image URL', async () => {
+        const pageUrl = 'https://example.com/page'
+        const html = `
+          <html>
+            <head>
+              <meta property="og:image" content="http://172.16.0.1/admin" />
+            </head>
+          </html>
+        `
+
+        mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+        const response = await app.handle(
+          new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe('Internal URLs are not allowed')
+      })
+
+      it('should reject private IP ranges (192.168.x.x) in image URL', async () => {
+        const pageUrl = 'https://example.com/page'
+        const html = `
+          <html>
+            <head>
+              <meta property="og:image" content="http://192.168.1.1/admin" />
+            </head>
+          </html>
+        `
+
+        mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+        const response = await app.handle(
+          new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe('Internal URLs are not allowed')
+      })
+
+      it('should reject cloud metadata endpoint (169.254.169.254) in image URL', async () => {
+        const pageUrl = 'https://example.com/page'
+        const html = `
+          <html>
+            <head>
+              <meta property="og:image" content="http://169.254.169.254/latest/meta-data/" />
+            </head>
+          </html>
+        `
+
+        mockFetch.mockImplementation(() => Promise.resolve(createMockHtmlResponse(html)))
+
+        const response = await app.handle(
+          new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+        )
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe('Internal URLs are not allowed')
+      })
+
+      it('should allow valid external image URLs', async () => {
+        const pageUrl = 'https://example.com/page'
+        const imageUrl = 'https://example.com/image.jpg'
+        const html = `
+          <html>
+            <head>
+              <meta property="og:image" content="${imageUrl}" />
+            </head>
+          </html>
+        `
+
+        let callCount = 0
+        mockFetch.mockImplementation(() => {
+          callCount++
+          if (callCount === 1) {
+            return Promise.resolve(createMockHtmlResponse(html))
+          }
+          return Promise.resolve(createMockImageResponse('image/jpeg'))
+        })
+
+        const response = await app.handle(
+          new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-type')).toBe('image/jpeg')
+      })
+    })
+  })
+
+  describe('GET /link-preview/proxy-image/*', () => {
+    const createMockImageResponse = (contentType = 'image/png', size = 100) =>
+      new Response(new Uint8Array(size), {
+        status: 200,
+        headers: { 'content-type': contentType },
+      })
+
+    it('should proxy image directly from image URL', async () => {
+      const imageUrl = 'https://example.com/image.jpg'
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockImageResponse('image/jpeg')))
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('image/jpeg')
+      const buffer = await response.arrayBuffer()
+      expect(buffer.byteLength).toBe(100)
+    })
+
+    it('should validate image URL and reject SSRF attempts', async () => {
+      const imageUrl = 'http://169.254.169.254/latest/meta-data/'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Internal URLs are not allowed')
+    })
+
+    it('should reject non-HTTP(S) protocols', async () => {
+      const imageUrl = 'file:///etc/passwd'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Only HTTP and HTTPS URLs are supported')
+    })
+
+    it('should reject localhost', async () => {
+      const imageUrl = 'http://localhost/admin'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Internal URLs are not allowed')
+    })
+
+    it('should reject private IP ranges', async () => {
+      const imageUrl = 'http://192.168.1.1/admin'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Internal URLs are not allowed')
+    })
+
+    it('should enforce size limits', async () => {
+      const imageUrl = 'https://example.com/huge.jpg'
+      const largeBuffer = new Uint8Array(2 * 1024 * 1024 + 1024) // 2MB + 1KB
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(largeBuffer, {
+            status: 200,
+            headers: { 'content-type': 'image/jpeg' },
+          }),
+        ),
+      )
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(413)
+      expect(await response.text()).toBe('Image too large')
+    })
+
+    it('should timeout after 2 seconds', async () => {
+      const imageUrl = 'https://example.com/slow.jpg'
+      const abortError = new Error('The operation was aborted')
+      abortError.name = 'AbortError'
+
+      mockFetch.mockImplementation(() => Promise.reject(abortError))
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(408)
+      expect(await response.text()).toBe('Image fetch timeout')
+    })
+
+    it('should infer content type from URL extension when header is missing', async () => {
+      const imageUrl = 'https://example.com/image.png'
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(new Uint8Array(100), {
+            status: 200,
+            headers: {}, // No content-type header
+          }),
+        ),
+      )
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('image/png')
+    })
+
+    it('should reject IPv6 link-local addresses', async () => {
+      // IPv6 addresses in URLs must be in brackets, and URL constructor preserves them in hostname
+      const imageUrl = 'http://[fe80::1]/admin'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${encodeURIComponent(imageUrl)}`, {
+          method: 'GET',
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Internal URLs are not allowed')
+    })
+
+    it('should reject IPv6 unique local addresses', async () => {
+      // IPv6 addresses in URLs must be in brackets, and URL constructor preserves them in hostname
+      const imageUrl = 'http://[fc00::1]/admin'
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${encodeURIComponent(imageUrl)}`, {
+          method: 'GET',
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(await response.text()).toBe('Internal URLs are not allowed')
+    })
+
+    it('should handle URLs with query strings', async () => {
+      const imageUrl = 'https://example.com/image.jpg?w=800&h=600'
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockImageResponse('image/jpeg')))
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${encodeURIComponent(imageUrl)}`, {
+          method: 'GET',
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('image/jpeg')
+    })
+
+    it('should handle Content-Length with negative or invalid values', async () => {
+      const imageUrl = 'https://example.com/image.jpg'
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(new Uint8Array(100), {
+            status: 200,
+            headers: { 'content-type': 'image/jpeg', 'content-length': '-100' },
+          }),
+        ),
+      )
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      // Should proceed with download since negative Content-Length is invalid
+      expect(response.status).toBe(200)
+    })
+
+    it('should handle Content-Type with charset parameter', async () => {
+      const imageUrl = 'https://example.com/image.png'
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(new Uint8Array(100), {
+            status: 200,
+            headers: { 'content-type': 'image/png; charset=utf-8' },
+          }),
+        ),
+      )
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('image/png; charset=utf-8')
     })
   })
 })

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -254,7 +254,7 @@ describe('Link Preview Routes', () => {
 
       const body = (await response.json()) as LinkPreviewResponse
       expect(body.success).toBe(false)
-      expect(body.error).toBe('Invalid URL provided')
+      expect(body.error).toBe('Invalid URL')
     })
 
     it('should return error when URL has malformed encoding', async () => {
@@ -269,6 +269,71 @@ describe('Link Preview Routes', () => {
       const body = (await response.json()) as LinkPreviewResponse
       expect(body.success).toBe(false)
       expect(body.error).toBe('Invalid URL encoding')
+    })
+
+    it('should block private IPs on metadata endpoint (SSRF protection)', async () => {
+      const privateIps = ['http://169.254.169.254/latest/meta-data/', 'http://10.0.0.1/', 'http://192.168.1.1/']
+
+      for (const privateUrl of privateIps) {
+        const encoded = encodeURIComponent(privateUrl)
+        const response = await app.handle(new Request(`http://localhost/link-preview/${encoded}`, { method: 'GET' }))
+
+        expect(response.status).toBe(200)
+        expect(mockFetch).not.toHaveBeenCalled()
+
+        const body = (await response.json()) as LinkPreviewResponse
+        expect(body.success).toBe(false)
+        expect(body.error).toBe('Internal URLs are not allowed')
+      }
+    })
+
+    it('should block localhost on metadata endpoint (SSRF protection)', async () => {
+      const encoded = encodeURIComponent('http://localhost/admin')
+      const response = await app.handle(new Request(`http://localhost/link-preview/${encoded}`, { method: 'GET' }))
+
+      expect(response.status).toBe(200)
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      const body = (await response.json()) as LinkPreviewResponse
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('Internal URLs are not allowed')
+    })
+
+    it('should return error when HTML response exceeds size limit', async () => {
+      const largeHtml = 'x'.repeat(3 * 1024 * 1024) // 3MB — exceeds 2MB limit
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(largeHtml, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+        ),
+      )
+
+      const encoded = encodeURIComponent('https://example.com')
+      const response = await app.handle(new Request(`http://localhost/link-preview/${encoded}`, { method: 'GET' }))
+
+      const body = (await response.json()) as LinkPreviewResponse
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('Response too large')
+    })
+
+    it('should reject when Content-Length exceeds size limit', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response('small body', {
+            status: 200,
+            headers: { 'Content-Type': 'text/html', 'Content-Length': String(5 * 1024 * 1024) },
+          }),
+        ),
+      )
+
+      const encoded = encodeURIComponent('https://example.com')
+      const response = await app.handle(new Request(`http://localhost/link-preview/${encoded}`, { method: 'GET' }))
+
+      const body = (await response.json()) as LinkPreviewResponse
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('Response too large')
     })
 
     it('should handle URL-encoded target URLs', async () => {

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -150,14 +150,6 @@ const validateImageUrl = (url: string): { valid: boolean; error?: string } => {
       return { valid: false, error: 'Internal URLs are not allowed' }
     }
 
-    // Block IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
-    if (hostname.startsWith('::ffff:')) {
-      const ipv4Part = hostname.slice(7)
-      if (ipv4Part === '127.0.0.1' || ipv4Part === '0.0.0.0') {
-        return { valid: false, error: 'Internal URLs are not allowed' }
-      }
-    }
-
     const ipv4Regex =
       /^(?:(?:10|127)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|172\.(?:1[6-9]|2[0-9]|3[01])\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|192\.168\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|169\.254\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$/
     const ipv6LinkLocalRegex = /^fe[89ab][0-9a-f]/
@@ -165,6 +157,22 @@ const validateImageUrl = (url: string): { valid: boolean; error?: string } => {
 
     if (ipv4Regex.test(hostname) || ipv6LinkLocalRegex.test(hostname) || ipv6UniqueLocalRegex.test(hostname)) {
       return { valid: false, error: 'Internal URLs are not allowed' }
+    }
+
+    // Block IPv4-mapped IPv6 (::ffff:XXYY:ZZWW) — Bun normalizes ::ffff:127.0.0.1 to ::ffff:7f00:1
+    if (hostname.startsWith('::ffff:')) {
+      const mapped = hostname.slice(7)
+      const hexParts = mapped.split(':')
+      if (hexParts.length === 2) {
+        const high = parseInt(hexParts[0], 16)
+        const low = parseInt(hexParts[1], 16)
+        if (!Number.isNaN(high) && !Number.isNaN(low)) {
+          const ipv4 = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`
+          if (ipv4Regex.test(ipv4)) {
+            return { valid: false, error: 'Internal URLs are not allowed' }
+          }
+        }
+      }
     }
 
     if (hostname.includes('metadata') || hostname.includes('169.254.169.254')) {

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -30,38 +30,196 @@ const resolveUrl = (baseUrl: string, relativeUrl: string): string => {
 }
 
 /**
- * Extracts Open Graph metadata from HTML content
+ * Fetches and proxies an image with size limits and timeout.
+ * Returns a Response with the image data or an error response.
+ */
+const fetchAndProxyImage = async (
+  imageUrl: string,
+  fetchFn: typeof fetch,
+  ctx: { set: { status?: number | string } },
+): Promise<Response> => {
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 2000)
+
+    try {
+      const response = await fetchFn(imageUrl, {
+        method: 'GET',
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        },
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        ctx.set.status = response.status
+        const errorMessage = response.statusText || `HTTP ${response.status}`
+        return new Response(`Failed to fetch image: ${errorMessage}`, {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      const contentLength = response.headers.get('content-length')
+      const maxSizeBytes = 2 * 1024 * 1024 // 2MB limit
+      const parsedLength = contentLength ? parseInt(contentLength, 10) : null
+      if (parsedLength !== null && !Number.isNaN(parsedLength) && parsedLength > 0 && parsedLength > maxSizeBytes) {
+        ctx.set.status = 413
+        return new Response('Image too large', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      const buffer = await response.arrayBuffer()
+
+      if (buffer.byteLength > maxSizeBytes) {
+        ctx.set.status = 413
+        return new Response('Image too large', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      const contentType = inferImageContentType(response.headers.get('content-type'), imageUrl)
+
+      return new Response(buffer, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Cache-Control': 'public, max-age=86400',
+          'Cross-Origin-Resource-Policy': 'cross-origin',
+        },
+      })
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      ctx.set.status = 408
+      return new Response('Image fetch timeout', {
+        headers: { 'Content-Type': 'text/plain' },
+      })
+    }
+
+    console.error('Link preview image error:', error)
+    ctx.set.status = 500
+    return new Response('Image fetch failed', {
+      headers: { 'Content-Type': 'text/plain' },
+    })
+  }
+}
+
+/** Infers image content type from response header or URL extension */
+const inferImageContentType = (headerContentType: string | null, imageUrl: string): string => {
+  if (headerContentType && headerContentType.startsWith('image/')) {
+    return headerContentType
+  }
+  try {
+    const ext = new URL(imageUrl).pathname.split('.').pop()?.toLowerCase()
+    if (ext === 'png') return 'image/png'
+    if (ext === 'gif') return 'image/gif'
+    if (ext === 'webp') return 'image/webp'
+    if (ext === 'svg') return 'image/svg+xml'
+    return 'image/jpeg'
+  } catch {
+    return 'image/jpeg'
+  }
+}
+
+/**
+ * Validates that an image URL is safe to fetch (prevents SSRF attacks).
+ * Only allows http/https protocols and blocks internal/private IP addresses.
+ */
+const validateImageUrl = (url: string): { valid: boolean; error?: string } => {
+  try {
+    const parsed = new URL(url)
+
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return { valid: false, error: 'Only HTTP and HTTPS URLs are supported' }
+    }
+
+    const rawHostname = parsed.hostname.toLowerCase()
+    const hostname = rawHostname.startsWith('[') && rawHostname.endsWith(']') ? rawHostname.slice(1, -1) : rawHostname
+
+    if (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '0.0.0.0' ||
+      hostname === '::1' ||
+      hostname === '::'
+    ) {
+      return { valid: false, error: 'Internal URLs are not allowed' }
+    }
+
+    // Block IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
+    if (hostname.startsWith('::ffff:')) {
+      const ipv4Part = hostname.slice(7)
+      if (ipv4Part === '127.0.0.1' || ipv4Part === '0.0.0.0') {
+        return { valid: false, error: 'Internal URLs are not allowed' }
+      }
+    }
+
+    const ipv4Regex =
+      /^(?:(?:10|127)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|172\.(?:1[6-9]|2[0-9]|3[01])\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|192\.168\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|169\.254\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$/
+    const ipv6LinkLocalRegex = /^fe[89ab][0-9a-f]/
+    const ipv6UniqueLocalRegex = /^f[cd][0-9a-f]/
+
+    if (ipv4Regex.test(hostname) || ipv6LinkLocalRegex.test(hostname) || ipv6UniqueLocalRegex.test(hostname)) {
+      return { valid: false, error: 'Internal URLs are not allowed' }
+    }
+
+    if (hostname.includes('metadata') || hostname.includes('169.254.169.254')) {
+      return { valid: false, error: 'Internal URLs are not allowed' }
+    }
+
+    return { valid: true }
+  } catch {
+    return { valid: false, error: 'Invalid image URL' }
+  }
+}
+
+/**
+ * Extracts Open Graph metadata from HTML content.
+ * Only falls back to <title> and <meta description> when at least one social
+ * meta tag (og:*) is present — pages without any social tags
+ * (e.g. captcha/block pages) return all nulls instead of garbage fallback text.
  */
 const extractMetadata = (html: string, url: string) => {
-  // Extract og:image or fallback to any meta image
-  const imageMatch =
-    html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["'][^>]*>/i) ||
-    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:image["'][^>]*>/i) ||
-    html.match(/<meta[^>]*name=["']twitter:image["'][^>]*content=["']([^"']+)["'][^>]*>/i) ||
-    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*name=["']twitter:image["'][^>]*>/i)
-  const rawImage = imageMatch?.[1] || null
-  const image = rawImage ? resolveUrl(url, rawImage) : null
-
-  // Extract og:title or fallback to title tag
   const ogTitleMatch =
     html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["'][^>]*>/i) ||
     html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:title["'][^>]*>/i)
-  const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i)
-  const title = ogTitleMatch?.[1] || titleMatch?.[1] || null
-
-  // Extract og:description or fallback to meta description
   const ogDescMatch =
     html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["'][^>]*>/i) ||
     html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:description["'][^>]*>/i)
-  const metaDescMatch =
-    html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["'][^>]*>/i) ||
-    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*name=["']description["'][^>]*>/i)
-  const description = ogDescMatch?.[1] || metaDescMatch?.[1] || null
+  const imageMatch =
+    html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["'][^>]*>/i) ||
+    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:image["'][^>]*>/i)
+  const siteNameMatch =
+    html.match(/<meta[^>]*property=["']og:site_name["'][^>]*content=["']([^"']+)["'][^>]*>/i) ||
+    html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:site_name["'][^>]*>/i)
+
+  const hasSocialTags = !!(ogTitleMatch || ogDescMatch || imageMatch || siteNameMatch)
+
+  const titleMatch = hasSocialTags ? html.match(/<title[^>]*>([^<]+)<\/title>/i) : null
+  const metaDescMatch = hasSocialTags
+    ? html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["'][^>]*>/i) ||
+      html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*name=["']description["'][^>]*>/i)
+    : null
+
+  const rawImage = imageMatch?.[1] || null
+  const image = rawImage ? resolveUrl(url, rawImage) : null
+  const rawTitle = ogTitleMatch?.[1] || titleMatch?.[1] || null
+  const rawDescription = ogDescMatch?.[1] || metaDescMatch?.[1] || null
+
+  const title = rawTitle?.trim() ? decodeHtmlEntities(rawTitle.trim()) : null
+  const description = rawDescription?.trim() ? decodeHtmlEntities(rawDescription.trim()) : null
+  const rawSiteName = siteNameMatch?.[1] || null
+  const siteName = rawSiteName?.trim() ? decodeHtmlEntities(rawSiteName.trim()) : null
 
   return {
-    title: title ? decodeHtmlEntities(title) : null,
-    description: description ? decodeHtmlEntities(description) : null,
+    title,
+    description,
     image,
+    siteName,
   }
 }
 
@@ -86,8 +244,15 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
     .get('/*', async (ctx): Promise<LinkPreviewResponse> => {
       const url = new URL(ctx.request.url)
 
-      // Extract the target URL from the path (everything after /link-preview/)
       const pathParts = url.pathname.split('/link-preview/')
+      if (pathParts.length < 2 || !pathParts[pathParts.length - 1]) {
+        return {
+          data: null,
+          success: false,
+          error: 'No URL provided',
+        }
+      }
+
       let pathOnly: string
       try {
         pathOnly = decodeURIComponent(pathParts[pathParts.length - 1])
@@ -98,9 +263,9 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
           error: 'Invalid URL encoding',
         }
       }
-      const targetUrl = pathOnly + url.search
+      const targetUrl = pathOnly.includes('?') ? pathOnly : pathOnly + url.search
 
-      if (!targetUrl) {
+      if (!targetUrl || !targetUrl.trim()) {
         return {
           data: null,
           success: false,
@@ -108,9 +273,15 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
         }
       }
 
-      // Validate that it's a valid URL
       try {
-        new URL(targetUrl)
+        const parsedUrl = new URL(targetUrl)
+        if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+          return {
+            data: null,
+            success: false,
+            error: 'Only HTTP and HTTPS URLs are supported',
+          }
+        }
       } catch {
         return {
           data: null,
@@ -120,38 +291,38 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
       }
 
       try {
-        // Fetch with timeout
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), 10_000)
 
-        const response = await fetchFn(targetUrl, {
-          method: 'GET',
-          headers: {
-            // Use a realistic user agent to avoid Forbidden errors
-            'User-Agent':
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-            Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-            'Accept-Language': 'en-US,en;q=0.9',
-          },
-          signal: controller.signal,
-        })
+        try {
+          const response = await fetchFn(targetUrl, {
+            method: 'GET',
+            headers: {
+              'User-Agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+              Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+              'Accept-Language': 'en-US,en;q=0.9',
+            },
+            signal: controller.signal,
+          })
 
-        clearTimeout(timeoutId)
-
-        if (!response.ok) {
-          return {
-            data: null,
-            success: false,
-            error: `Failed to fetch resource: ${response.statusText}`,
+          if (!response.ok) {
+            return {
+              data: null,
+              success: false,
+              error: `Failed to fetch resource: ${response.statusText}`,
+            }
           }
-        }
 
-        const html = await response.text()
-        const metadata = extractMetadata(html, targetUrl)
+          const html = await response.text()
+          const metadata = extractMetadata(html, targetUrl)
 
-        return {
-          data: metadata,
-          success: true,
+          return {
+            data: metadata,
+            success: true,
+          }
+        } finally {
+          clearTimeout(timeoutId)
         }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
@@ -169,5 +340,145 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
           error: error instanceof Error ? error.message : 'Link preview request failed',
         }
       }
+    })
+    .get('/image/*', async (ctx) => {
+      const url = new URL(ctx.request.url)
+
+      const pathParts = url.pathname.split('/link-preview/image/')
+      if (pathParts.length < 2 || !pathParts[pathParts.length - 1]) {
+        ctx.set.status = 400
+        return new Response('No URL provided', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      let pageUrl: string
+      try {
+        pageUrl = decodeURIComponent(pathParts[pathParts.length - 1])
+      } catch {
+        ctx.set.status = 400
+        return new Response('Invalid URL encoding', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      const fullPageUrl = pageUrl.includes('?') ? pageUrl : pageUrl + url.search
+
+      // Validate URL format and SSRF protection on page URL
+      const pageValidation = validateImageUrl(fullPageUrl)
+      if (!pageValidation.valid) {
+        ctx.set.status = 400
+        return new Response(pageValidation.error || 'Invalid URL', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      try {
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), 10_000)
+
+        try {
+          const response = await fetchFn(fullPageUrl, {
+            method: 'GET',
+            headers: {
+              'User-Agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+              Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+              'Accept-Language': 'en-US,en;q=0.9',
+            },
+            signal: controller.signal,
+          })
+
+          if (!response.ok) {
+            ctx.set.status = response.status
+            return new Response(`Failed to fetch page: ${response.statusText}`, {
+              headers: { 'Content-Type': 'text/plain' },
+            })
+          }
+
+          const html = await response.text()
+          const metadata = extractMetadata(html, fullPageUrl)
+
+          if (!metadata.image) {
+            ctx.set.status = 404
+            return new Response('No image found in page metadata', {
+              headers: { 'Content-Type': 'text/plain' },
+            })
+          }
+
+          const validation = validateImageUrl(metadata.image)
+          if (!validation.valid) {
+            ctx.set.status = 400
+            return new Response(validation.error || 'Invalid image URL', {
+              headers: { 'Content-Type': 'text/plain' },
+            })
+          }
+
+          return fetchAndProxyImage(metadata.image, fetchFn, ctx)
+        } finally {
+          clearTimeout(timeoutId)
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          ctx.set.status = 408
+          return new Response('Request timeout exceeded', {
+            headers: { 'Content-Type': 'text/plain' },
+          })
+        }
+
+        console.error('Link preview image error:', error)
+        ctx.set.status = 500
+        return new Response('Image fetch failed', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+    })
+    .get('/proxy-image/*', async (ctx) => {
+      const url = new URL(ctx.request.url)
+
+      const pathParts = url.pathname.split('/link-preview/proxy-image/')
+      if (pathParts.length < 2 || !pathParts[pathParts.length - 1]) {
+        ctx.set.status = 400
+        return new Response('No image URL provided', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      let imageUrl: string
+      try {
+        imageUrl = decodeURIComponent(pathParts[pathParts.length - 1])
+      } catch {
+        ctx.set.status = 400
+        return new Response('Invalid URL encoding', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      const fullImageUrl = imageUrl.includes('?') ? imageUrl : imageUrl + url.search
+
+      try {
+        const parsedUrl = new URL(fullImageUrl)
+        if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+          ctx.set.status = 400
+          return new Response('Only HTTP and HTTPS URLs are supported', {
+            headers: { 'Content-Type': 'text/plain' },
+          })
+        }
+      } catch {
+        ctx.set.status = 400
+        return new Response('Invalid URL provided', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      const validation = validateImageUrl(fullImageUrl)
+      if (!validation.valid) {
+        ctx.set.status = 400
+        return new Response(validation.error || 'Invalid image URL', {
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      }
+
+      return fetchAndProxyImage(fullImageUrl, fetchFn, ctx)
     })
 }

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -126,10 +126,10 @@ const inferImageContentType = (headerContentType: string | null, imageUrl: strin
 }
 
 /**
- * Validates that an image URL is safe to fetch (prevents SSRF attacks).
+ * Validates that a URL is safe to fetch (prevents SSRF attacks).
  * Only allows http/https protocols and blocks internal/private IP addresses.
  */
-const validateImageUrl = (url: string): { valid: boolean; error?: string } => {
+const validateSafeUrl = (url: string): { valid: boolean; error?: string } => {
   try {
     const parsed = new URL(url)
 
@@ -177,7 +177,7 @@ const validateImageUrl = (url: string): { valid: boolean; error?: string } => {
 
     return { valid: true }
   } catch {
-    return { valid: false, error: 'Invalid image URL' }
+    return { valid: false, error: 'Invalid URL' }
   }
 }
 
@@ -277,20 +277,12 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
         }
       }
 
-      try {
-        const parsedUrl = new URL(targetUrl)
-        if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-          return {
-            data: null,
-            success: false,
-            error: 'Only HTTP and HTTPS URLs are supported',
-          }
-        }
-      } catch {
+      const validation = validateSafeUrl(targetUrl)
+      if (!validation.valid) {
         return {
           data: null,
           success: false,
-          error: 'Invalid URL provided',
+          error: validation.error || 'Invalid URL provided',
         }
       }
 
@@ -318,7 +310,27 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
             }
           }
 
-          const html = await response.text()
+          const maxHtmlBytes = 2 * 1024 * 1024 // 2MB limit for HTML metadata extraction
+          const contentLength = response.headers.get('content-length')
+          const parsedLength = contentLength ? parseInt(contentLength, 10) : null
+          if (parsedLength !== null && !Number.isNaN(parsedLength) && parsedLength > maxHtmlBytes) {
+            return {
+              data: null,
+              success: false,
+              error: 'Response too large',
+            }
+          }
+
+          const buffer = await response.arrayBuffer()
+          if (buffer.byteLength > maxHtmlBytes) {
+            return {
+              data: null,
+              success: false,
+              error: 'Response too large',
+            }
+          }
+
+          const html = new TextDecoder().decode(buffer)
           const metadata = extractMetadata(html, targetUrl)
 
           return {
@@ -369,7 +381,7 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
       const fullPageUrl = pageUrl.includes('?') ? pageUrl : pageUrl + url.search
 
       // Validate URL format and SSRF protection on page URL
-      const pageValidation = validateImageUrl(fullPageUrl)
+      const pageValidation = validateSafeUrl(fullPageUrl)
       if (!pageValidation.valid) {
         ctx.set.status = 400
         return new Response(pageValidation.error || 'Invalid URL', {
@@ -410,7 +422,7 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
             })
           }
 
-          const validation = validateImageUrl(metadata.image)
+          const validation = validateSafeUrl(metadata.image)
           if (!validation.valid) {
             ctx.set.status = 400
             return new Response(validation.error || 'Invalid image URL', {
@@ -460,22 +472,7 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
 
       const fullImageUrl = imageUrl.includes('?') ? imageUrl : imageUrl + url.search
 
-      try {
-        const parsedUrl = new URL(fullImageUrl)
-        if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-          ctx.set.status = 400
-          return new Response('Only HTTP and HTTPS URLs are supported', {
-            headers: { 'Content-Type': 'text/plain' },
-          })
-        }
-      } catch {
-        ctx.set.status = 400
-        return new Response('Invalid URL provided', {
-          headers: { 'Content-Type': 'text/plain' },
-        })
-      }
-
-      const validation = validateImageUrl(fullImageUrl)
+      const validation = validateSafeUrl(fullImageUrl)
       if (!validation.valid) {
         ctx.set.status = 400
         return new Response(validation.error || 'Invalid image URL', {

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -29,6 +29,15 @@ const resolveUrl = (baseUrl: string, relativeUrl: string): string => {
   }
 }
 
+/** Decodes a URL path parameter, returning null on invalid encoding */
+const decodeUrlParam = (encoded: string): string | null => {
+  try {
+    return decodeURIComponent(encoded)
+  } catch {
+    return null
+  }
+}
+
 /**
  * Fetches and proxies an image with size limits and timeout.
  * Returns a Response with the image data or an error response.
@@ -257,10 +266,8 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
         }
       }
 
-      let pathOnly: string
-      try {
-        pathOnly = decodeURIComponent(pathParts[pathParts.length - 1])
-      } catch {
+      const pathOnly = decodeUrlParam(pathParts[pathParts.length - 1])
+      if (!pathOnly) {
         return {
           data: null,
           success: false,
@@ -368,10 +375,8 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
         })
       }
 
-      let pageUrl: string
-      try {
-        pageUrl = decodeURIComponent(pathParts[pathParts.length - 1])
-      } catch {
+      const pageUrl = decodeUrlParam(pathParts[pathParts.length - 1])
+      if (!pageUrl) {
         ctx.set.status = 400
         return new Response('Invalid URL encoding', {
           headers: { 'Content-Type': 'text/plain' },
@@ -412,7 +417,25 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
             })
           }
 
-          const html = await response.text()
+          const maxHtmlBytes = 2 * 1024 * 1024 // 2MB limit for HTML metadata extraction
+          const contentLength = response.headers.get('content-length')
+          const parsedLength = contentLength ? parseInt(contentLength, 10) : null
+          if (parsedLength !== null && !Number.isNaN(parsedLength) && parsedLength > maxHtmlBytes) {
+            ctx.set.status = 413
+            return new Response('Page response too large', {
+              headers: { 'Content-Type': 'text/plain' },
+            })
+          }
+
+          const buffer = await response.arrayBuffer()
+          if (buffer.byteLength > maxHtmlBytes) {
+            ctx.set.status = 413
+            return new Response('Page response too large', {
+              headers: { 'Content-Type': 'text/plain' },
+            })
+          }
+
+          const html = new TextDecoder().decode(buffer)
           const metadata = extractMetadata(html, fullPageUrl)
 
           if (!metadata.image) {
@@ -460,10 +483,8 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
         })
       }
 
-      let imageUrl: string
-      try {
-        imageUrl = decodeURIComponent(pathParts[pathParts.length - 1])
-      } catch {
+      const imageUrl = decodeUrlParam(pathParts[pathParts.length - 1])
+      if (!imageUrl) {
         ctx.set.status = 400
         return new Response('Invalid URL encoding', {
           headers: { 'Content-Type': 'text/plain' },

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -360,7 +360,7 @@ export const createLinkPreviewRoutes = (fetchFn: typeof fetch = globalThis.fetch
         return {
           data: null,
           success: false,
-          error: error instanceof Error ? error.message : 'Link preview request failed',
+          error: 'Link preview request failed',
         }
       }
     })

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -175,10 +175,6 @@ const validateImageUrl = (url: string): { valid: boolean; error?: string } => {
       }
     }
 
-    if (hostname.includes('metadata') || hostname.includes('169.254.169.254')) {
-      return { valid: false, error: 'Internal URLs are not allowed' }
-    }
-
     return { valid: true }
   } catch {
     return { valid: false, error: 'Invalid image URL' }

--- a/backend/src/pro/types.ts
+++ b/backend/src/pro/types.ts
@@ -114,6 +114,7 @@ export const linkPreviewDataSchema = z.object({
   title: z.string().nullable(),
   description: z.string().nullable(),
   image: z.string().nullable(),
+  siteName: z.string().nullable(),
 })
 
 export const linkPreviewResponseSchema = baseApiResponseSchema(linkPreviewDataSchema)

--- a/src/components/chat/text-part.tsx
+++ b/src/components/chat/text-part.tsx
@@ -1,5 +1,4 @@
 import { type ContentPart, parseContentParts } from '@/ai/widget-parser'
-import { decodeCitationSources } from '@/lib/citation-utils'
 import { sourceToCitation } from '@/lib/source-utils'
 import type { CitationMap, CitationSource } from '@/types/citation'
 import type { SourceMetadata } from '@/types/source'
@@ -15,14 +14,6 @@ type TextPartProps = {
   messageId: string
   sources?: SourceMetadata[]
 }
-
-/**
- * Text fragments that should be appended directly without a paragraph break:
- * - Punctuation/connectors between adjacent citations (e.g., ",", ".", ", and")
- * - Table row continuations that start with | (internal \n is preserved by the parser)
- */
-const shouldAppendInline = (text: string): boolean =>
-  /^[,;.·\s]*(and|or|,|;|\.)*\s*$/i.test(text) || text.trimStart().startsWith('|')
 
 /**
  * Matches one or more adjacent [N] citations separated by optional whitespace.
@@ -86,46 +77,6 @@ export const buildSourceCitationPlaceholders = (
   return { fullText, citations }
 }
 
-/**
- * Builds a single markdown string with {{CITE:N}} placeholders at the positions
- * where the AI placed citation widgets, and returns the citation data map.
- */
-const buildTextWithCitationPlaceholders = (
-  contentParts: ReturnType<typeof parseContentParts>,
-): { fullText: string; citations: CitationMap } => {
-  let fullText = ''
-  const citations: CitationMap = new Map()
-  const parts = [...contentParts]
-
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i]
-    if (part.type === 'text') {
-      if (fullText.length === 0 || shouldAppendInline(part.content)) {
-        fullText += part.content
-      } else if (!fullText.endsWith('\n\n')) {
-        fullText += '\n\n' + part.content
-      } else {
-        fullText += part.content
-      }
-    } else if (part.type === 'widget' && part.widget.widget === 'citation') {
-      const sources = decodeCitationSources(part.widget.args.sources)
-      if (sources) {
-        // Consume a leading period from the next text part so the citation
-        // renders after the sentence end: "sentence. [Source]"
-        const next = parts[i + 1]
-        if (next?.type === 'text' && next.content.startsWith('.')) {
-          fullText = fullText.trimEnd() + '.'
-          parts[i + 1] = { ...next, content: next.content.slice(1) }
-        }
-        fullText = fullText.trimEnd() + ` {{CITE:${citations.size}}}`
-        citations.set(citations.size, sources)
-      }
-    }
-  }
-
-  return { fullText, citations }
-}
-
 export const TextPart = memo(({ part, messageId, sources }: TextPartProps) => {
   const hasNewSources = !!sources && sources.length > 0
 
@@ -143,7 +94,6 @@ export const TextPart = memo(({ part, messageId, sources }: TextPartProps) => {
 
     const parts = parseContentParts(part.text)
 
-    // Path A: new [N] format — sources metadata exists
     if (hasNewSources) {
       const textContent = parts
         .filter((p) => p.type === 'text')
@@ -155,20 +105,13 @@ export const TextPart = memo(({ part, messageId, sources }: TextPartProps) => {
       return { contentParts: parts, ...result, hasCitations: hasCit, hasText: textContent.length > 0 }
     }
 
-    // Path B: old <widget:citation> format (backward compat)
-    const hasCit = parts.some((p) => p.type === 'widget' && p.widget.widget === 'citation')
     const hasTxt = parts.some((p) => p.type === 'text')
-
-    if (hasCit && hasTxt) {
-      const result = buildTextWithCitationPlaceholders(parts)
-      return { contentParts: parts, ...result, hasCitations: true, hasText: true }
-    }
 
     return {
       contentParts: parts,
       fullText: '',
       citations: new Map() as CitationMap,
-      hasCitations: hasCit,
+      hasCitations: false,
       hasText: hasTxt,
     }
   }, [part.text, hasNewSources, sources])

--- a/src/integrations/thunderbolt-pro/schemas.ts
+++ b/src/integrations/thunderbolt-pro/schemas.ts
@@ -109,4 +109,5 @@ export type LinkPreviewData = {
   title: string | null
   description: string | null
   image: string | null
+  siteName: string | null
 }

--- a/src/integrations/thunderbolt-pro/tools.ts
+++ b/src/integrations/thunderbolt-pro/tools.ts
@@ -3,7 +3,7 @@ import { deriveSiteName } from '@/lib/source-utils'
 import type { ToolConfig } from '@/types'
 import type { SourceMetadata } from '@/types/source'
 import ky from 'ky'
-import { fetchContent, getCurrentWeather, getWeatherForecast, search, searchLocations } from './api'
+import { fetchContent, fetchLinkPreview, getCurrentWeather, getWeatherForecast, search, searchLocations } from './api'
 import {
   fetchContentSchema,
   searchLocationSchema,
@@ -82,10 +82,15 @@ export const createConfigs = (httpClient: HttpClient, sourceCollector?: SourceMe
       verb: 'fetching {url}',
       parameters: fetchContentSchema,
       execute: async (params: FetchContentParams) => {
-        const result = await fetchContent(params, httpClient)
+        // Fetch content and link preview in parallel — link preview gives us og:site_name
+        const [result, preview] = await Promise.all([
+          fetchContent(params, httpClient),
+          fetchLinkPreview({ url: params.url }, httpClient).catch(() => null),
+        ])
 
         if (!result) return result
 
+        const ogSiteName = preview?.siteName
         const existingSource = sourceCollector?.find((s) => s.url === result.url)
         const sourceIndex = existingSource ? existingSource.index : nextIndex
 
@@ -95,9 +100,9 @@ export const createConfigs = (httpClient: HttpClient, sourceCollector?: SourceMe
             url: result.url,
             title: result.title ?? result.url,
             description: result.text?.slice(0, 200),
-            image: result.image,
+            image: preview?.image ?? result.image,
             favicon: result.favicon,
-            siteName: deriveSiteName(result.url),
+            siteName: ogSiteName || deriveSiteName(result.url),
             author: result.author,
             publishedDate: result.published_date,
             toolName: 'fetch_content',
@@ -107,8 +112,9 @@ export const createConfigs = (httpClient: HttpClient, sourceCollector?: SourceMe
           // fetch_content has the authoritative page title — update the existing entry
           if (result.title) existingSource.title = result.title
           if (result.text) existingSource.description = result.text.slice(0, 200)
-          if (result.image) existingSource.image = result.image
+          if (preview?.image ?? result.image) existingSource.image = preview?.image ?? result.image
           if (result.favicon) existingSource.favicon = result.favicon
+          if (ogSiteName) existingSource.siteName = ogSiteName
           if (result.author) existingSource.author = result.author
           if (result.published_date) existingSource.publishedDate = result.published_date
         } else {

--- a/src/integrations/thunderbolt-pro/tools.ts
+++ b/src/integrations/thunderbolt-pro/tools.ts
@@ -68,6 +68,11 @@ export const createConfigs = (httpClient: HttpClient, sourceCollector?: SourceMe
             })
             nextIndex++
           } else if (!existingSource) {
+            if (sourceCollector && sourceCollector.length >= sourceRegistryCap) {
+              console.warn(
+                `Source registry cap (${sourceRegistryCap}) reached — dropping source [${sourceIndex}]: ${result.url}`,
+              )
+            }
             nextIndex++
           }
 
@@ -118,6 +123,11 @@ export const createConfigs = (httpClient: HttpClient, sourceCollector?: SourceMe
           if (result.author) existingSource.author = result.author
           if (result.published_date) existingSource.publishedDate = result.published_date
         } else {
+          if (sourceCollector && sourceCollector.length >= sourceRegistryCap) {
+            console.warn(
+              `Source registry cap (${sourceRegistryCap}) reached — dropping source [${sourceIndex}]: ${result.url}`,
+            )
+          }
           nextIndex++
         }
 

--- a/src/widgets/link-preview/display.tsx
+++ b/src/widgets/link-preview/display.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react'
 
 type LinkPreviewProps = {
   url: string
-  title: string | null
+  title: string // Required: parent component must provide hostname fallback if backend returns null
   description: string | null
   image: string | null
 }
@@ -59,7 +59,7 @@ export const LinkPreview = ({ description, image, title, url }: LinkPreviewProps
               </>
             )}
           </div>
-          <CardHeader className="flex-1 flex flex-col pl-4 py-4">
+          <CardHeader className="flex-1 flex flex-col gap-1.5 pl-4 pt-4 pb-4">
             <CardTitle className="line-clamp-1">{title}</CardTitle>
             {description && <CardDescription className="line-clamp-2">{description}</CardDescription>}
           </CardHeader>

--- a/src/widgets/link-preview/stories.tsx
+++ b/src/widgets/link-preview/stories.tsx
@@ -193,3 +193,51 @@ export const ImageError: Story = {
     },
   },
 }
+
+export const HostnameAsTitleFallback: Story = {
+  args: {
+    url: 'https://www.example.com/some/long/path',
+    title: 'example.com',
+    description: 'A page where the hostname is used as the title fallback instead of the full URL',
+    image: null,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'When no og:title is found, the hostname is used as the title instead of the full URL',
+      },
+    },
+  },
+}
+
+export const MinimalPreview: Story = {
+  args: {
+    url: 'https://blocked-site.example.com/captcha',
+    title: 'blocked-site.example.com',
+    description: null,
+    image: null,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Minimal preview card shown when no metadata was found (e.g., captcha pages) - uses hostname as title',
+      },
+    },
+  },
+}
+
+export const MinimalPreviewLongHostname: Story = {
+  args: {
+    url: 'https://very-long-subdomain.deeply-nested.example.co.uk/path',
+    title: 'very-long-subdomain.deeply-nested.example.co.uk',
+    description: null,
+    image: null,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Minimal preview card with a long hostname to verify truncation',
+      },
+    },
+  },
+}

--- a/src/widgets/link-preview/utils.test.ts
+++ b/src/widgets/link-preview/utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import { getHostname } from './utils'
+
+describe('getHostname', () => {
+  test('extracts hostname from valid URL', () => {
+    expect(getHostname('https://example.com/path')).toBe('example.com')
+  })
+
+  test('strips www. prefix', () => {
+    expect(getHostname('https://www.example.com/path')).toBe('example.com')
+  })
+
+  test('preserves subdomains that are not www', () => {
+    expect(getHostname('https://blog.example.com')).toBe('blog.example.com')
+  })
+
+  test('handles URLs with ports', () => {
+    expect(getHostname('https://example.com:8080/path')).toBe('example.com')
+  })
+
+  test('handles URLs with query strings', () => {
+    expect(getHostname('https://example.com/page?q=test')).toBe('example.com')
+  })
+
+  test('returns Unknown for empty string', () => {
+    expect(getHostname('')).toBe('Unknown')
+  })
+
+  test('returns Unknown for whitespace-only string', () => {
+    expect(getHostname('   ')).toBe('Unknown')
+  })
+
+  test('falls back to regex extraction for malformed URLs', () => {
+    expect(getHostname('not-a-url')).toBe('not-a-url')
+  })
+
+  test('extracts hostname from URL-like strings without protocol', () => {
+    expect(getHostname('http://example.com')).toBe('example.com')
+  })
+
+  test('truncates very long hostnames', () => {
+    const longHostname = 'a'.repeat(60)
+    const result = getHostname(longHostname)
+    expect(result.length).toBeLessThanOrEqual(50)
+    expect(result).toEndWith('...')
+  })
+
+  test('handles http protocol', () => {
+    expect(getHostname('http://example.com/page')).toBe('example.com')
+  })
+
+  test('strips www. in regex fallback path', () => {
+    expect(getHostname('www.example.com/path')).toBe('example.com')
+  })
+})

--- a/src/widgets/link-preview/utils.ts
+++ b/src/widgets/link-preview/utils.ts
@@ -1,0 +1,21 @@
+/** Extracts a clean hostname from a URL (strips "www." prefix) */
+export const getHostname = (url: string): string => {
+  if (!url || !url.trim()) {
+    return 'Unknown'
+  }
+
+  try {
+    const parsed = new URL(url)
+    const hostname = parsed.hostname.replace(/^www\./, '')
+    return hostname || 'Unknown'
+  } catch {
+    // If URL parsing fails, try to extract hostname-like string from the input
+    // This handles edge cases like malformed URLs while still providing some value
+    const match = url.match(/^(?:https?:\/\/)?([^/\s?#]+)/i)
+    if (match && match[1]) {
+      const hostname = match[1].replace(/^www\./, '')
+      return hostname.length > 50 ? `${hostname.slice(0, 47)}...` : hostname
+    }
+    return url.length > 50 ? `${url.slice(0, 47)}...` : url
+  }
+}

--- a/src/widgets/link-preview/widget.test.tsx
+++ b/src/widgets/link-preview/widget.test.tsx
@@ -67,7 +67,7 @@ describe('LinkPreviewWidget', () => {
       )
 
       const img = container.querySelector('img')
-      expect(img?.getAttribute('src')).toContain('/pro/proxy/')
+      expect(img?.getAttribute('src')).toContain('/pro/link-preview/proxy-image/')
       expect(img?.getAttribute('src')).toContain(encodeURIComponent('https://example.com/photo.jpg'))
     })
 

--- a/src/widgets/link-preview/widget.tsx
+++ b/src/widgets/link-preview/widget.tsx
@@ -16,6 +16,7 @@ type LinkPreviewWidgetProps = {
     title: string | null
     description: string | null
     image: string | null
+    siteName?: string | null
   }>
 }
 
@@ -40,10 +41,16 @@ export const LinkPreviewSkeleton = () => {
   )
 }
 
-/** Builds a proxied image URL for the link preview image endpoint */
+/** Builds a proxied image URL via /proxy-image (when direct image URL is known) */
 const buildProxyImageUrl = (imageUrl: string | null | undefined, cloudUrl: string | null): string | null => {
   if (!imageUrl || !cloudUrl?.trim()) return null
   return `${cloudUrl}/pro/link-preview/proxy-image/${encodeURIComponent(imageUrl)}`
+}
+
+/** Builds an image URL via /image (extracts og:image from page and proxies it in one request) */
+const buildPageImageUrl = (pageUrl: string, cloudUrl: string | null): string | null => {
+  if (!pageUrl || !cloudUrl?.trim()) return null
+  return `${cloudUrl}/pro/link-preview/image/${encodeURIComponent(pageUrl)}`
 }
 
 /** Renders a link preview instantly from source registry metadata */
@@ -88,6 +95,7 @@ const FetchLinkPreview = ({
     title: string | null
     description: string | null
     image: string | null
+    siteName?: string | null
   }>
 }) => {
   const fetchFn = fetchPreviewFn ?? fetchLinkPreview
@@ -100,12 +108,13 @@ const FetchLinkPreview = ({
         title: preview.title,
         description: preview.description,
         image: preview.image,
-        siteName: 'siteName' in preview ? (preview.siteName as string | null) : null,
+        siteName: preview.siteName ?? null,
       }
     },
   })
 
-  const imageUrl = buildProxyImageUrl(data?.image, cloudUrl)
+  // Prefer proxying the known image URL; fall back to /image/ which extracts og:image from the page
+  const imageUrl = data?.image ? buildProxyImageUrl(data.image, cloudUrl) : buildPageImageUrl(url, cloudUrl)
 
   if (isLoading) {
     return <LinkPreviewSkeleton />

--- a/src/widgets/link-preview/widget.tsx
+++ b/src/widgets/link-preview/widget.tsx
@@ -5,6 +5,7 @@ import { useSettings } from '@/hooks/use-settings'
 import { fetchLinkPreview } from '@/integrations/thunderbolt-pro/api'
 import type { SourceMetadata } from '@/types/source'
 import { LinkPreview } from './display'
+import { getHostname } from './utils'
 
 type LinkPreviewWidgetProps = {
   url: string
@@ -12,16 +13,17 @@ type LinkPreviewWidgetProps = {
   sources?: SourceMetadata[]
   messageId: string
   fetchPreviewFn?: (params: { url: string }) => Promise<{
-    title: string
-    description: string
+    title: string | null
+    description: string | null
     image: string | null
   }>
 }
 
 type LinkPreviewMetadata = {
-  title: string
-  description: string
+  title: string | null
+  description: string | null
   image: string | null
+  siteName: string | null
 }
 
 export const LinkPreviewSkeleton = () => {
@@ -40,12 +42,15 @@ export const LinkPreviewSkeleton = () => {
 
 /** Renders a link preview instantly from source registry metadata */
 const InstantLinkPreview = ({ sourceData, cloudUrl }: { sourceData: SourceMetadata; cloudUrl: string | null }) => {
-  const imageUrl = sourceData.image && cloudUrl ? `${cloudUrl}/pro/proxy/${encodeURIComponent(sourceData.image)}` : null
+  const imageUrl =
+    sourceData.image && cloudUrl
+      ? `${cloudUrl}/pro/link-preview/proxy-image/${encodeURIComponent(sourceData.image)}`
+      : null
 
   return (
     <LinkPreview
-      title={sourceData.title}
-      description={sourceData.description ?? ''}
+      title={sourceData.title || getHostname(sourceData.url)}
+      description={sourceData.description ?? null}
       url={sourceData.url}
       image={imageUrl}
     />
@@ -79,8 +84,8 @@ const FetchLinkPreview = ({
   messageId: string
   cloudUrl: string | null
   fetchPreviewFn?: (params: { url: string }) => Promise<{
-    title: string
-    description: string
+    title: string | null
+    description: string | null
     image: string | null
   }>
 }) => {
@@ -91,27 +96,34 @@ const FetchLinkPreview = ({
     fetchFn: async () => {
       const preview = await fetchFn({ url })
       return {
-        title: preview.title || url,
-        description: preview.description || '',
+        title: preview.title,
+        description: preview.description,
         image: preview.image,
+        siteName: 'siteName' in preview ? (preview.siteName as string | null) : null,
       }
     },
   })
+
+  const imageUrl =
+    data?.image && cloudUrl && cloudUrl.trim()
+      ? `${cloudUrl}/pro/link-preview/proxy-image/${encodeURIComponent(data.image)}`
+      : null
 
   if (isLoading) {
     return <LinkPreviewSkeleton />
   }
 
-  if (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Failed to load preview'
-    return <LinkPreview title={url} description={errorMessage} url={url} image={null} />
+  if (error || !data) {
+    if (error) console.warn('Link preview failed:', url)
+    return <LinkPreview title={getHostname(url)} description={null} url={url} image={null} />
   }
 
-  if (!data) {
-    return <LinkPreview title={url} description="Failed to load preview" url={url} image={null} />
+  const isEmpty = !data.title && !data.description && !data.image
+  if (isEmpty) {
+    return <LinkPreview title={getHostname(url)} description={null} url={url} image={null} />
   }
 
-  const imageUrl = data.image && cloudUrl ? `${cloudUrl}/pro/proxy/${encodeURIComponent(data.image)}` : null
+  const displayTitle = data.title || data.siteName || getHostname(url)
 
-  return <LinkPreview title={data.title} description={data.description} url={url} image={imageUrl} />
+  return <LinkPreview title={displayTitle} description={data.description} url={url} image={imageUrl} />
 }

--- a/src/widgets/link-preview/widget.tsx
+++ b/src/widgets/link-preview/widget.tsx
@@ -40,19 +40,20 @@ export const LinkPreviewSkeleton = () => {
   )
 }
 
+/** Builds a proxied image URL for the link preview image endpoint */
+const buildProxyImageUrl = (imageUrl: string | null | undefined, cloudUrl: string | null): string | null => {
+  if (!imageUrl || !cloudUrl?.trim()) return null
+  return `${cloudUrl}/pro/link-preview/proxy-image/${encodeURIComponent(imageUrl)}`
+}
+
 /** Renders a link preview instantly from source registry metadata */
 const InstantLinkPreview = ({ sourceData, cloudUrl }: { sourceData: SourceMetadata; cloudUrl: string | null }) => {
-  const imageUrl =
-    sourceData.image && cloudUrl
-      ? `${cloudUrl}/pro/link-preview/proxy-image/${encodeURIComponent(sourceData.image)}`
-      : null
-
   return (
     <LinkPreview
       title={sourceData.title || getHostname(sourceData.url)}
       description={sourceData.description ?? null}
       url={sourceData.url}
-      image={imageUrl}
+      image={buildProxyImageUrl(sourceData.image, cloudUrl)}
     />
   )
 }
@@ -104,10 +105,7 @@ const FetchLinkPreview = ({
     },
   })
 
-  const imageUrl =
-    data?.image && cloudUrl && cloudUrl.trim()
-      ? `${cloudUrl}/pro/link-preview/proxy-image/${encodeURIComponent(data.image)}`
-      : null
+  const imageUrl = buildProxyImageUrl(data?.image, cloudUrl)
 
   if (isLoading) {
     return <LinkPreviewSkeleton />
@@ -118,7 +116,7 @@ const FetchLinkPreview = ({
     return <LinkPreview title={getHostname(url)} description={null} url={url} image={null} />
   }
 
-  const isEmpty = !data.title && !data.description && !data.image
+  const isEmpty = !data.title && !data.description && !data.image && !data.siteName
   if (isEmpty) {
     return <LinkPreview title={getHostname(url)} description={null} url={url} image={null} />
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Introduces new network-facing proxy endpoints and changes URL validation/SSRF logic; mistakes could reintroduce SSRF or break preview fetching for legitimate URLs despite added test coverage.
> 
> **Overview**
> Improves the `/pro/link-preview` backend to add **SSRF protection** (blocks localhost/private IPs incl. IPv6/IPv4-mapped), robust URL decoding/validation, and **2MB HTML size limits**, while extending extracted metadata to include `og:site_name` and avoiding title/description fallbacks on pages with no social tags.
> 
> Adds new endpoints to serve preview images safely: `/link-preview/image/*` (fetch page, extract `og:image`, then proxy) and `/link-preview/proxy-image/*` (proxy a direct image URL), both with **2MB image limits**, short timeouts, inferred content types, and clearer status/error handling.
> 
> Updates the frontend link preview widget to use the new proxy endpoints, prefer hostname/`siteName`/title fallbacks (including a new `getHostname` helper + tests and new Storybook scenarios), and drops legacy citation widget placeholder support in `TextPart`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45732334ea607b53e84a816a69ddee04c54a804f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->