### PR TITLE
fix: include X-Device-ID and X-Device-Name headers in corsAllowHeaders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,7 @@
 ## PowerSync and synced tables
 
 See [docs/powersync-account-devices.md](docs/powersync-account-devices.md) for: synced table requirements, adding a new table (frontend + backend + schema + config.yaml + production), account deletion, device management, and backend token/revoke API.
+
+## CORS and API headers
+
+When adding new custom headers to API requests (e.g. `X-Device-ID`, `X-Device-Name`), update `backend/src/config/settings.ts` so `corsAllowHeaders` includes them. Otherwise CORS preflight will fail and requests from the browser will be blocked.

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -48,7 +48,7 @@ const settingsSchema = z.object({
   corsAllowHeaders: z
     .string()
     .default(
-      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform',
+      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name',
     ),
   corsExposeHeaders: z.string().default('mcp-session-id'),
 })
@@ -88,7 +88,7 @@ const parseSettings = (): Settings => {
     corsAllowMethods: process.env.CORS_ALLOW_METHODS || 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:
       process.env.CORS_ALLOW_HEADERS ||
-      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform',
+      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name',
     corsExposeHeaders: process.env.CORS_EXPOSE_HEADERS || 'mcp-session-id',
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small configuration/docs change limited to expanding the CORS allowlist; minimal functional impact beyond enabling previously-blocked requests.
> 
> **Overview**
> Fixes browser CORS preflight failures for requests that include the custom `X-Device-ID` and `X-Device-Name` headers by adding them to the default `corsAllowHeaders` in `backend/src/config/settings.ts` (including the env-var fallback).
> 
> Updates `AGENTS.md` with guidance to keep `corsAllowHeaders` in sync whenever new custom API headers are introduced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6ea987cc54160c8aa6f1de694a97add6d1a80f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->