### PR TITLE
⚡ THU-329: Bottom-align chat input on mobile

### DIFF
--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -82,7 +82,7 @@ export default function ChatUI() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
             >
-              <AppLogo size={64} className="opacity-40" />
+              <AppLogo size={64} className="opacity-60" />
             </motion.div>
           ) : null}
         </AnimatePresence>

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -54,7 +54,7 @@ export default function ChatUI() {
           isMobile && 'pb-0',
         )}
       >
-        <AnimatePresence>
+        <AnimatePresence mode="wait">
           {hasMessages ? (
             <div key="messages" className="relative flex-1 overflow-hidden">
               <motion.div

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -10,6 +10,7 @@ import { useCurrentChatSession } from '@/chats/chat-store'
 import { useChat } from '@ai-sdk/react'
 import { useChatAutomation } from '@/chats/use-chat-automation'
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
+import { AppLogo } from '../app-logo'
 
 export default function ChatUI() {
   const { chatInstance } = useCurrentChatSession()
@@ -54,8 +55,8 @@ export default function ChatUI() {
         )}
       >
         <AnimatePresence>
-          {hasMessages && (
-            <div className="relative flex-1 overflow-hidden">
+          {hasMessages ? (
+            <div key="messages" className="relative flex-1 overflow-hidden">
               <motion.div
                 ref={scrollContainerRef}
                 {...scrollHandlers}
@@ -73,11 +74,23 @@ export default function ChatUI() {
                 className="bottom-2"
               />
             </div>
+          ) : (
+            isMobile && (
+              <motion.div
+                key="logo"
+                className="flex-1 flex items-center justify-center"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <AppLogo size={48} />
+              </motion.div>
+            )
           )}
         </AnimatePresence>
 
         <motion.div
-          className={cn('p-4 flex', !hasMessages && 'flex-1 items-center')}
+          className={cn('p-4 flex', !hasMessages && !isMobile && 'flex-1 items-center')}
           initial={false}
           layout
           transition={{

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -82,7 +82,7 @@ export default function ChatUI() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
             >
-              <AppLogo size={48} />
+              <AppLogo size={64} className="opacity-40" />
             </motion.div>
           ) : null}
         </AnimatePresence>

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -74,19 +74,17 @@ export default function ChatUI() {
                 className="bottom-2"
               />
             </div>
-          ) : (
-            isMobile && (
-              <motion.div
-                key="logo"
-                className="flex-1 flex items-center justify-center"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-              >
-                <AppLogo size={48} />
-              </motion.div>
-            )
-          )}
+          ) : isMobile ? (
+            <motion.div
+              key="logo"
+              className="flex-1 flex items-center justify-center"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+            >
+              <AppLogo size={48} />
+            </motion.div>
+          ) : null}
         </AnimatePresence>
 
         <motion.div


### PR DESCRIPTION
## Summary
- On mobile empty state, bottom-align the chat input (same position as during active conversation) instead of vertically centering it
- Show a centered Thunderbolt logo (48px) in the empty space above the input on mobile
- Desktop behavior unchanged (vertically centered input with suggestions)

## Linear
[THU-329](https://linear.app/mozilla-thunderbolt/issue/THU-329/on-mobile-move-chat-input-to-be-bottom-aligned)

## Test Plan
- [ ] On mobile viewport (< 768px), open a new chat — input should be at the bottom, Thunderbolt logo centered above
- [ ] On desktop, open a new chat — input should be vertically centered as before
- [ ] Start typing a message on mobile — input stays at bottom, logo disappears when conversation starts
- [ ] Framer Motion transitions animate smoothly between empty and conversation states

## Changes
- `src/components/chat/chat-ui.tsx` — Conditionally bottom-align input on mobile; add centered AppLogo in empty space

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes limited to `ChatUI` layout/animation; main risk is minor mobile/desktop layout regressions or animation flicker in the empty-state transition.
> 
> **Overview**
> Adjusts `ChatUI` empty-state behavior on mobile so the prompt input stays bottom-aligned (matching active conversations) instead of being vertically centered.
> 
> Adds a centered `AppLogo` empty-state visual for mobile and updates `AnimatePresence` to `mode="wait"` with keyed states to smooth the transition between empty and message views, while keeping desktop empty-state centering unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1f767a05a6666a4c66de971c486c6212a7c8005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->