### PR TITLE
⚡ THU-323: center model selector in mobile header

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -57,17 +57,17 @@ export const Header = () => {
     const showNewChatButton = isChatRoute && location.pathname !== '/chats/new'
 
     return (
-      <header className="flex h-12 w-full items-center justify-between px-2 flex-shrink-0 border-b border-border">
-        <div className="flex items-center w-7">
+      <header className="flex h-12 w-full items-center px-2 flex-shrink-0 border-b border-border">
+        <div className="flex flex-1 items-center">
           <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={toggleSidebar}>
             <Menu className="h-5 w-5" />
             <span className="sr-only">Toggle Sidebar</span>
           </Button>
         </div>
 
-        <div className="flex items-center justify-center flex-1">{modelSelector}</div>
+        <div className="flex shrink-0 items-center justify-center">{modelSelector}</div>
 
-        <div className="flex items-center gap-1 justify-end">
+        <div className="flex flex-1 items-center gap-1 justify-end">
           {showNewChatButton && (
             <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={handleNewChat}>
               <MessageCirclePlus className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- Fix model selector not being truly centered on mobile by using a symmetric 3-column flex layout
- Both left and right columns now use `flex-1` with the center column using `shrink-0`, ensuring the model selector sits at exact screen center regardless of side content widths
- Desktop layout remains unchanged (left-aligned)

## Linear
[THU-323](https://linear.app/mozilla-thunderbolt/issue/THU-323/model-selector-no-longer-centered)

## Test Plan
- [ ] Mobile: model selector appears at exact center of screen
- [ ] Mobile: centering holds regardless of whether "new chat" button is visible
- [ ] Desktop: model selector remains left-aligned
- [ ] PowerSync status indicator still displays correctly on both breakpoints

## Changes
- `src/components/ui/header.tsx` — Changed mobile header from fixed-width left column (`w-7`) + `flex-1` center to symmetric `flex-1` / `shrink-0` / `flex-1` three-column layout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change to the mobile header flex layout; no business logic or data flow changes.
> 
> **Overview**
> Adjusts the mobile `Header` layout to a symmetric three-column flex arrangement (`flex-1` / `shrink-0` / `flex-1`) so the `ModelSelector` stays truly centered regardless of left/right button widths.
> 
> Desktop header behavior remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19238bb0f4efa77d2bdbada8ef6aa9308e949396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->