### PR TITLE
THU-314: Verification failed error message displays before navigating away

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -29,6 +29,7 @@ import { AppErrorScreen } from './components/app-error-screen'
 import { AuthGate } from './components/auth-gate'
 import NotFound from './components/not-found'
 import { OnboardingDialog } from './components/onboarding/onboarding-dialog'
+import { WelcomeDialog } from './components/welcome-dialog'
 import { UpdateNotification } from './components/update-notification'
 import { ExternalLinkDialogProvider } from './components/chat/markdown-utils'
 import { ContentViewProvider } from './content-view/context'
@@ -93,6 +94,7 @@ function AppRoutes({ initData }: { initData: InitData }) {
             <>
               <Layout />
               <OnboardingDialog />
+              <WelcomeDialog />
             </>
           }
         >

--- a/src/components/magic-link-verify.tsx
+++ b/src/components/magic-link-verify.tsx
@@ -37,7 +37,9 @@ export const MagicLinkVerify = () => {
   const hasAttempted = useRef(false)
 
   useEffect(() => {
-    if (hasAttempted.current) return
+    if (hasAttempted.current) {
+      return
+    }
     hasAttempted.current = true
 
     const verify = async () => {

--- a/src/components/magic-link-verify.tsx
+++ b/src/components/magic-link-verify.tsx
@@ -32,15 +32,17 @@ export const MagicLinkVerify = () => {
   const email = searchParams.get('email')
   const otp = searchParams.get('otp')
 
-  // Prevent double-verification: refetchSession changes identity after cache update,
-  // which would re-trigger this effect and send the already-consumed OTP again.
-  const hasAttempted = useRef(false)
+  // Track which email+otp pair was last attempted so we suppress re-submission of
+  // the same (already-consumed) OTP when refetchSession changes identity and
+  // re-triggers this effect, while still allowing a new magic link's OTP through.
+  const lastAttemptedRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (hasAttempted.current) {
+    const key = `${email}:${otp}`
+    if (lastAttemptedRef.current === key) {
       return
     }
-    hasAttempted.current = true
+    lastAttemptedRef.current = key
 
     const verify = async () => {
       if (!email || !otp) {

--- a/src/components/magic-link-verify.tsx
+++ b/src/components/magic-link-verify.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
 
 import { Button } from '@/components/ui/button'
@@ -32,7 +32,14 @@ export const MagicLinkVerify = () => {
   const email = searchParams.get('email')
   const otp = searchParams.get('otp')
 
+  // Prevent double-verification: refetchSession changes identity after cache update,
+  // which would re-trigger this effect and send the already-consumed OTP again.
+  const hasAttempted = useRef(false)
+
   useEffect(() => {
+    if (hasAttempted.current) return
+    hasAttempted.current = true
+
     const verify = async () => {
       if (!email || !otp) {
         setState({ status: 'error', message: 'Invalid verification link. Please request a new one.' })

--- a/src/components/welcome-dialog.test.ts
+++ b/src/components/welcome-dialog.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { useWelcomeStore } from './welcome-dialog'
+
+describe('useWelcomeStore', () => {
+  afterEach(() => {
+    // Reset store between tests
+    useWelcomeStore.setState({ pending: false })
+  })
+
+  it('starts with pending = false', () => {
+    expect(useWelcomeStore.getState().pending).toBe(false)
+  })
+
+  it('trigger() sets pending to true', () => {
+    useWelcomeStore.getState().trigger()
+    expect(useWelcomeStore.getState().pending).toBe(true)
+  })
+
+  it('consume() returns true and resets pending', () => {
+    useWelcomeStore.getState().trigger()
+
+    const result = useWelcomeStore.getState().consume()
+    expect(result).toBe(true)
+    expect(useWelcomeStore.getState().pending).toBe(false)
+  })
+
+  it('consume() returns false when nothing was triggered', () => {
+    const result = useWelcomeStore.getState().consume()
+    expect(result).toBe(false)
+  })
+
+  it('double consume() returns false on the second call', () => {
+    useWelcomeStore.getState().trigger()
+
+    expect(useWelcomeStore.getState().consume()).toBe(true)
+    expect(useWelcomeStore.getState().consume()).toBe(false)
+  })
+})

--- a/src/components/welcome-dialog.tsx
+++ b/src/components/welcome-dialog.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState } from 'react'
+
+import { SignInSuccessStep } from '@/components/sign-in/sign-in-success-step'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import { useSettings } from '@/hooks/use-settings'
+
+/** Module-level flag — survives route changes since it's just a JS variable. */
+let pendingWelcome = false
+
+/** Call after successful OTP verification to show the welcome dialog on the next mount. */
+export const triggerWelcome = () => {
+  pendingWelcome = true
+}
+
+/**
+ * Shows a welcome dialog after successful sign-in from the waitlist page.
+ */
+export const WelcomeDialog = () => {
+  const { preferredName } = useSettings({ preferred_name: '' })
+  const [isOpen, setIsOpen] = useState(() => {
+    if (pendingWelcome) {
+      pendingWelcome = false
+      return true
+    }
+    return false
+  })
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogContent className="sm:max-w-md" showCloseButton={false}>
+        <DialogTitle className="sr-only">Welcome</DialogTitle>
+        <DialogDescription className="sr-only">Sign-in successful</DialogDescription>
+        <SignInSuccessStep
+          displayName={preferredName.value as string}
+          onContinue={() => setIsOpen(false)}
+          variant="modal"
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/welcome-dialog.tsx
+++ b/src/components/welcome-dialog.tsx
@@ -1,31 +1,32 @@
 'use client'
 
 import { useState } from 'react'
+import { create } from 'zustand'
 
 import { SignInSuccessStep } from '@/components/sign-in/sign-in-success-step'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { useSettings } from '@/hooks/use-settings'
 
-/** Module-level flag — survives route changes since it's just a JS variable. */
-let pendingWelcome = false
-
-/** Call after successful OTP verification to show the welcome dialog on the next mount. */
-export const triggerWelcome = () => {
-  pendingWelcome = true
-}
+export const useWelcomeStore = create<{
+  pending: boolean
+  trigger: () => void
+  consume: () => boolean
+}>((set, get) => ({
+  pending: false,
+  trigger: () => set({ pending: true }),
+  consume: () => {
+    const val = get().pending
+    if (val) set({ pending: false })
+    return val
+  },
+}))
 
 /**
  * Shows a welcome dialog after successful sign-in from the waitlist page.
  */
 export const WelcomeDialog = () => {
   const { preferredName } = useSettings({ preferred_name: '' })
-  const [isOpen, setIsOpen] = useState(() => {
-    if (pendingWelcome) {
-      pendingWelcome = false
-      return true
-    }
-    return false
-  })
+  const [isOpen, setIsOpen] = useState(() => useWelcomeStore.getState().consume())
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>

--- a/src/components/welcome-dialog.tsx
+++ b/src/components/welcome-dialog.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useState } from 'react'
 import { create } from 'zustand'
 

--- a/src/components/welcome-dialog.tsx
+++ b/src/components/welcome-dialog.tsx
@@ -16,7 +16,9 @@ export const useWelcomeStore = create<{
   trigger: () => set({ pending: true }),
   consume: () => {
     const val = get().pending
-    if (val) set({ pending: false })
+    if (val) {
+      set({ pending: false })
+    }
     return val
   },
 }))

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -81,6 +81,8 @@ export const AuthProvider = ({ children, authClient: overrideClient }: AuthProvi
   // Keep the last valid context so that transient React Query refetches
   // (e.g. PowerSync invalidating the settings table after auth) don't
   // unmount the entire tree and destroy in-flight flows like MagicLinkVerify.
+  // Note: this briefly serves a stale client if cloudUrl genuinely changes,
+  // but cloudUrl is effectively immutable at runtime (set once during setup).
   const lastValueRef = useRef<AuthContextType | null>(null)
 
   const value = useMemo(() => {

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -7,7 +7,7 @@ import { getAuthToken, setAuthToken } from '@/lib/auth-token'
 import { getPlatform } from '@/lib/platform'
 import { emailOTPClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/react'
-import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { createContext, useContext, useMemo, useRef, type ReactNode } from 'react'
 
 /**
  * Create an auth client instance with the given base URL
@@ -78,6 +78,11 @@ export const AuthProvider = ({ children, authClient: overrideClient }: AuthProvi
 
   const { cloudUrl } = useSettings({ cloud_url: String })
 
+  // Keep the last valid context so that transient React Query refetches
+  // (e.g. PowerSync invalidating the settings table after auth) don't
+  // unmount the entire tree and destroy in-flight flows like MagicLinkVerify.
+  const lastValueRef = useRef<AuthContextType | null>(null)
+
   const value = useMemo(() => {
     if (overrideClient) {
       return { authClient: overrideClient }
@@ -93,13 +98,19 @@ export const AuthProvider = ({ children, authClient: overrideClient }: AuthProvi
     return { authClient: client }
   }, [cloudUrl.value, cloudUrl.isLoading, overrideClient])
 
-  // Wait for auth client to be ready before rendering children
-  // This prevents useSession from triggering requests to wrong URL
-  if (!value) {
+  if (value) {
+    lastValueRef.current = value
+  }
+
+  // Wait for auth client to be ready before rendering children.
+  // Once initialized, keep children mounted during transient reloads
+  // to avoid unmounting in-flight auth flows (e.g. magic link verification).
+  const resolvedValue = value ?? lastValueRef.current
+  if (!resolvedValue) {
     return null
   }
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  return <AuthContext.Provider value={resolvedValue}>{children}</AuthContext.Provider>
 }
 
 export const useAuth = () => {

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -7,7 +7,7 @@ import { getAuthToken, setAuthToken } from '@/lib/auth-token'
 import { getPlatform } from '@/lib/platform'
 import { emailOTPClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/react'
-import { createContext, useContext, useMemo, useRef, type ReactNode } from 'react'
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
 
 /**
  * Create an auth client instance with the given base URL
@@ -78,13 +78,6 @@ export const AuthProvider = ({ children, authClient: overrideClient }: AuthProvi
 
   const { cloudUrl } = useSettings({ cloud_url: String })
 
-  // Keep the last valid context so that transient React Query refetches
-  // (e.g. PowerSync invalidating the settings table after auth) don't
-  // unmount the entire tree and destroy in-flight flows like MagicLinkVerify.
-  // Note: this briefly serves a stale client if cloudUrl genuinely changes,
-  // but cloudUrl is effectively immutable at runtime (set once during setup).
-  const lastValueRef = useRef<AuthContextType | null>(null)
-
   const value = useMemo(() => {
     if (overrideClient) {
       return { authClient: overrideClient }
@@ -100,19 +93,11 @@ export const AuthProvider = ({ children, authClient: overrideClient }: AuthProvi
     return { authClient: client }
   }, [cloudUrl.value, cloudUrl.isLoading, overrideClient])
 
-  if (value) {
-    lastValueRef.current = value
-  }
-
-  // Wait for auth client to be ready before rendering children.
-  // Once initialized, keep children mounted during transient reloads
-  // to avoid unmounting in-flight auth flows (e.g. magic link verification).
-  const resolvedValue = value ?? lastValueRef.current
-  if (!resolvedValue) {
+  if (!value) {
     return null
   }
 
-  return <AuthContext.Provider value={resolvedValue}>{children}</AuthContext.Provider>
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
 
 export const useAuth = () => {

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -4,7 +4,7 @@ import { getSettingsRecords, resetSettingToDefault, updateSettings } from '@/dal
 import { deserializeValue, inferTypeFromSchema } from '@/lib/serialization'
 import { camelCased } from '@/lib/utils'
 import type { Setting } from '@/types'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
 /**
@@ -210,6 +210,7 @@ export function useSettings<T extends SettingSchema>(
       const result = await getSettingsRecords(schema)
       return Object.values(result)
     },
+    placeholderData: keepPreviousData,
   })
 
   const updateMutation = useMutation({

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -6,7 +6,7 @@ import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { isValidEmailFormat } from '@/lib/utils'
 import { useReducer, type FormEvent } from 'react'
 
-type WaitlistStatus = 'idle' | 'joining' | 'checkEmail' | 'verifying' | 'error'
+type WaitlistStatus = 'idle' | 'joining' | 'checkEmail' | 'verifying' | 'verified' | 'error'
 
 type State = {
   email: string
@@ -22,6 +22,7 @@ type Action =
   | { type: 'JOIN_SUCCESS' }
   | { type: 'JOIN_ERROR'; payload: string }
   | { type: 'START_VERIFYING' }
+  | { type: 'VERIFY_SUCCESS' }
   | { type: 'VERIFY_ERROR'; payload: string }
   | { type: 'RESET' }
 
@@ -46,6 +47,8 @@ const reducer = (state: State, action: Action): State => {
       return { ...state, status: 'error', errorMessage: action.payload }
     case 'START_VERIFYING':
       return { ...state, status: 'verifying', errorMessage: '' }
+    case 'VERIFY_SUCCESS':
+      return { ...state, status: 'verified' }
     case 'VERIFY_ERROR':
       return { ...state, status: 'checkEmail', otp: '', errorMessage: action.payload }
     case 'RESET':
@@ -57,7 +60,6 @@ const reducer = (state: State, action: Action): State => {
 
 type UseWaitlistStateOptions = {
   authClient: AuthClient
-  onVerified?: () => void
 }
 
 /**
@@ -67,7 +69,7 @@ type UseWaitlistStateOptions = {
  * Privacy note: The API always returns { success: true } regardless of user status.
  * Approved users receive an OTP email; others receive waitlist status emails.
  */
-export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOptions) => {
+export const useWaitlistState = ({ authClient }: UseWaitlistStateOptions) => {
   const httpClient = useHttpClient()
   const [state, dispatch] = useReducer(reducer, initialState)
 
@@ -119,7 +121,7 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
       const isNewUser = isNewAuthUser(result.data.user)
       await onSignInSuccess(isNewUser)
 
-      onVerified?.()
+      dispatch({ type: 'VERIFY_SUCCESS' })
     } catch (error) {
       console.error('OTP verification error:', error)
       dispatch({ type: 'VERIFY_ERROR', payload: 'Verification failed. Please try again.' })

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -1,4 +1,5 @@
 import { isNewAuthUser, onSignInSuccess } from '@/components/sign-in/use-sign-in-form-state'
+import { triggerWelcome } from '@/components/welcome-dialog'
 import type { AuthClient } from '@/contexts'
 import { useHttpClient } from '@/contexts'
 import { setAuthToken } from '@/lib/auth-token'
@@ -6,7 +7,7 @@ import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { isValidEmailFormat } from '@/lib/utils'
 import { useReducer, type FormEvent } from 'react'
 
-type WaitlistStatus = 'idle' | 'joining' | 'checkEmail' | 'verifying' | 'verified' | 'error'
+type WaitlistStatus = 'idle' | 'joining' | 'checkEmail' | 'verifying' | 'error'
 
 type State = {
   email: string
@@ -22,7 +23,6 @@ type Action =
   | { type: 'JOIN_SUCCESS' }
   | { type: 'JOIN_ERROR'; payload: string }
   | { type: 'START_VERIFYING' }
-  | { type: 'VERIFY_SUCCESS' }
   | { type: 'VERIFY_ERROR'; payload: string }
   | { type: 'RESET' }
 
@@ -47,8 +47,6 @@ const reducer = (state: State, action: Action): State => {
       return { ...state, status: 'error', errorMessage: action.payload }
     case 'START_VERIFYING':
       return { ...state, status: 'verifying', errorMessage: '' }
-    case 'VERIFY_SUCCESS':
-      return { ...state, status: 'verified' }
     case 'VERIFY_ERROR':
       return { ...state, status: 'checkEmail', otp: '', errorMessage: action.payload }
     case 'RESET':
@@ -60,6 +58,7 @@ const reducer = (state: State, action: Action): State => {
 
 type UseWaitlistStateOptions = {
   authClient: AuthClient
+  onVerified?: () => void
 }
 
 /**
@@ -69,7 +68,7 @@ type UseWaitlistStateOptions = {
  * Privacy note: The API always returns { success: true } regardless of user status.
  * Approved users receive an OTP email; others receive waitlist status emails.
  */
-export const useWaitlistState = ({ authClient }: UseWaitlistStateOptions) => {
+export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOptions) => {
   const httpClient = useHttpClient()
   const [state, dispatch] = useReducer(reducer, initialState)
 
@@ -121,7 +120,8 @@ export const useWaitlistState = ({ authClient }: UseWaitlistStateOptions) => {
       const isNewUser = isNewAuthUser(result.data.user)
       await onSignInSuccess(isNewUser)
 
-      dispatch({ type: 'VERIFY_SUCCESS' })
+      triggerWelcome()
+      onVerified?.()
     } catch (error) {
       console.error('OTP verification error:', error)
       dispatch({ type: 'VERIFY_ERROR', payload: 'Verification failed. Please try again.' })

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -120,7 +120,9 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
       const isNewUser = isNewAuthUser(result.data.user)
       await onSignInSuccess(isNewUser)
 
-      triggerWelcome()
+      if (!isNewUser) {
+        triggerWelcome()
+      }
       onVerified?.()
     } catch (error) {
       console.error('OTP verification error:', error)

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -1,5 +1,5 @@
 import { isNewAuthUser, onSignInSuccess } from '@/components/sign-in/use-sign-in-form-state'
-import { triggerWelcome } from '@/components/welcome-dialog'
+import { useWelcomeStore } from '@/components/welcome-dialog'
 import type { AuthClient } from '@/contexts'
 import { useHttpClient } from '@/contexts'
 import { setAuthToken } from '@/lib/auth-token'
@@ -115,13 +115,13 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
         return
       }
 
-      await setAuthToken(token)
+      setAuthToken(token)
 
       const isNewUser = isNewAuthUser(result.data.user)
       await onSignInSuccess(isNewUser)
 
       if (!isNewUser) {
-        triggerWelcome()
+        useWelcomeStore.getState().trigger()
       }
       onVerified?.()
     } catch (error) {

--- a/src/waitlist/waitlist-page.tsx
+++ b/src/waitlist/waitlist-page.tsx
@@ -1,8 +1,10 @@
+import { SignInSuccessStep } from '@/components/sign-in/sign-in-success-step'
 import { BackButton } from '@/components/ui/back-button'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
 import { useAuth } from '@/contexts'
+import { useSettings } from '@/hooks/use-settings'
 import { privacyPolicyUrl, termsOfServiceUrl } from '@/lib/constants'
 import { REGEXP_ONLY_DIGITS } from 'input-otp'
 import { Loader2 } from 'lucide-react'
@@ -21,12 +23,24 @@ import { WaitlistHeader } from './waitlist-header'
 export const WaitlistPage = () => {
   const authClient = useAuth()
   const navigate = useNavigate()
-  const { state, isValidEmail, actions } = useWaitlistState({
-    authClient,
-    onVerified: () => navigate('/', { replace: true }),
-  })
+  const { preferredName } = useSettings({ preferred_name: '' })
+  const { state, isValidEmail, actions } = useWaitlistState({ authClient })
 
   const isVerifying = state.status === 'verifying'
+
+  if (state.status === 'verified') {
+    return (
+      <WaitlistCard>
+        <div className="flex w-full flex-1 flex-col items-center justify-center p-4">
+          <SignInSuccessStep
+            displayName={preferredName.value as string}
+            onContinue={() => navigate('/', { replace: true })}
+            variant="page"
+          />
+        </div>
+      </WaitlistCard>
+    )
+  }
 
   if (state.status === 'checkEmail' || state.status === 'verifying') {
     return (

--- a/src/waitlist/waitlist-page.tsx
+++ b/src/waitlist/waitlist-page.tsx
@@ -1,10 +1,8 @@
-import { SignInSuccessStep } from '@/components/sign-in/sign-in-success-step'
 import { BackButton } from '@/components/ui/back-button'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
 import { useAuth } from '@/contexts'
-import { useSettings } from '@/hooks/use-settings'
 import { privacyPolicyUrl, termsOfServiceUrl } from '@/lib/constants'
 import { REGEXP_ONLY_DIGITS } from 'input-otp'
 import { Loader2 } from 'lucide-react'
@@ -23,24 +21,12 @@ import { WaitlistHeader } from './waitlist-header'
 export const WaitlistPage = () => {
   const authClient = useAuth()
   const navigate = useNavigate()
-  const { preferredName } = useSettings({ preferred_name: '' })
-  const { state, isValidEmail, actions } = useWaitlistState({ authClient })
+  const { state, isValidEmail, actions } = useWaitlistState({
+    authClient,
+    onVerified: () => navigate('/', { replace: true }),
+  })
 
   const isVerifying = state.status === 'verifying'
-
-  if (state.status === 'verified') {
-    return (
-      <WaitlistCard>
-        <div className="flex w-full flex-1 flex-col items-center justify-center p-4">
-          <SignInSuccessStep
-            displayName={preferredName.value as string}
-            onContinue={() => navigate('/', { replace: true })}
-            variant="page"
-          />
-        </div>
-      </WaitlistCard>
-    )
-  }
 
   if (state.status === 'checkEmail' || state.status === 'verifying') {
     return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OTP verification/sign-in flows and React Query settings caching, which can affect authentication UX and session initialization if regressions occur.
> 
> **Overview**
> Improves sign-in verification stability by preventing `MagicLinkVerify` from re-submitting an already-consumed OTP when the session `refetch` function changes and re-triggers the effect.
> 
> Adds a lightweight, one-shot `WelcomeDialog` (backed by a small Zustand store + tests) that is triggered after successful waitlist OTP verification for *returning* users, and mounts it at the app root so it appears after redirect.
> 
> Tweaks `useSettings` to use React Query `keepPreviousData` as `placeholderData`, reducing transient "missing settings" states during refetches (e.g., around auth client initialization).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30992ee4f6f2dc2bff8adf71e168139afee3cf48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->