### PR TITLE
THU-309: Fix rounded corner clipping on model selector

### DIFF
--- a/src/components/ui/model-selector/model-selector.tsx
+++ b/src/components/ui/model-selector/model-selector.tsx
@@ -85,7 +85,7 @@ export const ModelSelector = ({
     const content = (
       <div
         className={cn(
-          'w-full flex items-center justify-between px-3 py-2 mt-1.5 rounded-lg transition-colors text-left cursor-pointer',
+          'w-full flex items-center justify-between px-3 py-2 mt-1.5 transition-colors text-left cursor-pointer',
           'hover:bg-accent/50',
           isSelected && 'bg-accent',
           item.disabled && 'opacity-50 cursor-not-allowed',
@@ -143,6 +143,7 @@ export const ModelSelector = ({
       footer={footer}
       width={320}
       maxHeight={340}
+      contentClassName="overflow-hidden"
     />
   )
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized CSS/className changes to a single UI component with no behavioral, data, or security impact.
> 
> **Overview**
> Fixes the model selector popover’s visual clipping by moving rounded-corner responsibility off individual menu items and onto the popover container.
> 
> Specifically, removes the per-item `rounded-lg` styling in `ModelSelector` and passes `contentClassName="overflow-hidden"` to `SearchableMenu` so the popover content clips cleanly within its rounded container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8bc05dc9a0d1e70165de7157aebb204acefa3c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->