### PR TITLE
[DO NOT MERGE] THU-285: Implement a PowerSync middleware to enable data transformation capabilities in sync operations

### DIFF
--- a/src/db/powersync/ThunderboltPowerSyncDatabase.ts
+++ b/src/db/powersync/ThunderboltPowerSyncDatabase.ts
@@ -1,0 +1,39 @@
+import type { BucketStorageAdapter } from '@powersync/common'
+import { PowerSyncDatabase } from '@powersync/web'
+import type { WebPowerSyncDatabaseOptions } from '@powersync/web'
+import { TransformableBucketStorage } from './TransformableBucketStorage'
+import type { DataTransformMiddleware } from './TransformableBucketStorage'
+
+export type ThunderboltPowerSyncOptions = WebPowerSyncDatabaseOptions & {
+  transformers?: DataTransformMiddleware[]
+}
+
+/**
+ * PowerSync database with optional data transformation middleware.
+ *
+ * Extends PowerSyncDatabase to use TransformableBucketStorage instead of SqliteBucketStorage,
+ * enabling middleware to transform sync data before it is written to the local database.
+ */
+export class ThunderboltPowerSyncDatabase extends PowerSyncDatabase {
+  constructor(options: ThunderboltPowerSyncOptions) {
+    super(options)
+  }
+
+  /**
+   * Override: Returns TransformableBucketStorage instead of SqliteBucketStorage.
+   *
+   * Why: PowerSyncDatabase creates a plain SqliteBucketStorage by default. We need our
+   * TransformableBucketStorage so we can intercept control() and run middleware.
+   *
+   * What it does: Creates TransformableBucketStorage, registers any transformers from
+   * options.transformers, and returns it. The adapter is used for all sync operations.
+   */
+  protected generateBucketStorageAdapter(): BucketStorageAdapter {
+    const storage = new TransformableBucketStorage(this.database)
+    const transformers = (this.options as ThunderboltPowerSyncOptions).transformers ?? []
+    for (const t of transformers) {
+      storage.addTransformer(t)
+    }
+    return storage
+  }
+}

--- a/src/db/powersync/TransformableBucketStorage.ts
+++ b/src/db/powersync/TransformableBucketStorage.ts
@@ -1,0 +1,96 @@
+import type { DBAdapter, SyncDataBatch } from '@powersync/common'
+import {
+  PowerSyncControlCommand,
+  SqliteBucketStorage,
+  SyncDataBucket,
+  SyncDataBatch as SyncDataBatchClass,
+} from '@powersync/common'
+import type { SyncDataBucketJSON } from '@powersync/common'
+
+/**
+ * A middleware that transforms sync data before it is written to the local database.
+ *
+ * Use for: data normalization, format conversion, decompression, etc.
+ * Do NOT use for decryption—use mirror tables for true E2E encryption.
+ */
+export type DataTransformMiddleware = {
+  /** Receives a batch of sync data; returns the transformed batch. */
+  transform(batch: SyncDataBatch): Promise<SyncDataBatch> | SyncDataBatch
+}
+
+/**
+ * Extends SqliteBucketStorage with a transformation pipeline.
+ *
+ * PowerSync's Rust client bypasses saveSyncData and sends sync data directly to the WASM
+ * engine via adapter.control(PROCESS_TEXT_LINE, payload). We override control() to intercept
+ * sync data, run our middleware pipeline, then pass the transformed payload to the parent.
+ */
+export class TransformableBucketStorage extends SqliteBucketStorage {
+  private transformers: DataTransformMiddleware[] = []
+
+  constructor(db: DBAdapter) {
+    super(db)
+  }
+
+  /** Registers a transformer to run on incoming sync data. Order matters: first added runs first. */
+  addTransformer(transformer: DataTransformMiddleware): void {
+    this.transformers.push(transformer)
+  }
+
+  /** Removes a previously added transformer. */
+  removeTransformer(transformer: DataTransformMiddleware): void {
+    const index = this.transformers.indexOf(transformer)
+    if (index > -1) {
+      this.transformers.splice(index, 1)
+    }
+  }
+
+  /** Clears all transformers from the pipeline. */
+  clearTransformers(): void {
+    this.transformers = []
+  }
+
+  /** Runs all transformers in order. Each transformer receives the output of the previous. */
+  private async runTransformers(batch: SyncDataBatch): Promise<SyncDataBatch> {
+    let result = batch
+    for (const transformer of this.transformers) {
+      result = await transformer.transform(result)
+    }
+    return result
+  }
+
+  /**
+   * Override: Intercepts control() for PROCESS_TEXT_LINE sync data.
+   *
+   * Why: The Rust client calls this when it receives sync data from the server. The default
+   * implementation passes the payload straight to powersync_control (WASM). We intercept to
+   * run our middleware (transformers) before the data reaches the database.
+   *
+   * What it does: For PROCESS_TEXT_LINE with sync data, parses the payload, runs the
+   * transformer pipeline, and passes the transformed payload to the parent. All other
+   * commands (STOP, START, PROCESS_BSON_LINE, etc.) pass through unchanged.
+   */
+  async control(op: PowerSyncControlCommand, payload: string | Uint8Array | ArrayBuffer | null): Promise<string> {
+    if (
+      op === PowerSyncControlCommand.PROCESS_TEXT_LINE &&
+      typeof payload === 'string' &&
+      this.transformers.length > 0
+    ) {
+      try {
+        const line = JSON.parse(payload) as { data?: SyncDataBucketJSON }
+        if (line?.data) {
+          const bucket = SyncDataBucket.fromRow(line.data)
+          const batch = new SyncDataBatchClass([bucket])
+          const transformed = await this.runTransformers(batch)
+          const transformedPayload = JSON.stringify({
+            data: transformed.buckets[0].toJSON(true),
+          })
+          return super.control(op, transformedPayload)
+        }
+      } catch {
+        // Fall through to super on parse/transform error
+      }
+    }
+    return super.control(op, payload)
+  }
+}

--- a/src/db/powersync/connector.ts
+++ b/src/db/powersync/connector.ts
@@ -2,6 +2,7 @@ import { getDeviceId, getAuthToken } from '@/lib/auth-token'
 import { getDeviceDisplayName } from '@/lib/platform'
 import ky from 'ky'
 import type { AbstractPowerSyncDatabase, PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web'
+import { encodeToBase64 } from '@/lib/base64'
 
 /** Dispatched when backend returns 410 (account deleted), 403 + DEVICE_DISCONNECTED, or 409 + DEVICE_ID_TAKEN. App should reset and reload. */
 export const powersyncCredentialsInvalid = 'powersync_credentials_invalid'
@@ -113,12 +114,36 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
 
     try {
       // Convert CRUD operations to our API format
-      const operations = transaction.crud.map((op) => ({
-        op: op.op.toUpperCase() as 'PUT' | 'PATCH' | 'DELETE',
-        type: op.table,
-        id: op.id,
-        data: op.opData,
-      }))
+      const operations = transaction.crud.map((op) => {
+        /**
+         * **************************************************************
+         * Encode base64 for tasks.item when the value is valid base64.
+         * Temporary solution for testing purposes.
+         *
+         * TODO: Remove this once we have a proper encryption middleware.
+         */
+        let data = op.opData
+        if (
+          op.table === 'tasks' &&
+          data != null &&
+          typeof data.item === 'string' &&
+          (op.op === 'PUT' || op.op === 'PATCH')
+        ) {
+          data = { ...data, item: encodeToBase64(data.item) }
+        }
+        /**
+         * Temporary solution for testing purposes.
+         * TODO: Remove this once we have a proper encryption middleware.
+         * **************************************************************
+         */
+
+        return {
+          op: op.op.toUpperCase() as 'PUT' | 'PATCH' | 'DELETE',
+          type: op.table,
+          id: op.id,
+          data,
+        }
+      })
 
       console.info(`Uploading ${operations.length} operations to backend`)
 

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -10,6 +10,7 @@ import { AppSchema, drizzleSchema } from './schema'
 import { ThunderboltConnector } from './connector'
 import { getPlatform, getWebBrowser } from '@/lib/platform'
 import { ThunderboltPowerSyncDatabase } from './ThunderboltPowerSyncDatabase'
+import { encryptionMiddleware } from './middleware/EncryptionMiddleware'
 
 /** PowerSync config: default (Chrome/Edge/Firefox web) vs safari-tauri (Safari web, Tauri) */
 export type PowerSyncDatabaseConfig = 'default' | 'safari-tauri'
@@ -102,6 +103,7 @@ export const getPowerSyncOptions = (path: string) => {
       // Required for both approaches: SharedWorker creates its own storage and bypasses our adapter.
       // Ref: https://docs.powersync.com/client-sdks/reference/javascript-web#available-flags
       flags: { enableMultiTabs: false, useWebWorker: false },
+      transformers: [encryptionMiddleware],
     }
   }
 
@@ -129,6 +131,7 @@ export const getPowerSyncOptions = (path: string) => {
     // Ref: https://docs.powersync.com/client-sdks/reference/javascript-web#available-flags
     flags: { enableMultiTabs: false, useWebWorker: false },
     sync: { worker: '/@powersync/worker/SharedSyncImplementation.umd.js' },
+    transformers: [encryptionMiddleware],
   }
 }
 

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -1,7 +1,7 @@
 import { getSettings } from '@/dal'
 import { defaultSettingCloudUrl } from '@/defaults/settings'
 import type { AbstractPowerSyncDatabase } from '@powersync/common'
-import { PowerSyncDatabase, SyncStreamConnectionMethod, WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web'
+import { type PowerSyncDatabase, SyncStreamConnectionMethod, WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web'
 import type { WebPowerSyncDatabaseOptions } from '@powersync/web'
 import { wrapPowerSyncWithDrizzle } from '@powersync/drizzle-driver'
 import type { DatabaseInterface, AnyDrizzleDatabase } from '../database-interface'
@@ -9,6 +9,7 @@ import { DatabaseSingleton } from '../singleton'
 import { AppSchema, drizzleSchema } from './schema'
 import { ThunderboltConnector } from './connector'
 import { getPlatform, getWebBrowser } from '@/lib/platform'
+import { ThunderboltPowerSyncDatabase } from './ThunderboltPowerSyncDatabase'
 
 /** PowerSync config: default (Chrome/Edge/Firefox web) vs safari-tauri (Safari web, Tauri) */
 export type PowerSyncDatabaseConfig = 'default' | 'safari-tauri'
@@ -98,6 +99,9 @@ export const getPowerSyncOptions = (path: string) => {
     return {
       database: { dbFilename },
       schema: AppSchema as unknown as WebPowerSyncDatabaseOptions['schema'],
+      // Required for both approaches: SharedWorker creates its own storage and bypasses our adapter.
+      // Ref: https://docs.powersync.com/client-sdks/reference/javascript-web#available-flags
+      flags: { enableMultiTabs: false, useWebWorker: false },
     }
   }
 
@@ -116,10 +120,14 @@ export const getPowerSyncOptions = (path: string) => {
       dbFilename: dbFilename,
       vfs: WASQLiteVFS.OPFSCoopSyncVFS,
       worker: '/@powersync/worker/WASQLiteDB.umd.js',
-      flags: { enableMultiTabs: false },
+      // Required for both approaches: SharedWorker creates its own storage and bypasses our adapter.
+      // Ref: https://docs.powersync.com/client-sdks/reference/javascript-web#available-flags
+      flags: { enableMultiTabs: false, useWebWorker: false },
     }),
     schema: AppSchema as unknown as WebPowerSyncDatabaseOptions['schema'],
-    flags: { enableMultiTabs: false },
+    // Required for both approaches: SharedWorker creates its own storage and bypasses our adapter.
+    // Ref: https://docs.powersync.com/client-sdks/reference/javascript-web#available-flags
+    flags: { enableMultiTabs: false, useWebWorker: false },
     sync: { worker: '/@powersync/worker/SharedSyncImplementation.umd.js' },
   }
 }
@@ -160,7 +168,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
 
     const options = getPowerSyncOptions(path)
 
-    this.powerSync = new PowerSyncDatabase(options)
+    this.powerSync = new ThunderboltPowerSyncDatabase(options)
 
     // Wrap with Drizzle for type-safe queries.
     // Cast instance: drizzle-driver expects AbstractPowerSyncDatabase from root @powersync/common; PowerSyncDatabase is from @powersync/web (nested common).

--- a/src/db/powersync/middleware/EncryptionMiddleware.ts
+++ b/src/db/powersync/middleware/EncryptionMiddleware.ts
@@ -1,0 +1,35 @@
+import type { DataTransformMiddleware } from '../TransformableBucketStorage'
+import { isValidBase64, decodeIfValidBase64 } from '@/lib/base64'
+
+const tasksTable = 'tasks'
+const itemColumn = 'item'
+
+/**
+ * Decodes base64 for tasks.item when the value is valid base64.
+ * Will evolve to full decryption layer for all tables/columns.
+ *
+ * Temporary solution for testing purposes.
+ */
+export const encryptionMiddleware: DataTransformMiddleware = {
+  transform(batch) {
+    for (const bucket of batch.buckets) {
+      for (const entry of bucket.data) {
+        if (entry.object_type !== tasksTable || !entry.data) {
+          continue
+        }
+
+        try {
+          const obj = JSON.parse(entry.data) as Record<string, unknown>
+          const item = obj[itemColumn]
+          if (typeof item === 'string' && isValidBase64(item)) {
+            obj[itemColumn] = decodeIfValidBase64(item)
+            entry.data = JSON.stringify(obj)
+          }
+        } catch {
+          // Leave entry.data unchanged on parse error
+        }
+      }
+    }
+    return batch
+  },
+}

--- a/src/lib/base64.ts
+++ b/src/lib/base64.ts
@@ -1,0 +1,34 @@
+/**
+ * Returns true if the string is valid base64 (non-empty, decodable).
+ * Uses try/catch around atob(); refactor later for format checks or encryption markers.
+ */
+export const isValidBase64 = (value: string): boolean => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false
+  }
+  try {
+    atob(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * If valid base64, returns decoded string; otherwise returns original.
+ */
+export const decodeIfValidBase64 = (value: string): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return value
+  }
+  try {
+    return atob(value)
+  } catch {
+    return value
+  }
+}
+
+/**
+ * Encodes a string to base64.
+ */
+export const encodeToBase64 = (value: string): string => btoa(value)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the PowerSync sync ingestion/upload paths by intercepting `control(PROCESS_TEXT_LINE)` and mutating CRUD payloads, which can affect data correctness and sync stability. Disabling multi-tab/worker flags also changes runtime behavior across environments.
> 
> **Overview**
> Adds a `ThunderboltPowerSyncDatabase` wrapper that swaps PowerSync’s default bucket storage adapter for `TransformableBucketStorage`, enabling a configurable middleware pipeline to transform incoming sync data by intercepting `control(PROCESS_TEXT_LINE)` before it reaches the local DB.
> 
> Wires this into database initialization by passing `transformers` (currently `encryptionMiddleware`) and forcing PowerSync flags to `enableMultiTabs: false` and `useWebWorker: false` so the custom adapter is actually used.
> 
> Implements a temporary base64 layer: uploads now base64-encode `tasks.item`, and the new `encryptionMiddleware` decodes `tasks.item` on incoming sync when it looks like valid base64; adds shared base64 helpers in `src/lib/base64.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41f158c80f5b6e4040486bc91da98d38f9369ab7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #431 
- <kbd>&nbsp;1&nbsp;</kbd> #430 👈 
<!-- GitButler Footer Boundary Bottom -->

