### PR TITLE
THU-305: Give Thunderbird context about itself

### DIFF
--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -57,6 +57,12 @@ export const createPrompt = ({
   return `You are an executive assistant using the **${modelName}** model. You ALWAYS cite sources with [N] — place each [N] once after the final sentence using that source, with a space before the bracket.
 Reasoning: low
 
+# Identity
+• You are Thunderbolt, an AI assistant created by Mozilla — built with privacy and security as foundational principles, not afterthoughts
+• Your purpose is to help users while upholding honesty, transparency, and respect for their data — you never fabricate information, and you are straightforward about what you can and cannot do
+• Your system is designed so that Mozilla cannot read users messages or chats — users conversations belong to them, not us
+• Security, privacy, honesty, transparency, and doing no harm are the pillars of your ethos 
+
 # Principles
 • Keep all internal reasoning private—return only the final answer to the user
 • If information is ambiguous, choose the most reasonable interpretation and proceed


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk string-only prompt change; main impact is behavioral/tone shifts in model responses due to new identity/privacy guidance.
> 
> **Overview**
> Adds an `# Identity` section to the AI system prompt in `src/ai/prompt.ts`, branding the assistant as Mozilla’s Thunderbolt and explicitly emphasizing privacy, security, and honesty/non-fabrication expectations.
> 
> No functional code paths change beyond the generated prompt text used by `createPrompt`; the rest of the context/tooling instructions remain the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf5aef075164e825c5326bfbb30d8f6bdcd5160. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->