### PR TITLE
⚡ THU-286: Improve non-confidential models popover UX for mobile

### DIFF
--- a/src/components/ui/model-selector/model-selector.test.ts
+++ b/src/components/ui/model-selector/model-selector.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+import { categorizeModels } from './model-selector'
+import type { Model } from '@/types'
+import type { ChatThread } from '@/layout/sidebar/types'
+
+const makeModel = (overrides: Partial<Model> & { id: string; name: string }): Model =>
+  ({
+    model: 'test-model',
+    provider: 'test',
+    enabled: 1,
+    toolUsage: 'auto',
+    isConfidential: 0,
+    startWithReasoning: 0,
+    supportsParallelToolCalls: 1,
+    isSystem: 1,
+    ...overrides,
+  }) as Model
+
+const confidentialModel = makeModel({ id: 'conf-1', name: 'GPT Confidential', isConfidential: 1 })
+const standardModel = makeModel({ id: 'std-1', name: 'Mistral Standard', isConfidential: 0 })
+const customModel = makeModel({ id: 'custom-1', name: 'Custom Model', isConfidential: 0, isSystem: 0 })
+
+const confidentialChat = { isEncrypted: 1 } as ChatThread
+const standardChat = { isEncrypted: 0 } as ChatThread
+
+describe('categorizeModels', () => {
+  test('no chat thread: all models are available, no disabled sections', () => {
+    const groups = categorizeModels([confidentialModel, standardModel, customModel], null)
+
+    expect(groups).toHaveLength(2)
+    expect(groups[0].id).toBe('provided')
+    expect(groups[0].items).toHaveLength(2)
+    expect(groups[0].items.every((i) => !i.disabled)).toBe(true)
+    expect(groups[1].id).toBe('custom')
+    expect(groups[1].items).toHaveLength(1)
+    expect(groups[1].items[0].disabled).toBe(false)
+  })
+
+  test('confidential chat: standard models in disabled section with subtitle', () => {
+    const groups = categorizeModels([confidentialModel, standardModel], confidentialChat)
+
+    const provided = groups.find((g) => g.id === 'provided')
+    expect(provided).toBeDefined()
+    expect(provided!.items).toHaveLength(1)
+    expect(provided!.items[0].id).toBe('conf-1')
+    expect(provided!.items[0].disabled).toBe(false)
+
+    const disabled = groups.find((g) => g.id === 'standard-disabled')
+    expect(disabled).toBeDefined()
+    expect(disabled!.label).toBe('Standard Models')
+    expect(disabled!.subtitle).toBe('Only confidential models can be used in this chat')
+    expect(disabled!.items).toHaveLength(1)
+    expect(disabled!.items[0].id).toBe('std-1')
+    expect(disabled!.items[0].disabled).toBe(true)
+  })
+
+  test('standard chat: confidential models in disabled section with subtitle', () => {
+    const groups = categorizeModels([confidentialModel, standardModel], standardChat)
+
+    const provided = groups.find((g) => g.id === 'provided')
+    expect(provided).toBeDefined()
+    expect(provided!.items).toHaveLength(1)
+    expect(provided!.items[0].id).toBe('std-1')
+
+    const disabled = groups.find((g) => g.id === 'confidential-disabled')
+    expect(disabled).toBeDefined()
+    expect(disabled!.label).toBe('Confidential Models')
+    expect(disabled!.subtitle).toBe('Only available in confidential chats')
+    expect(disabled!.items).toHaveLength(1)
+    expect(disabled!.items[0].id).toBe('conf-1')
+    expect(disabled!.items[0].disabled).toBe(true)
+  })
+
+  test('custom models are grouped separately when available', () => {
+    const groups = categorizeModels([standardModel, customModel], null)
+
+    expect(groups.find((g) => g.id === 'provided')!.items).toHaveLength(1)
+    expect(groups.find((g) => g.id === 'custom')!.items).toHaveLength(1)
+  })
+
+  test('disabled custom models go to the disabled section', () => {
+    const groups = categorizeModels([confidentialModel, customModel], confidentialChat)
+
+    const disabled = groups.find((g) => g.id === 'standard-disabled')
+    expect(disabled).toBeDefined()
+    expect(disabled!.items).toHaveLength(1)
+    expect(disabled!.items[0].id).toBe('custom-1')
+  })
+
+  test('empty models returns empty groups', () => {
+    const groups = categorizeModels([], null)
+    expect(groups).toHaveLength(0)
+  })
+})

--- a/src/components/ui/model-selector/model-selector.tsx
+++ b/src/components/ui/model-selector/model-selector.tsx
@@ -1,5 +1,4 @@
 import { SearchableMenu, type SearchableMenuGroup, type SearchableMenuItem } from '@/components/ui/searchable-menu'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useHaptics } from '@/hooks/use-haptics'
 import { cn } from '@/lib/utils'
 import type { ChatThread } from '@/layout/sidebar/types'
@@ -17,40 +16,38 @@ export type ModelSelectorProps = {
 
 type ModelItemData = {
   model: Model
-  disabledReason?: string
 }
 
-const categorizeModels = (
+const toMenuItem = (model: Model, isDisabled: boolean): SearchableMenuItem<ModelItemData> => ({
+  id: model.id,
+  label: model.name,
+  description: model.description || model.model,
+  searchTerms: [model.model, model.vendor].filter(Boolean).join(' '),
+  icon: model.isConfidential === 1 ? <Lock className="size-3.5 text-green-600 dark:text-green-500" /> : undefined,
+  disabled: isDisabled,
+  data: { model },
+})
+
+export const categorizeModels = (
   models: Model[],
   chatThread: ModelSelectorProps['chatThread'],
 ): SearchableMenuGroup<ModelItemData>[] => {
   const provided: SearchableMenuItem<ModelItemData>[] = []
   const custom: SearchableMenuItem<ModelItemData>[] = []
+  const disabledConfidential: SearchableMenuItem<ModelItemData>[] = []
+  const disabledStandard: SearchableMenuItem<ModelItemData>[] = []
 
   for (const model of models) {
     const isDisabled = chatThread ? chatThread.isEncrypted !== model.isConfidential : false
+    const item = toMenuItem(model, isDisabled)
 
-    const getDisabledReason = () => {
-      if (!isDisabled) {
-        return undefined
-      }
+    if (isDisabled) {
       if (model.isConfidential === 1) {
-        return 'This model is only available in confidential chats'
+        disabledConfidential.push(item)
+      } else {
+        disabledStandard.push(item)
       }
-      return 'Non-confidential models cannot be used in confidential chats'
-    }
-
-    const item: SearchableMenuItem<ModelItemData> = {
-      id: model.id,
-      label: model.name,
-      description: model.description || model.model,
-      searchTerms: [model.model, model.vendor].filter(Boolean).join(' '),
-      icon: model.isConfidential === 1 ? <Lock className="size-3.5 text-green-600 dark:text-green-500" /> : undefined,
-      disabled: isDisabled,
-      data: { model, disabledReason: getDisabledReason() },
-    }
-
-    if (model.isSystem) {
+    } else if (model.isSystem) {
       provided.push(item)
     } else {
       custom.push(item)
@@ -58,11 +55,28 @@ const categorizeModels = (
   }
 
   const groups: SearchableMenuGroup<ModelItemData>[] = []
+
   if (provided.length > 0) {
     groups.push({ id: 'provided', label: 'Provided Models', items: provided })
   }
   if (custom.length > 0) {
     groups.push({ id: 'custom', label: 'Custom Models', items: custom })
+  }
+  if (disabledStandard.length > 0) {
+    groups.push({
+      id: 'standard-disabled',
+      label: 'Standard Models',
+      subtitle: 'Only confidential models can be used in this chat',
+      items: disabledStandard,
+    })
+  }
+  if (disabledConfidential.length > 0) {
+    groups.push({
+      id: 'confidential-disabled',
+      label: 'Confidential Models',
+      subtitle: 'Only available in confidential chats',
+      items: disabledConfidential,
+    })
   }
 
   return groups
@@ -90,39 +104,24 @@ export const ModelSelector = ({
     </div>
   )
 
-  const renderItem = (item: SearchableMenuItem<ModelItemData>, isSelected: boolean) => {
-    const content = (
-      <div
-        className={cn(
-          'w-full flex items-center justify-between px-3 py-2 rounded-lg transition-colors text-left cursor-pointer',
-          'hover:bg-accent/50',
-          isSelected && 'bg-accent',
-          item.disabled && 'opacity-50 cursor-not-allowed',
-        )}
-      >
-        <div className="flex flex-col gap-0.5 min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="font-medium truncate">{item.label}</span>
-            {item.icon}
-          </div>
-          <span className="text-sm text-muted-foreground truncate">{item.description}</span>
+  const renderItem = (item: SearchableMenuItem<ModelItemData>, isSelected: boolean) => (
+    <div
+      className={cn(
+        'w-full flex items-center justify-between px-3 py-2 rounded-lg transition-colors text-left cursor-pointer',
+        'hover:bg-accent/50',
+        isSelected && 'bg-accent',
+        item.disabled && 'opacity-50 cursor-not-allowed',
+      )}
+    >
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium truncate">{item.label}</span>
+          {item.icon}
         </div>
+        <span className="text-sm text-muted-foreground truncate">{item.description}</span>
       </div>
-    )
-
-    if (item.disabled && item.data?.disabledReason) {
-      return (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div>{content}</div>
-          </TooltipTrigger>
-          <TooltipContent side="right">{item.data.disabledReason}</TooltipContent>
-        </Tooltip>
-      )
-    }
-
-    return content
-  }
+    </div>
+  )
 
   const footer = onAddModels ? (
     <button

--- a/src/components/ui/searchable-menu/searchable-menu.tsx
+++ b/src/components/ui/searchable-menu/searchable-menu.tsx
@@ -60,7 +60,12 @@ const GroupSection = memo(<T,>({ group, value, onSelect, renderItem }: GroupSect
 
   return (
     <div className="flex flex-col gap-1">
-      {group.label && <h3 className="text-xs font-medium text-muted-foreground px-3 pt-2">{group.label}</h3>}
+      {group.label && (
+        <div className="px-3 pt-2">
+          <h3 className="text-xs font-medium text-muted-foreground">{group.label}</h3>
+          {group.subtitle && <p className="text-xs text-muted-foreground/70 mt-0.5">{group.subtitle}</p>}
+        </div>
+      )}
       <div className="flex flex-col gap-1.5">
         {group.items.map((item) => (
           <ItemButton

--- a/src/components/ui/searchable-menu/types.ts
+++ b/src/components/ui/searchable-menu/types.ts
@@ -14,6 +14,7 @@ export type SearchableMenuItem<T = unknown> = {
 export type SearchableMenuGroup<T = unknown> = {
   id: string
   label: string
+  subtitle?: string
   items: SearchableMenuItem<T>[]
 }
 


### PR DESCRIPTION
## Summary
- Replace hover-only tooltip on disabled models with clearly labeled section groups ("Standard Models" / "Confidential Models") with descriptive subtitles
- Add `subtitle` support to `SearchableMenuGroup` for reuse across any searchable menu
- Remove Tooltip dependency from model selector — the group subtitle is always visible, works on mobile

## Linear
[THU-286](https://linear.app/mozilla-thunderbolt/issue/THU-286/improve-non-confidential-models-popover-ux-for-mobile-accessibility)

## Test Plan
- [ ] Open a confidential chat → non-confidential models appear under "Standard Models" with "Only confidential models can be used in this chat" subtitle
- [ ] Open a standard chat → confidential models appear under "Confidential Models" with "Only available in confidential chats" subtitle
- [ ] New chat (no thread) → all models shown without restriction sections
- [ ] Disabled models still cannot be selected
- [ ] Desktop: no behavioral changes to available model selection
- [ ] Mobile: subtitle text visible without hovering

## Changes
- `src/components/ui/searchable-menu/types.ts` — added optional `subtitle` to `SearchableMenuGroup`
- `src/components/ui/searchable-menu/searchable-menu.tsx` — render subtitle in `GroupSection`
- `src/components/ui/model-selector/model-selector.tsx` — split disabled models into labeled groups, removed tooltip, extracted `toMenuItem` helper
- `src/components/ui/model-selector/model-selector.test.ts` — 6 tests for `categorizeModels` logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, mostly UI/UX changes plus an additive `subtitle` field on shared `SearchableMenuGroup` types/rendering. Main risk is unintended layout changes anywhere grouped searchable menus are used.
> 
> **Overview**
> Improves the model selector popover UX by replacing hover-only disabled-model tooltips with **always-visible disabled sections**: standard models are grouped under `Standard Models` (for confidential chats) and confidential models under `Confidential Models` (for standard chats), each with a short explanatory subtitle.
> 
> Extends `SearchableMenuGroup` with an optional `subtitle` and updates `SearchableMenu` group rendering to display it. Adds Bun tests for `categorizeModels` covering grouping and disabled-state behavior, and removes the model-level `disabledReason`/Tooltip dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6e7a26199ec79505038ea9ed398f3e2575b8b22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->