### PR TITLE
⚡ THU-332: Move sync icon to sidebar header on mobile

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -74,7 +74,6 @@ export const Header = () => {
               <span className="sr-only">New Chat</span>
             </Button>
           )}
-          <PowerSyncStatus />
         </div>
       </header>
     )

--- a/src/layout/sidebar/sidebar-header.tsx
+++ b/src/layout/sidebar/sidebar-header.tsx
@@ -7,6 +7,7 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 import { SidebarCloseButton } from '@/components/ui/sidebar-close-button'
+import { PowerSyncStatus } from '@/components/powersync-status'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { PanelLeft } from 'lucide-react'
 import { useState } from 'react'
@@ -54,7 +55,10 @@ export const SidebarHeader = ({ onToggle }: SidebarHeaderProps) => {
       {isExpanded && (
         <div className="flex items-center">
           {isMobile ? (
-            <SidebarCloseButton onClick={onToggle} />
+            <>
+              <PowerSyncStatus />
+              <SidebarCloseButton onClick={onToggle} />
+            </>
           ) : (
             <SidebarGroup className="p-0 w-auto">
               <SidebarGroupContent>


### PR DESCRIPTION
## Summary
- On mobile, moved the PowerSync status icon from the main header to the sidebar header, positioned to the left of the close (X) button
- The "New Chat" button is now the only right-side icon in the mobile main header
- Desktop layout remains unchanged

## Linear
[THU-332](https://linear.app/mozilla-thunderbolt/issue/THU-332/on-mobile-lets-move-the-sync-icon-from-the-main-header-to-the-right)

## Test Plan
- [ ] On mobile: open sidebar → sync icon appears to the left of the close (X) button
- [ ] On mobile: main header only shows "New Chat" button on the right
- [ ] On desktop: PowerSync status still appears in the main header (no change)

## Changes
- `src/components/ui/header.tsx` — Removed `<PowerSyncStatus />` from mobile layout
- `src/layout/sidebar/sidebar-header.tsx` — Added `<PowerSyncStatus />` next to close button on mobile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout change that repositions an existing status component without altering sync logic or data flows.
> 
> **Overview**
> On mobile, removes `PowerSyncStatus` from `Header` so the right side only shows the optional **New Chat** action.
> 
> Adds `PowerSyncStatus` to the mobile `SidebarHeader`, placed next to the sidebar close button; desktop header placement remains the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 739044c54ca413a242ff6ee441ad274399b09a41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->