### PR TITLE
⚡ THU-335: Fix desktop app Google Auth flow

### DIFF
--- a/src-tauri/capabilities/auth.json
+++ b/src-tauri/capabilities/auth.json
@@ -15,6 +15,12 @@
         },
         {
           "url": "https://www.googleapis.com"
+        },
+        {
+          "url": "https://login.microsoftonline.com"
+        },
+        {
+          "url": "https://thunderbolt.io"
         }
       ]
     },

--- a/src/lib/oauth-redirect.test.ts
+++ b/src/lib/oauth-redirect.test.ts
@@ -23,13 +23,6 @@ describe('getOAuthRedirectUri', () => {
     })
   })
 
-  it('returns App Link for mobile platforms', () => {
-    const uri = getOAuthRedirectUri()
-
-    // In test environment (not Tauri), should return web callback
-    expect(uri).toContain('/oauth/callback')
-  })
-
   it('returns valid URL format', () => {
     const originalLocation = window.location
     const mockLocation = { origin: 'https://test.example.com' } as Location
@@ -41,10 +34,7 @@ describe('getOAuthRedirectUri', () => {
 
     const uri = getOAuthRedirectUri()
 
-    // Should be a valid URL
     expect(() => new URL(uri)).not.toThrow()
-
-    // Should end with /oauth/callback
     expect(uri).toMatch(/\/oauth\/callback$/)
 
     // Restore
@@ -53,5 +43,11 @@ describe('getOAuthRedirectUri', () => {
       writable: true,
       configurable: true,
     })
+  })
+
+  it('always uses /oauth/callback path (never oauth-callback.html)', () => {
+    const uri = getOAuthRedirectUri()
+    expect(uri).not.toContain('oauth-callback.html')
+    expect(uri).toContain('/oauth/callback')
   })
 })

--- a/src/lib/oauth-redirect.ts
+++ b/src/lib/oauth-redirect.ts
@@ -1,11 +1,12 @@
-import { isMobile, isTauri } from '@/lib/platform'
+import { isTauri } from '@/lib/platform'
 
 /**
  * Determines the correct OAuth redirect URI based on the platform
  *
  * - Web: Uses the web callback route at the current origin
- * - Mobile (iOS/Android): Uses App Link / Universal Link (https://thunderbolt.io/oauth/callback)
- * - Desktop (Tauri): Uses local webview callback
+ * - Tauri (desktop + mobile): Uses https://thunderbolt.io/oauth/callback
+ *   Desktop intercepts via tauri://navigate before the URL loads.
+ *   Mobile intercepts via App Link / Universal Link.
  *
  * @returns The appropriate redirect URI for the current platform
  */
@@ -14,10 +15,5 @@ export const getOAuthRedirectUri = (): string => {
     return window.location.origin + '/oauth/callback'
   }
 
-  if (isMobile()) {
-    // Mobile: Use App Link / Universal Link (verified HTTPS domain)
-    return 'https://thunderbolt.io/oauth/callback'
-  }
-
-  return window.location.origin + '/oauth-callback.html'
+  return 'https://thunderbolt.io/oauth/callback'
 }

--- a/src/lib/oauth-webview.ts
+++ b/src/lib/oauth-webview.ts
@@ -104,7 +104,7 @@ const waitForCallback = async (window: WebviewWindow): Promise<{ code: string; s
 
     const unlistenNavigate = await window.listen('tauri://navigate', (event: any) => {
       const url = new URL(event.payload)
-      if (!url.pathname.includes('oauth-callback.html')) {
+      if (!url.pathname.includes('/oauth/callback')) {
         return
       }
 


### PR DESCRIPTION
## Summary
- Desktop OAuth now uses `https://thunderbolt.io/oauth/callback` instead of `tauri://localhost/oauth-callback.html`
- Google recently started rejecting custom URI schemes (`tauri://`) in redirect URIs — only `http://localhost` or `https://` URLs are allowed
- The webview's `tauri://navigate` event intercepts the redirect before the URL loads, so Google never needs to serve anything at `thunderbolt.io/oauth/callback`

## Linear
[THU-335](https://linear.app/mozilla-thunderbolt/issue/THU-335/fix-desktop-app-google-auth-flow-properly)

## Changes
- `src/lib/oauth-redirect.ts` — Unified desktop + mobile to both use `https://thunderbolt.io/oauth/callback`
- `src/lib/oauth-webview.ts` — Updated URL matching from `oauth-callback.html` to `/oauth/callback`
- `src-tauri/capabilities/auth.json` — Added `thunderbolt.io` and `login.microsoftonline.com` to allowed HTTP URLs
- `src/lib/oauth-redirect.test.ts` — Updated tests

## Test Plan
- [ ] Verify `https://thunderbolt.io/oauth/callback` is registered as an authorized redirect URI in Google Cloud Console
- [ ] Test Google OAuth flow in desktop app (released build, not dev mode)
- [ ] Test Microsoft OAuth flow in desktop app
- [ ] Test mobile OAuth flow still works (should be unchanged)
- [ ] Test web OAuth flow still works (should be unchanged)

## Note
The GCP Console must have `https://thunderbolt.io/oauth/callback` as an authorized redirect URI. It likely already is (for mobile), but verify before testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth redirect/callback handling for Tauri, so mistakes can break login flows for Google/Microsoft. Scope is small and largely path/allowlist updates, but impacts authentication across desktop/mobile builds.
> 
> **Overview**
> Tauri OAuth redirects are unified to always use `https://thunderbolt.io/oauth/callback` (desktop and mobile), removing the previous `oauth-callback.html`/origin-based redirect behavior and aligning tests to enforce the `/oauth/callback` path.
> 
> The OAuth webview callback interception is updated to match `/oauth/callback`, and the Tauri `auth` capability allowlist is expanded to permit requests to `https://thunderbolt.io` and `https://login.microsoftonline.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb5c79cc5769137dcf2c7aa9f42238d8cbe00475. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->