### PR TITLE
⚡ THU-290: Fix tool call group duration showing conversation total

### DIFF
--- a/src/ai/message-metadata.test.ts
+++ b/src/ai/message-metadata.test.ts
@@ -34,12 +34,13 @@ describe('createMessageMetadata', () => {
   })
 
   describe('tool call timing', () => {
-    it('returns modelId on tool-call start', () => {
+    it('returns modelId and start time on tool-call start', () => {
       const metadata = createMessageMetadata(modelId)
+      Date.now = () => 1000
 
       const result = metadata({ part: { type: 'tool-call', toolCallId: 'call-123' } })
 
-      expect(result).toEqual({ modelId })
+      expect(result).toEqual({ modelId, reasoningStartTimes: { 'call-123': 1000 } })
     })
 
     it('returns duration on tool-result', () => {
@@ -111,12 +112,13 @@ describe('createMessageMetadata', () => {
   })
 
   describe('reasoning timing', () => {
-    it('returns modelId on reasoning-start', () => {
+    it('returns modelId and start time on reasoning-start', () => {
       const metadata = createMessageMetadata(modelId)
+      Date.now = () => 1000
 
       const result = metadata({ part: { type: 'reasoning-start' } })
 
-      expect(result).toEqual({ modelId })
+      expect(result).toEqual({ modelId, reasoningStartTimes: { 'reasoning-0': 1000 } })
     })
 
     it('returns duration on reasoning-end', () => {
@@ -282,20 +284,20 @@ describe('createMessageMetadata', () => {
     it('does not include sources in tool-call events', () => {
       const sourceCollector: SourceMetadata[] = [...mockSources]
       const metadata = createMessageMetadata(modelId, sourceCollector)
+      Date.now = () => 1000
 
       const result = metadata({ part: { type: 'tool-call', toolCallId: 'call-1' } })
 
-      expect(result).toEqual({ modelId })
       expect(result).not.toHaveProperty('sources')
     })
 
     it('does not include sources in reasoning events', () => {
       const sourceCollector: SourceMetadata[] = [...mockSources]
       const metadata = createMessageMetadata(modelId, sourceCollector)
+      Date.now = () => 1000
 
       const result = metadata({ part: { type: 'reasoning-start' } })
 
-      expect(result).toEqual({ modelId })
       expect(result).not.toHaveProperty('sources')
     })
   })

--- a/src/ai/message-metadata.ts
+++ b/src/ai/message-metadata.ts
@@ -32,15 +32,17 @@ export const createMessageMetadata = (modelId: string, sourceCollector?: SourceM
 
       case 'tool-call': {
         const id = part.toolCallId ?? part.id ?? 'unknown'
-        startTimes.set(id, Date.now())
-        return { modelId }
+        const now = Date.now()
+        startTimes.set(id, now)
+        return { modelId, reasoningStartTimes: { [id]: now } }
       }
 
       case 'reasoning-start': {
         const id = `reasoning-${reasoningIdCounter++}`
-        startTimes.set(id, Date.now())
+        const now = Date.now()
+        startTimes.set(id, now)
         reasoningStack.push(id)
-        return { modelId }
+        return { modelId, reasoningStartTimes: { [id]: now } }
       }
 
       case 'tool-result': {

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -36,6 +36,7 @@ export const mountMessageParts = (
   isStreaming: boolean,
   messageId: string,
   reasoningTime: Record<string, number>,
+  reasoningStartTimes?: Record<string, number>,
   sources?: SourceMetadata[],
 ) => {
   const partElements: ReactNode[] = []
@@ -64,6 +65,7 @@ export const mountMessageParts = (
             isLastPartInMessage={isLastPart}
             hasTextPart={hasTextPart}
             reasoningTime={reasoningTime}
+            reasoningStartTimes={reasoningStartTimes}
           />,
         )
         break
@@ -93,6 +95,12 @@ export const AssistantMessage = memo(
       [JSON.stringify(message.metadata?.reasoningTime)],
     )
 
+    const reasoningStartTimes = useMemo(
+      () => message.metadata?.reasoningStartTimes,
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [JSON.stringify(message.metadata?.reasoningStartTimes)],
+    )
+
     const sources = useMemo(
       () => message.metadata?.sources,
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -101,8 +109,8 @@ export const AssistantMessage = memo(
 
     // Memoize part element creation to prevent recreating React nodes unnecessarily
     const partElements: ReactNode[] = useMemo(
-      () => mountMessageParts(groupedParts, isStreaming, message.id, reasoningTime, sources),
-      [groupedParts, isStreaming, message.id, reasoningTime, sources],
+      () => mountMessageParts(groupedParts, isStreaming, message.id, reasoningTime, reasoningStartTimes, sources),
+      [groupedParts, isStreaming, message.id, reasoningTime, reasoningStartTimes, sources],
     )
 
     return (

--- a/src/components/chat/reasoning-group.test.tsx
+++ b/src/components/chat/reasoning-group.test.tsx
@@ -308,6 +308,38 @@ describe('ReasoningGroup', () => {
       expect(screen.getByText(/3\.0s|3s/i)).toBeInTheDocument()
     })
 
+    it('should only sum durations for parts in this group, ignoring other groups', () => {
+      const searchTool = createMockToolPart('search', 'output-available', 1000)
+      const readFileTool = createMockToolPart('read_file', 'output-available', 500)
+      const parts: ReasoningGroupItem[] = [
+        { type: 'tool', content: searchTool, id: searchTool.toolCallId },
+        { type: 'tool', content: readFileTool, id: readFileTool.toolCallId },
+      ]
+      const reasoningTime = {
+        [searchTool.toolCallId]: 1000,
+        [readFileTool.toolCallId]: 500,
+        // These belong to a different group in the same message
+        'call-other-tool-1': 5000,
+        'call-other-tool-2': 3000,
+        'reasoning-5': 2000,
+      }
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={reasoningTime}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
+
+      // Total duration should be 1500ms (1000 + 500), NOT 11500ms
+      expect(screen.getByText(/1\.5s/i)).toBeInTheDocument()
+    })
+
     it('should handle parts without duration', () => {
       const searchTool = createMockToolPart('search')
       const readFileTool = createMockToolPart('read_file', 'output-available', 2000)

--- a/src/components/chat/reasoning-group.test.tsx
+++ b/src/components/chat/reasoning-group.test.tsx
@@ -340,6 +340,40 @@ describe('ReasoningGroup', () => {
       expect(screen.getByText(/1\.5s/i)).toBeInTheDocument()
     })
 
+    it('should show wall-clock time for parallel tool calls when start times are available', () => {
+      const toolA = createMockToolPart('fetch_url', 'output-available', 1000)
+      const toolB = createMockToolPart('search_web', 'output-available', 1500)
+      const parts: ReasoningGroupItem[] = [
+        { type: 'tool', content: toolA, id: toolA.toolCallId },
+        { type: 'tool', content: toolB, id: toolB.toolCallId },
+      ]
+      const reasoningTime = {
+        [toolA.toolCallId]: 1000,
+        [toolB.toolCallId]: 1500,
+      }
+      // Both tools started at the same time (parallel execution)
+      const reasoningStartTimes = {
+        [toolA.toolCallId]: 5000,
+        [toolB.toolCallId]: 5000,
+      }
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={false}
+          hasTextPart={false}
+          reasoningTime={reasoningTime}
+          reasoningStartTimes={reasoningStartTimes}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      )
+
+      // Wall-clock time should be 1.5s (the longer parallel call), NOT 2.5s (sum)
+      expect(screen.getByText(/1\.5s/i)).toBeInTheDocument()
+    })
+
     it('should handle parts without duration', () => {
       const searchTool = createMockToolPart('search')
       const readFileTool = createMockToolPart('read_file', 'output-available', 2000)

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -49,7 +49,9 @@ export const ReasoningGroup = ({
     const intervals = parts.flatMap((part) => {
       const start = reasoningStartTimes[part.id]
       const duration = reasoningTime?.[part.id]
-      if (start === undefined || duration === undefined) return []
+      if (start === undefined || duration === undefined) {
+        return []
+      }
       return [{ start, end: start + duration }]
     })
 

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -1,6 +1,7 @@
 import { useObjectView } from '@/content-view/context'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { type ReasoningGroupItem } from '@/lib/assistant-message'
+import { computeWallClockTime } from '@/lib/utils'
 import { type ReasoningUIPart, type ToolUIPart } from 'ai'
 import { CheckIcon, Loader2 } from 'lucide-react'
 import { Expandable } from '../ui/expandable'
@@ -14,6 +15,7 @@ type ReasoningGroupProps = {
   isLastPartInMessage: boolean
   hasTextPart: boolean
   reasoningTime: Record<string, number>
+  reasoningStartTimes?: Record<string, number>
 }
 
 export const ReasoningGroup = ({
@@ -22,6 +24,7 @@ export const ReasoningGroup = ({
   isLastPartInMessage,
   hasTextPart,
   reasoningTime,
+  reasoningStartTimes,
 }: ReasoningGroupProps) => {
   const { openObjectSidebar } = useObjectView()
 
@@ -38,7 +41,20 @@ export const ReasoningGroup = ({
     ? `reasoning-${currentReasoningPart.content.text.substring(0, 50)}-${parts.indexOf(currentReasoningPart)}`
     : ''
 
-  const totalDuration = parts.reduce((sum, part) => sum + (reasoningTime?.[part.id] ?? 0), 0)
+  const totalDuration = (() => {
+    if (!reasoningStartTimes) {
+      return parts.reduce((sum, part) => sum + (reasoningTime?.[part.id] ?? 0), 0)
+    }
+
+    const intervals = parts.flatMap((part) => {
+      const start = reasoningStartTimes[part.id]
+      const duration = reasoningTime?.[part.id]
+      if (start === undefined || duration === undefined) return []
+      return [{ start, end: start + duration }]
+    })
+
+    return computeWallClockTime(intervals)
+  })()
 
   const { scrollContainerRef, scrollTargetRef } = useAutoScroll({
     dependencies: [parts.length],

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -38,7 +38,7 @@ export const ReasoningGroup = ({
     ? `reasoning-${currentReasoningPart.content.text.substring(0, 50)}-${parts.indexOf(currentReasoningPart)}`
     : ''
 
-  const totalDuration = Object.values(reasoningTime ?? {}).reduce((previous, current) => previous + current, 0)
+  const totalDuration = parts.reduce((sum, part) => sum + (reasoningTime?.[part.id] ?? 0), 0)
 
   const { scrollContainerRef, scrollTargetRef } = useAutoScroll({
     dependencies: [parts.length],

--- a/src/lib/compute-wall-clock-time.test.ts
+++ b/src/lib/compute-wall-clock-time.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test'
+import { computeWallClockTime } from './utils'
+
+describe('computeWallClockTime', () => {
+  it('returns 0 for empty intervals', () => {
+    expect(computeWallClockTime([])).toBe(0)
+  })
+
+  it('returns duration for a single interval', () => {
+    expect(computeWallClockTime([{ start: 0, end: 1000 }])).toBe(1000)
+  })
+
+  it('sums non-overlapping intervals', () => {
+    const intervals = [
+      { start: 0, end: 1000 },
+      { start: 2000, end: 3000 },
+    ]
+    expect(computeWallClockTime(intervals)).toBe(2000)
+  })
+
+  it('merges fully overlapping intervals', () => {
+    const intervals = [
+      { start: 0, end: 2000 },
+      { start: 500, end: 1500 },
+    ]
+    expect(computeWallClockTime(intervals)).toBe(2000)
+  })
+
+  it('merges partially overlapping intervals', () => {
+    const intervals = [
+      { start: 0, end: 1000 },
+      { start: 500, end: 1500 },
+    ]
+    expect(computeWallClockTime(intervals)).toBe(1500)
+  })
+
+  it('handles parallel tool calls correctly', () => {
+    // Two tools start at the same time, finish at different times
+    const intervals = [
+      { start: 1000, end: 2000 }, // Tool A: 1s
+      { start: 1000, end: 2500 }, // Tool B: 1.5s (parallel)
+    ]
+    expect(computeWallClockTime(intervals)).toBe(1500)
+  })
+
+  it('handles mix of parallel and sequential intervals', () => {
+    // Group 1: two parallel calls (t=0 to t=1500)
+    // Gap
+    // Group 2: one sequential call (t=3000 to t=4000)
+    const intervals = [
+      { start: 0, end: 1000 },
+      { start: 0, end: 1500 },
+      { start: 3000, end: 4000 },
+    ]
+    expect(computeWallClockTime(intervals)).toBe(2500)
+  })
+
+  it('handles unsorted intervals', () => {
+    const intervals = [
+      { start: 3000, end: 4000 },
+      { start: 0, end: 1000 },
+      { start: 500, end: 1500 },
+    ]
+    expect(computeWallClockTime(intervals)).toBe(2500)
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -244,6 +244,33 @@ export const formatDuration = (ms: number): string => {
 }
 
 /**
+ * Computes the wall-clock duration covered by a set of potentially overlapping time intervals.
+ * Uses interval union: sorts by start time, merges overlapping intervals, sums their lengths.
+ * Returns the total in milliseconds.
+ */
+export const computeWallClockTime = (intervals: Array<{ start: number; end: number }>): number => {
+  if (intervals.length === 0) return 0
+
+  const sorted = [...intervals].sort((a, b) => a.start - b.start)
+  let totalMs = 0
+  let currentStart = sorted[0].start
+  let currentEnd = sorted[0].end
+
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i].start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, sorted[i].end)
+    } else {
+      totalMs += currentEnd - currentStart
+      currentStart = sorted[i].start
+      currentEnd = sorted[i].end
+    }
+  }
+  totalMs += currentEnd - currentStart
+
+  return totalMs
+}
+
+/**
  * Check if a URL points to localhost
  */
 export const isLocalhostUrl = (url: string | null): boolean => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -249,7 +249,9 @@ export const formatDuration = (ms: number): string => {
  * Returns the total in milliseconds.
  */
 export const computeWallClockTime = (intervals: Array<{ start: number; end: number }>): number => {
-  if (intervals.length === 0) return 0
+  if (intervals.length === 0) {
+    return 0
+  }
 
   const sorted = [...intervals].sort((a, b) => a.start - b.start)
   let totalMs = 0

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export type UIMessageMetadata = {
   usage?: LanguageModelV2Usage
   oauthRetry?: boolean
   reasoningTime?: Record<string, number>
+  reasoningStartTimes?: Record<string, number>
   sources?: SourceMetadata[]
 }
 


### PR DESCRIPTION
## Summary
- Tool call group duration was showing the total for the entire conversation instead of just the group's own duration
- The `totalDuration` calculation in `ReasoningGroup` was summing all values in the `reasoningTime` record (which contains durations for every group in the message), instead of only the durations for parts belonging to the current group
- Additionally, parallel tool calls now show wall-clock time instead of summed individual durations — e.g., two parallel 1s calls show "1s" not "2s"

## Linear
[THU-290](https://linear.app/mozilla-thunderbolt/issue/THU-290/duration-of-tool-call-groups-is-showing-total-for-entire-conversation)

## Test Plan
- [x] Added test verifying group ignores durations from other groups in the same message
- [x] Added test verifying parallel tool calls show wall-clock time (1.5s not 2.5s)
- [x] Added unit tests for `computeWallClockTime` (overlapping, non-overlapping, mixed, unsorted intervals)
- [x] Updated message-metadata tests for new `reasoningStartTimes` emission
- [x] All 71 related tests pass

## Changes
- `src/components/chat/reasoning-group.tsx` — Fixed `totalDuration` to scope to group parts; use wall-clock time when start times available
- `src/components/chat/assistant-message.tsx` — Thread `reasoningStartTimes` through to `ReasoningGroup`
- `src/ai/message-metadata.ts` — Emit `reasoningStartTimes` on tool-call and reasoning-start events
- `src/lib/utils.ts` — Added `computeWallClockTime` utility for interval union
- `src/types.ts` — Added `reasoningStartTimes` to `UIMessageMetadata`
- Tests updated across all changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message metadata shape and reasoning-group duration logic, which can affect chat rendering and displayed timings; covered by added/updated unit tests.
> 
> **Overview**
> Fixes `ReasoningGroup` duration reporting to **only count parts in the current group** (instead of summing all entries in `reasoningTime` for the whole message).
> 
> Adds support for **wall-clock timing** when tool/reasoning start times are available: `createMessageMetadata` now emits `reasoningStartTimes` on `tool-call` and `reasoning-start`, `AssistantMessage` threads it through to `ReasoningGroup`, and `computeWallClockTime` (new in `utils.ts`) unions overlapping intervals so parallel tool calls don’t double-count.
> 
> Updates types (`UIMessageMetadata.reasoningStartTimes`) and expands tests for metadata emission, group-scoped duration, and wall-clock interval merging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c7878eaa5dbb695b666b4edd02d7a9343221667. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->