### PR TITLE
THU-312: implement db.transaction to optimize PowerSync operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Use camelCase for const and variable names
 - Prefer early return over long if statements and nested code
 - Use direct imports: `useEffect` not `React.useEffect`
+- Prefer top-level imports over inline/dynamic imports (`await import(...)`) when no circular dependency exists
 - Prefer async/await over .then/.catch
 - Add JSDoc comments to new utility functions
 - Only comment non-obvious code - avoid useless comments like "// Save data collection mutation" before `saveDataCollection()`

--- a/src/chats/use-hydrate-chat-store.test.tsx
+++ b/src/chats/use-hydrate-chat-store.test.tsx
@@ -94,7 +94,9 @@ const createTestModel = async () => {
  */
 const createTestThread = async (modelId: string, title: string = 'Test Thread') => {
   const model = await getModel(modelId)
-  if (!model) throw new Error('Test setup failed')
+  if (!model) {
+    throw new Error('Test setup failed')
+  }
   const threadId = uuidv7()
   await createChatThread(
     {

--- a/src/chats/use-hydrate-chat-store.test.tsx
+++ b/src/chats/use-hydrate-chat-store.test.tsx
@@ -9,6 +9,7 @@ import { DatabaseSingleton } from '@/db/singleton'
 import { modelsTable, modesTable } from '@/db/tables'
 import { v7 as uuidv7 } from 'uuid'
 import { createChatThread } from '@/dal/chat-threads'
+import { getModel } from '@/dal/models'
 import { saveMessagesWithContextUpdate } from '@/dal/chat-messages'
 import type { ThunderboltUIMessage } from '@/types'
 import { createElement } from 'react'
@@ -92,6 +93,8 @@ const createTestModel = async () => {
  * Helper function to create a test thread
  */
 const createTestThread = async (modelId: string, title: string = 'Test Thread') => {
+  const model = await getModel(modelId)
+  if (!model) throw new Error('Test setup failed')
   const threadId = uuidv7()
   await createChatThread(
     {
@@ -101,7 +104,7 @@ const createTestThread = async (modelId: string, title: string = 'Test Thread') 
       triggeredBy: null,
       wasTriggeredByAutomation: 0,
     },
-    modelId,
+    model,
   )
   return threadId
 }

--- a/src/dal/chat-messages.ts
+++ b/src/dal/chat-messages.ts
@@ -78,37 +78,39 @@ export const saveMessagesWithContextUpdate = async (
     return convertUIMessageToDbChatMessage(message, threadId, messageParentId)
   })
 
-  // Insert-first pattern for PowerSync compatibility.
-  // PowerSync uses views which don't support ON CONFLICT, so we can't use upsert.
-  // Try insert first, then update on unique constraint violation to avoid race conditions
-  // when multiple components save messages simultaneously.
-  for (const msg of dbChatMessages) {
-    try {
-      await db.insert(chatMessagesTable).values(msg)
-    } catch (err) {
-      if (!isInsertConflictError(err)) {
-        throw err
+  await db.transaction(async (tx) => {
+    // Insert-first pattern for PowerSync compatibility.
+    // PowerSync uses views which don't support ON CONFLICT, so we can't use upsert.
+    // Try insert first, then update on unique constraint violation to avoid race conditions
+    // when multiple components save messages simultaneously.
+    for (const msg of dbChatMessages) {
+      try {
+        await tx.insert(chatMessagesTable).values(msg)
+      } catch (err) {
+        if (!isInsertConflictError(err)) {
+          throw err
+        }
+        await tx
+          .update(chatMessagesTable)
+          .set({
+            content: msg.content,
+            parts: msg.parts,
+            role: msg.role,
+            parentId: msg.parentId,
+            metadata: msg.metadata,
+          })
+          .where(eq(chatMessagesTable.id, msg.id))
       }
-      await db
-        .update(chatMessagesTable)
-        .set({
-          content: msg.content,
-          parts: msg.parts,
-          role: msg.role,
-          parentId: msg.parentId,
-          metadata: msg.metadata,
-        })
-        .where(eq(chatMessagesTable.id, msg.id))
     }
-  }
 
-  // Update context size if available in latest message
-  const latestMessage = messages[messages.length - 1]
-  const metadata = latestMessage?.metadata as UIMessageMetadata | undefined
+    // Update context size if available in latest message
+    const latestMessage = messages[messages.length - 1]
+    const metadata = latestMessage?.metadata as UIMessageMetadata | undefined
 
-  if (metadata?.usage?.totalTokens) {
-    await updateChatThread(threadId, { contextSize: metadata.usage.totalTokens })
-  }
+    if (metadata?.usage?.totalTokens) {
+      await updateChatThread(threadId, { contextSize: metadata.usage.totalTokens }, tx)
+    }
+  })
 
   return dbChatMessages
 }

--- a/src/dal/chat-threads.test.ts
+++ b/src/dal/chat-threads.test.ts
@@ -14,6 +14,7 @@ import {
   isChatThreadDeleted,
   updateChatThread,
 } from './chat-threads'
+import { getModel } from './models'
 import { getChatMessages } from './chat-messages'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 import { nowIso } from '@/lib/utils'
@@ -63,10 +64,12 @@ describe('Chat Threads DAL', () => {
     it('should create a new chat thread with the provided ID', async () => {
       const threadId = uuidv7()
       const modelId = await createTestModel()
+      const model = await getModel(modelId)
+      if (!model) throw new Error('Test setup failed')
 
       await createChatThread(
         { id: threadId, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
-        modelId,
+        model,
       )
 
       const db = DatabaseSingleton.instance.db
@@ -80,14 +83,16 @@ describe('Chat Threads DAL', () => {
       const threadId1 = uuidv7()
       const threadId2 = uuidv7()
       const modelId = await createTestModel()
+      const model = await getModel(modelId)
+      if (!model) throw new Error('Test setup failed')
 
       await createChatThread(
         { id: threadId1, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
-        modelId,
+        model,
       )
       await createChatThread(
         { id: threadId2, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
-        modelId,
+        model,
       )
 
       const db = DatabaseSingleton.instance.db
@@ -100,17 +105,19 @@ describe('Chat Threads DAL', () => {
     it('should throw when creating thread with same ID twice', async () => {
       const threadId = uuidv7()
       const modelId = await createTestModel()
+      const model = await getModel(modelId)
+      if (!model) throw new Error('Test setup failed')
 
       await createChatThread(
         { id: threadId, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
-        modelId,
+        model,
       )
 
       // Should throw due to UNIQUE constraint
       await expect(
         createChatThread(
           { id: threadId, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
-          modelId,
+          model,
         ),
       ).rejects.toThrow()
 

--- a/src/dal/chat-threads.test.ts
+++ b/src/dal/chat-threads.test.ts
@@ -65,7 +65,9 @@ describe('Chat Threads DAL', () => {
       const threadId = uuidv7()
       const modelId = await createTestModel()
       const model = await getModel(modelId)
-      if (!model) throw new Error('Test setup failed')
+      if (!model) {
+        throw new Error('Test setup failed')
+      }
 
       await createChatThread(
         { id: threadId, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
@@ -84,7 +86,9 @@ describe('Chat Threads DAL', () => {
       const threadId2 = uuidv7()
       const modelId = await createTestModel()
       const model = await getModel(modelId)
-      if (!model) throw new Error('Test setup failed')
+      if (!model) {
+        throw new Error('Test setup failed')
+      }
 
       await createChatThread(
         { id: threadId1, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
@@ -106,7 +110,9 @@ describe('Chat Threads DAL', () => {
       const threadId = uuidv7()
       const modelId = await createTestModel()
       const model = await getModel(modelId)
-      if (!model) throw new Error('Test setup failed')
+      if (!model) {
+        throw new Error('Test setup failed')
+      }
 
       await createChatThread(
         { id: threadId, title: 'New Chat', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -3,7 +3,7 @@ import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { DatabaseSingleton } from '../db/singleton'
 import { chatMessagesTable, chatThreadsTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
-import { type ChatThread } from '@/types'
+import { type ChatThread, type Model } from '@/types'
 import { getModel } from './models'
 
 /**
@@ -47,21 +47,15 @@ export const getChatThread = async (id: string): Promise<ChatThread | null> => {
 
 /**
  * Create a new chat thread
+ * @param model - Resolved model (caller must fetch via getModel);
  * @param db - Optional database/transaction to use (e.g. when batching within a PowerSync transaction)
  */
 export const createChatThread = async (
   data: Pick<ChatThread, 'contextSize' | 'id' | 'title' | 'triggeredBy' | 'wasTriggeredByAutomation'>,
-  modelId: string,
+  model: Model,
   db?: AnyDrizzleDatabase,
 ): Promise<void> => {
   const database = db ?? DatabaseSingleton.instance.db
-
-  const model = await getModel(modelId)
-
-  if (!model) {
-    throw new Error('No model found')
-  }
-
   await database.insert(chatThreadsTable).values({ ...data, isEncrypted: model.isConfidential })
 }
 
@@ -87,6 +81,11 @@ export const getOrCreateChatThread = async (id: string, modelId: string): Promis
     return thread
   }
 
+  const model = await getModel(modelId)
+  if (!model) {
+    throw new Error('No model found')
+  }
+
   await createChatThread(
     {
       id,
@@ -95,7 +94,7 @@ export const getOrCreateChatThread = async (id: string, modelId: string): Promis
       triggeredBy: null,
       wasTriggeredByAutomation: 0,
     },
-    modelId,
+    model,
   )
 
   return (await getChatThread(id))! // We know the thread exists because we just created it

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm'
+import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { DatabaseSingleton } from '../db/singleton'
 import { chatMessagesTable, chatThreadsTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
@@ -46,12 +47,14 @@ export const getChatThread = async (id: string): Promise<ChatThread | null> => {
 
 /**
  * Create a new chat thread
+ * @param db - Optional database/transaction to use (e.g. when batching within a PowerSync transaction)
  */
 export const createChatThread = async (
   data: Pick<ChatThread, 'contextSize' | 'id' | 'title' | 'triggeredBy' | 'wasTriggeredByAutomation'>,
   modelId: string,
+  db?: AnyDrizzleDatabase,
 ): Promise<void> => {
-  const db = DatabaseSingleton.instance.db
+  const database = db ?? DatabaseSingleton.instance.db
 
   const model = await getModel(modelId)
 
@@ -59,15 +62,19 @@ export const createChatThread = async (
     throw new Error('No model found')
   }
 
-  await db.insert(chatThreadsTable).values({ ...data, isEncrypted: model.isConfidential })
+  await database.insert(chatThreadsTable).values({ ...data, isEncrypted: model.isConfidential })
 }
 
+/**
+ * @param db - Optional database/transaction to use (e.g. when batching within a PowerSync transaction)
+ */
 export const updateChatThread = async (
   id: string,
   data: Partial<Pick<ChatThread, 'contextSize' | 'modeId' | 'title' | 'triggeredBy' | 'wasTriggeredByAutomation'>>,
+  db?: AnyDrizzleDatabase,
 ): Promise<void> => {
-  const db = DatabaseSingleton.instance.db
-  await db.update(chatThreadsTable).set(data).where(eq(chatThreadsTable.id, id))
+  const database = db ?? DatabaseSingleton.instance.db
+  await database.update(chatThreadsTable).set(data).where(eq(chatThreadsTable.id, id))
 }
 
 /**
@@ -118,14 +125,16 @@ export const getContextSizeForThread = async (threadId: string): Promise<number 
 export const deleteChatThread = async (id: string): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   const deletedAt = nowIso()
-  await db
-    .update(chatMessagesTable)
-    .set({ ...clearNullableColumns(chatMessagesTable), deletedAt })
-    .where(and(eq(chatMessagesTable.chatThreadId, id), isNull(chatMessagesTable.deletedAt)))
-  await db
-    .update(chatThreadsTable)
-    .set({ ...clearNullableColumns(chatThreadsTable), deletedAt })
-    .where(and(eq(chatThreadsTable.id, id), isNull(chatThreadsTable.deletedAt)))
+  await db.transaction(async (tx) => {
+    await tx
+      .update(chatMessagesTable)
+      .set({ ...clearNullableColumns(chatMessagesTable), deletedAt })
+      .where(and(eq(chatMessagesTable.chatThreadId, id), isNull(chatMessagesTable.deletedAt)))
+    await tx
+      .update(chatThreadsTable)
+      .set({ ...clearNullableColumns(chatThreadsTable), deletedAt })
+      .where(and(eq(chatThreadsTable.id, id), isNull(chatThreadsTable.deletedAt)))
+  })
 }
 
 /**
@@ -137,12 +146,14 @@ export const deleteChatThread = async (id: string): Promise<void> => {
 export const deleteAllChatThreads = async (): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   const deletedAt = nowIso()
-  await db
-    .update(chatMessagesTable)
-    .set({ ...clearNullableColumns(chatMessagesTable), deletedAt })
-    .where(isNull(chatMessagesTable.deletedAt))
-  await db
-    .update(chatThreadsTable)
-    .set({ ...clearNullableColumns(chatThreadsTable), deletedAt })
-    .where(isNull(chatThreadsTable.deletedAt))
+  await db.transaction(async (tx) => {
+    await tx
+      .update(chatMessagesTable)
+      .set({ ...clearNullableColumns(chatMessagesTable), deletedAt })
+      .where(isNull(chatMessagesTable.deletedAt))
+    await tx
+      .update(chatThreadsTable)
+      .set({ ...clearNullableColumns(chatThreadsTable), deletedAt })
+      .where(isNull(chatThreadsTable.deletedAt))
+  })
 }

--- a/src/dal/model-profiles.ts
+++ b/src/dal/model-profiles.ts
@@ -2,6 +2,7 @@ import { and, eq, isNull } from 'drizzle-orm'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { DatabaseSingleton } from '../db/singleton'
 import { modelProfilesTable } from '../db/tables'
+import { defaultModelProfiles, hashModelProfile } from '../defaults/model-profiles'
 import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { ModelProfile, ModelProfileRow } from '../types'
 
@@ -35,8 +36,6 @@ export const upsertModelProfile = async (
 
 /** Create default profile for a model using seed data */
 export const createDefaultModelProfile = async (modelId: string, db?: AnyDrizzleDatabase): Promise<void> => {
-  // Lazy import to avoid circular dependency
-  const { defaultModelProfiles, hashModelProfile } = await import('../defaults/model-profiles')
   const defaultProfile = defaultModelProfiles.find((p) => p.modelId === modelId)
   if (!defaultProfile) {
     return
@@ -63,7 +62,6 @@ export const deleteModelProfileForModel = async (modelId: string, db?: AnyDrizzl
 
 /** Reset a profile to its default values */
 export const resetModelProfileToDefault = async (modelId: string): Promise<void> => {
-  const { defaultModelProfiles, hashModelProfile } = await import('../defaults/model-profiles')
   const defaultProfile = defaultModelProfiles.find((p) => p.modelId === modelId)
   if (!defaultProfile) {
     return

--- a/src/dal/model-profiles.ts
+++ b/src/dal/model-profiles.ts
@@ -1,4 +1,5 @@
 import { and, eq, isNull } from 'drizzle-orm'
+import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { DatabaseSingleton } from '../db/singleton'
 import { modelProfilesTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
@@ -33,7 +34,7 @@ export const upsertModelProfile = async (
 }
 
 /** Create default profile for a model using seed data */
-export const createDefaultModelProfile = async (modelId: string): Promise<void> => {
+export const createDefaultModelProfile = async (modelId: string, db?: AnyDrizzleDatabase): Promise<void> => {
   // Lazy import to avoid circular dependency
   const { defaultModelProfiles, hashModelProfile } = await import('../defaults/model-profiles')
   const defaultProfile = defaultModelProfiles.find((p) => p.modelId === modelId)
@@ -41,8 +42,8 @@ export const createDefaultModelProfile = async (modelId: string): Promise<void> 
     return
   }
 
-  const db = DatabaseSingleton.instance.db
-  await db
+  const database = db ?? DatabaseSingleton.instance.db
+  await database
     .insert(modelProfilesTable)
     .values({
       ...defaultProfile,
@@ -52,9 +53,9 @@ export const createDefaultModelProfile = async (modelId: string): Promise<void> 
 }
 
 /** Soft-delete profile for a model */
-export const deleteModelProfileForModel = async (modelId: string): Promise<void> => {
-  const db = DatabaseSingleton.instance.db
-  await db
+export const deleteModelProfileForModel = async (modelId: string, db?: AnyDrizzleDatabase): Promise<void> => {
+  const database = db ?? DatabaseSingleton.instance.db
+  await database
     .update(modelProfilesTable)
     .set({ ...clearNullableColumns(modelProfilesTable), deletedAt: nowIso() })
     .where(and(eq(modelProfilesTable.modelId, modelId), isNull(modelProfilesTable.deletedAt)))

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -145,21 +145,18 @@ export const resetModelToDefault = async (id: string, defaultModel: Model): Prom
  * Only updates records that haven't been deleted yet to preserve original deletion datetimes
  */
 export const deleteModel = async (id: string): Promise<void> => {
-  // Import locally to avoid circular dependency
-  const { deletePromptsForModel } = await import('./prompts')
-
-  // Soft-delete model profile
-  const { deleteModelProfileForModel } = await import('./model-profiles')
-  await deleteModelProfileForModel(id)
-
-  // Soft-delete prompts and their triggers first (replaces onDelete: 'cascade')
-  await deletePromptsForModel(id)
-
   const db = DatabaseSingleton.instance.db
-  await db
-    .update(modelsTable)
-    .set({ ...clearNullableColumns(modelsTable), deletedAt: nowIso() })
-    .where(and(eq(modelsTable.id, id), isNull(modelsTable.deletedAt)))
+  await db.transaction(async (tx) => {
+    const { deletePromptsForModel } = await import('./prompts')
+    const { deleteModelProfileForModel } = await import('./model-profiles')
+
+    await deleteModelProfileForModel(id, tx)
+    await deletePromptsForModel(id, tx)
+    await tx
+      .update(modelsTable)
+      .set({ ...clearNullableColumns(modelsTable), deletedAt: nowIso() })
+      .where(and(eq(modelsTable.id, id), isNull(modelsTable.deletedAt)))
+  })
 }
 
 /**
@@ -169,9 +166,9 @@ export const createModel = async (
   data: Partial<Model> & Pick<Model, 'id' | 'provider' | 'name' | 'model'>,
 ): Promise<void> => {
   const db = DatabaseSingleton.instance.db
-  await db.insert(modelsTable).values(data)
-
-  // Auto-create default profile if one exists in seed data
-  const { createDefaultModelProfile } = await import('./model-profiles')
-  await createDefaultModelProfile(data.id)
+  await db.transaction(async (tx) => {
+    await tx.insert(modelsTable).values(data)
+    const { createDefaultModelProfile } = await import('./model-profiles')
+    await createDefaultModelProfile(data.id, tx)
+  })
 }

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -5,6 +5,8 @@ import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { Model, ModelRow } from '../types'
 import { getSettings } from './settings'
 import { getLastMessage } from './chat-messages'
+import { deletePromptsForModel } from './prompts'
+import { createDefaultModelProfile, deleteModelProfileForModel } from './model-profiles'
 
 const mapModel = (row: ModelRow): Model => {
   return {
@@ -147,9 +149,6 @@ export const resetModelToDefault = async (id: string, defaultModel: Model): Prom
 export const deleteModel = async (id: string): Promise<void> => {
   const db = DatabaseSingleton.instance.db
   await db.transaction(async (tx) => {
-    const { deletePromptsForModel } = await import('./prompts')
-    const { deleteModelProfileForModel } = await import('./model-profiles')
-
     await deleteModelProfileForModel(id, tx)
     await deletePromptsForModel(id, tx)
     await tx
@@ -168,7 +167,6 @@ export const createModel = async (
   const db = DatabaseSingleton.instance.db
   await db.transaction(async (tx) => {
     await tx.insert(modelsTable).values(data)
-    const { createDefaultModelProfile } = await import('./model-profiles')
     await createDefaultModelProfile(data.id, tx)
   })
 }

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -5,7 +5,6 @@ import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { Model, ModelRow } from '../types'
 import { getSettings } from './settings'
 import { getLastMessage } from './chat-messages'
-import { deletePromptsForModel } from './prompts'
 import { createDefaultModelProfile, deleteModelProfileForModel } from './model-profiles'
 
 const mapModel = (row: ModelRow): Model => {
@@ -148,6 +147,8 @@ export const resetModelToDefault = async (id: string, defaultModel: Model): Prom
  */
 export const deleteModel = async (id: string): Promise<void> => {
   const db = DatabaseSingleton.instance.db
+  // Dynamic import to avoid circular dependency: models → prompts → models (via getModel)
+  const { deletePromptsForModel } = await import('./prompts')
   await db.transaction(async (tx) => {
     await deleteModelProfileForModel(id, tx)
     await deletePromptsForModel(id, tx)

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, isNull, like } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
+import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { DatabaseSingleton } from '../db/singleton'
 import { chatMessagesTable, chatThreadsTable, promptsTable } from '../db/tables'
 import type { AutomationRun, Prompt } from '../types'
@@ -89,13 +90,13 @@ export const resetAutomationToDefault = async (id: string, defaultAutomation: Pr
  */
 export const deleteAutomation = async (id: string): Promise<void> => {
   const db = DatabaseSingleton.instance.db
-  // Delete triggers first (due to foreign key)
-  await deleteTriggersForPrompt(id)
-  // Soft delete with data scrubbing
-  await db
-    .update(promptsTable)
-    .set({ ...clearNullableColumns(promptsTable), deletedAt: nowIso() })
-    .where(and(eq(promptsTable.id, id), isNull(promptsTable.deletedAt)))
+  await db.transaction(async (tx) => {
+    await deleteTriggersForPrompt(id, tx)
+    await tx
+      .update(promptsTable)
+      .set({ ...clearNullableColumns(promptsTable), deletedAt: nowIso() })
+      .where(and(eq(promptsTable.id, id), isNull(promptsTable.deletedAt)))
+  })
 }
 
 /**
@@ -104,22 +105,18 @@ export const deleteAutomation = async (id: string): Promise<void> => {
  * Scrubs all nullable columns for privacy
  * This replaces the cascade behavior that no longer fires with soft deletes
  */
-export const deletePromptsForModel = async (modelId: string): Promise<void> => {
-  const db = DatabaseSingleton.instance.db
+export const deletePromptsForModel = async (modelId: string, db?: AnyDrizzleDatabase): Promise<void> => {
+  const database = db ?? DatabaseSingleton.instance.db
 
-  // Find all prompts for this model that aren't already deleted
-  const prompts = await db
+  const prompts = await database
     .select({ id: promptsTable.id })
     .from(promptsTable)
     .where(and(eq(promptsTable.modelId, modelId), isNull(promptsTable.deletedAt)))
 
   const promptIds = prompts.map((p) => p.id)
 
-  // Soft-delete all triggers for these prompts in a single query
-  await deleteTriggersForPrompts(promptIds)
-
-  // Soft-delete all prompts for this model with data scrubbing
-  await db
+  await deleteTriggersForPrompts(promptIds, database)
+  await database
     .update(promptsTable)
     .set({ ...clearNullableColumns(promptsTable), deletedAt: nowIso() })
     .where(and(eq(promptsTable.modelId, modelId), isNull(promptsTable.deletedAt)))
@@ -154,38 +151,39 @@ export const runAutomation = async (promptId: string): Promise<string> => {
   const db = DatabaseSingleton.instance.db
 
   const prompt = await getPrompt(promptId)
-
   if (!prompt) {
     throw new Error('Prompt not found')
   }
 
   const model = await getModel(prompt.modelId)
-
   if (!model) {
     throw new Error('Model not found')
   }
 
   const threadId = uuidv7()
 
-  await createChatThread(
-    {
-      id: threadId,
-      title: prompt.title ?? 'Automation',
-      triggeredBy: prompt.id,
-      wasTriggeredByAutomation: 1,
-      contextSize: null,
-    },
-    model.id,
-  )
+  await db.transaction(async (tx) => {
+    await createChatThread(
+      {
+        id: threadId,
+        title: prompt.title ?? 'Automation',
+        triggeredBy: prompt.id,
+        wasTriggeredByAutomation: 1,
+        contextSize: null,
+      },
+      model.id,
+      tx,
+    )
 
-  const userMessage = {
-    id: uuidv7(),
-    role: 'user' as const,
-    metadata: { modelId: model.id },
-    parts: [{ type: 'text' as const, text: prompt.prompt }],
-  }
+    const userMessage = {
+      id: uuidv7(),
+      role: 'user' as const,
+      metadata: { modelId: model.id },
+      parts: [{ type: 'text' as const, text: prompt.prompt }],
+    }
 
-  await db.insert(chatMessagesTable).values(convertUIMessageToDbChatMessage(userMessage, threadId, null))
+    await tx.insert(chatMessagesTable).values(convertUIMessageToDbChatMessage(userMessage, threadId, null))
+  })
 
   return threadId
 }

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -171,7 +171,7 @@ export const runAutomation = async (promptId: string): Promise<string> => {
         wasTriggeredByAutomation: 1,
         contextSize: null,
       },
-      model.id,
+      model,
       tx,
     )
 

--- a/src/dal/settings.ts
+++ b/src/dal/settings.ts
@@ -1,4 +1,5 @@
 import { eq, sql } from 'drizzle-orm'
+import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { DatabaseSingleton } from '../db/singleton'
 import { isInsertConflictError } from '../lib/sqlite-errors'
 import { settingsTable } from '../db/tables'
@@ -226,11 +227,12 @@ export const hasSetting = async (key: string): Promise<boolean> => {
  * Create a setting only if it doesn't already exist
  * Does nothing if the setting already exists (preserves existing value)
  * Uses insert-then-catch-conflict to avoid TOCTOU race (PowerSync views don't support ON CONFLICT)
+ * @param db - Optional database/transaction to use (e.g. when batching within a PowerSync transaction)
  */
-export const createSetting = async (key: string, value: string | null): Promise<void> => {
-  const db = DatabaseSingleton.instance.db
+export const createSetting = async (key: string, value: string | null, db?: AnyDrizzleDatabase): Promise<void> => {
+  const database = db ?? DatabaseSingleton.instance.db
   try {
-    await db.insert(settingsTable).values({ key, value })
+    await database.insert(settingsTable).values({ key, value })
   } catch (err) {
     if (!isInsertConflictError(err)) {
       throw err

--- a/src/dal/triggers.ts
+++ b/src/dal/triggers.ts
@@ -1,4 +1,5 @@
 import { and, eq, inArray, isNull } from 'drizzle-orm'
+import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { DatabaseSingleton } from '../db/singleton'
 import { triggersTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
@@ -31,9 +32,9 @@ export const getAllEnabledTriggers = async (): Promise<Trigger[]> => {
  * Scrubs all nullable columns for privacy
  * Only updates records that haven't been deleted yet to preserve original deletion datetimes
  */
-export const deleteTriggersForPrompt = async (promptId: string): Promise<void> => {
-  const db = DatabaseSingleton.instance.db
-  await db
+export const deleteTriggersForPrompt = async (promptId: string, db?: AnyDrizzleDatabase): Promise<void> => {
+  const database = db ?? DatabaseSingleton.instance.db
+  await database
     .update(triggersTable)
     .set({ ...clearNullableColumns(triggersTable), deletedAt: nowIso() })
     .where(and(eq(triggersTable.promptId, promptId), isNull(triggersTable.deletedAt)))
@@ -44,13 +45,13 @@ export const deleteTriggersForPrompt = async (promptId: string): Promise<void> =
  * Scrubs all nullable columns for privacy
  * Only updates records that haven't been deleted yet to preserve original deletion datetimes
  */
-export const deleteTriggersForPrompts = async (promptIds: string[]): Promise<void> => {
+export const deleteTriggersForPrompts = async (promptIds: string[], db?: AnyDrizzleDatabase): Promise<void> => {
   if (promptIds.length === 0) {
     return
   }
 
-  const db = DatabaseSingleton.instance.db
-  await db
+  const database = db ?? DatabaseSingleton.instance.db
+  await database
     .update(triggersTable)
     .set({ ...clearNullableColumns(triggersTable), deletedAt: nowIso() })
     .where(and(inArray(triggersTable.promptId, promptIds), isNull(triggersTable.deletedAt)))

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -193,6 +193,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       // Use HTTP streaming to avoid WebSocket "invalid opcode 7" with self-hosted service (ws library).
       await this.powerSync.connect(connector, {
         connectionMethod: SyncStreamConnectionMethod.HTTP,
+        crudUploadThrottleMs: 5000,
       })
       this._isConnected = true
     } catch (error) {

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -76,24 +76,26 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
 }
 
 export const reconcileDefaults = async (db: AnyDrizzleDatabase) => {
-  // AI models
-  await reconcileDefaultsForTable(db, modelsTable, defaultModels, hashModel)
+  await db.transaction(async (tx) => {
+    // AI models
+    await reconcileDefaultsForTable(tx, modelsTable, defaultModels, hashModel)
 
-  // Model profiles (after models, because they reference model IDs)
-  await reconcileDefaultsForTable(db, modelProfilesTable, defaultModelProfiles, hashModelProfile, 'modelId')
+    // Model profiles (after models, because they reference model IDs)
+    await reconcileDefaultsForTable(tx, modelProfilesTable, defaultModelProfiles, hashModelProfile, 'modelId')
 
-  // Modes
-  await reconcileDefaultsForTable(db, modesTable, defaultModes, hashMode)
+    // Modes
+    await reconcileDefaultsForTable(tx, modesTable, defaultModes, hashMode)
 
-  // Tasks
-  await reconcileDefaultsForTable(db, tasksTable, defaultTasks, hashTask)
+    // Tasks
+    await reconcileDefaultsForTable(tx, tasksTable, defaultTasks, hashTask)
 
-  // Automations (Prompts)
-  await reconcileDefaultsForTable(db, promptsTable, defaultAutomations, hashPrompt)
+    // Automations (Prompts)
+    await reconcileDefaultsForTable(tx, promptsTable, defaultAutomations, hashPrompt)
 
-  // Settings
-  await reconcileDefaultsForTable(db, settingsTable, defaultSettings, hashSetting, 'key')
+    // Settings
+    await reconcileDefaultsForTable(tx, settingsTable, defaultSettings, hashSetting, 'key')
 
-  // Initialize anonymous ID for analytics (unique per user)
-  await createSetting('anonymous_id', uuidv7())
+    // Initialize anonymous ID for analytics (unique per user)
+    await createSetting('anonymous_id', uuidv7(), tx)
+  })
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes touch multiple DAL write paths (models/prompts/triggers/chat threads/messages/settings) and adjust function signatures to accept transactions, which could introduce subtle behavior differences or missed call-site updates, but the logic is largely refactoring for atomicity and PowerSync compatibility.
> 
> **Overview**
> **PowerSync write operations are now batched/atomic via `db.transaction(...)`** across key DAL flows to reduce sync overhead and avoid partial updates.
> 
> This refactors several DAL helpers to accept an optional `AnyDrizzleDatabase` transaction and threads it through multi-step operations (e.g. `createModel` + default profile creation, `deleteModel` + prompt/trigger/profile cleanup, `runAutomation` thread + seed message, `saveMessagesWithContextUpdate` message writes + thread context update, and chat thread/message soft-deletes).
> 
> Separately, `createChatThread` now takes a resolved `Model` object (instead of a `modelId`) to avoid redundant lookups and to support transactional callers; tests were updated accordingly. PowerSync connection is also tuned with `crudUploadThrottleMs: 5000`, and coding guidelines now prefer top-level imports over dynamic imports when possible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abdccd2aff801aea6854ebed005ce6f1846ea6f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->