### PR TITLE
refactor: mobile detection logic for chat input

### DIFF
--- a/src/components/chat/chat-prompt-input.test.tsx
+++ b/src/components/chat/chat-prompt-input.test.tsx
@@ -32,10 +32,9 @@ const createMockUseContextTracking =
   })
 
 const createMockUseIsMobile =
-  (isMobile: boolean = false, isReady: boolean = true) =>
+  (isMobile: boolean = false) =>
   () => ({
     isMobile,
-    isReady,
   })
 
 const TestWrapper = ({ children }: { children: React.ReactNode }) => {
@@ -90,28 +89,6 @@ describe('ChatPromptInput', () => {
       })
 
       expect(screen.getByPlaceholderText('Ask me anything...')).toBeInTheDocument()
-    })
-
-    it('should return null when mobile detection is not ready', () => {
-      const { mockUseChat } = setupStore()
-
-      const { container } = render(
-        <ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile(false, false)} />,
-        { wrapper: TestWrapper },
-      )
-
-      expect(container.querySelector('form')).toBeNull()
-    })
-
-    it('should render once mobile detection is ready', () => {
-      const { mockUseChat } = setupStore()
-
-      const { container } = render(
-        <ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile(false, true)} />,
-        { wrapper: TestWrapper },
-      )
-
-      expect(container.querySelector('form')).not.toBeNull()
     })
   })
 

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -41,8 +41,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
     const modes = useChatStore((state) => state.modes)
     const setSelectedMode = useChatStore((state) => state.setSelectedMode)
 
-    // Use isReady to prevent layout flash on mobile
-    const { isMobile, isReady } = useIsMobile()
+    const { isMobile } = useIsMobile()
 
     const { chatInstance, id: chatThreadId, selectedMode, selectedModel } = useCurrentChatSession()
 
@@ -114,8 +113,6 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
       },
       setInput,
     }))
-
-    if (!isReady) return null
 
     const footerStartElements = (
       <div className="flex items-center gap-2">

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -24,7 +24,7 @@ export default function ChatUI() {
     useChatScrollHandler()
 
   const chatPromptInputRef = useRef<ChatPromptInputRef>(null)
-  const { isMobile, isReady } = useIsMobile()
+  const { isMobile } = useIsMobile()
 
   const handleSelectPrompt = useCallback((prompt: string) => {
     chatPromptInputRef.current?.setInput(prompt)
@@ -44,10 +44,6 @@ export default function ChatUI() {
       }
     }
   }, [hasMessages, scrollToBottom])
-
-  if (!isReady) {
-    return null
-  }
 
   return (
     <div className="h-full w-full">

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,22 +1,16 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
-const MOBILE_BREAKPOINT = 768
+const mobileBreakpoint = 768
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined)
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < mobileBreakpoint)
 
   useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
+    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
+    const onChange = () => setIsMobile(window.innerWidth < mobileBreakpoint)
     mql.addEventListener('change', onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener('change', onChange)
   }, [])
 
-  return {
-    isMobile: !!isMobile,
-    isReady: isMobile !== undefined,
-  }
+  return { isMobile }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes initial render behavior for `ChatUI`/`ChatPromptInput` by removing the `isReady` null-render guard, which could affect first-paint/layout and any environments where `window` isn’t available (e.g., SSR/tests). The new hook initializes from `window.innerWidth`, so regressions are most likely around hydration or resize handling rather than core chat logic.
> 
> **Overview**
> **Mobile detection is simplified** by changing `useIsMobile` to return only `{ isMobile }`, initialized from `window.innerWidth` and updated via `matchMedia` change events.
> 
> **Chat rendering no longer waits for mobile detection**: `ChatUI` and `ChatPromptInput` drop the `isReady` guard and always render immediately, and associated tests remove the “not ready/ready” cases and adjust the injected `useIsMobile` mock accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da0c5d2d87c994643e69eb10678d8013187889d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->