### PR TITLE
⚡ THU-334: Fix scrolling whitespace on mobile chat input

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -166,6 +166,7 @@ body {
   #root {
     position: fixed;
     inset: 0;
+    height: auto;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -162,6 +162,11 @@ body {
     height: 100%;
     overflow: hidden;
   }
+
+  #root {
+    position: fixed;
+    inset: 0;
+  }
 }
 
 /* Subtle table borders for markdown content */


### PR DESCRIPTION
## Summary
- On mobile web, scrolling up created whitespace between the bottom of the browser and the chat input area
- Fix: add `position: fixed; inset: 0` to `#root` on mobile (≤768px), pinning it to the viewport so the browser can't scroll past it
- Desktop layout is unaffected (the rule only applies within the mobile media query)

## Linear
[THU-334](https://linear.app/mozilla-thunderbolt/issue/THU-334/scrolling-up-causes-whitespace-between-the-bottom-of-browser-and-chat)

## Test Plan
- [ ] Mobile Safari: pull up from bottom of chat — no whitespace appears
- [ ] Mobile Chrome: same test — no whitespace
- [ ] Desktop: layout unchanged, no regressions
- [ ] Mobile: keyboard open/close behavior unaffected

## Changes
- `src/index.css` — Added `position: fixed; inset: 0` to `#root` within the existing `@media (max-width: 768px)` block

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, limited to a mobile-only CSS tweak; potential risk is minor mobile layout/keyboard interaction regressions due to `position: fixed` on `#root`.
> 
> **Overview**
> Fixes a mobile web scrolling issue by updating `src/index.css` so that within `@media (max-width: 768px)` the `#root` container is `position: fixed` with `inset: 0` (and `height: auto`), preventing the page from scrolling past the app and creating bottom whitespace.
> 
> Desktop styling is unchanged because the new rule only applies to the mobile media query.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8998562baba959849614a331c166cb5739e9fda8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->