### PR TITLE
THU-308: Mobile sidebar opens 80%, dims/blurs content

### DIFF
--- a/src/components/ui/mobile-sidebar.tsx
+++ b/src/components/ui/mobile-sidebar.tsx
@@ -24,24 +24,13 @@ export const MobileSidebar = ({
   const [internalOpen, setInternalOpen] = useState(open)
   const x = useMotionValue(0)
 
-  const [sidebarWidth, setSidebarWidth] = useState(() =>
-    typeof window !== 'undefined' ? window.innerWidth * 0.8 : 300,
-  )
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const updateWidth = () => setSidebarWidth(window.innerWidth * 0.8)
-    window.addEventListener('resize', updateWidth)
-    window.addEventListener('orientationchange', updateWidth)
-    return () => {
-      window.removeEventListener('resize', updateWidth)
-      window.removeEventListener('orientationchange', updateWidth)
-    }
-  }, [])
+  // Calculate 80vw inline - no need to track in state since CSS already handles the visual width
+  const getSidebarWidth = () => (typeof window !== 'undefined' ? window.innerWidth * 0.8 : 300)
 
   // Transform x position to overlay opacity (fade out as sidebar moves away).
   // Output [0, 1] so backdrop-blur and bg dimming render at full strength when open
   // (opacity multiplies the whole composited layer including backdrop-filter).
+  const sidebarWidth = getSidebarWidth()
   const overlayOpacity = useTransform(
     x,
     side === 'left' ? [-sidebarWidth, 0] : [0, sidebarWidth],
@@ -50,10 +39,11 @@ export const MobileSidebar = ({
 
   // Handle external open/close requests
   useEffect(() => {
+    const width = getSidebarWidth()
     if (open && !internalOpen) {
       // Opening: set position first, then animate in
       // Set position synchronously before rendering to avoid flicker
-      x.set(side === 'left' ? -sidebarWidth : sidebarWidth)
+      x.set(side === 'left' ? -width : width)
       setInternalOpen(true)
 
       // Animate to position after render
@@ -74,7 +64,7 @@ export const MobileSidebar = ({
       // Closing: animate first, then close
       const animateClose = async () => {
         setIsAnimating(true)
-        await animate(x, side === 'left' ? -sidebarWidth : sidebarWidth, {
+        await animate(x, side === 'left' ? -width : width, {
           type: 'spring',
           // Same optimized spring physics for consistent feel across all animations
           damping: 35,
@@ -86,13 +76,14 @@ export const MobileSidebar = ({
       }
       animateClose()
     }
-  }, [open, internalOpen, isAnimating, x, side, sidebarWidth])
+  }, [open, internalOpen, isAnimating, x, side])
 
   const handleClose = async () => {
     if (isAnimating) return
 
+    const width = getSidebarWidth()
     setIsAnimating(true)
-    await animate(x, side === 'left' ? -sidebarWidth : sidebarWidth, {
+    await animate(x, side === 'left' ? -width : width, {
       type: 'spring',
       // Same optimized spring physics for consistent feel across all animations
       damping: 35,
@@ -140,8 +131,8 @@ export const MobileSidebar = ({
         <motion.div
           drag="x"
           dragConstraints={{
-            left: side === 'left' ? -sidebarWidth : 0,
-            right: side === 'left' ? 0 : sidebarWidth,
+            left: side === 'left' ? -getSidebarWidth() : 0,
+            right: side === 'left' ? 0 : getSidebarWidth(),
           }}
           dragElastic={0.2}
           onDragEnd={handleDragEnd}

--- a/src/components/ui/mobile-sidebar.tsx
+++ b/src/components/ui/mobile-sidebar.tsx
@@ -23,14 +23,29 @@ export const MobileSidebar = ({
   const [isAnimating, setIsAnimating] = useState(false)
   const [internalOpen, setInternalOpen] = useState(open)
   const x = useMotionValue(0)
-  // Sidebar takes 80% of screen width
-  const sidebarWidth = typeof window !== 'undefined' ? window.innerWidth * 0.8 : 300
 
-  // Transform x position to overlay opacity (fade out as sidebar moves away)
+  const [sidebarWidth, setSidebarWidth] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth * 0.8 : 300,
+  )
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const updateWidth = () => setSidebarWidth(window.innerWidth * 0.8)
+    window.addEventListener('resize', updateWidth)
+    window.addEventListener('orientationchange', updateWidth)
+    return () => {
+      window.removeEventListener('resize', updateWidth)
+      window.removeEventListener('orientationchange', updateWidth)
+    }
+  }, [])
+
+  // Transform x position to overlay opacity (fade out as sidebar moves away).
+  // Output [0, 1] so backdrop-blur and bg dimming render at full strength when open
+  // (opacity multiplies the whole composited layer including backdrop-filter).
   const overlayOpacity = useTransform(
     x,
     side === 'left' ? [-sidebarWidth, 0] : [0, sidebarWidth],
-    side === 'left' ? [0, 0.5] : [0.5, 0],
+    side === 'left' ? [0, 1] : [1, 0],
   )
 
   // Handle external open/close requests

--- a/src/components/ui/mobile-sidebar.tsx
+++ b/src/components/ui/mobile-sidebar.tsx
@@ -23,7 +23,8 @@ export const MobileSidebar = ({
   const [isAnimating, setIsAnimating] = useState(false)
   const [internalOpen, setInternalOpen] = useState(open)
   const x = useMotionValue(0)
-  const sidebarWidth = typeof window !== 'undefined' ? window.innerWidth : 375
+  // Sidebar takes 80% of screen width
+  const sidebarWidth = typeof window !== 'undefined' ? window.innerWidth * 0.8 : 300
 
   // Transform x position to overlay opacity (fade out as sidebar moves away)
   const overlayOpacity = useTransform(
@@ -109,9 +110,9 @@ export const MobileSidebar = ({
   return (
     <DialogPrimitive.Root open={internalOpen}>
       <DialogPrimitive.Portal>
-        {/* Animated overlay */}
+        {/* Animated overlay with blur */}
         <motion.div
-          className="fixed inset-0 z-50 bg-sidebar"
+          className="fixed inset-0 z-50 bg-black/40 backdrop-blur-lg"
           style={{
             opacity: overlayOpacity,
             // willChange hints to browser this property will animate, enabling GPU acceleration
@@ -137,7 +138,7 @@ export const MobileSidebar = ({
             ...style,
           }}
           className={cn(
-            'bg-sidebar text-sidebar-foreground fixed inset-y-0 z-50 h-full w-full border-r shadow-lg flex flex-col',
+            'bg-sidebar text-sidebar-foreground fixed inset-y-0 z-50 h-full w-[80vw] border-r shadow-lg flex flex-col',
             side === 'left' ? 'left-0' : 'right-0',
             className,
           )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only changes to sidebar sizing and overlay animation; low risk aside from possible layout/animation regressions on some mobile widths/SSR.
> 
> **Overview**
> Updates `MobileSidebar` to render at a fixed `80vw` width (instead of full-width) and recalculates animation/drag distances from `window.innerWidth * 0.8`.
> 
> Changes the overlay to use a dimmed, blurred backdrop (`bg-black/40 backdrop-blur-lg`) and adjusts the overlay opacity transform to animate to full strength (`1`) when open, with corresponding dependency cleanup in the open/close effect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f7d53c019d23f45de7692842c3be5642733e6d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->