### PR TITLE
fix: prevent thunderout CWD from becoming invalid after worktree removal

### DIFF
--- a/.claude/commands/thunderout.md
+++ b/.claude/commands/thunderout.md
@@ -18,15 +18,15 @@ Leave the current worktree, tear it down, and return to the main repo on the mai
    - Ask whether to proceed (unpushed commits will be lost) or abort so they can push first
    - If the user aborts, stop
 
-5. **Leave the worktree.** `cd` to the main repo path.
+5. **Leave, remove, and switch — all in one command.** The Bash tool's working directory doesn't persist between calls, so run steps 5-7 as a single command to avoid the CWD becoming invalid after the worktree is deleted:
+   ```
+   cd <main-repo-path> && git worktree remove <worktree-path> && git checkout main
+   ```
+   - If `git worktree remove` fails (e.g., dirty state after user chose to proceed), retry with `--force`
+   - If the worktree path no longer exists on disk, run `git worktree prune` instead of `git worktree remove`
 
-6. **Remove the worktree.** Run `git worktree remove <worktree-path>`.
-   - If removal fails (e.g., dirty state after user chose to proceed), use `git worktree remove --force <worktree-path>`
-
-7. **Switch to main branch.** Run `git checkout main`.
-
-8. **Report:**
+6. **Report:**
    - Worktree removed
    - Now on `main` in the main repo
 
-9. After reporting, tell the user to run `/clear` to start with a fresh context.
+7. After reporting, tell the user to run `/clear` to start with a fresh context.

--- a/.claude/commands/thunderout.md
+++ b/.claude/commands/thunderout.md
@@ -22,8 +22,14 @@ Leave the current worktree, tear it down, and return to the main repo on the mai
    ```
    cd <main-repo-path> && git worktree remove <worktree-path> && git checkout main
    ```
-   - If `git worktree remove` fails (e.g., dirty state after user chose to proceed), retry with `--force`
-   - If the worktree path no longer exists on disk, run `git worktree prune` instead of `git worktree remove`
+   - If `git worktree remove` fails (e.g., dirty state after user chose to proceed), retry the entire chained command with `--force`:
+     ```
+     cd <main-repo-path> && git worktree remove --force <worktree-path> && git checkout main
+     ```
+   - If the worktree path no longer exists on disk, use `git worktree prune` instead:
+     ```
+     cd <main-repo-path> && git worktree prune && git checkout main
+     ```
 
 6. **Report:**
    - Worktree removed


### PR DESCRIPTION
Combine cd, worktree remove, and checkout into a single Bash command so the working directory doesn't point to a deleted path. Also add a fallback to `git worktree prune` when the directory is already gone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/procedure tweak limited to Claude command instructions; no runtime code paths change. Main risk is minor workflow confusion if the chained git commands behave differently in edge cases.
> 
> **Overview**
> Updates `/thunderout` instructions to run `cd`, `git worktree remove`, and `git checkout main` as a single chained command to avoid the Bash tool’s non-persistent CWD becoming invalid after deleting the worktree.
> 
> Adds explicit fallbacks: retry removal with `--force` on failure, or run `git worktree prune` when the worktree directory is already missing, then report and prompt the user to `/clear`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0810aeb667d0d8cf95974316f02a8114510e26d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->