### PR TITLE
chore: reduce Claude PR reviewer noise with parallel agents

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,25 +55,121 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Resolve previous Claude review threads so each run starts clean.
+      # Uses GraphQL because review threads don't exist in the REST API.
+      - name: Resolve previous Claude review threads
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          THREADS=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $number) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      id
+                      isResolved
+                      comments(first: 1) {
+                        nodes { author { login } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' -f owner="$REPO_OWNER" \
+            -f repo="$REPO_NAME" \
+            -F number="$PR_NUMBER")
+
+          THREAD_IDS=$(echo "$THREADS" | jq -r '
+            .data.repository.pullRequest.reviewThreads.nodes[]
+            | select(.isResolved == false)
+            | select(.comments.nodes[0].author.login == "github-actions[bot]")
+            | .id
+          ')
+
+          if [ -z "$THREAD_IDS" ]; then
+            echo "No previous review threads to resolve"
+            exit 0
+          fi
+
+          echo "$THREAD_IDS" | while read -r thread_id; do
+            [ -z "$thread_id" ] && continue
+            gh api graphql -f query='
+              mutation($threadId: ID!) {
+                resolveReviewThread(input: {threadId: $threadId}) {
+                  thread { id }
+                }
+              }
+            ' -f threadId="$thread_id" > /dev/null
+            echo "Resolved thread: $thread_id"
+          done
+
       - name: PR Review with Claude
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           allowed_bots: 'dependabot[bot],renovate[bot]'
+          include_fix_links: true
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            Your goal is HIGH-SIGNAL, LOW-NOISE feedback.
 
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+            ## Step 1 — Gather context
+            Read the project's CLAUDE.md and get the PR diff using `gh pr diff`.
 
-            Note: The PR branch is already checked out in the current working directory.
+            ## Step 2 — Parallel review
+            Launch these 3 review agents in parallel using the Task tool (subagent_type: "Explore").
+            Each agent must ONLY flag issues INTRODUCED in this PR — ignore pre-existing code.
+            Each agent must return findings as a list: description, file path, line number(s), confidence (0-100), category.
+            Each agent must ONLY return findings with confidence >= 80.
 
-            Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
-            Only post GitHub comments - don't submit review text as messages.
+            **Agent 1 — Bugs & Data Loss**
+            Analyze the changed files for: logic errors, null/undefined access, race conditions,
+            off-by-one errors, broken control flow, silent failures, dropped errors,
+            incorrect mutations, missing rollbacks.
+
+            **Agent 2 — Security & Breaking Changes**
+            Analyze the changed files for: injection, XSS, auth bypasses, credential exposure,
+            SSRF, API contract violations, backwards-incompatible changes.
+
+            **Agent 3 — Project Convention Compliance**
+            Read CLAUDE.md and check the changed files against project guidelines.
+            Only flag violations where CLAUDE.md EXPLICITLY addresses the pattern.
+            Return the specific CLAUDE.md rule violated with each finding.
+
+            ## Step 3 — Consolidate and post
+            After all agents complete:
+            1. Merge findings, remove duplicates (same file + line range)
+            2. Keep only findings with confidence >= 80
+            3. Sort by confidence descending
+
+            ## NEVER include
+            - Style, formatting, naming (linting handles this)
+            - Refactoring or "nice to have" suggestions
+            - Missing comments, docs, or type annotations
+            - Performance micro-optimizations without measurable impact
+            - Subjective preferences
+            - Pre-existing issues not introduced in this PR
+            - Code that looks unusual but works correctly
+
+            ## Posting rules
+            Post ONE summary via `gh pr comment`:
+            - If no issues survive the filter, approve in one sentence. Do NOT invent issues.
+            - If there are issues, list them grouped by category with file:line references.
+
+            Use `mcp__github_inline_comment__create_inline_comment` for at most 5 inline comments.
+            Fewer is better. Zero is fine.
+
+            For each comment:
+            - Max one short paragraph
+            - Describe the exact scenario where the bug manifests
+            - State WHAT is wrong and HOW to fix it
+            - No code suggestions longer than 3 lines
+            - Matter-of-fact tone
+
+            Only post GitHub comments — don't submit review text as messages.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Task,Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(git log:*),Bash(git blame:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only changes that affect review automation, with minimal risk beyond potential `gh`/GraphQL step failures or unintended thread resolution.
> 
> **Overview**
> **Reduces Claude auto-review noise and improves repeat-run hygiene** in `.github/workflows/claude.yml`.
> 
> Each PR review run now auto-resolves any previous unresolved review threads authored by `github-actions[bot]` via a `gh api graphql` step, so fresh runs don’t pile onto old discussions. The Claude action is reconfigured to use a stricter, parallel “3-agent” review prompt (bugs/data loss, security/breaking changes, and CLAUDE.md convention compliance), post a single top-level summary, and limit inline comments; it also enables `include_fix_links` and expands the allowed tool list to include `Task` and repo inspection commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7f962ca2a524435010d6d856425650b091bb757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->