### PR TITLE
⚡ THU-333: Fix Enter sending on mobile web

### DIFF
--- a/src/components/chat/chat-prompt-input.test.tsx
+++ b/src/components/chat/chat-prompt-input.test.tsx
@@ -190,6 +190,27 @@ describe('ChatPromptInput', () => {
     })
   })
 
+  describe('submitOnEnter', () => {
+    it('should disable submit on enter when mobile viewport', () => {
+      const { mockUseChat } = setupStore()
+
+      const { container } = render(
+        <ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile(true)} />,
+        { wrapper: TestWrapper },
+      )
+
+      const textarea = container.querySelector('textarea')!
+      const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      const preventDefaultSpy = mock(() => {})
+      Object.defineProperty(enterEvent, 'preventDefault', { value: preventDefaultSpy })
+
+      textarea.dispatchEvent(enterEvent)
+
+      // On mobile, Enter should NOT be prevented (it creates a newline naturally)
+      expect(preventDefaultSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe('dependency injection', () => {
     it('should accept injected useChat', () => {
       const { mockUseChat } = setupStore()

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -52,8 +52,8 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
 
     // isMobile = viewport is narrow (responsive breakpoint, e.g. desktop browser resized small)
     // isPlatformMobile() = native platform is iOS/Android (Tauri mobile app)
-    // Either condition means the user likely has a virtual keyboard where Enter should insert a newline.
-    const hasVirtualKeyboard = isMobile || isPlatformMobile()
+    // Either condition means we prefer mobile-style input where Enter inserts a newline.
+    const shouldInsertNewlineOnEnter = isMobile || isPlatformMobile()
 
     const [showOverflowModal, setShowOverflowModal] = useState(false)
     const [input, setInput] = useState('')
@@ -148,7 +148,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
           isStreaming={isStreaming}
           onStop={stop}
           autoFocus={!isMobile}
-          submitOnEnter={!isStreaming && !hasVirtualKeyboard}
+          submitOnEnter={!isStreaming && !shouldInsertNewlineOnEnter}
           className={cn(
             'flex flex-col bg-background dark:bg-input/30 border dark:border-input rounded-2xl w-full',
             isMobile ? 'gap-0 p-4' : 'gap-2 p-3',

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -143,7 +143,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
           isStreaming={isStreaming}
           onStop={stop}
           autoFocus={!isMobile}
-          submitOnEnter={!isStreaming && !isPlatformMobile()}
+          submitOnEnter={!isStreaming && !isPlatformMobile() && !isMobile}
           className={cn(
             'flex flex-col bg-background dark:bg-input/30 border dark:border-input rounded-2xl w-full',
             isMobile ? 'gap-0 p-4' : 'gap-2 p-3',

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -50,6 +50,11 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
 
     const isStreaming = status === 'streaming'
 
+    // isMobile = viewport is narrow (responsive breakpoint, e.g. desktop browser resized small)
+    // isPlatformMobile() = native platform is iOS/Android (Tauri mobile app)
+    // Either condition means the user likely has a virtual keyboard where Enter should insert a newline.
+    const hasVirtualKeyboard = isMobile || isPlatformMobile()
+
     const [showOverflowModal, setShowOverflowModal] = useState(false)
     const [input, setInput] = useState('')
     const formRef = useRef<HTMLFormElement>(null)
@@ -143,7 +148,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
           isStreaming={isStreaming}
           onStop={stop}
           autoFocus={!isMobile}
-          submitOnEnter={!isStreaming && !isPlatformMobile() && !isMobile}
+          submitOnEnter={!isStreaming && !hasVirtualKeyboard}
           className={cn(
             'flex flex-col bg-background dark:bg-input/30 border dark:border-input rounded-2xl w-full',
             isMobile ? 'gap-0 p-4' : 'gap-2 p-3',


### PR DESCRIPTION
## Summary
- On mobile web, pressing Enter was sending the message instead of creating a newline
- `isPlatformMobile()` only detects native Tauri iOS/Android, returning `false` on mobile web browsers
- Added viewport-based `isMobile` check to also disable submit-on-enter for mobile web users

## Linear
[THU-333](https://linear.app/mozilla-thunderbolt/issue/THU-333/enter-on-mobile-web-causes-send-instead-of-newline-in-some-cases)

## Test Plan
- [x] Open app on mobile web browser (or use responsive mode < 768px)
- [x] Type in chat input and press Enter — should create a newline, not send
- [x] Tap the send button — should still send the message
- [x] On desktop, Enter should still send the message as before

## Changes
- `src/components/chat/chat-prompt-input.tsx` — add `!isMobile` to `submitOnEnter` condition
- `src/components/chat/chat-prompt-input.test.tsx` — add test verifying Enter doesn't submit on mobile viewport

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX behavior change limited to how `Enter` is handled in the chat prompt on narrow/mobile contexts; potential regressions are confined to input submission ergonomics.
> 
> **Overview**
> Fixes mobile web chat input behavior so pressing `Enter` inserts a newline instead of sending.
> 
> `ChatPromptInput` now disables `submitOnEnter` when either the responsive `isMobile` viewport flag or native `isPlatformMobile()` is true, and adds a unit test asserting `Enter` does not call `preventDefault()` in a mobile viewport.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 226682aa45a6124e5bb97b40132e83bb1317e312. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->