### PR TITLE
THU-278: Back button from settings now returns to correct chat, or falls back to new chat

### DIFF
--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -161,9 +161,8 @@ export default function Sidebar() {
   }
 
   const goToMainMenu = async () => {
-    // Only block navigation if query is pending AND we have no safe fallback
-    // (no current chat ID from URL, no last chat path)
-    if (isPending && !currentChatThreadId && !lastChatPathRef.current) {
+    // Only block navigation if query is pending and we have no last chat path to return to
+    if (isPending && !lastChatPathRef.current) {
       return
     }
 
@@ -171,9 +170,6 @@ export default function Sidebar() {
     // Use lastChatPathRef if available (skip validation if query is pending since we can't validate against empty array)
     if (lastChatPathRef.current && (isPending || isChatPathValid(lastChatPathRef.current, allThreads))) {
       navigate(lastChatPathRef.current)
-    } else if (currentChatThreadId) {
-      // Safe fallback: use current chat ID from URL params (doesn't depend on query)
-      navigate(`/chats/${currentChatThreadId}`)
     } else if (allThreads.length > 0) {
       navigate(`/chats/${allThreads[0].id}`)
     } else {

--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -59,7 +59,7 @@ export default function Sidebar() {
     }
   }, [showSearch, isCollapsed])
 
-  const { data } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: ['chatThreads'],
     queryFn: getAllChatThreads,
     placeholderData: (previousData) => previousData,
@@ -161,6 +161,12 @@ export default function Sidebar() {
   }
 
   const goToMainMenu = async () => {
+    // Wait for data to load to avoid race condition where we create a new chat
+    // when the user's last chat exists but hasn't loaded yet
+    if (isPending) {
+      return
+    }
+
     const allThreads = data ?? []
     if (lastChatPathRef.current && isChatPathValid(lastChatPathRef.current, allThreads)) {
       navigate(lastChatPathRef.current)

--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -1,6 +1,7 @@
 import type { DeleteAllChatsDialogRef } from '@/components/delete-all-chats-dialog'
 import type { DeleteChatDialogRef } from '@/components/delete-chat-dialog'
 import { Sidebar as SidebarRoot, useSidebar } from '@/components/ui/sidebar'
+import type { ChatThread } from '@/types'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { deleteAllChatThreads, deleteChatThread, getAllChatThreads } from '@/dal'
 import { useDebounce } from '@/hooks/use-debounce'
@@ -130,8 +131,37 @@ export default function Sidebar() {
     }
   }
 
+  /**
+   * Extracts the chat ID from a chat path (e.g., "/chats/123" -> "123")
+   * Returns null if the path is invalid
+   */
+  const extractChatIdFromPath = (path: string): string | null => {
+    const match = path.match(/^\/chats\/(.+)$/)
+    return match ? match[1] : null
+  }
+
+  /**
+   * Checks if a chat path points to an existing, non-deleted chat
+   * @param path - The path to validate (e.g., "/chats/123" or "/chats/new")
+   * @param chatThreads - Array of active chat threads
+   * @returns true if the path is valid
+   */
+  const isChatPathValid = (path: string, chatThreads: ChatThread[]): boolean => {
+    const chatId = extractChatIdFromPath(path)
+
+    if (!chatId) {
+      return false
+    }
+
+    if (chatId === 'new') {
+      return true
+    }
+
+    return chatThreads.some((thread) => thread.id === chatId)
+  }
+
   const goToMainMenu = async () => {
-    if (lastChatPathRef.current) {
+    if (lastChatPathRef.current && isChatPathValid(lastChatPathRef.current, chatThreads)) {
       navigate(lastChatPathRef.current)
     } else if (chatThreads.length > 0) {
       navigate(`/chats/${chatThreads[0].id}`)

--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -161,14 +161,15 @@ export default function Sidebar() {
   }
 
   const goToMainMenu = async () => {
-    // If query is pending and we don't have a current chat ID, wait for data
-    // to avoid creating a new chat when the user's last chat exists but hasn't loaded yet
-    if (isPending && !currentChatThreadId) {
+    // Only block navigation if query is pending AND we have no safe fallback
+    // (no current chat ID from URL, no last chat path)
+    if (isPending && !currentChatThreadId && !lastChatPathRef.current) {
       return
     }
 
     const allThreads = data ?? []
-    if (lastChatPathRef.current && isChatPathValid(lastChatPathRef.current, allThreads)) {
+    // Use lastChatPathRef if available (skip validation if query is pending since we can't validate against empty array)
+    if (lastChatPathRef.current && (isPending || isChatPathValid(lastChatPathRef.current, allThreads))) {
       navigate(lastChatPathRef.current)
     } else if (currentChatThreadId) {
       // Safe fallback: use current chat ID from URL params (doesn't depend on query)

--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -161,10 +161,11 @@ export default function Sidebar() {
   }
 
   const goToMainMenu = async () => {
-    if (lastChatPathRef.current && isChatPathValid(lastChatPathRef.current, chatThreads)) {
+    const allThreads = data ?? []
+    if (lastChatPathRef.current && isChatPathValid(lastChatPathRef.current, allThreads)) {
       navigate(lastChatPathRef.current)
-    } else if (chatThreads.length > 0) {
-      navigate(`/chats/${chatThreads[0].id}`)
+    } else if (allThreads.length > 0) {
+      navigate(`/chats/${allThreads[0].id}`)
     } else {
       await createNewChat(false)
     }

--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -1,7 +1,6 @@
 import type { DeleteAllChatsDialogRef } from '@/components/delete-all-chats-dialog'
 import type { DeleteChatDialogRef } from '@/components/delete-chat-dialog'
 import { Sidebar as SidebarRoot, useSidebar } from '@/components/ui/sidebar'
-import type { ChatThread } from '@/types'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { deleteAllChatThreads, deleteChatThread, getAllChatThreads } from '@/dal'
 import { useDebounce } from '@/hooks/use-debounce'
@@ -131,47 +130,16 @@ export default function Sidebar() {
     }
   }
 
-  /**
-   * Extracts the chat ID from a chat path (e.g., "/chats/123" -> "123")
-   * Returns null if the path is invalid
-   */
-  const extractChatIdFromPath = (path: string): string | null => {
-    const match = path.match(/^\/chats\/(.+)$/)
-    return match ? match[1] : null
-  }
-
-  /**
-   * Checks if a chat path points to an existing, non-deleted chat
-   * @param path - The path to validate (e.g., "/chats/123" or "/chats/new")
-   * @param chatThreads - Array of active chat threads
-   * @returns true if the path is valid
-   */
-  const isChatPathValid = (path: string, chatThreads: ChatThread[]): boolean => {
-    const chatId = extractChatIdFromPath(path)
-
-    if (!chatId) {
-      return false
-    }
-
-    if (chatId === 'new') {
-      return true
-    }
-
-    return chatThreads.some((thread) => thread.id === chatId)
-  }
-
   const goToMainMenu = async () => {
-    // Only block navigation if query is pending and we have no last chat path to return to
+    // Only wait if query is pending and we have no fallback
     if (isPending && !lastChatPathRef.current) {
       return
     }
 
-    const allThreads = data ?? []
-    // Use lastChatPathRef if available (skip validation if query is pending since we can't validate against empty array)
-    if (lastChatPathRef.current && (isPending || isChatPathValid(lastChatPathRef.current, allThreads))) {
+    if (lastChatPathRef.current) {
       navigate(lastChatPathRef.current)
-    } else if (allThreads.length > 0) {
-      navigate(`/chats/${allThreads[0].id}`)
+    } else if (data && data.length > 0) {
+      navigate(`/chats/${data[0].id}`)
     } else {
       await createNewChat(false)
     }

--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -25,6 +25,7 @@ export default function Sidebar() {
   const deleteAllChatsDialogRef = useRef<DeleteAllChatsDialogRef>(null)
   const deleteChatDialogRef = useRef<DeleteChatDialogRef>(null)
   const threadIdRef = useRef<string | null>(null)
+  const lastChatPathRef = useRef<string | null>(null)
 
   const { chatThreadId: currentChatThreadId } = useParams()
 
@@ -42,6 +43,12 @@ export default function Sidebar() {
   const { experimentalFeatureTasks } = useSettings({
     experimental_feature_tasks: false,
   })
+
+  useEffect(() => {
+    if (location.pathname.startsWith('/chats/')) {
+      lastChatPathRef.current = location.pathname
+    }
+  }, [location.pathname])
 
   useEffect(() => {
     if (showSearch && searchInputRef.current && !isCollapsed) {
@@ -124,9 +131,10 @@ export default function Sidebar() {
   }
 
   const goToMainMenu = async () => {
-    const chatThreadId = currentChatThreadId || (chatThreads.length > 0 ? chatThreads[0].id : null)
-    if (chatThreadId) {
-      navigate(`/chats/${chatThreadId}`)
+    if (lastChatPathRef.current) {
+      navigate(lastChatPathRef.current)
+    } else if (chatThreads.length > 0) {
+      navigate(`/chats/${chatThreads[0].id}`)
     } else {
       await createNewChat(false)
     }

--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -161,15 +161,18 @@ export default function Sidebar() {
   }
 
   const goToMainMenu = async () => {
-    // Wait for data to load to avoid race condition where we create a new chat
-    // when the user's last chat exists but hasn't loaded yet
-    if (isPending) {
+    // If query is pending and we don't have a current chat ID, wait for data
+    // to avoid creating a new chat when the user's last chat exists but hasn't loaded yet
+    if (isPending && !currentChatThreadId) {
       return
     }
 
     const allThreads = data ?? []
     if (lastChatPathRef.current && isChatPathValid(lastChatPathRef.current, allThreads)) {
       navigate(lastChatPathRef.current)
+    } else if (currentChatThreadId) {
+      // Safe fallback: use current chat ID from URL params (doesn't depend on query)
+      navigate(`/chats/${currentChatThreadId}`)
     } else if (allThreads.length > 0) {
       navigate(`/chats/${allThreads[0].id}`)
     } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small client-side navigation change scoped to the sidebar’s back behavior; low risk aside from potential edge cases around pending query state and stale stored paths.
> 
> **Overview**
> Updates the settings sidebar “back” behavior to navigate to the *last visited* `/chats/*` path (tracked via a new `lastChatPathRef`) instead of always selecting the current/first thread.
> 
> Adds `isPending` awareness to `chatThreads` loading so the back action waits for data when no last-chat fallback exists, and otherwise falls back to the first loaded thread or `/chats/new` creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c95ecd47bfa1fcf6b31093a0e74730894f822541. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->