### PR TITLE
[DO NOT MERGE] THU-285: implement a custom SharedWorker to allow custom transformers in the PowerSync middleware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@
 
 See [docs/powersync-account-devices.md](docs/powersync-account-devices.md) for: synced table requirements, adding a new table (frontend + backend + schema + config.yaml + production), account deletion, device management, and backend token/revoke API.
 
+See [docs/powersync-sync-middleware.md](docs/powersync-sync-middleware.md) for: sync data transformation middleware, custom SharedWorker (multi-tab + encryption), adding new transformers, and the future E2E encryption key-passing pattern.
+
 **Deploying new synced tables (two-PR process):**
 
 1. **PR 1 (backend-only):** Backend schema, Drizzle migration, `shared/powersync-tables.ts`, and `config.yaml` sync rule. Merge → run migration → update PowerSync Cloud dashboard rules.

--- a/docs/powersync-account-devices.md
+++ b/docs/powersync-account-devices.md
@@ -12,6 +12,8 @@ This document consolidates documentation for:
 
 PowerSync provides offline-first sync between the backend (PostgreSQL) and clients (SQLite). Data is scoped by `user_id` from the JWT. The backend issues PowerSync JWTs and can apply client uploads (PUT/PATCH/DELETE) to Postgres. Production uses PowerSync Cloud; local development uses the Docker stack in `powersync-service/`.
 
+For the sync data transformation middleware and custom SharedWorker (E2E encryption pipeline), see [docs/powersync-sync-middleware.md](powersync-sync-middleware.md).
+
 ---
 
 ## 2. Synced tables

--- a/docs/powersync-sync-middleware.md
+++ b/docs/powersync-sync-middleware.md
@@ -1,0 +1,272 @@
+# PowerSync Sync Middleware & Custom SharedWorker
+
+This document explains the data transformation middleware built on top of PowerSync and the custom SharedWorker required to make it work with multi-tab support.
+
+---
+
+## Overview
+
+PowerSync syncs data from the server (PostgreSQL) to the local SQLite database. By default, sync data arrives from the server and is written to SQLite as-is. The middleware layer intercepts sync data **before it is written**, allowing transformations such as decoding, normalization, or decryption.
+
+The current implementation uses base64 decode as a test. The long-term goal is full E2E decryption of fields before local storage.
+
+---
+
+## Architecture
+
+### Key files
+
+| File                                                                                                                                              | Role                                                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [src/db/powersync/TransformableBucketStorage.ts](../src/db/powersync/TransformableBucketStorage.ts)                                               | Extends `SqliteBucketStorage` to intercept sync data and run the transformer pipeline             |
+| [src/db/powersync/ThunderboltPowerSyncDatabase.ts](../src/db/powersync/ThunderboltPowerSyncDatabase.ts)                                           | Extends `PowerSyncDatabase` to inject `TransformableBucketStorage` as the storage adapter         |
+| [src/db/powersync/middleware/EncryptionMiddleware.ts](../src/db/powersync/middleware/EncryptionMiddleware.ts)                                     | Example middleware: base64-decodes `tasks.item` on incoming sync data                             |
+| [src/db/powersync/worker/ThunderboltSharedSyncImplementation.ts](../src/db/powersync/worker/ThunderboltSharedSyncImplementation.ts)               | Extends `SharedSyncImplementation` to inject `TransformableBucketStorage` inside the SharedWorker |
+| [src/db/powersync/worker/ThunderboltSharedSyncImplementation.worker.ts](../src/db/powersync/worker/ThunderboltSharedSyncImplementation.worker.ts) | SharedWorker entry point — mirrors PowerSync's original but uses the custom implementation        |
+| [src/db/powersync/database.ts](../src/db/powersync/database.ts)                                                                                   | Database config — wires up the custom SharedWorker for Chrome/Edge/Firefox                        |
+
+---
+
+## Data flow
+
+Two distinct paths exist depending on the platform. Both end at the same point — decrypted data in SQLite — but the interception happens in different execution contexts.
+
+### Chrome / Edge / Firefox (SharedWorker path)
+
+```mermaid
+flowchart TD
+    Server["PowerSync Cloud<br/>(encrypted data)"]
+
+    subgraph MainThread["Main Thread"]
+        TPS["ThunderboltPowerSyncDatabase<br/>extends PowerSyncDatabase<br/><br/>generateBucketStorageAdapter()<br/>→ creates TransformableBucketStorage<br/>  (unused in SharedWorker path)"]
+        Drizzle["Drizzle / DAL<br/>(reads decrypted data)"]
+        SQLite[("SQLite<br/>(decrypted)")]
+    end
+
+    subgraph SharedWorker["SharedWorker — ThunderboltSharedSyncImplementation.worker.ts"]
+        TSSI["ThunderboltSharedSyncImplementation<br/>extends SharedSyncImplementation<br/><br/>generateStreamingImplementation()<br/>→ creates TransformableBucketStorage<br/>  + registers encryptionMiddleware"]
+        TBS["TransformableBucketStorage<br/>extends SqliteBucketStorage<br/><br/>control(PROCESS_TEXT_LINE)<br/>→ parse → transform → super.control()"]
+        MW["encryptionMiddleware<br/>(base64 decode tasks.item)"]
+        SBS["SqliteBucketStorage<br/>super.control()"]
+    end
+
+    Server -->|"sync stream<br/>(PROCESS_TEXT_LINE)"| TSSI
+    TSSI --> TBS
+    TBS -->|"SyncDataBatch"| MW
+    MW -->|"transformed batch"| TBS
+    TBS --> SBS
+    SBS -->|"writes"| SQLite
+    SQLite --> Drizzle
+```
+
+### Safari / Tauri (dedicated worker path)
+
+```mermaid
+flowchart TD
+    Server["PowerSync Cloud<br/>(encrypted data)"]
+
+    subgraph MainThread["Main Thread"]
+        TPS["ThunderboltPowerSyncDatabase<br/>extends PowerSyncDatabase<br/><br/>generateBucketStorageAdapter()<br/>→ creates TransformableBucketStorage<br/>  + registers encryptionMiddleware"]
+        TBS["TransformableBucketStorage<br/>extends SqliteBucketStorage<br/><br/>control(PROCESS_TEXT_LINE)<br/>→ parse → transform → super.control()"]
+        MW["encryptionMiddleware<br/>(base64 decode tasks.item)"]
+        SBS["SqliteBucketStorage<br/>super.control()"]
+        Drizzle["Drizzle / DAL<br/>(reads decrypted data)"]
+        SQLite[("SQLite<br/>(decrypted)")]
+    end
+
+    subgraph DedicatedWorker["Dedicated Worker — WASQLiteDB.umd.js"]
+        WASM["Rust sync client (WASM)<br/>OPFSCoopSyncVFS"]
+    end
+
+    Server -->|"sync stream"| WASM
+    WASM -->|"control(PROCESS_TEXT_LINE)<br/>via MessagePort"| TPS
+    TPS --> TBS
+    TBS -->|"SyncDataBatch"| MW
+    MW -->|"transformed batch"| TBS
+    TBS --> SBS
+    SBS -->|"writes"| SQLite
+    SQLite --> Drizzle
+```
+
+---
+
+## How `TransformableBucketStorage` works
+
+PowerSync's Rust sync client sends incoming data to the storage adapter via:
+
+```
+adapter.control(PROCESS_TEXT_LINE, jsonPayload)
+```
+
+`TransformableBucketStorage` overrides `control()` to intercept this call. When a `PROCESS_TEXT_LINE` command arrives with sync data, it:
+
+1. Parses the JSON payload into a `SyncDataBatch`
+2. Runs it through the registered transformer pipeline (each transformer receives the output of the previous)
+3. Serializes the transformed batch back to JSON
+4. Passes the result to `super.control()` → `SqliteBucketStorage` → SQLite
+
+All other control commands (START, STOP, PROCESS_BSON_LINE, etc.) pass through unchanged.
+
+### Middleware interface
+
+```typescript
+type DataTransformMiddleware = {
+  transform(batch: SyncDataBatch): Promise<SyncDataBatch> | SyncDataBatch
+}
+```
+
+Transformers operate on `SyncDataBatch` → `SyncDataBucket[]` → `OplogEntry[]`. Each entry has:
+
+- `object_type` — table name (e.g. `"tasks"`)
+- `object_id` — row ID
+- `data` — JSON string of the row (modify this to transform field values)
+- `op` — `INSERT` / `UPDATE` / `DELETE`
+
+### Registering transformers
+
+Pass them via `ThunderboltPowerSyncDatabaseOptions.transformers` in `getPowerSyncOptions()`:
+
+```typescript
+transformers: [encryptionMiddleware]
+```
+
+`ThunderboltPowerSyncDatabase.generateBucketStorageAdapter()` picks these up and registers them on `TransformableBucketStorage`.
+
+---
+
+## The multi-tab problem
+
+PowerSync defaults to `enableMultiTabs: true` on Chrome/Edge/Firefox. This launches a **SharedWorker** that:
+
+- Manages a single sync connection shared across all browser tabs
+- Deduplicates CRUD uploads (only one tab uploads at a time)
+
+**The problem**: the SharedWorker creates its own `SqliteBucketStorage` instance internally (in `SharedSyncImplementation.generateStreamingImplementation()`). It completely ignores any custom `BucketStorageAdapter` configured on the main thread. Setting `enableMultiTabs: false` was the original workaround — but this sacrifices cross-tab sync efficiency.
+
+The root cause is architectural:
+
+- `SharedSyncImplementation` hardcodes `new SqliteBucketStorage(...)` with no injection hook
+- Transformer functions cannot be serialized across the worker boundary (Comlink limitation)
+- The `adapter` field is explicitly omitted from the `SharedSyncInitOptions` type passed to the worker
+
+---
+
+## Solution: custom SharedWorker
+
+Instead of disabling multi-tab, we provide a custom SharedWorker that **embeds** the transformer logic at bundle time.
+
+### How it works
+
+`ThunderboltSharedSyncImplementation` extends `SharedSyncImplementation` and overrides `generateStreamingImplementation()` — the one `protected` method that controls which storage adapter is used. The override is a direct copy of the parent method with `SqliteBucketStorage` replaced by `TransformableBucketStorage + encryptionMiddleware`.
+
+`ThunderboltSharedSyncImplementation.worker.ts` is the SharedWorker entry point, mirroring PowerSync's original `SharedSyncImplementation.worker.ts` but instantiating the custom class.
+
+In `database.ts`, the default config (Chrome/Edge/Firefox) points PowerSync to this custom worker via:
+
+```typescript
+sync: {
+  worker: () =>
+    new SharedWorker(
+      new URL('./worker/ThunderboltSharedSyncImplementation.worker.ts', import.meta.url),
+      { type: 'module', name: `shared-sync-${dbFilename}` },
+    ),
+}
+```
+
+Vite detects the `new SharedWorker(new URL(...))` pattern and bundles the worker file as a separate ES module chunk.
+
+### Why this works
+
+- Transformer **logic** lives in the worker bundle (compiled at build time) — no serialization needed
+- Transformer **keys** (for future real encryption) are serializable data — can be passed via `postMessage` before `setParams()` is called
+- Multi-tab sync efficiency is preserved: SharedWorker still manages a single connection
+
+### Accessing `SharedSyncImplementation` internals
+
+`SharedSyncImplementation` is marked `@internal` and not in `@powersync/web`'s public exports map. We access it via a Vite alias and a matching TypeScript `paths` entry that both point to the compiled lib output:
+
+**`vite.config.ts`:**
+
+```typescript
+resolve: {
+  alias: {
+    'powersync-web-internal': path.resolve(__dirname, 'node_modules/@powersync/web/lib/src'),
+  }
+}
+```
+
+**`tsconfig.json`:**
+
+```json
+"paths": {
+  "powersync-web-internal/*": ["./node_modules/@powersync/web/lib/src/*"]
+}
+```
+
+Imports then look like:
+
+```typescript
+import { SharedSyncImplementation } from 'powersync-web-internal/worker/sync/SharedSyncImplementation.js'
+```
+
+> **Upgrade note**: When upgrading `@powersync/web`, verify that `generateStreamingImplementation()` in `node_modules/@powersync/web/src/worker/sync/SharedSyncImplementation.ts` hasn't changed. If it has, update the override in `ThunderboltSharedSyncImplementation.ts` to match.
+
+---
+
+## Safari / Tauri: why it stays different
+
+The Safari and Tauri config keeps `enableMultiTabs: false` and the main-thread transformer path. This is not a limitation of our middleware — it's an inherent constraint of the environment:
+
+- **OPFSCoopSyncVFS** (required on Safari/iOS for stack size reasons) does not support SharedWorker
+- **Tauri** (`tauri://` protocol) blocks SharedWorker and `import.meta.url`-based worker loading
+- SharedWorker itself exceeds iOS WKWebView memory limits and causes black-screen crashes
+
+For Safari/Tauri, `ThunderboltPowerSyncDatabase.generateBucketStorageAdapter()` is called on the main thread and the transformer runs there via the dedicated worker path.
+
+---
+
+## Adding a new transformer
+
+1. Create a file in `src/db/powersync/middleware/` implementing `DataTransformMiddleware`:
+
+```typescript
+export const myMiddleware: DataTransformMiddleware = {
+  transform(batch) {
+    for (const bucket of batch.buckets) {
+      for (const entry of bucket.data) {
+        if (entry.object_type !== 'my_table' || !entry.data) continue
+        const row = JSON.parse(entry.data)
+        row.my_field = decode(row.my_field)
+        entry.data = JSON.stringify(row)
+      }
+    }
+    return batch
+  },
+}
+```
+
+2. Register it in **two places** (both paths must be kept in sync):
+   - `getPowerSyncOptions()` in [src/db/powersync/database.ts](../src/db/powersync/database.ts) — `transformers: [myMiddleware]` (used by the Safari/Tauri main-thread path)
+   - `ThunderboltSharedSyncImplementation.generateStreamingImplementation()` in [src/db/powersync/worker/ThunderboltSharedSyncImplementation.ts](../src/db/powersync/worker/ThunderboltSharedSyncImplementation.ts) — `storage.addTransformer(myMiddleware)` (used by the Chrome/Edge/Firefox SharedWorker path)
+
+---
+
+## Future: real E2E encryption with key passing
+
+When moving from base64 to real encryption (AES-GCM, ChaCha20, etc.), the encryption key needs to reach the SharedWorker. Since keys are serializable data (unlike functions), they can be passed before the worker connects:
+
+```typescript
+// In database.ts — default config
+sync: {
+  worker: () => {
+    const worker = new SharedWorker(
+      new URL('./worker/ThunderboltSharedSyncImplementation.worker.ts', import.meta.url),
+      { type: 'module', name: `shared-sync-${dbFilename}` },
+    )
+    worker.port.postMessage({ type: 'SET_KEY', key: derivedEncryptionKey })
+    return worker
+  }
+}
+```
+
+In `ThunderboltSharedSyncImplementation`, listen for the key before `setParams()` is called, store it, and pass it to the middleware when `generateStreamingImplementation()` runs.

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -100,10 +100,17 @@ export const getPowerSyncOptions = (path: string) => {
     return {
       database: { dbFilename },
       schema: AppSchema as unknown as WebPowerSyncDatabaseOptions['schema'],
-      // Required for both approaches: SharedWorker creates its own storage and bypasses our adapter.
-      // Ref: https://docs.powersync.com/client-sdks/reference/javascript-web#available-flags
-      flags: { enableMultiTabs: false, useWebWorker: false },
       transformers: [encryptionMiddleware],
+      // Use a custom SharedWorker that embeds TransformableBucketStorage with encryption middleware.
+      // This enables multi-tab support while still running transformations before local DB writes.
+      // The standard SharedWorker hardcodes SqliteBucketStorage and ignores any main-thread adapter.
+      sync: {
+        worker: () =>
+          new SharedWorker(new URL('./worker/ThunderboltSharedSyncImplementation.worker.ts', import.meta.url), {
+            type: 'module',
+            name: `shared-sync-${dbFilename}`,
+          }),
+      },
     }
   }
 
@@ -122,14 +129,10 @@ export const getPowerSyncOptions = (path: string) => {
       dbFilename: dbFilename,
       vfs: WASQLiteVFS.OPFSCoopSyncVFS,
       worker: '/@powersync/worker/WASQLiteDB.umd.js',
-      // Required for both approaches: SharedWorker creates its own storage and bypasses our adapter.
-      // Ref: https://docs.powersync.com/client-sdks/reference/javascript-web#available-flags
-      flags: { enableMultiTabs: false, useWebWorker: false },
+      flags: { enableMultiTabs: false },
     }),
     schema: AppSchema as unknown as WebPowerSyncDatabaseOptions['schema'],
-    // Required for both approaches: SharedWorker creates its own storage and bypasses our adapter.
-    // Ref: https://docs.powersync.com/client-sdks/reference/javascript-web#available-flags
-    flags: { enableMultiTabs: false, useWebWorker: false },
+    flags: { enableMultiTabs: false },
     sync: { worker: '/@powersync/worker/SharedSyncImplementation.umd.js' },
     transformers: [encryptionMiddleware],
   }

--- a/src/db/powersync/worker/ThunderboltSharedSyncImplementation.ts
+++ b/src/db/powersync/worker/ThunderboltSharedSyncImplementation.ts
@@ -1,0 +1,95 @@
+import type { SubscribedStream } from '@powersync/common'
+import { WebRemote } from 'powersync-web-internal/db/sync/WebRemote.js'
+import { WebStreamingSyncImplementation } from 'powersync-web-internal/db/sync/WebStreamingSyncImplementation.js'
+import { SharedSyncImplementation } from 'powersync-web-internal/worker/sync/SharedSyncImplementation.js'
+import { encryptionMiddleware } from '../middleware/EncryptionMiddleware'
+import { TransformableBucketStorage } from '../TransformableBucketStorage'
+
+/**
+ * Extends SharedSyncImplementation to inject TransformableBucketStorage with
+ * encryption middleware into the SharedWorker's sync pipeline.
+ *
+ * This enables multi-tab support (enableMultiTabs: true) while still running
+ * data transformations before sync data is written to the local database.
+ *
+ * The parent class hardcodes SqliteBucketStorage in generateStreamingImplementation().
+ * We override it to use TransformableBucketStorage with our middleware instead.
+ */
+export class ThunderboltSharedSyncImplementation extends SharedSyncImplementation {
+  protected generateStreamingImplementation() {
+    const syncParams = this.syncParams!
+
+    const storage = new TransformableBucketStorage(this.distributedDB!)
+    storage.addTransformer(encryptionMiddleware)
+
+    // `subscriptions` is declared private in SharedSyncImplementation — access at runtime.
+    const subscriptions = (this as unknown as { subscriptions: SubscribedStream[] }).subscriptions
+
+    return new WebStreamingSyncImplementation({
+      adapter: storage,
+      remote: new WebRemote(
+        {
+          invalidateCredentials: async () => {
+            const lastPort = await this.getLastWrappedPort()
+            if (!lastPort) {
+              throw new Error('No client port found to invalidate credentials')
+            }
+            try {
+              this.logger.log('calling the last port client provider to invalidate credentials')
+              lastPort.clientProvider.invalidateCredentials()
+            } catch (ex) {
+              this.logger.error('error invalidating credentials', ex)
+            }
+          },
+          fetchCredentials: async () => {
+            const lastPort = await this.getLastWrappedPort()
+            if (!lastPort) {
+              throw new Error('No client port found to fetch credentials')
+            }
+            return new Promise(async (resolve, reject) => {
+              const abortController = new AbortController()
+              this.fetchCredentialsController = {
+                controller: abortController,
+                activePort: lastPort,
+              }
+              abortController.signal.onabort = reject
+              try {
+                this.logger.log('calling the last port client provider for credentials')
+                resolve(await lastPort.clientProvider.fetchCredentials())
+              } catch (ex) {
+                reject(ex)
+              } finally {
+                this.fetchCredentialsController = undefined
+              }
+            })
+          },
+        },
+        this.logger,
+      ),
+      uploadCrud: async () => {
+        const lastPort = await this.getLastWrappedPort()
+        if (!lastPort) {
+          throw new Error('No client port found to upload crud')
+        }
+        return new Promise(async (resolve, reject) => {
+          const abortController = new AbortController()
+          this.uploadDataController = {
+            controller: abortController,
+            activePort: lastPort,
+          }
+          abortController.signal.onabort = () => resolve()
+          try {
+            resolve(await lastPort.clientProvider.uploadCrud())
+          } catch (ex) {
+            reject(ex)
+          } finally {
+            this.uploadDataController = undefined
+          }
+        })
+      },
+      ...syncParams.streamOptions,
+      subscriptions,
+      logger: this.logger,
+    })
+  }
+}

--- a/src/db/powersync/worker/ThunderboltSharedSyncImplementation.worker.ts
+++ b/src/db/powersync/worker/ThunderboltSharedSyncImplementation.worker.ts
@@ -1,0 +1,14 @@
+import { createBaseLogger } from '@powersync/common'
+import { WorkerClient } from 'powersync-web-internal/worker/sync/WorkerClient.js'
+import { ThunderboltSharedSyncImplementation } from './ThunderboltSharedSyncImplementation'
+
+const logger = createBaseLogger()
+logger.useDefaults()
+
+const sharedSyncImplementation = new ThunderboltSharedSyncImplementation()
+
+// `self` in a SharedWorker context is SharedWorkerGlobalScope — not typed in DOM lib.
+;(self as unknown as { onconnect: (event: MessageEvent) => void }).onconnect = async (event: MessageEvent) => {
+  const port = event.ports[0]
+  new WorkerClient(sharedSyncImplementation, port)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@/src/*": ["./src/*"],
-      "@shared/*": ["./shared/*"]
+      "@shared/*": ["./shared/*"],
+      "powersync-web-internal/*": ["./node_modules/@powersync/web/lib/src/*"]
     },
     /* Types */
     "typeRoots": ["./node_modules/@types", "./src/types"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,6 +70,9 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@shared': path.resolve(__dirname, './shared'),
+      // Exposes PowerSync internal lib path so our custom SharedWorker can extend
+      // SharedSyncImplementation (not in public exports map).
+      'powersync-web-internal': path.resolve(__dirname, 'node_modules/@powersync/web/lib/src'),
     },
     conditions: ['browser'],
   },


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #431 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #430 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the web sync execution path by replacing PowerSync’s default SharedWorker with a custom implementation that depends on `@powersync/web` internal APIs; upgrades to that dependency or worker bundling issues could break sync or data transformations.
> 
> **Overview**
> Enables PowerSync multi-tab sync on non-Safari web while still running the `TransformableBucketStorage` transformer pipeline (e.g. `encryptionMiddleware`) *inside the SharedWorker* before data is written to SQLite.
> 
> This replaces the previous `enableMultiTabs: false` workaround in the default web config with a custom worker (`ThunderboltSharedSyncImplementation.worker.ts`) that overrides `SharedSyncImplementation.generateStreamingImplementation()` to use `TransformableBucketStorage`. It also adds Vite/TypeScript aliasing (`powersync-web-internal`) to import `@powersync/web` internal worker classes, and updates docs to describe the middleware + custom SharedWorker approach and how to add new transformers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1799a543adfa5efe130f49bf9637287d9ffaece9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->