### PR TITLE
[Prompt Separation] 3 - Mistral Citation Reinforcement

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -1,5 +1,6 @@
 import { createPrompt } from '@/ai/prompt'
 import { getModelConfig } from '@/ai/prompts'
+import { mistralCitationReinforcement } from '@/ai/prompts/vendors/mistral/citation-reinforcement'
 import {
   extractTextFromMessages,
   getNudgeMessages,
@@ -259,10 +260,17 @@ export const aiFetchStreamingResponse = async ({
         providerOptions,
 
         prepareStep: ({ steps, stepNumber, messages: stepMessages }) => {
+          // Mistral citation reinforcement: after tool calls, strengthen the system prompt
+          // with citation format instructions (system prompt = highest authority for Mistral)
+          const isMistral = model.vendor === 'mistral'
+          const hadToolCallSteps = steps.some((s) => s.finishReason === 'tool-calls')
+          const citationSystem = isMistral && hadToolCallSteps ? systemPrompt + mistralCitationReinforcement : undefined
+
           // Final step: disable tools to force a response
           if (isFinalStep(steps.length, maxSteps)) {
             console.info(`Final step ${stepNumber} - telling model to wrap it up...`)
             return {
+              ...(citationSystem && { system: citationSystem }),
               activeTools: [],
               messages: [...stepMessages, { role: 'user' as const, content: activeNudges.finalStep }],
             }
@@ -271,8 +279,14 @@ export const aiFetchStreamingResponse = async ({
           // Nudge after many tool calls (but not on final step)
           if (shouldShowPreventiveNudge(steps, nudgeThreshold)) {
             return {
+              ...(citationSystem && { system: citationSystem }),
               messages: [...stepMessages, { role: 'user' as const, content: activeNudges.preventive }],
             }
+          }
+
+          // For Mistral: reinforce citations via system prompt even without a nudge
+          if (citationSystem) {
+            return { system: citationSystem }
           }
         },
 

--- a/src/ai/prompts/vendors/mistral/citation-reinforcement.ts
+++ b/src/ai/prompts/vendors/mistral/citation-reinforcement.ts
@@ -1,0 +1,19 @@
+/**
+ * Dynamic system prompt reinforcement for Mistral citation compliance.
+ *
+ * Mistral's native citation system uses structured ReferenceChunk objects,
+ * but through vLLM's OpenAI-compatible API this mechanism is unavailable.
+ * The model sometimes falls back to its training (no text-based citations)
+ * rather than following prompt instructions.
+ *
+ * This reinforcement is appended to the system prompt on later steps
+ * (after tool calls) via prepareStep's `system` override — the highest
+ * authority channel for instruction-tuned models.
+ */
+export const mistralCitationReinforcement = `
+
+<citation-format>
+When writing your response, place [N] after each fact from a tool result.
+N = the source number shown in the tool result as [Source N].
+Every paragraph must contain at least one [N] reference.
+</citation-format>`


### PR DESCRIPTION
## Summary
- Adds `citation-reinforcement.ts` for Mistral that injects a system-level citation nudge when the model hasn't cited sources after N tool calls
- Wires the reinforcement into `fetch.ts` via the existing `createPrompt` pipeline

## Stack context
This is **PR 3 of 3** in a stacked series:
- [PR 1] Evaluation Framework (`italomenezes/eval-framework`)
- [PR 2] Prompt Architecture Refactor (`italomenezes/prompt-architecture`)
- **→ [PR 3] Mistral Citation Reinforcement** ← you are here