### PR TITLE
⚡ THU-330: Keep header fixed on mobile when keyboard opens

### DIFF
--- a/.claude/commands/thunderbot.md
+++ b/.claude/commands/thunderbot.md
@@ -204,17 +204,39 @@ Follow the project's CLAUDE.md strictly:
    ```
    Fix any failures before proceeding.
 
-3. Run `/thunderimprove` to review your changes:
+3. **Review changes via subagent** — launch a general-purpose Agent to review and fix code quality issues:
    ```
-   Skill(skill="thunderimprove")
+   Agent(subagent_type="general-purpose", prompt="
+     You are reviewing code changes in $WORKTREE_PATH.
+     Read .claude/commands/thunderimprove.md for the review criteria.
+     Run git diff to see changes, review against those criteria, and fix any issues you find.
+     Do NOT ask for permission — just fix issues and report what you changed.
+     If the code looks good, say so briefly.
+   ")
    ```
-   Apply any suggested improvements, then re-run steps 1-2 if changes were made.
+   If the agent made fixes, re-run steps 1-2.
 
-4. Push and fix:
+4. **Push via subagent** — launch a general-purpose Agent to stage, commit, and push:
    ```
-   Skill(skill="thunderpush")
-   Skill(skill="thunderfix")
+   Agent(subagent_type="general-purpose", prompt="
+     You are in $WORKTREE_PATH.
+     Read .claude/commands/thunderpush.md for instructions.
+     Follow those instructions to stage, commit, and push all changes.
+     Report the commit hash and push result.
+   ")
    ```
+
+5. **Fix PR issues via subagent** — after the PR exists, launch a general-purpose Agent to fix CI and review feedback:
+   ```
+   Agent(subagent_type="general-purpose", prompt="
+     You are in $WORKTREE_PATH.
+     Read .claude/commands/thunderfix.md for the fix loop instructions.
+     Follow those instructions to fix all PR issues (review comments, issue comments, CI failures).
+     Report final status: how many issues fixed, CI result, whether PR is clean.
+   ")
+   ```
+
+**IMPORTANT**: Always use `Agent()` subagents for mid-flow skills, NOT `Skill()`. Using `Skill()` injects the skill prompt into the current conversation and causes the thunderbot flow to lose context. Subagents keep the thunderbot flow in the main context.
 
 Never manually run `git add`, `git commit`, or `git push`. This ensures atomic, conventional commits with proper formatting.
 
@@ -260,11 +282,7 @@ linear issue update <identifier> --state "In Review"
 
 This phase is handled automatically by `/thunderfix` (used in Phase 7). By this point, the last push should have already passed CI and addressed bot feedback.
 
-If the PR was finalized in Phase 9 without a `/thunderfix` cycle (e.g., only `gh pr ready` was run), do a final check:
-
-```
-Skill(skill="thunderfix")
-```
+If the PR was finalized in Phase 9 without a `/thunderfix` cycle (e.g., only `gh pr ready` was run), do a final check using a subagent (same as step 5 in Phase 7's "Committing Changes").
 
 ## Phase 11: Cleanup & Report
 

--- a/.claude/commands/thunderbot.md
+++ b/.claude/commands/thunderbot.md
@@ -204,39 +204,17 @@ Follow the project's CLAUDE.md strictly:
    ```
    Fix any failures before proceeding.
 
-3. **Review changes via subagent** — launch a general-purpose Agent to review and fix code quality issues:
+3. Run `/thunderimprove` to review your changes:
    ```
-   Agent(subagent_type="general-purpose", prompt="
-     You are reviewing code changes in $WORKTREE_PATH.
-     Read .claude/commands/thunderimprove.md for the review criteria.
-     Run git diff to see changes, review against those criteria, and fix any issues you find.
-     Do NOT ask for permission — just fix issues and report what you changed.
-     If the code looks good, say so briefly.
-   ")
+   Skill(skill="thunderimprove")
    ```
-   If the agent made fixes, re-run steps 1-2.
+   Apply any suggested improvements, then re-run steps 1-2 if changes were made.
 
-4. **Push via subagent** — launch a general-purpose Agent to stage, commit, and push:
+4. Push and fix:
    ```
-   Agent(subagent_type="general-purpose", prompt="
-     You are in $WORKTREE_PATH.
-     Read .claude/commands/thunderpush.md for instructions.
-     Follow those instructions to stage, commit, and push all changes.
-     Report the commit hash and push result.
-   ")
+   Skill(skill="thunderpush")
+   Skill(skill="thunderfix")
    ```
-
-5. **Fix PR issues via subagent** — after the PR exists, launch a general-purpose Agent to fix CI and review feedback:
-   ```
-   Agent(subagent_type="general-purpose", prompt="
-     You are in $WORKTREE_PATH.
-     Read .claude/commands/thunderfix.md for the fix loop instructions.
-     Follow those instructions to fix all PR issues (review comments, issue comments, CI failures).
-     Report final status: how many issues fixed, CI result, whether PR is clean.
-   ")
-   ```
-
-**IMPORTANT**: Always use `Agent()` subagents for mid-flow skills, NOT `Skill()`. Using `Skill()` injects the skill prompt into the current conversation and causes the thunderbot flow to lose context. Subagents keep the thunderbot flow in the main context.
 
 Never manually run `git add`, `git commit`, or `git push`. This ensures atomic, conventional commits with proper formatting.
 
@@ -282,7 +260,11 @@ linear issue update <identifier> --state "In Review"
 
 This phase is handled automatically by `/thunderfix` (used in Phase 7). By this point, the last push should have already passed CI and addressed bot feedback.
 
-If the PR was finalized in Phase 9 without a `/thunderfix` cycle (e.g., only `gh pr ready` was run), do a final check using a subagent (same as step 5 in Phase 7's "Committing Changes").
+If the PR was finalized in Phase 9 without a `/thunderfix` cycle (e.g., only `gh pr ready` was run), do a final check:
+
+```
+Skill(skill="thunderfix")
+```
 
 ## Phase 11: Cleanup & Report
 

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -17,7 +17,9 @@ import { useEffect } from 'react'
 export const useKeyboardInset = (): void => {
   useEffect(() => {
     const vv = window.visualViewport
-    if (!vv) return
+    if (!vv) {
+      return
+    }
 
     const update = () => {
       const el = document.documentElement.style

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -1,40 +1,33 @@
 import { useEffect } from 'react'
 
 /**
- * React hook that maintains the `--kb` CSS custom property on the root `<html>` element.
- * The property reflects the height (in pixels) of the area currently covered by the
- * software keyboard. When the keyboard is hidden, the value is `0px`.
+ * React hook that keeps `#root` pinned to the visual viewport on mobile.
  *
- * It relies on the Visual Viewport API, which is supported by all major mobile browsers
- * (Safari iOS, Chrome/Edge/Opera/Samsung Internet, Firefox Android) and desktop Chromium.
+ * Sets two CSS custom properties on `<html>`:
+ * - `--vv-top`:    the visual-viewport's scroll offset (px). On iOS, when the
+ *                  keyboard opens the browser scrolls the layout viewport --
+ *                  `position: fixed` elements drift off-screen. Applying this
+ *                  value to `top` compensates for that scroll.
+ * - `--vv-height`: the visual-viewport's height (px). This shrinks when the
+ *                  keyboard is visible, so it naturally subtracts the keyboard.
  *
- * The hook is safe to use on older engines that don’t expose `window.visualViewport` –
- * it simply becomes a no-op, leaving `--kb` at its initial `0px`.
- *
- * Usage:
- *   // Call it once at the top level of your app
- *   useKeyboardInset()
+ * Relies on the Visual Viewport API (all major mobile browsers). Falls back to
+ * a no-op on engines that don't expose `window.visualViewport`.
  */
 export const useKeyboardInset = (): void => {
   useEffect(() => {
     const vv = window.visualViewport
-    if (!vv) {
-      return
-    } // VisualViewport API not supported
+    if (!vv) return
 
-    /**
-     * Calculates and sets the CSS variable based on the difference between the
-     * layout viewport (`window.innerHeight`) and the visual viewport (`vv.height`).
-     * On iOS the layout viewport stays constant and the visual viewport shrinks
-     * when the keyboard appears. On Android/Chromium both shrink, but the math
-     * still produces a non-negative inset that matches the covered area.
-     */
     const update = () => {
-      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
-      document.documentElement.style.setProperty('--kb', `${inset}px`)
+      const el = document.documentElement.style
+      el.setProperty('--vv-top', `${vv.offsetTop}px`)
+      el.setProperty('--vv-height', `${vv.height}px`)
+      // --kb is still used by position:fixed dialogs (e.g. onboarding) that
+      // sit outside #root's flow and need to know the keyboard height directly.
+      el.setProperty('--kb', `${Math.max(0, window.innerHeight - vv.height - vv.offsetTop)}px`)
     }
 
-    // Initial run
     update()
 
     // iOS fires `scroll` when the viewport pans, Android fires `resize`

--- a/src/index.css
+++ b/src/index.css
@@ -162,6 +162,15 @@ body {
     height: 100%;
     overflow: hidden;
   }
+
+  #root {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: var(--kb, 0px);
+    height: auto;
+  }
 }
 
 /* Subtle table borders for markdown content */

--- a/src/index.css
+++ b/src/index.css
@@ -165,11 +165,10 @@ body {
 
   #root {
     position: fixed;
-    top: 0;
+    top: var(--vv-top, 0px);
     left: 0;
     right: 0;
-    bottom: var(--kb, 0px);
-    height: auto;
+    height: var(--vv-height, 100svh);
   }
 }
 


### PR DESCRIPTION
## Summary
- On iOS Safari, the virtual keyboard causes the browser to scroll the viewport, pushing the header offscreen
- Adds `position: fixed` with keyboard-aware `bottom: var(--kb)` inset to `#root` on mobile (≤768px)
- Uses the existing `--kb` CSS variable from `useKeyboardInset` — no new JS needed

## Linear
[THU-330](https://linear.app/mozilla-thunderbolt/issue/THU-330/keep-header-fixed-to-top-on-mobile-when-keyboard-opens-instead-of)

## Test Plan
- [ ] Mobile (iOS Safari): Open keyboard → header stays fixed at top
- [ ] Mobile: Close keyboard → layout returns to normal full height
- [ ] Desktop: No visual or behavioral changes
- [ ] Mobile: Safe area insets still work correctly

## Changes
- `src/index.css` — Added mobile media query for `#root` with `position: fixed` and keyboard-aware bottom inset

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global mobile layout by fixing `#root` and driving its `top`/`height` from the Visual Viewport API; regressions could include scroll/positioning issues on specific mobile browsers or overlays. Logic is straightforward and gated behind `window.visualViewport`, reducing impact on unsupported engines.
> 
> **Overview**
> Keeps the app container pinned on mobile when the on-screen keyboard opens (notably iOS Safari), preventing fixed UI like headers from drifting off-screen.
> 
> Updates `useKeyboardInset` to also maintain `--vv-top` and `--vv-height` CSS variables (while still updating `--kb`), and applies them in `index.css` to make `#root` `position: fixed` with keyboard-aware `top` and `height` under the `<=768px` media query.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15b435d75cbf3c32ce64b56e7b70bb7d49252b8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->