### PR TITLE
chore: replace Skill() calls with Agent subagents in thunderbot

### DIFF
--- a/.claude/commands/thunderbot.md
+++ b/.claude/commands/thunderbot.md
@@ -204,17 +204,39 @@ Follow the project's CLAUDE.md strictly:
    ```
    Fix any failures before proceeding.
 
-3. Run `/thunderimprove` to review your changes:
+3. **Review changes via subagent** — launch a general-purpose Agent to review and fix code quality issues:
    ```
-   Skill(skill="thunderimprove")
+   Agent(subagent_type="general-purpose", prompt="
+     You are reviewing code changes in $WORKTREE_PATH.
+     Read .claude/commands/thunderimprove.md for the review criteria.
+     Run git diff to see changes, review against those criteria, and fix any issues you find.
+     Do NOT ask for permission — just fix issues and report what you changed.
+     If the code looks good, say so briefly.
+   ")
    ```
-   Apply any suggested improvements, then re-run steps 1-2 if changes were made.
+   If the agent made fixes, re-run steps 1-2.
 
-4. Push and fix:
+4. **Push via subagent** — launch a general-purpose Agent to stage, commit, and push:
    ```
-   Skill(skill="thunderpush")
-   Skill(skill="thunderfix")
+   Agent(subagent_type="general-purpose", prompt="
+     You are in $WORKTREE_PATH.
+     Read .claude/commands/thunderpush.md for instructions.
+     Follow those instructions to stage, commit, and push all changes.
+     Report the commit hash and push result.
+   ")
    ```
+
+5. **Fix PR issues via subagent** — after the PR exists, launch a general-purpose Agent to fix CI and review feedback:
+   ```
+   Agent(subagent_type="general-purpose", prompt="
+     You are in $WORKTREE_PATH.
+     Read .claude/commands/thunderfix.md for the fix loop instructions.
+     Follow those instructions to fix all PR issues (review comments, issue comments, CI failures).
+     Report final status: how many issues fixed, CI result, whether PR is clean.
+   ")
+   ```
+
+**IMPORTANT**: Always use `Agent()` subagents for mid-flow skills, NOT `Skill()`. Using `Skill()` injects the skill prompt into the current conversation and causes the thunderbot flow to lose context. Subagents keep the thunderbot flow in the main context.
 
 Never manually run `git add`, `git commit`, or `git push`. This ensures atomic, conventional commits with proper formatting.
 
@@ -260,11 +282,7 @@ linear issue update <identifier> --state "In Review"
 
 This phase is handled automatically by `/thunderfix` (used in Phase 7). By this point, the last push should have already passed CI and addressed bot feedback.
 
-If the PR was finalized in Phase 9 without a `/thunderfix` cycle (e.g., only `gh pr ready` was run), do a final check:
-
-```
-Skill(skill="thunderfix")
-```
+If the PR was finalized in Phase 9 without a `/thunderfix` cycle (e.g., only `gh pr ready` was run), do a final check using a subagent (same as step 5 in Phase 7's "Committing Changes").
 
 ## Phase 11: Cleanup & Report
 


### PR DESCRIPTION
## Summary
- When thunderbot invokes mid-flow skills (thunderimprove, thunderpush, thunderfix) via `Skill()`, the skill prompt gets injected into the conversation, causing thunderbot to lose its flow context
- Replaces `Skill()` calls with `Agent()` subagent calls so the main thunderbot flow stays intact while skill work runs in isolated subprocesses

## Test Plan
- [ ] Run `/thunderbot` end-to-end — verify it completes all phases without losing track after review/push/fix steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the thunderbot workflow; low risk aside from potentially altering how contributors follow the prescribed review/push/fix steps.
> 
> **Overview**
> Updates the thunderbot runbook (`.claude/commands/thunderbot.md`) to replace mid-flow `Skill()` invocations (`thunderimprove`, `thunderpush`, `thunderfix`) with `Agent(subagent_type="general-purpose")` subagent prompts.
> 
> Adds an explicit post-PR *fix loop* step and clarifies that `Agent()` must be used to avoid losing thunderbot flow context; Phase 10 guidance is updated to reference the subagent-based fix check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af5b0196dab8a0cc70129ad1d30a9e1b3cd548ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->