### PR TITLE
fix: register model_profiles migration in drizzle journal

### DIFF
--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1771958071916,
       "tag": "0006_modern_annihilus",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1772150455000,
+      "tag": "0007_magenta_landau",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `0007_magenta_landau.sql` migration file and snapshot were merged in PR #400, but the Drizzle journal (`backend/drizzle/meta/_journal.json`) was not updated with the entry for migration 0007. This means Drizzle never runs the migration — the `powersync.model_profiles` table is never created in Postgres.

## Root cause

When cherry-picking files from the feature branch to create the backend-only PR #400, the journal file was not included. The migration SQL and snapshot were present, but Drizzle needs the journal entry to discover and execute pending migrations.

## Fix

Adds the missing `idx: 7` entry for `0007_magenta_landau` to `_journal.json`.

## Test plan

- [ ] After merge + deploy, verify the migration runs: `SELECT * FROM powersync.model_profiles LIMIT 1;` should return empty (not "table does not exist")
- [ ] Then update PowerSync Cloud dashboard rules

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Drizzle's migration journal metadata so an already-merged migration can run; no application logic changes.
> 
> **Overview**
> Registers the missing Drizzle migration journal entry for `0007_magenta_landau` by adding `idx: 7` to `backend/drizzle/meta/_journal.json`, ensuring the migration is discovered and executed during deploys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15e692b3fb31aa9b1ea16389b2ba41a8a0066c2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->