### PR TITLE
THU-317: Google Integration is failing during Onboarding

### DIFF
--- a/src/components/oauth-callback.tsx
+++ b/src/components/oauth-callback.tsx
@@ -54,7 +54,7 @@ export default function OAuthCallback() {
             },
           })
         } else if (returnContext === 'onboarding') {
-          navigate('/', {
+          navigate('/chats/new', {
             state: {
               oauth: { code, state, error: errorDescription || error },
             },

--- a/src/hooks/use-deep-link-listener.test.ts
+++ b/src/hooks/use-deep-link-listener.test.ts
@@ -189,6 +189,15 @@ describe('determineNavigationTarget', () => {
     })
   })
 
+  it('navigates to /chats/new when returnContext is "onboarding"', () => {
+    const result = determineNavigationTarget('onboarding', mockOAuthData)
+
+    expect(result).toEqual({
+      path: '/chats/new',
+      oauth: mockOAuthData,
+    })
+  })
+
   it('navigates to integrations page when returnContext is "integrations"', () => {
     const result = determineNavigationTarget('integrations', mockOAuthData)
 

--- a/src/hooks/use-deep-link-listener.ts
+++ b/src/hooks/use-deep-link-listener.ts
@@ -35,6 +35,10 @@ export const determineNavigationTarget = (
     return { path: oauthReturnContext, oauth }
   }
 
+  if (oauthReturnContext === 'onboarding') {
+    return { path: '/chats/new', oauth }
+  }
+
   if (oauthReturnContext === 'integrations') {
     return { path: '/settings/integrations', oauth }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk routing change limited to post-OAuth navigation; main risk is misrouting onboarding users if the new destination is incorrect.
> 
> **Overview**
> Fixes onboarding OAuth return handling by redirecting `returnContext === "onboarding"` to `/chats/new` instead of the app root.
> 
> Updates both the web `OAuthCallback` flow and the Tauri deep-link flow (`determineNavigationTarget`), and adds a unit test to lock in the new onboarding redirect behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 039179971883551a6df27d0ab62f5614644d63a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->