### PR TITLE
THU-323: center model selector in header

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -52,30 +52,37 @@ export const Header = () => {
     />
   )
 
-  const showNewChatButton = isMobile && isChatRoute && location.pathname !== '/chats/new'
+  if (isMobile) {
+    const showNewChatButton = isChatRoute && location.pathname !== '/chats/new'
 
-  return (
-    <header className="flex h-12 w-full items-center px-2 flex-shrink-0 border-b border-border">
-      <div className="flex flex-1 items-center">
-        {isMobile && (
+    return (
+      <header className="flex h-12 w-full items-center px-2 flex-shrink-0 border-b border-border">
+        <div className="flex flex-1 items-center">
           <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={toggleSidebar}>
             <Menu className="h-5 w-5" />
             <span className="sr-only">Toggle Sidebar</span>
           </Button>
-        )}
-      </div>
+        </div>
 
-      <div className="flex shrink-0 items-center justify-center">{modelSelector}</div>
+        <div className="flex shrink-0 items-center justify-center">{modelSelector}</div>
 
-      <div className="flex flex-1 items-center justify-end gap-1">
-        {showNewChatButton && (
-          <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={handleNewChat}>
-            <MessageCirclePlus className="h-5 w-5" />
-            <span className="sr-only">New Chat</span>
-          </Button>
-        )}
-        <PowerSyncStatus />
-      </div>
+        <div className="flex flex-1 items-center justify-end gap-1">
+          {showNewChatButton && (
+            <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={handleNewChat}>
+              <MessageCirclePlus className="h-5 w-5" />
+              <span className="sr-only">New Chat</span>
+            </Button>
+          )}
+          <PowerSyncStatus />
+        </div>
+      </header>
+    )
+  }
+
+  return (
+    <header className="flex h-12 w-full items-center justify-between px-2 flex-shrink-0 border-b border-border">
+      <div className="flex items-center">{modelSelector}</div>
+      <PowerSyncStatus />
     </header>
   )
 }

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -52,39 +52,30 @@ export const Header = () => {
     />
   )
 
-  // Mobile: 3-column layout with centered model selector
-  if (isMobile) {
-    const showNewChatButton = isChatRoute && location.pathname !== '/chats/new'
+  const showNewChatButton = isMobile && isChatRoute && location.pathname !== '/chats/new'
 
-    return (
-      <header className="flex h-12 w-full items-center justify-between px-2 flex-shrink-0 border-b border-border">
-        <div className="flex items-center w-7">
+  return (
+    <header className="flex h-12 w-full items-center px-2 flex-shrink-0 border-b border-border">
+      <div className="flex flex-1 items-center">
+        {isMobile && (
           <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={toggleSidebar}>
             <Menu className="h-5 w-5" />
             <span className="sr-only">Toggle Sidebar</span>
           </Button>
-        </div>
+        )}
+      </div>
 
-        <div className="flex items-center justify-center flex-1">{modelSelector}</div>
+      <div className="flex shrink-0 items-center justify-center">{modelSelector}</div>
 
-        <div className="flex items-center gap-1 justify-end">
-          {showNewChatButton && (
-            <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={handleNewChat}>
-              <MessageCirclePlus className="h-5 w-5" />
-              <span className="sr-only">New Chat</span>
-            </Button>
-          )}
-          <PowerSyncStatus />
-        </div>
-      </header>
-    )
-  }
-
-  // Desktop: Left-aligned with PowerSync status on the right
-  return (
-    <header className="flex h-12 w-full items-center justify-between px-2 flex-shrink-0 border-b border-border">
-      <div className="flex items-center">{modelSelector}</div>
-      <PowerSyncStatus />
+      <div className="flex flex-1 items-center justify-end gap-1">
+        {showNewChatButton && (
+          <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={handleNewChat}>
+            <MessageCirclePlus className="h-5 w-5" />
+            <span className="sr-only">New Chat</span>
+          </Button>
+        )}
+        <PowerSyncStatus />
+      </div>
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- Fix model selector not being centered in the header (both mobile and desktop)
- Use equal-width `flex-1` side columns with `shrink-0` center to keep the model selector truly centered regardless of side content widths
- Unify mobile/desktop into a single layout since the only difference is which elements appear in the side columns

## Linear
[THU-323](https://linear.app/mozilla-thunderbolt/issue/THU-323/model-selector-no-longer-centered)

## Test Plan
- [ ] Model selector is visually centered on mobile
- [ ] Model selector is visually centered on desktop
- [ ] Menu button visible on mobile (left side)
- [ ] New Chat button visible on mobile (right side)
- [ ] PowerSyncStatus visible on both layouts (right side)
- [ ] Non-chat routes don't show model selector

## Changes
- `src/components/ui/header.tsx` — Replaced separate mobile/desktop layouts with unified 3-column flex layout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only flexbox layout adjustments; main risk is minor visual regression/alignment differences on mobile routes.
> 
> **Overview**
> Adjusts the mobile `Header` layout to keep the `ModelSelector` visually centered by using equal-width (`flex-1`) side columns and a non-shrinking (`shrink-0`) center column.
> 
> This changes the header’s flex alignment (removing `justify-between` on mobile) so the menu button and right-side actions no longer affect the selector’s centering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7867073eba93192e3612c7a80fa6caa2ea46d81f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->