### PR TITLE
⚡ THU-336: Move auto-approved waitlist domains to env variable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,7 +19,7 @@ PORT=8000
 # When true, inference/pro routes require authentication
 WAITLIST_ENABLED=false
 # Comma-separated list of email domains that are auto-approved for waitlist access
-AUTO_APPROVED_DOMAINS=mozilla.org,thunderbird.net,mozilla.ai,mozilla.com
+WAITLIST_AUTO_APPROVE_DOMAINS=mozilla.org,thunderbird.net,mozilla.ai,mozilla.com
 
 # Fireworks
 FIREWORKS_API_KEY=""

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,8 @@ PORT=8000
 # Waitlist settings
 # When true, inference/pro routes require authentication
 WAITLIST_ENABLED=false
+# Comma-separated list of email domains that are auto-approved for waitlist access
+AUTO_APPROVED_DOMAINS=mozilla.org,thunderbird.net,mozilla.ai,mozilla.com
 
 # Fireworks
 FIREWORKS_API_KEY=""

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -31,7 +31,7 @@ const powersyncSettings: Settings = {
   corsAllowHeaders: '',
   corsExposeHeaders: '',
   waitlistEnabled: false,
-  autoApprovedDomains: '',
+  waitlistAutoApproveDomains: '',
   powersyncUrl: 'https://powersync.example.com',
   powersyncJwtKid: 'test-kid',
   powersyncJwtSecret: 'test-jwt-secret-min-32-chars-long',

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -31,6 +31,7 @@ const powersyncSettings: Settings = {
   corsAllowHeaders: '',
   corsExposeHeaders: '',
   waitlistEnabled: false,
+  autoApprovedDomains: '',
   powersyncUrl: 'https://powersync.example.com',
   powersyncJwtKid: 'test-kid',
   powersyncJwtSecret: 'test-jwt-secret-min-32-chars-long',

--- a/backend/src/api/routes.test.ts
+++ b/backend/src/api/routes.test.ts
@@ -56,7 +56,7 @@ describe('Main Routes', () => {
         'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With',
       corsExposeHeaders: 'mcp-session-id',
       waitlistEnabled: false,
-      autoApprovedDomains: '',
+      waitlistAutoApproveDomains: '',
       powersyncUrl: '',
       powersyncJwtKid: '',
       powersyncJwtSecret: '',

--- a/backend/src/api/routes.test.ts
+++ b/backend/src/api/routes.test.ts
@@ -56,6 +56,7 @@ describe('Main Routes', () => {
         'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With',
       corsExposeHeaders: 'mcp-session-id',
       waitlistEnabled: false,
+      autoApprovedDomains: '',
       powersyncUrl: '',
       powersyncJwtKid: '',
       powersyncJwtSecret: '',

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -45,7 +45,7 @@ describe('Authentication Routes', () => {
       corsAllowHeaders: 'Content-Type,Authorization',
       corsExposeHeaders: '',
       waitlistEnabled: false,
-      autoApprovedDomains: '',
+      waitlistAutoApproveDomains: '',
       powersyncUrl: '',
       powersyncJwtKid: '',
       powersyncJwtSecret: '',

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -45,6 +45,7 @@ describe('Authentication Routes', () => {
       corsAllowHeaders: 'Content-Type,Authorization',
       corsExposeHeaders: '',
       waitlistEnabled: false,
+      autoApprovedDomains: '',
       powersyncUrl: '',
       powersyncJwtKid: '',
       powersyncJwtSecret: '',

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { clearSettingsCache, getCorsMethodsList, getCorsOriginsList, getSettings } from './settings'
+import {
+  clearSettingsCache,
+  getAutoApprovedDomainsList,
+  getCorsMethodsList,
+  getCorsOriginsList,
+  getSettings,
+} from './settings'
 
 describe('Config Settings', () => {
   describe('getCorsOriginsList', () => {
@@ -36,6 +42,43 @@ describe('Config Settings', () => {
       const origins = getCorsOriginsList(settings as any)
 
       expect(origins).toEqual([])
+    })
+  })
+
+  describe('getAutoApprovedDomainsList', () => {
+    it('should split comma-separated domains', () => {
+      const settings = { autoApprovedDomains: 'mozilla.org,thunderbird.net,mozilla.ai' }
+      const domains = getAutoApprovedDomainsList(settings as any)
+
+      expect(domains).toEqual(['mozilla.org', 'thunderbird.net', 'mozilla.ai'])
+    })
+
+    it('should handle single domain', () => {
+      const settings = { autoApprovedDomains: 'mozilla.org' }
+      const domains = getAutoApprovedDomainsList(settings as any)
+
+      expect(domains).toEqual(['mozilla.org'])
+    })
+
+    it('should trim whitespace and lowercase domains', () => {
+      const settings = { autoApprovedDomains: ' Mozilla.ORG , Thunderbird.NET ' }
+      const domains = getAutoApprovedDomainsList(settings as any)
+
+      expect(domains).toEqual(['mozilla.org', 'thunderbird.net'])
+    })
+
+    it('should filter out empty domains', () => {
+      const settings = { autoApprovedDomains: 'mozilla.org,,thunderbird.net,' }
+      const domains = getAutoApprovedDomainsList(settings as any)
+
+      expect(domains).toEqual(['mozilla.org', 'thunderbird.net'])
+    })
+
+    it('should handle empty string', () => {
+      const settings = { autoApprovedDomains: '' }
+      const domains = getAutoApprovedDomainsList(settings as any)
+
+      expect(domains).toEqual([])
     })
   })
 

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
   clearSettingsCache,
-  getAutoApprovedDomainsList,
+  getWaitlistAutoApproveDomains,
   getCorsMethodsList,
   getCorsOriginsList,
   getSettings,
@@ -45,38 +45,38 @@ describe('Config Settings', () => {
     })
   })
 
-  describe('getAutoApprovedDomainsList', () => {
+  describe('getWaitlistAutoApproveDomains', () => {
     it('should split comma-separated domains', () => {
-      const settings = { autoApprovedDomains: 'mozilla.org,thunderbird.net,mozilla.ai' }
-      const domains = getAutoApprovedDomainsList(settings as any)
+      const settings = { waitlistAutoApproveDomains: 'mozilla.org,thunderbird.net,mozilla.ai' }
+      const domains = getWaitlistAutoApproveDomains(settings as any)
 
       expect(domains).toEqual(['mozilla.org', 'thunderbird.net', 'mozilla.ai'])
     })
 
     it('should handle single domain', () => {
-      const settings = { autoApprovedDomains: 'mozilla.org' }
-      const domains = getAutoApprovedDomainsList(settings as any)
+      const settings = { waitlistAutoApproveDomains: 'mozilla.org' }
+      const domains = getWaitlistAutoApproveDomains(settings as any)
 
       expect(domains).toEqual(['mozilla.org'])
     })
 
     it('should trim whitespace and lowercase domains', () => {
-      const settings = { autoApprovedDomains: ' Mozilla.ORG , Thunderbird.NET ' }
-      const domains = getAutoApprovedDomainsList(settings as any)
+      const settings = { waitlistAutoApproveDomains: ' Mozilla.ORG , Thunderbird.NET ' }
+      const domains = getWaitlistAutoApproveDomains(settings as any)
 
       expect(domains).toEqual(['mozilla.org', 'thunderbird.net'])
     })
 
     it('should filter out empty domains', () => {
-      const settings = { autoApprovedDomains: 'mozilla.org,,thunderbird.net,' }
-      const domains = getAutoApprovedDomainsList(settings as any)
+      const settings = { waitlistAutoApproveDomains: 'mozilla.org,,thunderbird.net,' }
+      const domains = getWaitlistAutoApproveDomains(settings as any)
 
       expect(domains).toEqual(['mozilla.org', 'thunderbird.net'])
     })
 
     it('should handle empty string', () => {
-      const settings = { autoApprovedDomains: '' }
-      const domains = getAutoApprovedDomainsList(settings as any)
+      const settings = { waitlistAutoApproveDomains: '' }
+      const domains = getWaitlistAutoApproveDomains(settings as any)
 
       expect(domains).toEqual([])
     })

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -31,7 +31,7 @@ const settingsSchema = z.object({
 
   // Waitlist settings
   waitlistEnabled: z.boolean().default(false),
-  autoApprovedDomains: z.string().default(''),
+  waitlistAutoApproveDomains: z.string().default(''),
 
   // PowerSync settings
   powersyncUrl: z.string().default(''),
@@ -77,7 +77,7 @@ const parseSettings = (): Settings => {
     posthogHost: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
     posthogApiKey: process.env.POSTHOG_API_KEY || '',
     waitlistEnabled: process.env.WAITLIST_ENABLED === 'true',
-    autoApprovedDomains: process.env.AUTO_APPROVED_DOMAINS || '',
+    waitlistAutoApproveDomains: process.env.WAITLIST_AUTO_APPROVE_DOMAINS || '',
     powersyncUrl: process.env.POWERSYNC_URL || '',
     powersyncJwtKid: process.env.POWERSYNC_JWT_KID || '',
     powersyncJwtSecret: process.env.POWERSYNC_JWT_SECRET || '',
@@ -142,8 +142,8 @@ export const getCorsMethodsList = (settings: Settings): string[] => {
 }
 
 /** Parse comma-separated auto-approved domains into a list */
-export const getAutoApprovedDomainsList = (settings: Settings): string[] => {
-  return settings.autoApprovedDomains
+export const getWaitlistAutoApproveDomains = (settings: Settings): string[] => {
+  return settings.waitlistAutoApproveDomains
     .split(',')
     .map((domain) => domain.trim().toLowerCase())
     .filter((domain) => domain.length > 0)

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -31,6 +31,7 @@ const settingsSchema = z.object({
 
   // Waitlist settings
   waitlistEnabled: z.boolean().default(false),
+  autoApprovedDomains: z.string().default(''),
 
   // PowerSync settings
   powersyncUrl: z.string().default(''),
@@ -76,6 +77,7 @@ const parseSettings = (): Settings => {
     posthogHost: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
     posthogApiKey: process.env.POSTHOG_API_KEY || '',
     waitlistEnabled: process.env.WAITLIST_ENABLED === 'true',
+    autoApprovedDomains: process.env.AUTO_APPROVED_DOMAINS || '',
     powersyncUrl: process.env.POWERSYNC_URL || '',
     powersyncJwtKid: process.env.POWERSYNC_JWT_KID || '',
     powersyncJwtSecret: process.env.POWERSYNC_JWT_SECRET || '',
@@ -137,4 +139,12 @@ export const getCorsMethodsList = (settings: Settings): string[] => {
     .split(',')
     .map((method) => method.trim())
     .filter((method) => method.length > 0)
+}
+
+/** Parse comma-separated auto-approved domains into a list */
+export const getAutoApprovedDomainsList = (settings: Settings): string[] => {
+  return settings.autoApprovedDomains
+    .split(',')
+    .map((domain) => domain.trim().toLowerCase())
+    .filter((domain) => domain.length > 0)
 }

--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -1,6 +1,0 @@
-/**
- * Backend-specific constants
- */
-
-/** Email domains that are auto-approved for waitlist access */
-export const autoApprovedDomains = ['mozilla.org', 'thunderbird.net', 'mozilla.ai', 'mozilla.com']

--- a/backend/src/middleware/waitlist-auth.test.ts
+++ b/backend/src/middleware/waitlist-auth.test.ts
@@ -27,7 +27,7 @@ const createMockSettings = (overrides: Partial<Settings> = {}): Settings => ({
   corsAllowHeaders: 'Content-Type,Authorization',
   corsExposeHeaders: '',
   waitlistEnabled: false,
-  autoApprovedDomains: '',
+  waitlistAutoApproveDomains: '',
   powersyncUrl: '',
   powersyncJwtKid: '',
   powersyncJwtSecret: '',

--- a/backend/src/middleware/waitlist-auth.test.ts
+++ b/backend/src/middleware/waitlist-auth.test.ts
@@ -27,6 +27,7 @@ const createMockSettings = (overrides: Partial<Settings> = {}): Settings => ({
   corsAllowHeaders: 'Content-Type,Authorization',
   corsExposeHeaders: '',
   waitlistEnabled: false,
+  autoApprovedDomains: '',
   powersyncUrl: '',
   powersyncJwtKid: '',
   powersyncJwtSecret: '',

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -51,7 +51,7 @@ describe('Link Preview Routes', () => {
       corsAllowHeaders: 'Content-Type,Authorization',
       corsExposeHeaders: '',
       waitlistEnabled: false,
-      autoApprovedDomains: '',
+      waitlistAutoApproveDomains: '',
       powersyncUrl: '',
       powersyncJwtKid: '',
       powersyncJwtSecret: '',

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -51,6 +51,7 @@ describe('Link Preview Routes', () => {
       corsAllowHeaders: 'Content-Type,Authorization',
       corsExposeHeaders: '',
       waitlistEnabled: false,
+      autoApprovedDomains: '',
       powersyncUrl: '',
       powersyncJwtKid: '',
       powersyncJwtSecret: '',

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -52,7 +52,7 @@ describe('Proxy Routes', () => {
       corsAllowHeaders: 'Content-Type,Authorization',
       corsExposeHeaders: '',
       waitlistEnabled: false,
-      autoApprovedDomains: '',
+      waitlistAutoApproveDomains: '',
       powersyncUrl: '',
       powersyncJwtKid: '',
       powersyncJwtSecret: '',

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -52,6 +52,7 @@ describe('Proxy Routes', () => {
       corsAllowHeaders: 'Content-Type,Authorization',
       corsExposeHeaders: '',
       waitlistEnabled: false,
+      autoApprovedDomains: '',
       powersyncUrl: '',
       powersyncJwtKid: '',
       powersyncJwtSecret: '',

--- a/backend/src/waitlist/routes.test.ts
+++ b/backend/src/waitlist/routes.test.ts
@@ -1,5 +1,6 @@
 import { user } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
+import { clearSettingsCache } from '@/config/settings'
 import { createApp } from '@/index'
 import { createTestDb } from '@/test-utils/db'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -9,8 +10,12 @@ describe('Waitlist API', () => {
   let app: Awaited<ReturnType<typeof createApp>>
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
   let cleanup: () => Promise<void>
+  let savedAutoApprovedDomains: string | undefined
 
   beforeEach(async () => {
+    savedAutoApprovedDomains = process.env.AUTO_APPROVED_DOMAINS
+    process.env.AUTO_APPROVED_DOMAINS = 'mozilla.org,thunderbird.net,mozilla.ai,mozilla.com'
+    clearSettingsCache()
     const testEnv = await createTestDb()
     db = testEnv.db
     cleanup = testEnv.cleanup
@@ -18,6 +23,12 @@ describe('Waitlist API', () => {
   })
 
   afterEach(async () => {
+    if (savedAutoApprovedDomains !== undefined) {
+      process.env.AUTO_APPROVED_DOMAINS = savedAutoApprovedDomains
+    } else {
+      delete process.env.AUTO_APPROVED_DOMAINS
+    }
+    clearSettingsCache()
     await cleanup()
   })
 

--- a/backend/src/waitlist/routes.test.ts
+++ b/backend/src/waitlist/routes.test.ts
@@ -10,11 +10,11 @@ describe('Waitlist API', () => {
   let app: Awaited<ReturnType<typeof createApp>>
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
   let cleanup: () => Promise<void>
-  let savedAutoApprovedDomains: string | undefined
+  let savedWaitlistDomains: string | undefined
 
   beforeEach(async () => {
-    savedAutoApprovedDomains = process.env.AUTO_APPROVED_DOMAINS
-    process.env.AUTO_APPROVED_DOMAINS = 'mozilla.org,thunderbird.net,mozilla.ai,mozilla.com'
+    savedWaitlistDomains = process.env.WAITLIST_AUTO_APPROVE_DOMAINS
+    process.env.WAITLIST_AUTO_APPROVE_DOMAINS = 'mozilla.org,thunderbird.net,mozilla.ai,mozilla.com'
     clearSettingsCache()
     const testEnv = await createTestDb()
     db = testEnv.db
@@ -23,10 +23,10 @@ describe('Waitlist API', () => {
   })
 
   afterEach(async () => {
-    if (savedAutoApprovedDomains !== undefined) {
-      process.env.AUTO_APPROVED_DOMAINS = savedAutoApprovedDomains
+    if (savedWaitlistDomains !== undefined) {
+      process.env.WAITLIST_AUTO_APPROVE_DOMAINS = savedWaitlistDomains
     } else {
-      delete process.env.AUTO_APPROVED_DOMAINS
+      delete process.env.WAITLIST_AUTO_APPROVE_DOMAINS
     }
     clearSettingsCache()
     await cleanup()

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -4,7 +4,7 @@ import { user } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
 import { normalizeEmail } from '@/lib/email'
 import { safeErrorHandler } from '@/middleware/error-handling'
-import { autoApprovedDomains } from '@/lib/constants'
+import { getAutoApprovedDomainsList, getSettings } from '@/config/settings'
 import { eq } from 'drizzle-orm'
 import { Elysia, t } from 'elysia'
 import {
@@ -33,7 +33,7 @@ const defaultEmailService: WaitlistEmailService = {
 const isAutoApprovedDomain = (email: string): boolean => {
   const parts = email.split('@')
   const domain = parts.length > 1 ? parts[parts.length - 1].toLowerCase() : null
-  return domain ? autoApprovedDomains.includes(domain) : false
+  return domain ? getAutoApprovedDomainsList(getSettings()).includes(domain) : false
 }
 
 /** Trigger Better Auth's OTP flow for approved users. */

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -4,7 +4,7 @@ import { user } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
 import { normalizeEmail } from '@/lib/email'
 import { safeErrorHandler } from '@/middleware/error-handling'
-import { getAutoApprovedDomainsList, getSettings } from '@/config/settings'
+import { getWaitlistAutoApproveDomains, getSettings } from '@/config/settings'
 import { eq } from 'drizzle-orm'
 import { Elysia, t } from 'elysia'
 import {
@@ -33,7 +33,7 @@ const defaultEmailService: WaitlistEmailService = {
 const isAutoApprovedDomain = (email: string): boolean => {
   const parts = email.split('@')
   const domain = parts.length > 1 ? parts[parts.length - 1].toLowerCase() : null
-  return domain ? getAutoApprovedDomainsList(getSettings()).includes(domain) : false
+  return domain ? getWaitlistAutoApproveDomains(getSettings()).includes(domain) : false
 }
 
 /** Trigger Better Auth's OTP flow for approved users. */

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -537,48 +537,53 @@ const SidebarMenuButton = forwardRef<
     isActive?: boolean
     tooltip?: string | ComponentProps<typeof TooltipContent>
   } & VariantProps<typeof sidebarMenuButtonVariants>
->(({ asChild = false, isActive = false, variant = 'default', size = 'default', tooltip, className, onClick, ...props }, ref) => {
-  const Comp = asChild ? Slot : 'button'
-  const { isMobile, state } = useSidebar()
-  const { triggerSelection } = useHaptics()
+>(
+  (
+    { asChild = false, isActive = false, variant = 'default', size = 'default', tooltip, className, onClick, ...props },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'button'
+    const { isMobile, state } = useSidebar()
+    const { triggerSelection } = useHaptics()
 
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
-      triggerSelection()
-      onClick?.(e)
-    },
-    [onClick, triggerSelection],
-  )
+    const handleClick = useCallback(
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        triggerSelection()
+        onClick?.(e)
+      },
+      [onClick, triggerSelection],
+    )
 
-  const button = (
-    <Comp
-      ref={ref}
-      data-sidebar="menu-button"
-      data-size={size}
-      data-active={isActive}
-      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
-      onClick={handleClick}
-      {...props}
-    />
-  )
+    const button = (
+      <Comp
+        ref={ref}
+        data-sidebar="menu-button"
+        data-size={size}
+        data-active={isActive}
+        className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+        onClick={handleClick}
+        {...props}
+      />
+    )
 
-  if (!tooltip) {
-    return button
-  }
-
-  if (typeof tooltip === 'string') {
-    tooltip = {
-      children: tooltip,
+    if (!tooltip) {
+      return button
     }
-  }
 
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent side="right" align="center" hidden={state !== 'collapsed' || isMobile} {...tooltip} />
-    </Tooltip>
-  )
-})
+    if (typeof tooltip === 'string') {
+      tooltip = {
+        children: tooltip,
+      }
+    }
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent side="right" align="center" hidden={state !== 'collapsed' || isMobile} {...tooltip} />
+      </Tooltip>
+    )
+  },
+)
 SidebarMenuButton.displayName = 'SidebarMenuButton'
 
 const SidebarMenuAction = forwardRef<


### PR DESCRIPTION
## Summary
- Moved hardcoded `autoApprovedDomains` array from `backend/src/lib/constants.ts` to `AUTO_APPROVED_DOMAINS` env variable (comma-separated)
- Added `getAutoApprovedDomainsList()` helper in settings following the existing CORS comma-separated pattern
- Deleted `backend/src/lib/constants.ts` (no longer needed)

## Linear
[THU-336](https://linear.app/mozilla-thunderbolt/issue/THU-336/move-waitlist-whitelist-domains-out-of-backend-code-and-into-an-env)

## Render env update needed
After merging, set on Render:
```
AUTO_APPROVED_DOMAINS=mozilla.org,thunderbird.net,mozilla.ai,mozilla.com
```

## Test Plan
- [x] All 351 existing tests pass
- [x] New tests for `getAutoApprovedDomainsList`: comma splitting, whitespace trimming, lowercase normalization, empty filtering
- [x] Waitlist route tests updated to set `AUTO_APPROVED_DOMAINS` env var
- [x] Auto-approval works with env var set
- [x] Empty env var results in no auto-approvals (no hardcoded defaults)

## Changes
- `backend/src/config/settings.ts` — Added `autoApprovedDomains` field + `getAutoApprovedDomainsList()` helper
- `backend/src/waitlist/routes.ts` — Import from settings instead of constants
- `backend/src/lib/constants.ts` — Deleted (was only export)
- `backend/.env.example` — Added `AUTO_APPROVED_DOMAINS`
- `backend/src/config/settings.test.ts` — Added domain list parsing tests
- `backend/src/waitlist/routes.test.ts` — Set env var in test setup/teardown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the waitlist auto-approval decision to be driven by environment configuration, which can inadvertently broaden or block access if misconfigured. Logic is simple and covered by tests, but it impacts who gets immediately approved and receives magic-link sign-in.
> 
> **Overview**
> **Waitlist auto-approval is now configurable via env.** The hardcoded allowlist was removed and replaced with `WAITLIST_AUTO_APPROVE_DOMAINS`, parsed by a new `getWaitlistAutoApproveDomains()` helper in `settings` (comma-split, trimmed, lowercased, empties filtered).
> 
> `waitlist/routes.ts` now consults the settings-derived domain list when deciding whether to auto-approve an email address. Tests and settings mocks were updated to include the new settings field, and `waitlist/routes.test.ts` now sets/unsets the env var and clears the settings cache for isolation.
> 
> Minor: `bun.lock` gains `configVersion`, and `SidebarMenuButton` was reformatted with no behavioral change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a0339cbd9f161399957cbe7b6dd5cc68676d46b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->