### PR TITLE
THU-322: Add SSRF protection to proxy route

### DIFF
--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -138,7 +138,7 @@ const inferImageContentType = (headerContentType: string | null, imageUrl: strin
  * Validates that a URL is safe to fetch (prevents SSRF attacks).
  * Only allows http/https protocols and blocks internal/private IP addresses.
  */
-const validateSafeUrl = (url: string): { valid: boolean; error?: string } => {
+export const validateSafeUrl = (url: string): { valid: boolean; error?: string } => {
   try {
     const parsed = new URL(url)
 

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -168,7 +168,7 @@ describe('Proxy Routes', () => {
       expect(mockFetch).not.toHaveBeenCalled()
 
       const body = await response.text()
-      expect(body).toBe('Invalid URL provided')
+      expect(body).toBe('Invalid URL')
     })
 
     it('should return 400 when URL has malformed encoding', async () => {
@@ -318,6 +318,49 @@ describe('Proxy Routes', () => {
 
       const body = await response.text()
       expect(body.length).toBe(10000)
+    })
+
+    it('should block requests to localhost', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/proxy/http://127.0.0.1/secret', { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      const body = await response.text()
+      expect(body).toBe('Internal URLs are not allowed')
+    })
+
+    it('should block requests to cloud metadata endpoints', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/proxy/http://169.254.169.254/latest/meta-data/', { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      const body = await response.text()
+      expect(body).toBe('Internal URLs are not allowed')
+    })
+
+    it('should block requests to private network addresses', async () => {
+      const urls = ['http://10.0.0.1/internal', 'http://192.168.1.1/admin', 'http://172.16.0.1/secret']
+
+      for (const url of urls) {
+        mockFetch.mockClear()
+        const response = await app.handle(new Request(`http://localhost/proxy/${url}`, { method: 'GET' }))
+
+        expect(response.status).toBe(400)
+        expect(mockFetch).not.toHaveBeenCalled()
+      }
+    })
+
+    it('should block non-HTTP protocols', async () => {
+      const response = await app.handle(new Request('http://localhost/proxy/file:///etc/passwd', { method: 'GET' }))
+
+      expect(response.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('should not forward headers that are not in the allowed list', async () => {

--- a/backend/src/pro/proxy.ts
+++ b/backend/src/pro/proxy.ts
@@ -2,6 +2,7 @@ import { getCorsOrigins, getSettings } from '@/config/settings'
 import { safeErrorHandler } from '@/middleware/error-handling'
 import cors from '@elysiajs/cors'
 import { Elysia } from 'elysia'
+import { validateSafeUrl } from './link-preview'
 
 /**
  * General-purpose proxy routes
@@ -49,12 +50,10 @@ export const createProxyRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
         })
       }
 
-      // Validate that it's a valid URL
-      try {
-        new URL(targetUrl)
-      } catch {
+      const validation = validateSafeUrl(targetUrl)
+      if (!validation.valid) {
         ctx.set.status = 400
-        return new Response('Invalid URL provided', {
+        return new Response(validation.error || 'Invalid URL provided', {
           headers: {
             'Content-Type': 'text/plain',
           },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches request validation on a general-purpose proxy route; behavior changes can break previously-working URLs and any gaps in hostname/IP parsing could still allow bypasses.
> 
> **Overview**
> Adds SSRF protection to `GET /proxy/*` by reusing `validateSafeUrl` from `link-preview` to block non-HTTP(S) schemes and internal/private/metadata IP targets before issuing the upstream fetch.
> 
> Updates proxy error messaging for invalid URLs and extends `proxy.test.ts` coverage to assert blocking of localhost, private ranges, and cloud metadata endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d41f21a04f9a63211c6028d8ee20550109cb00ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->