### PR TITLE
feat: integrate ResetDialog component and update credential invalidation logic

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -45,6 +45,7 @@ import SettingsLayout from './settings/layout'
 import type { InitData } from './types'
 import { useSettings } from './hooks/use-settings'
 import { isPrPreview } from './lib/platform'
+import { ResetDialog } from './components/reset-dialog'
 
 const queryClient = new QueryClient()
 
@@ -172,6 +173,7 @@ export const App = () => {
 
   return (
     <ThemeProvider defaultTheme="system" storageKey="ui_theme">
+      <ResetDialog />
       {renderAppContent()}
     </ThemeProvider>
   )

--- a/src/components/reset-dialog.test.tsx
+++ b/src/components/reset-dialog.test.tsx
@@ -1,0 +1,55 @@
+import { act, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+import { getClock } from '@/testing-library'
+import { ResetDialog, triggerResetDialog } from './reset-dialog'
+
+describe('ResetDialog', () => {
+  it('should not show dialog initially', () => {
+    render(<ResetDialog />)
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  it('should show device revoked dialog when triggered', async () => {
+    render(<ResetDialog />)
+
+    await act(async () => {
+      triggerResetDialog('device-revoked')
+      await getClock().tickAsync(0)
+    })
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByText('Device Revoked')).toBeInTheDocument()
+    expect(
+      screen.getByText('This device has been revoked. The app will now reset and you will need to sign in again.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Resetting app and deleting data...')).toBeInTheDocument()
+  })
+
+  it('should show account deleted dialog when triggered', async () => {
+    render(<ResetDialog />)
+
+    await act(async () => {
+      triggerResetDialog('account-deleted')
+      await getClock().tickAsync(0)
+    })
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByText('Account Deleted')).toBeInTheDocument()
+    expect(
+      screen.getByText('Your account has been deleted. The app will now reset and all local data will be removed.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Resetting app and deleting data...')).toBeInTheDocument()
+  })
+
+  it('should trigger dialog via custom event', async () => {
+    render(<ResetDialog />)
+
+    await act(async () => {
+      triggerResetDialog('device-revoked')
+      await getClock().tickAsync(0)
+    })
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByText('Device Revoked')).toBeInTheDocument()
+  })
+})

--- a/src/components/reset-dialog.tsx
+++ b/src/components/reset-dialog.tsx
@@ -1,0 +1,67 @@
+import { Loader2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog'
+
+export type ResetReason = 'device-revoked' | 'account-deleted'
+
+const resetDialogEvent = 'thunderbolt:reset-dialog'
+
+type ResetDialogEventDetail = {
+  reason: ResetReason
+}
+
+/**
+ * Shows a modal when the device is revoked or account is deleted.
+ * Rendered outside the main app component tree to ensure it works
+ * even when the app state is being cleared during reset.
+ */
+export const ResetDialog = () => {
+  const [reason, setReason] = useState<ResetReason | null>(null)
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const customEvent = event as CustomEvent<ResetDialogEventDetail>
+      setReason(customEvent.detail.reason)
+    }
+
+    window.addEventListener(resetDialogEvent, handler)
+    return () => window.removeEventListener(resetDialogEvent, handler)
+  }, [])
+
+  const isOpen = reason !== null
+
+  const title = reason === 'device-revoked' ? 'Device Revoked' : 'Account Deleted'
+  const description =
+    reason === 'device-revoked'
+      ? 'This device has been revoked. The app will now reset and you will need to sign in again.'
+      : 'Your account has been deleted. The app will now reset and all local data will be removed.'
+
+  return (
+    <AlertDialog open={isOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="flex items-center justify-center gap-2 py-4">
+          <Loader2 className="animate-spin text-gray-500" size={20} />
+          <span className="text-sm text-muted-foreground">Resetting app and deleting data...</span>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+/**
+ * Helper function to trigger the reset dialog
+ */
+export const triggerResetDialog = (reason: ResetReason): void => {
+  const event = new CustomEvent(resetDialogEvent, { detail: { reason } })
+  window.dispatchEvent(event)
+}

--- a/src/hooks/use-powersync-credentials-invalid-listener.ts
+++ b/src/hooks/use-powersync-credentials-invalid-listener.ts
@@ -26,7 +26,7 @@ const performCredentialsInvalidReset = async (reason: ResetReason): Promise<void
     console.error('Failed to perform credentials invalid reset:', error)
   } finally {
     localStorage.clear()
-    window.location.reload()
+    window.location.replace('/')
   }
 }
 

--- a/src/hooks/use-powersync-credentials-invalid-listener.ts
+++ b/src/hooks/use-powersync-credentials-invalid-listener.ts
@@ -1,3 +1,4 @@
+import { triggerResetDialog, type ResetReason } from '@/components/reset-dialog'
 import { getDevice } from '@/dal'
 import { setSyncEnabled } from '@/db/powersync'
 import { powersyncCredentialsInvalid } from '@/db/powersync/connector'
@@ -7,11 +8,17 @@ import { useQuery } from '@tanstack/react-query'
 import { useEffect, useRef } from 'react'
 
 /**
- * Full app reset when credentials are no longer valid: disable PowerSync sync, clear
- * localStorage (token + device id), reset app directory (DB), then reload. Leaves the user
+ * Full app reset when credentials are no longer valid: show reset dialog, disable PowerSync sync,
+ * clear localStorage (token + device id), reset app directory (DB), then reload. Leaves the user
  * in a clean signed-out state so they can sign in again or use the app offline.
  */
-const performCredentialsInvalidReset = async (): Promise<void> => {
+const performCredentialsInvalidReset = async (reason: ResetReason): Promise<void> => {
+  // Show the reset dialog to the user
+  triggerResetDialog(reason)
+
+  // Give the user time to see the dialog before performing the reset
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+
   try {
     await setSyncEnabled(false)
     await resetAppDir()
@@ -64,7 +71,8 @@ export const usePowerSyncCredentialsInvalidListener = (): void => {
         return
       }
       hasTriggeredRef.current = true
-      void performCredentialsInvalidReset()
+      // 410 = account deleted, 403/409 = device revoked
+      void performCredentialsInvalidReset('account-deleted')
     }
 
     window.addEventListener(powersyncCredentialsInvalid, handler)
@@ -92,6 +100,8 @@ export const usePowerSyncCredentialsInvalidListener = (): void => {
       return
     }
     hasTriggeredRef.current = true
-    void performCredentialsInvalidReset()
+    // Device revoked if revokedAt is set, account deleted if device row is missing
+    const reason: ResetReason = revoked ? 'device-revoked' : 'account-deleted'
+    void performCredentialsInvalidReset(reason)
   }, [isFetched, deviceId, device])
 }

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -63,24 +63,41 @@ const resetAppDirTauri = async (): Promise<void> => {
   await remove(appDataDirPath, { recursive: true })
 }
 
+const opfsResetTimeoutMs = 8_000
+
 /**
- * Resets app data directory in web environment using OPFS
+ * Resets app data directory in web environment using OPFS.
+ *
+ * Wrapped in a timeout because OPFS operations (getDirectory, entries, removeEntry)
+ * can hang indefinitely on some platforms — notably Tauri iOS WKWebView, where
+ * the File System Access API behaves unreliably. If we hang, the reset never
+ * completes and the finally block (localStorage.clear + reload) never runs,
+ * leaving the app in a broken state. The timeout ensures we bail and the caller
+ * can still run its finally block.
  */
 const resetAppDirOpfs = async (): Promise<void> => {
-  if (!(await isOpfsAvailable())) {
-    throw new Error('OPFS is not available')
+  const reset = async (): Promise<void> => {
+    if (!(await isOpfsAvailable())) {
+      throw new Error('OPFS is not available')
+    }
+
+    const appDataDirPath = await createAppDir()
+    const root: any = await navigator.storage.getDirectory()
+
+    for await (const [name] of root.entries()) {
+      await root.removeEntry(name, { recursive: true })
+    }
+
+    if (!isTauri()) {
+      await root.getDirectoryHandle(appDataDirPath, { create: true })
+    }
   }
 
-  const appDataDirPath = await createAppDir()
-  const root: any = await navigator.storage.getDirectory()
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(`OPFS reset timed out after ${opfsResetTimeoutMs}ms`)), opfsResetTimeoutMs)
+  })
 
-  for await (const [name] of root.entries()) {
-    await root.removeEntry(name, { recursive: true })
-  }
-
-  if (!isTauri()) {
-    await root.getDirectoryHandle(appDataDirPath, { create: true })
-  }
+  await Promise.race([reset(), timeoutPromise])
 }
 
 /**


### PR DESCRIPTION

<img width="548" height="245" alt="Screenshot 2026-03-06 at 09 46 50" src="https://github.com/user-attachments/assets/63b0686f-65e3-4f41-afee-5e9fb6582688" />



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches credential-invalidation reset flow and local data deletion/reload behavior, which could strand users if the dialog/reset timing or navigation change misbehaves. Adds an OPFS timeout to avoid hangs, but introduces a new failure mode where directory cleanup may be partial before forcing a reset.
> 
> **Overview**
> **Adds a global `ResetDialog` UX during forced app resets.** The dialog is rendered at the `App` root and is triggered via a custom window event (`triggerResetDialog`) with copy tailored for *device revoked* vs *account deleted*, with tests covering the event-driven behavior.
> 
> **Updates the credentials-invalidation reset path.** `usePowerSyncCredentialsInvalidListener` now triggers the dialog, waits briefly, then disables sync, clears local storage, resets the app DB dir, and navigates via `window.location.replace('/')`.
> 
> **Hardens web (OPFS) data directory reset.** `resetAppDirOpfs` is wrapped in an 8s timeout via `Promise.race` to prevent indefinite hangs (notably on WKWebView/Tauri iOS) so callers can still complete their reset cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b9159f5412e35bb0fff163aa52217ee7b7054b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->