### PR TITLE
⚡ THU-320: Fix citation bottom sheet blocked by Android nav bar

### DIFF
--- a/src/components/chat/citation-badge.tsx
+++ b/src/components/chat/citation-badge.tsx
@@ -127,7 +127,7 @@ const StandaloneBadge = memo(({ sources }: { sources: CitationSource[] }) => {
         <SheetContent
           side="bottom"
           className="inset-x-1 overflow-hidden rounded-2xl border p-0"
-          style={{ bottom: 'calc(16px + var(--safe-area-bottom-padding, 0px))' }}
+          style={{ bottom: 'calc(20px + var(--safe-area-bottom-padding, 0px))' }}
           hideCloseButton
         >
           <SheetHeader className="sr-only">

--- a/src/components/chat/citation-badge.tsx
+++ b/src/components/chat/citation-badge.tsx
@@ -126,7 +126,8 @@ const StandaloneBadge = memo(({ sources }: { sources: CitationSource[] }) => {
       <Sheet open={isOpen} onOpenChange={setIsOpen}>
         <SheetContent
           side="bottom"
-          className="inset-x-1 bottom-4 overflow-hidden rounded-2xl border p-0"
+          className="inset-x-1 overflow-hidden rounded-2xl border p-0"
+          style={{ bottom: 'calc(16px + var(--safe-area-bottom-padding, 0px))' }}
           hideCloseButton
         >
           <SheetHeader className="sr-only">

--- a/src/components/chat/citation-popover.tsx
+++ b/src/components/chat/citation-popover.tsx
@@ -63,7 +63,8 @@ const CitationOverlay = ({ popover, close }: { popover: PopoverData | null; clos
       <Sheet open onOpenChange={(open) => !open && close()}>
         <SheetContent
           side="bottom"
-          className="inset-x-1 bottom-4 overflow-hidden rounded-2xl border p-0"
+          className="inset-x-1 overflow-hidden rounded-2xl border p-0"
+          style={{ bottom: 'calc(16px + var(--safe-area-bottom-padding, 0px))' }}
           hideCloseButton
         >
           <SheetHeader className="sr-only">

--- a/src/components/chat/citation-popover.tsx
+++ b/src/components/chat/citation-popover.tsx
@@ -64,7 +64,7 @@ const CitationOverlay = ({ popover, close }: { popover: PopoverData | null; clos
         <SheetContent
           side="bottom"
           className="inset-x-1 overflow-hidden rounded-2xl border p-0"
-          style={{ bottom: 'calc(16px + var(--safe-area-bottom-padding, 0px))' }}
+          style={{ bottom: 'calc(20px + var(--safe-area-bottom-padding, 0px))' }}
           hideCloseButton
         >
           <SheetHeader className="sr-only">

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -537,48 +537,53 @@ const SidebarMenuButton = forwardRef<
     isActive?: boolean
     tooltip?: string | ComponentProps<typeof TooltipContent>
   } & VariantProps<typeof sidebarMenuButtonVariants>
->(({ asChild = false, isActive = false, variant = 'default', size = 'default', tooltip, className, onClick, ...props }, ref) => {
-  const Comp = asChild ? Slot : 'button'
-  const { isMobile, state } = useSidebar()
-  const { triggerSelection } = useHaptics()
+>(
+  (
+    { asChild = false, isActive = false, variant = 'default', size = 'default', tooltip, className, onClick, ...props },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'button'
+    const { isMobile, state } = useSidebar()
+    const { triggerSelection } = useHaptics()
 
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
-      triggerSelection()
-      onClick?.(e)
-    },
-    [onClick, triggerSelection],
-  )
+    const handleClick = useCallback(
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        triggerSelection()
+        onClick?.(e)
+      },
+      [onClick, triggerSelection],
+    )
 
-  const button = (
-    <Comp
-      ref={ref}
-      data-sidebar="menu-button"
-      data-size={size}
-      data-active={isActive}
-      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
-      onClick={handleClick}
-      {...props}
-    />
-  )
+    const button = (
+      <Comp
+        ref={ref}
+        data-sidebar="menu-button"
+        data-size={size}
+        data-active={isActive}
+        className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+        onClick={handleClick}
+        {...props}
+      />
+    )
 
-  if (!tooltip) {
-    return button
-  }
-
-  if (typeof tooltip === 'string') {
-    tooltip = {
-      children: tooltip,
+    if (!tooltip) {
+      return button
     }
-  }
 
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent side="right" align="center" hidden={state !== 'collapsed' || isMobile} {...tooltip} />
-    </Tooltip>
-  )
-})
+    if (typeof tooltip === 'string') {
+      tooltip = {
+        children: tooltip,
+      }
+    }
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent side="right" align="center" hidden={state !== 'collapsed' || isMobile} {...tooltip} />
+      </Tooltip>
+    )
+  },
+)
 SidebarMenuButton.displayName = 'SidebarMenuButton'
 
 const SidebarMenuAction = forwardRef<


### PR DESCRIPTION
## Summary
- Citation bottom sheets used hardcoded `bottom-4` (20px) positioning which gets hidden behind Android's navigation bar
- Replaced with `calc(20px + var(--safe-area-bottom-padding, 0px))` to dynamically account for the safe area inset
- Fix applied in both `citation-popover.tsx` (managed overlay) and `citation-badge.tsx` (standalone variant)

## Linear
[THU-320](https://linear.app/mozilla-thunderbolt/issue/THU-320/fix-bottom-sheet-for-citations-blocked-by-android-navigation)

## Test Plan
- [x] Open a citation on Android — bottom sheet should clear the navigation bar
- [x] Open a citation on iOS — bottom sheet should still look correct (fallback to 0px)
- [x] Open a citation on desktop — should use popover, not bottom sheet (no change)
- [x] Standalone citation widget bottom sheet also respects safe area

## Changes
- `src/components/chat/citation-popover.tsx` — replace `bottom-4` class with inline style using safe area variable
- `src/components/chat/citation-badge.tsx` — same fix for standalone badge variant

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks sheet positioning on mobile to avoid being obscured by OS navigation bars; no data or auth logic touched.
> 
> **Overview**
> Fixes mobile citation bottom sheets being hidden behind Android navigation by replacing the hardcoded `bottom-4` positioning with an inline `bottom: calc(20px + var(--safe-area-bottom-padding, 0px))` offset in both `citation-popover` and the standalone `citation-badge` sheet.
> 
> Also reformats the `SidebarMenuButton` `forwardRef` definition in `sidebar.tsx` without changing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f44edea9df8b1f109b4aeb8c657b959482d7c55c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->