### PR TITLE
Replace useQuery from @tanstack/react-query with @powersync/tanstack-react-query

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.1",
-        "@journeyapps/wa-sqlite": "^1.4.1",
+        "@journeyapps/wa-sqlite": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.17.3",
         "@openrouter/ai-sdk-provider": "^1.1.2",
         "@powersync/drizzle-driver": "^0.7.2",
@@ -339,7 +339,7 @@
 
     "@joshwooding/vite-plugin-react-docgen-typescript": ["@joshwooding/vite-plugin-react-docgen-typescript@0.6.1", "", { "dependencies": { "glob": "^10.0.0", "magic-string": "^0.30.0", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "typescript": ">= 4.3.x", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["typescript"] }, "sha512-J4BaTocTOYFkMHIra1JDWrMWpNmBl4EkplIwHEsV8aeUOtdWjwSnln9U7twjMFTAEB7mptNtSKyVi1Y2W9sDJw=="],
 
-    "@journeyapps/wa-sqlite": ["@journeyapps/wa-sqlite@1.4.1", "", {}, "sha512-xAWys6opteBpWaKmHG1pZvBmQViEKFK/46YVEkYlWxa4F9VAG0gIjCpfIdcQvXdqZf7X3ByADGmNBcR/cJ1DqQ=="],
+    "@journeyapps/wa-sqlite": ["@journeyapps/wa-sqlite@1.5.0", "", {}, "sha512-oASXW/9Ktbhn6kJjxCJzRKxNnlOyj7GKBLF/59dkz1kbOLw7kAXBTwWTUvqfT97OEshtrK/J8bJUYbpggdCZ9Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,8 @@
         "@modelcontextprotocol/sdk": "^1.17.3",
         "@openrouter/ai-sdk-provider": "^1.1.2",
         "@powersync/drizzle-driver": "^0.7.2",
-        "@powersync/react": "^1.8.2",
+        "@powersync/react": "^1.9.0",
+        "@powersync/tanstack-react-query": "^0.2.1",
         "@powersync/web": "^1.32.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -418,7 +419,9 @@
 
     "@powersync/drizzle-driver": ["@powersync/drizzle-driver@0.7.2", "", { "dependencies": { "tslib": "^2.8.1" }, "peerDependencies": { "@powersync/common": "^1.46.0", "drizzle-orm": "<1.0.0" } }, "sha512-urzkvimN44qWufmNonDdvwI3tcN9qFA0XB6BpoQDXFonkRzjunnZiUHas558PdDiw98AEJ4bD+FbtvvgJKzDcw=="],
 
-    "@powersync/react": ["@powersync/react@1.8.2", "", { "peerDependencies": { "@powersync/common": "^1.41.1", "react": "*" } }, "sha512-15z8JKt66dq2bqX2P7QQ71eUIx3DWLc5WMdB/PDc9MIAHf1SERqKfzbzWGxKplQGHC/GogDA7G8IDoRadhNXOA=="],
+    "@powersync/react": ["@powersync/react@1.9.0", "", { "peerDependencies": { "@powersync/common": "^1.47.0", "react": "*" } }, "sha512-FypJ1RSQXhbpLJ1WOSLi1ph+q6JXAX5GHqXhczaOr0dhngsr1zHIsFTANh6N0tfx838SM+MDgYO1d0LZxv1WWw=="],
+
+    "@powersync/tanstack-react-query": ["@powersync/tanstack-react-query@0.2.1", "", { "dependencies": { "@powersync/common": "1.48.0", "@powersync/react": "1.9.0", "@tanstack/react-query": "^5.70.0" }, "peerDependencies": { "react": "*" } }, "sha512-lPmWCZ1T6fkC61yPCNpOWJQTFlDU2Fc6brFXy3wFeWKsYRKf3Ezx7sc8PAJEJT3olZ0LSs8Ycli9FBf5fgTJFQ=="],
 
     "@powersync/web": ["@powersync/web@1.32.0", "", { "dependencies": { "@powersync/common": "1.46.0", "async-mutex": "^0.5.0", "bson": "^6.10.4", "comlink": "^4.4.2", "commander": "^12.1.0" }, "peerDependencies": { "@journeyapps/wa-sqlite": "^1.4.1" }, "bin": { "powersync-web": "bin/powersync.cjs" } }, "sha512-AYXF+0x5DTfyjPc2Eh89GZLTSanCZYqxsE/js1C9yRzI9+e3NkAjnX7r9n3FFkJS9PSlHlctDMxyb5x2epvMJg=="],
 
@@ -2047,6 +2050,10 @@
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@powersync/react/@powersync/common": ["@powersync/common@1.48.0", "", { "dependencies": { "async-mutex": "^0.5.0", "event-iterator": "^2.0.0" } }, "sha512-CMnQQdQdheJMOobcQJWPW2CLv17+Yyqtg+zk+kS45EyZSV5wnC5tiRcsrGb6f3ShvHSfKaHZJFIySgp9Lbkkbg=="],
+
+    "@powersync/tanstack-react-query/@powersync/common": ["@powersync/common@1.48.0", "", { "dependencies": { "async-mutex": "^0.5.0", "event-iterator": "^2.0.0" } }, "sha512-CMnQQdQdheJMOobcQJWPW2CLv17+Yyqtg+zk+kS45EyZSV5wnC5tiRcsrGb6f3ShvHSfKaHZJFIySgp9Lbkkbg=="],
 
     "@powersync/web/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "@powersync/drizzle-driver": "^0.7.2",
         "@powersync/react": "^1.8.2",
         "@powersync/tanstack-react-query": "^0.2.1",
-        "@powersync/web": "^1.32.0",
+        "@powersync/web": "^1.35.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -423,7 +423,7 @@
 
     "@powersync/tanstack-react-query": ["@powersync/tanstack-react-query@0.2.1", "", { "dependencies": { "@powersync/common": "1.48.0", "@powersync/react": "1.9.0", "@tanstack/react-query": "^5.70.0" }, "peerDependencies": { "react": "*" } }, "sha512-lPmWCZ1T6fkC61yPCNpOWJQTFlDU2Fc6brFXy3wFeWKsYRKf3Ezx7sc8PAJEJT3olZ0LSs8Ycli9FBf5fgTJFQ=="],
 
-    "@powersync/web": ["@powersync/web@1.32.0", "", { "dependencies": { "@powersync/common": "1.46.0", "async-mutex": "^0.5.0", "bson": "^6.10.4", "comlink": "^4.4.2", "commander": "^12.1.0" }, "peerDependencies": { "@journeyapps/wa-sqlite": "^1.4.1" }, "bin": { "powersync-web": "bin/powersync.cjs" } }, "sha512-AYXF+0x5DTfyjPc2Eh89GZLTSanCZYqxsE/js1C9yRzI9+e3NkAjnX7r9n3FFkJS9PSlHlctDMxyb5x2epvMJg=="],
+    "@powersync/web": ["@powersync/web@1.35.0", "", { "dependencies": { "@powersync/common": "1.48.0", "async-mutex": "^0.5.0", "bson": "^6.10.4", "comlink": "^4.4.2", "commander": "^12.1.0" }, "peerDependencies": { "@journeyapps/wa-sqlite": "^1.5.0" }, "bin": { "powersync-web": "bin/powersync.cjs" } }, "sha512-ks2XrtHzENMBEUBkgtzpXdZGDOeN8s9N/bQj21Ty1eMRo1tbGZYSMmTb0F2GCuTCIVKaWq2O11o3TX4fw2lc9g=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -2054,6 +2054,8 @@
     "@powersync/react/@powersync/common": ["@powersync/common@1.48.0", "", { "dependencies": { "async-mutex": "^0.5.0", "event-iterator": "^2.0.0" } }, "sha512-CMnQQdQdheJMOobcQJWPW2CLv17+Yyqtg+zk+kS45EyZSV5wnC5tiRcsrGb6f3ShvHSfKaHZJFIySgp9Lbkkbg=="],
 
     "@powersync/tanstack-react-query/@powersync/common": ["@powersync/common@1.48.0", "", { "dependencies": { "async-mutex": "^0.5.0", "event-iterator": "^2.0.0" } }, "sha512-CMnQQdQdheJMOobcQJWPW2CLv17+Yyqtg+zk+kS45EyZSV5wnC5tiRcsrGb6f3ShvHSfKaHZJFIySgp9Lbkkbg=="],
+
+    "@powersync/web/@powersync/common": ["@powersync/common@1.48.0", "", { "dependencies": { "async-mutex": "^0.5.0", "event-iterator": "^2.0.0" } }, "sha512-CMnQQdQdheJMOobcQJWPW2CLv17+Yyqtg+zk+kS45EyZSV5wnC5tiRcsrGb6f3ShvHSfKaHZJFIySgp9Lbkkbg=="],
 
     "@powersync/web/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@modelcontextprotocol/sdk": "^1.17.3",
         "@openrouter/ai-sdk-provider": "^1.1.2",
         "@powersync/drizzle-driver": "^0.7.2",
-        "@powersync/react": "^1.9.0",
+        "@powersync/react": "^1.8.2",
         "@powersync/tanstack-react-query": "^0.2.1",
         "@powersync/web": "^1.32.0",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@openrouter/ai-sdk-provider": "^1.1.2",
     "@powersync/drizzle-driver": "^0.7.2",
     "@powersync/react": "^1.8.2",
+    "@powersync/tanstack-react-query": "^0.2.1",
     "@powersync/web": "^1.32.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@powersync/drizzle-driver": "^0.7.2",
     "@powersync/react": "^1.8.2",
     "@powersync/tanstack-react-query": "^0.2.1",
-    "@powersync/web": "^1.32.0",
+    "@powersync/web": "^1.35.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.1",
-    "@journeyapps/wa-sqlite": "^1.4.1",
+    "@journeyapps/wa-sqlite": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.17.3",
     "@openrouter/ai-sdk-provider": "^1.1.2",
     "@powersync/drizzle-driver": "^0.7.2",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,7 @@
 import '@/lib/dayjs'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router'
+import { PowerSyncContext } from '@powersync/react'
 
 import ChatDetailPage from '@/chats/detail'
 import MagicLinkVerify from '@/components/magic-link-verify'
@@ -45,6 +46,7 @@ import SettingsLayout from './settings/layout'
 import type { InitData } from './types'
 import { useSettings } from './hooks/use-settings'
 import { isPrPreview } from './lib/platform'
+import { getPowerSyncInstance } from './db/powersync'
 
 const queryClient = new QueryClient()
 
@@ -140,33 +142,36 @@ export const App = () => {
       return <Loading />
     }
 
+    const powerSyncInstance = getPowerSyncInstance()
     return (
-      <QueryClientProvider client={queryClient}>
-        <HttpClientProvider httpClient={initData.httpClient}>
-          <AuthProvider>
-            <SignInModalProvider>
-              <PostHogProvider client={initData.posthogClient}>
-                <TrayProvider tray={initData.tray} window={initData.window}>
-                  <MCPProvider>
-                    <HapticsProvider>
-                      <SidebarProvider>
-                        <ContentViewProvider
-                          initialSideviewType={initData.sideviewType}
-                          initialSideviewId={initData.sideviewId}
-                        >
-                          <ExternalLinkDialogProvider>
-                            <AppContent initData={initData} />
-                          </ExternalLinkDialogProvider>
-                        </ContentViewProvider>
-                      </SidebarProvider>
-                    </HapticsProvider>
-                  </MCPProvider>
-                </TrayProvider>
-              </PostHogProvider>
-            </SignInModalProvider>
-          </AuthProvider>
-        </HttpClientProvider>
-      </QueryClientProvider>
+      <PowerSyncContext.Provider value={powerSyncInstance}>
+        <QueryClientProvider client={queryClient}>
+          <HttpClientProvider httpClient={initData.httpClient}>
+            <AuthProvider>
+              <SignInModalProvider>
+                <PostHogProvider client={initData.posthogClient}>
+                  <TrayProvider tray={initData.tray} window={initData.window}>
+                    <MCPProvider>
+                      <HapticsProvider>
+                        <SidebarProvider>
+                          <ContentViewProvider
+                            initialSideviewType={initData.sideviewType}
+                            initialSideviewId={initData.sideviewId}
+                          >
+                            <ExternalLinkDialogProvider>
+                              <AppContent initData={initData} />
+                            </ExternalLinkDialogProvider>
+                          </ContentViewProvider>
+                        </SidebarProvider>
+                      </HapticsProvider>
+                    </MCPProvider>
+                  </TrayProvider>
+                </PostHogProvider>
+              </SignInModalProvider>
+            </AuthProvider>
+          </HttpClientProvider>
+        </QueryClientProvider>
+      </PowerSyncContext.Provider>
     )
   }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -139,18 +139,18 @@ export const App = () => {
       return <AppErrorScreen error={initError} isClearingDatabase={isInitializing} onClearDatabase={clearDatabase} />
     }
 
-    if (!initData) {
+    // TODO: PowerSync is our only database provider, so we can safely assert it's not null.
+    // We may need to refactor the database classes to make this more robust.
+    const powerSyncInstance = getPowerSyncInstance()
+
+    if (!initData || !powerSyncInstance) {
       return <Loading />
     }
 
-    // TODO: PowerSync is our only database provider, so we can safely assert it's not null.
-    // We may need to refactor the database classes to make this more robust.
-    const powerSyncInstance = getPowerSyncInstance()! as unknown as ComponentProps<
-      typeof PowerSyncContext.Provider
-    >['value']
-
     return (
-      <PowerSyncContext.Provider value={powerSyncInstance}>
+      <PowerSyncContext.Provider
+        value={powerSyncInstance as unknown as ComponentProps<typeof PowerSyncContext.Provider>['value']}
+      >
         <QueryClientProvider client={queryClient}>
           <HttpClientProvider httpClient={initData.httpClient}>
             <AuthProvider>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -47,6 +47,7 @@ import type { InitData } from './types'
 import { useSettings } from './hooks/use-settings'
 import { isPrPreview } from './lib/platform'
 import { getPowerSyncInstance } from './db/powersync'
+import { ComponentProps } from 'react'
 
 const queryClient = new QueryClient()
 
@@ -142,13 +143,14 @@ export const App = () => {
       return <Loading />
     }
 
-    const powerSyncInstance = getPowerSyncInstance()
+    // TODO: PowerSync is our only database provider, so we can safely assert it's not null.
+    // We may need to refactor the database classes to make this more robust.
+    const powerSyncInstance = getPowerSyncInstance()! as unknown as ComponentProps<
+      typeof PowerSyncContext.Provider
+    >['value']
+
     return (
-      <PowerSyncContext.Provider
-        // TODO: refactor database instance to always return PowerSyncDatabase - we no longer have other database types
-        // @ts-ignore
-        value={powerSyncInstance}
-      >
+      <PowerSyncContext.Provider value={powerSyncInstance}>
         <QueryClientProvider client={queryClient}>
           <HttpClientProvider httpClient={initData.httpClient}>
             <AuthProvider>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -47,7 +47,7 @@ import type { InitData } from './types'
 import { useSettings } from './hooks/use-settings'
 import { isPrPreview } from './lib/platform'
 import { getPowerSyncInstance } from './db/powersync'
-import { ComponentProps } from 'react'
+import { type ComponentProps } from 'react'
 
 const queryClient = new QueryClient()
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -144,7 +144,11 @@ export const App = () => {
 
     const powerSyncInstance = getPowerSyncInstance()
     return (
-      <PowerSyncContext.Provider value={powerSyncInstance}>
+      <PowerSyncContext.Provider
+        // TODO: refactor database instance to always return PowerSyncDatabase - we no longer have other database types
+        // @ts-ignore
+        value={powerSyncInstance}
+      >
         <QueryClientProvider client={queryClient}>
           <HttpClientProvider httpClient={initData.httpClient}>
             <AuthProvider>

--- a/src/dal/tasks.test.ts
+++ b/src/dal/tasks.test.ts
@@ -131,7 +131,7 @@ describe('Tasks DAL', () => {
 
   describe('getIncompleteTasksCount', () => {
     it('should return 0 when no incomplete tasks exist', async () => {
-      const count = await getIncompleteTasksCount()
+      const [{ count }] = await getIncompleteTasksCount()
       expect(count).toBe(0)
     })
 
@@ -162,7 +162,7 @@ describe('Tasks DAL', () => {
         },
       ])
 
-      const count = await getIncompleteTasksCount()
+      const [{ count }] = await getIncompleteTasksCount()
       expect(count).toBe(2)
     })
   })
@@ -465,7 +465,7 @@ describe('Tasks DAL', () => {
       const incompleteTasks = await getIncompleteTasks()
       expect(incompleteTasks).toHaveLength(0)
 
-      const count = await getIncompleteTasksCount()
+      const [{ count }] = await getIncompleteTasksCount()
       expect(count).toBe(0)
     })
   })

--- a/src/dal/tasks.ts
+++ b/src/dal/tasks.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, like, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, inArray, isNotNull, isNull, like, sql } from 'drizzle-orm'
 import { DatabaseSingleton } from '../db/singleton'
 import { tasksTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
@@ -12,36 +12,38 @@ export const getAllTasks = async (): Promise<Task[]> => {
   return (await db.select().from(tasksTable).where(isNull(tasksTable.deletedAt))) as Task[]
 }
 
+const itemNotEmpty = and(isNotNull(tasksTable.item), sql`trim(${tasksTable.item}) != ''`)
+
 /**
- * Gets all incomplete tasks, optionally filtered by search query (excluding soft-deleted)
+ * Returns a Drizzle query for incomplete tasks, optionally filtered by search query (excluding soft-deleted).
+ * Use with PowerSync's toCompilableQuery, or await the result to execute.
  */
-export const getIncompleteTasks = async (searchQuery?: string): Promise<Task[]> => {
-  const db = DatabaseSingleton.instance.db
-  const result = (await db
+export const getIncompleteTasks = (searchQuery?: string) =>
+  DatabaseSingleton.instance.db
     .select()
     .from(tasksTable)
     .where(
       searchQuery
-        ? and(eq(tasksTable.isComplete, 0), like(tasksTable.item, `%${searchQuery}%`), isNull(tasksTable.deletedAt))
-        : and(eq(tasksTable.isComplete, 0), isNull(tasksTable.deletedAt)),
+        ? and(
+            eq(tasksTable.isComplete, 0),
+            like(tasksTable.item, `%${searchQuery}%`),
+            isNull(tasksTable.deletedAt),
+            itemNotEmpty,
+          )
+        : and(eq(tasksTable.isComplete, 0), isNull(tasksTable.deletedAt), itemNotEmpty),
     )
     .orderBy(asc(tasksTable.order), desc(tasksTable.id))
-    .limit(50)) as Task[]
-
-  return result.filter((task) => task.item && task.item.trim() !== '')
-}
+    .limit(50)
 
 /**
- * Gets the count of incomplete tasks (excluding soft-deleted)
+ * Returns a Drizzle query for the count of incomplete tasks (excluding soft-deleted).
+ * Use with PowerSync's toCompilableQuery, or await the result to execute.
  */
-export const getIncompleteTasksCount = async (): Promise<number> => {
-  const db = DatabaseSingleton.instance.db
-  const [{ count }] = await db
+export const getIncompleteTasksCount = () =>
+  DatabaseSingleton.instance.db
     .select({ count: sql<number>`count(*)` })
     .from(tasksTable)
-    .where(and(eq(tasksTable.isComplete, 0), isNull(tasksTable.deletedAt)))
-  return count
-}
+    .where(and(eq(tasksTable.isComplete, 0), isNull(tasksTable.deletedAt), itemNotEmpty))
 
 /**
  * Update a task (preserves defaultHash for modification tracking)

--- a/src/tasks/index.tsx
+++ b/src/tasks/index.tsx
@@ -27,10 +27,13 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
+import { useQuery } from '@powersync/tanstack-react-query'
+import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { CheckCircle2, GripVertical, Plus, Square } from 'lucide-react'
 import { type KeyboardEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { v7 as uuidv7 } from 'uuid'
+import { type CompilableQuery } from '@powersync/web'
 
 // Task Item Component - Memoized for performance
 type TaskItemProps = {
@@ -240,8 +243,6 @@ const NewTaskInput = ({ onAdd, onCancel }: NewTaskInputProps) => {
 
 // Main Tasks Page Component
 export default function TasksPage() {
-  const queryClient = useQueryClient()
-
   // State
   const [isAddingNew, setIsAddingNew] = useState(false)
   const [completingTasks, setCompletingTasks] = useState<Set<string>>(new Set())
@@ -268,14 +269,14 @@ export default function TasksPage() {
     easing: 'ease-out',
   }
 
-  // Fetch tasks
+  // Fetch tasks via PowerSync for reactive/live updates
   const {
     data: tasks = [],
     isLoading,
     isPlaceholderData,
   } = useQuery({
     queryKey: ['tasks', debouncedSearchQuery],
-    queryFn: () => getIncompleteTasks(debouncedSearchQuery),
+    query: toCompilableQuery(getIncompleteTasks(debouncedSearchQuery)) as CompilableQuery<Task>,
     placeholderData: (previousData) => previousData,
   })
 
@@ -298,11 +299,12 @@ export default function TasksPage() {
     return tasks
   }, [tasks, optimisticOrder])
 
-  // Count total tasks
-  const { data: totalCount = 0 } = useQuery({
+  // Count total tasks (query returns [{ count }])
+  const { data: countResult } = useQuery({
     queryKey: ['tasks', 'count'],
-    queryFn: getIncompleteTasksCount,
+    query: toCompilableQuery(getIncompleteTasksCount()),
   })
+  const totalCount = countResult?.[0]?.count ?? 0
 
   // Mutations
   const addTaskMutation = useMutation({
@@ -318,7 +320,6 @@ export default function TasksPage() {
     },
     onSuccess: (_, item) => {
       trackEvent('task_add', { task_length: item.length })
-      queryClient.invalidateQueries({ queryKey: ['tasks'] })
     },
   })
 
@@ -328,15 +329,11 @@ export default function TasksPage() {
     },
     onSuccess: (_, values) => {
       trackEvent('task_update_text', { task_id: values.id, new_length: values.item.length })
-      queryClient.invalidateQueries({ queryKey: ['tasks'] })
     },
   })
 
   const deleteTaskMutation = useMutation({
     mutationFn: deleteTask,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tasks'] })
-    },
   })
 
   const updateOrderMutation = useMutation({
@@ -357,7 +354,6 @@ export default function TasksPage() {
     },
     onSuccess: (_, id) => {
       trackEvent('task_mark_complete', { task_id: id })
-      queryClient.invalidateQueries({ queryKey: ['tasks'] })
     },
   })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
     },
   ],
   resolve: {
-    dedupe: ['@powersync/react', 'react'],
+    dedupe: ['@powersync/common', '@powersync/react', 'react'],
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@shared': path.resolve(__dirname, './shared'),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,11 +71,6 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@shared': path.resolve(__dirname, './shared'),
-      // Force single @powersync/react instance so PowerSyncContext is shared (usePowerSyncQuery needs it)
-      '@powersync/react': path.resolve(__dirname, 'node_modules/@powersync/react'),
-      // Exposes PowerSync internal lib path so our custom SharedWorker can extend
-      // SharedSyncImplementation (not in public exports map).
-      'powersync-web-internal': path.resolve(__dirname, 'node_modules/@powersync/web/lib/src'),
     },
     conditions: ['browser'],
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,9 +67,15 @@ export default defineConfig({
     },
   ],
   resolve: {
+    dedupe: ['@powersync/react', 'react'],
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@shared': path.resolve(__dirname, './shared'),
+      // Force single @powersync/react instance so PowerSyncContext is shared (usePowerSyncQuery needs it)
+      '@powersync/react': path.resolve(__dirname, 'node_modules/@powersync/react'),
+      // Exposes PowerSync internal lib path so our custom SharedWorker can extend
+      // SharedSyncImplementation (not in public exports map).
+      'powersync-web-internal': path.resolve(__dirname, 'node_modules/@powersync/web/lib/src'),
     },
     conditions: ['browser'],
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the task list’s data-fetching path to PowerSync live queries and adjusts query return shapes/filters, which could impact UI updates and counts if the new queries don’t match previous behavior.
> 
> **Overview**
> Switches the Tasks page from `@tanstack/react-query` fetch functions + manual invalidation to **PowerSync live queries** via `@powersync/tanstack-react-query`, using `toCompilableQuery` for both the task list and the incomplete-task count.
> 
> Updates DAL task selectors to return Drizzle query objects (instead of executing immediately) and moves the “non-empty item” filtering into SQL, which changes which rows are eligible for the list/count. The app root now provides `PowerSyncContext`, and dependencies/build config are updated to newer PowerSync/WA-SQLite versions (plus Vite `dedupe`) to support the integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddb21067c1c19739fba173c4b1ae28bfe16d269e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR migrates the application's data fetching for PowerSync-related queries from `@tanstack/react-query` to `@powersync/tanstack-react-query`. This change integrates PowerSync's live query capabilities more deeply, ensuring reactive updates without manual cache invalidation.

#### Key Changes
- Introduced `@powersync/tanstack-react-query` and updated related PowerSync dependencies.
- Wrapped the application with `PowerSyncContext.Provider` to make the PowerSync instance available.
- Modified data access layer (DAL) functions (`getIncompleteTasks`, `getIncompleteTasksCount`) to return Drizzle queries directly, compatible with PowerSync's `toCompilableQuery`.
- Updated the `TasksPage` component to use `useQuery` from `@powersync/tanstack-react-query` and removed explicit `queryClient.invalidateQueries` calls due to PowerSync's live updates.
- Added a `dedupe` configuration in `vite.config.ts` for PowerSync and React dependencies to optimize bundling.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 35 (33.7%)    |
| Churn       | 15 (14.4%)    |
| Rework      | 54 (51.9%)    |
| Total Changes | 104         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>