### PR TITLE
⚡ THU-331: Persist prompt input draft per chat thread

### DIFF
--- a/.thunderbot/thunderfix.md
+++ b/.thunderbot/thunderfix.md
@@ -29,7 +29,7 @@ query($id: ID!) {
   node(id: $id) {
     ... on PullRequest {
       reviewThreads(first: 100) {
-        nodes { id isResolved comments(first: 10) { nodes { body path line author { login } } } }
+        nodes { id isResolved comments(first: 10) { nodes { id databaseId body path line author { login } } } }
       }
     }
   }
@@ -104,8 +104,10 @@ gh pr checks "$PR_NUMBER"
 #### Review thread comments
 Read each unresolved review thread. Fix legitimate bugs, violations, and requested changes. Ignore pure style nits and subjective preferences unless the reviewer insists.
 
+**Important:** For each thread, note whether the reviewer asked a question, made a suggestion, or proposed an alternative approach. You will need to **reply** to these before resolving (see Step 4). Track which threads need replies and what the reply should say.
+
 #### Issue-level comments
-Read issue-level comments from reviewers. These are general PR feedback not attached to specific code lines. Address actionable feedback the same as review thread comments.
+Read issue-level comments from reviewers. These are general PR feedback not attached to specific code lines. Address actionable feedback the same as review thread comments. If a comment poses a question, you must reply to it (see Step 4).
 
 #### Commit type
 When calling `/thunderpush`, these fixes address feedback on the current PR — they are NOT pre-existing bugs. The commit type should match the nature of the fix (usually `chore:` or `refactor:`), never `fix:` (which is reserved for bugs that existed on main before this branch).
@@ -135,9 +137,27 @@ If CI fails (max **3 CI fix attempts** per loop iteration):
 
 If CI still fails after 3 attempts, stop and report the failure.
 
-### 4. Resolve & Mark Complete
+### 4. Reply, Resolve & Mark Complete
 
-After CI passes, resolve ALL addressed items:
+After CI passes, **reply to every comment that asked a question or proposed an alternative**, then resolve.
+
+#### Reply to review threads
+
+For each unresolved review thread that contained a question, suggestion, or alternative approach: reply **before** resolving. Use the REST API to reply to the thread (the comment ID is the first comment's `id` from the thread's `comments.nodes[0]`):
+
+```bash
+# For each thread that needs a reply, get the numeric comment ID from the
+# GraphQL `id` field of the first comment (it's also available via REST).
+# Then reply:
+gh api "repos/$REPO/pulls/$PR_NUMBER/comments/{COMMENT_ID}/replies" -X POST -f body="<your reply>"
+```
+
+**Reply guidelines:**
+- Answer questions directly and concisely
+- If you adopted a suggestion, say so briefly (e.g., "Good call — done in the latest push.")
+- If you considered but declined a suggestion, explain why (e.g., "Considered this, but X because Y. Happy to revisit if you feel strongly.")
+- If a comment was a pure bug report with no question, a reply is optional — resolving is sufficient
+- Prefix replies with ⚡ so they're filtered out of future counts
 
 #### Resolve review threads
 ```bash
@@ -148,19 +168,23 @@ for THREAD_ID in $THREAD_IDS; do
 done
 ```
 
-#### Minimize addressed issue-level comments
-Minimize each non-author, non-bot issue comment as "resolved" so they collapse in the PR timeline:
+#### Reply to and minimize issue-level comments
+
+For each actionable issue comment: reply first (answering any questions), then minimize.
+
 ```bash
-COMMENT_NODE_IDS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" | jq -r -f "$GQL_DIR/issue_comments.jq" | jq -r '.[].node_id')
+# Get comments that need replies
+ISSUE_COMMENT_DATA=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" | jq -f "$GQL_DIR/issue_comments.jq")
+
+# For each comment, reply if it contained a question or suggestion:
+# gh api "repos/$REPO/issues/$PR_NUMBER/comments" -X POST -f body="⚡ <your reply>"
+
+# Then minimize
+COMMENT_NODE_IDS=$(echo "$ISSUE_COMMENT_DATA" | jq -r '.[].node_id')
 
 for COMMENT_ID in $COMMENT_NODE_IDS; do
   gh api graphql -F "query=@$GQL_DIR/minimize.graphql" -f "id=$COMMENT_ID"
 done
-```
-
-Then post a single acknowledgment reply (prefixed with ⚡ so it's filtered out of future counts):
-```bash
-gh api "repos/$REPO/issues/$PR_NUMBER/comments" -X POST -f body="⚡ Addressed in the latest push."
 ```
 
 ### 5. Verify Clean

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -45,14 +45,16 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
 
     const { isMobile } = useIsMobile()
 
-    const { chatInstance, id: chatThreadId, selectedMode, selectedModel } = useCurrentChatSession()
+    const { chatInstance, chatThread, id: chatThreadId, selectedMode, selectedModel } = useCurrentChatSession()
 
     const { messages, status, stop, sendMessage } = useChat({ chat: chatInstance })
 
     const isStreaming = status === 'streaming'
 
+    // Use a stable "new" key for unsaved chats so the draft persists across /chats/new navigations
+    const draftKey = chatThread ? chatThreadId : 'new'
     const [showOverflowModal, setShowOverflowModal] = useState(false)
-    const [input, setInput, clearDraft] = useDraftInput(chatThreadId)
+    const [input, setInput, clearDraft] = useDraftInput(draftKey)
     const formRef = useRef<HTMLFormElement>(null)
     const { triggerSelection } = useHaptics()
 

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 import { trackEvent as trackEvent_default } from '@/lib/posthog'
 import { type Model } from '@/types'
 import { useChat as useChat_default } from '@ai-sdk/react'
+import { useDraftInput } from '@/hooks/use-draft-input'
 import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react'
 import { useNavigate as useNavigate_default } from 'react-router'
 import { ContextOverflowModal } from '../context-overflow-modal'
@@ -51,7 +52,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
     const isStreaming = status === 'streaming'
 
     const [showOverflowModal, setShowOverflowModal] = useState(false)
-    const [input, setInput] = useState('')
+    const [input, setInput, clearDraft] = useDraftInput(chatThreadId)
     const formRef = useRef<HTMLFormElement>(null)
     const { triggerSelection } = useHaptics()
 
@@ -83,8 +84,8 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
           return
         }
 
-        // Clear the input immediately for responsive UX
-        setInput('')
+        // Clear input and persisted draft immediately for responsive UX
+        clearDraft()
 
         await sendMessage({ text: textToSend })
       } catch (error) {

--- a/src/hooks/use-draft-input.test.ts
+++ b/src/hooks/use-draft-input.test.ts
@@ -133,6 +133,23 @@ describe('useDraftInput', () => {
     expect(localStorage.getItem('draft:thread-1')).toBeNull()
   })
 
+  it('flushes pending draft on thread switch', () => {
+    fakeTimers()
+    const { result, rerender } = renderHook(({ id }) => useDraftInput(id), {
+      initialProps: { id: 'thread-1' },
+    })
+
+    act(() => {
+      result.current[1]('unsaved text')
+    })
+
+    // Switch threads before debounce fires
+    rerender({ id: 'thread-2' })
+
+    // The pending draft for thread-1 should have been flushed
+    expect(localStorage.getItem('draft:thread-1')).toBe('unsaved text')
+  })
+
   it('loads correct draft when chatThreadId changes', () => {
     localStorage.setItem('draft:thread-1', 'draft one')
     localStorage.setItem('draft:thread-2', 'draft two')

--- a/src/hooks/use-draft-input.test.ts
+++ b/src/hooks/use-draft-input.test.ts
@@ -1,0 +1,150 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { useDraftInput } from './use-draft-input'
+
+const fakeTimers = () => {
+  let time = 0
+  const timers: Array<{ id: number; callback: () => void; fireAt: number }> = []
+  let nextId = 1
+
+  globalThis.setTimeout = ((callback: () => void, ms: number) => {
+    const id = nextId++
+    timers.push({ id, callback, fireAt: time + ms })
+    return id
+  }) as unknown as typeof setTimeout
+
+  globalThis.clearTimeout = ((id: number) => {
+    const index = timers.findIndex((t) => t.id === id)
+    if (index !== -1) {
+      timers.splice(index, 1)
+    }
+  }) as unknown as typeof clearTimeout
+
+  return {
+    advance: (ms: number) => {
+      time += ms
+      const ready = timers.filter((t) => t.fireAt <= time)
+      for (const t of ready) {
+        timers.splice(timers.indexOf(t), 1)
+        t.callback()
+      }
+    },
+  }
+}
+
+describe('useDraftInput', () => {
+  let originalSetTimeout: typeof setTimeout
+  let originalClearTimeout: typeof clearTimeout
+
+  beforeEach(() => {
+    localStorage.clear()
+    originalSetTimeout = globalThis.setTimeout
+    originalClearTimeout = globalThis.clearTimeout
+  })
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout
+    globalThis.clearTimeout = originalClearTimeout
+  })
+
+  it('initializes with empty string when no draft exists', () => {
+    const { result } = renderHook(() => useDraftInput('thread-1'))
+    expect(result.current[0]).toBe('')
+  })
+
+  it('initializes with saved draft from localStorage', () => {
+    localStorage.setItem('draft:thread-1', 'saved text')
+    const { result } = renderHook(() => useDraftInput('thread-1'))
+    expect(result.current[0]).toBe('saved text')
+  })
+
+  it('saves draft to localStorage after debounce', () => {
+    const timers = fakeTimers()
+    const { result } = renderHook(() => useDraftInput('thread-1'))
+
+    act(() => {
+      result.current[1]('hello')
+    })
+
+    // Not saved yet (debounce pending)
+    expect(localStorage.getItem('draft:thread-1')).toBeNull()
+
+    act(() => {
+      timers.advance(300)
+    })
+
+    expect(localStorage.getItem('draft:thread-1')).toBe('hello')
+  })
+
+  it('debounces rapid typing', () => {
+    const timers = fakeTimers()
+    const { result } = renderHook(() => useDraftInput('thread-1'))
+
+    act(() => {
+      result.current[1]('h')
+    })
+    act(() => {
+      result.current[1]('he')
+    })
+    act(() => {
+      result.current[1]('hel')
+    })
+
+    act(() => {
+      timers.advance(300)
+    })
+
+    // Only the last value should be saved
+    expect(localStorage.getItem('draft:thread-1')).toBe('hel')
+  })
+
+  it('clears draft from localStorage', () => {
+    const timers = fakeTimers()
+    const { result } = renderHook(() => useDraftInput('thread-1'))
+
+    act(() => {
+      result.current[1]('some text')
+    })
+    act(() => {
+      timers.advance(300)
+    })
+    expect(localStorage.getItem('draft:thread-1')).toBe('some text')
+
+    act(() => {
+      result.current[2]()
+    })
+
+    expect(result.current[0]).toBe('')
+    expect(localStorage.getItem('draft:thread-1')).toBeNull()
+  })
+
+  it('removes key when draft is set to empty string', () => {
+    localStorage.setItem('draft:thread-1', 'old')
+    const timers = fakeTimers()
+    const { result } = renderHook(() => useDraftInput('thread-1'))
+
+    act(() => {
+      result.current[1]('')
+    })
+    act(() => {
+      timers.advance(300)
+    })
+
+    expect(localStorage.getItem('draft:thread-1')).toBeNull()
+  })
+
+  it('loads correct draft when chatThreadId changes', () => {
+    localStorage.setItem('draft:thread-1', 'draft one')
+    localStorage.setItem('draft:thread-2', 'draft two')
+
+    const { result, rerender } = renderHook(({ id }) => useDraftInput(id), {
+      initialProps: { id: 'thread-1' },
+    })
+
+    expect(result.current[0]).toBe('draft one')
+
+    rerender({ id: 'thread-2' })
+
+    expect(result.current[0]).toBe('draft two')
+  })
+})

--- a/src/hooks/use-draft-input.ts
+++ b/src/hooks/use-draft-input.ts
@@ -28,6 +28,7 @@ export const useDraftInput = (chatThreadId: string) => {
   const [input, setInputState] = useState(() => readDraft(chatThreadId))
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const chatThreadIdRef = useRef(chatThreadId)
+  const pendingValueRef = useRef<string | null>(null)
 
   // When the chat thread changes, load that thread's draft
   useEffect(() => {
@@ -35,15 +36,21 @@ export const useDraftInput = (chatThreadId: string) => {
     setInputState(readDraft(chatThreadId))
 
     return () => {
+      // Flush any pending debounced write before switching threads
       if (timerRef.current) {
         clearTimeout(timerRef.current)
         timerRef.current = null
+      }
+      if (pendingValueRef.current !== null) {
+        writeDraft(chatThreadIdRef.current, pendingValueRef.current)
+        pendingValueRef.current = null
       }
     }
   }, [chatThreadId])
 
   const setInput = useCallback((value: string) => {
     setInputState(value)
+    pendingValueRef.current = value
 
     if (timerRef.current) {
       clearTimeout(timerRef.current)
@@ -52,11 +59,13 @@ export const useDraftInput = (chatThreadId: string) => {
     timerRef.current = setTimeout(() => {
       writeDraft(chatThreadIdRef.current, value)
       timerRef.current = null
+      pendingValueRef.current = null
     }, debounceMs)
   }, [])
 
   const clearDraft = useCallback(() => {
     setInputState('')
+    pendingValueRef.current = null
     if (timerRef.current) {
       clearTimeout(timerRef.current)
       timerRef.current = null

--- a/src/hooks/use-draft-input.ts
+++ b/src/hooks/use-draft-input.ts
@@ -1,23 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback } from 'react'
+import { useLocalStorage } from './use-local-storage'
 
 const draftKeyPrefix = 'draft:'
-const debounceMs = 300
-
-/** Get the localStorage key for a chat thread's draft. */
-const getDraftKey = (chatThreadId: string) => `${draftKeyPrefix}${chatThreadId}`
-
-/** Read a draft from localStorage. */
-const readDraft = (chatThreadId: string): string => localStorage.getItem(getDraftKey(chatThreadId)) ?? ''
-
-/** Write a draft to localStorage (or remove if empty). */
-const writeDraft = (chatThreadId: string, value: string) => {
-  const key = getDraftKey(chatThreadId)
-  if (value) {
-    localStorage.setItem(key, value)
-  } else {
-    localStorage.removeItem(key)
-  }
-}
 
 /**
  * Persists prompt input text to localStorage, keyed by chat thread ID.
@@ -25,53 +9,11 @@ const writeDraft = (chatThreadId: string, value: string) => {
  * Returns [input, setInput, clearDraft] — drop-in replacement for useState('').
  */
 export const useDraftInput = (chatThreadId: string) => {
-  const [input, setInputState] = useState(() => readDraft(chatThreadId))
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const chatThreadIdRef = useRef(chatThreadId)
-  const pendingValueRef = useRef<string | null>(null)
-
-  // When the chat thread changes, load that thread's draft
-  useEffect(() => {
-    chatThreadIdRef.current = chatThreadId
-    setInputState(readDraft(chatThreadId))
-
-    return () => {
-      // Flush any pending debounced write before switching threads
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-      if (pendingValueRef.current !== null) {
-        writeDraft(chatThreadIdRef.current, pendingValueRef.current)
-        pendingValueRef.current = null
-      }
-    }
-  }, [chatThreadId])
-
-  const setInput = useCallback((value: string) => {
-    setInputState(value)
-    pendingValueRef.current = value
-
-    if (timerRef.current) {
-      clearTimeout(timerRef.current)
-    }
-
-    timerRef.current = setTimeout(() => {
-      writeDraft(chatThreadIdRef.current, value)
-      timerRef.current = null
-      pendingValueRef.current = null
-    }, debounceMs)
-  }, [])
+  const [input, setInput] = useLocalStorage(`${draftKeyPrefix}${chatThreadId}`, '', { debounceMs: 300 })
 
   const clearDraft = useCallback(() => {
-    setInputState('')
-    pendingValueRef.current = null
-    if (timerRef.current) {
-      clearTimeout(timerRef.current)
-      timerRef.current = null
-    }
-    writeDraft(chatThreadIdRef.current, '')
-  }, [])
+    setInput('', { immediate: true })
+  }, [setInput])
 
   return [input, setInput, clearDraft] as const
 }

--- a/src/hooks/use-draft-input.ts
+++ b/src/hooks/use-draft-input.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const draftKeyPrefix = 'draft:'
+const debounceMs = 300
+
+/** Get the localStorage key for a chat thread's draft. */
+const getDraftKey = (chatThreadId: string) => `${draftKeyPrefix}${chatThreadId}`
+
+/** Read a draft from localStorage. */
+const readDraft = (chatThreadId: string): string => localStorage.getItem(getDraftKey(chatThreadId)) ?? ''
+
+/** Write a draft to localStorage (or remove if empty). */
+const writeDraft = (chatThreadId: string, value: string) => {
+  const key = getDraftKey(chatThreadId)
+  if (value) {
+    localStorage.setItem(key, value)
+  } else {
+    localStorage.removeItem(key)
+  }
+}
+
+/**
+ * Persists prompt input text to localStorage, keyed by chat thread ID.
+ * Debounces writes so rapid typing doesn't thrash storage.
+ * Returns [input, setInput, clearDraft] — drop-in replacement for useState('').
+ */
+export const useDraftInput = (chatThreadId: string) => {
+  const [input, setInputState] = useState(() => readDraft(chatThreadId))
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const chatThreadIdRef = useRef(chatThreadId)
+
+  // When the chat thread changes, load that thread's draft
+  useEffect(() => {
+    chatThreadIdRef.current = chatThreadId
+    setInputState(readDraft(chatThreadId))
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [chatThreadId])
+
+  const setInput = useCallback((value: string) => {
+    setInputState(value)
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+
+    timerRef.current = setTimeout(() => {
+      writeDraft(chatThreadIdRef.current, value)
+      timerRef.current = null
+    }, debounceMs)
+  }, [])
+
+  const clearDraft = useCallback(() => {
+    setInputState('')
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    writeDraft(chatThreadIdRef.current, '')
+  }, [])
+
+  return [input, setInput, clearDraft] as const
+}

--- a/src/hooks/use-local-storage.test.ts
+++ b/src/hooks/use-local-storage.test.ts
@@ -1,0 +1,209 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { useLocalStorage } from './use-local-storage'
+
+const fakeTimers = () => {
+  let time = 0
+  const timers: Array<{ id: number; callback: () => void; fireAt: number }> = []
+  let nextId = 1
+
+  globalThis.setTimeout = ((callback: () => void, ms: number) => {
+    const id = nextId++
+    timers.push({ id, callback, fireAt: time + ms })
+    return id
+  }) as unknown as typeof setTimeout
+
+  globalThis.clearTimeout = ((id: number) => {
+    const index = timers.findIndex((t) => t.id === id)
+    if (index !== -1) {
+      timers.splice(index, 1)
+    }
+  }) as unknown as typeof clearTimeout
+
+  return {
+    advance: (ms: number) => {
+      time += ms
+      const ready = timers.filter((t) => t.fireAt <= time)
+      for (const t of ready) {
+        timers.splice(timers.indexOf(t), 1)
+        t.callback()
+      }
+    },
+  }
+}
+
+describe('useLocalStorage', () => {
+  let originalSetTimeout: typeof setTimeout
+  let originalClearTimeout: typeof clearTimeout
+
+  beforeEach(() => {
+    localStorage.clear()
+    originalSetTimeout = globalThis.setTimeout
+    originalClearTimeout = globalThis.clearTimeout
+  })
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout
+    globalThis.clearTimeout = originalClearTimeout
+  })
+
+  describe('immediate mode (no debounce)', () => {
+    it('returns default value when key is absent', () => {
+      const { result } = renderHook(() => useLocalStorage('test-key', 'default'))
+      expect(result.current[0]).toBe('default')
+    })
+
+    it('returns stored value when key exists', () => {
+      localStorage.setItem('test-key', 'stored')
+      const { result } = renderHook(() => useLocalStorage('test-key', 'default'))
+      expect(result.current[0]).toBe('stored')
+    })
+
+    it('writes to localStorage immediately', () => {
+      const { result } = renderHook(() => useLocalStorage('test-key', ''))
+      act(() => {
+        result.current[1]('hello')
+      })
+      expect(localStorage.getItem('test-key')).toBe('hello')
+    })
+
+    it('removes key when value matches default', () => {
+      localStorage.setItem('test-key', 'something')
+      const { result } = renderHook(() => useLocalStorage('test-key', ''))
+      act(() => {
+        result.current[1]('')
+      })
+      expect(localStorage.getItem('test-key')).toBeNull()
+    })
+  })
+
+  describe('debounced mode', () => {
+    it('does not write until debounce fires', () => {
+      const timers = fakeTimers()
+      const { result } = renderHook(() => useLocalStorage('test-key', '', { debounceMs: 300 }))
+
+      act(() => {
+        result.current[1]('hello')
+      })
+      expect(localStorage.getItem('test-key')).toBeNull()
+
+      act(() => {
+        timers.advance(300)
+      })
+      expect(localStorage.getItem('test-key')).toBe('hello')
+    })
+
+    it('debounces rapid updates', () => {
+      const timers = fakeTimers()
+      const { result } = renderHook(() => useLocalStorage('test-key', '', { debounceMs: 300 }))
+
+      act(() => {
+        result.current[1]('a')
+      })
+      act(() => {
+        result.current[1]('ab')
+      })
+      act(() => {
+        result.current[1]('abc')
+      })
+
+      act(() => {
+        timers.advance(300)
+      })
+      expect(localStorage.getItem('test-key')).toBe('abc')
+    })
+
+    it('writes immediately when immediate option is set', () => {
+      fakeTimers()
+      const { result } = renderHook(() => useLocalStorage('test-key', '', { debounceMs: 300 }))
+
+      act(() => {
+        result.current[1]('immediate value', { immediate: true })
+      })
+      expect(localStorage.getItem('test-key')).toBe('immediate value')
+    })
+
+    it('cancels pending debounce when immediate write is called', () => {
+      const timers = fakeTimers()
+      const { result } = renderHook(() => useLocalStorage('test-key', '', { debounceMs: 300 }))
+
+      act(() => {
+        result.current[1]('debounced')
+      })
+      expect(localStorage.getItem('test-key')).toBeNull()
+
+      act(() => {
+        result.current[1]('final', { immediate: true })
+      })
+      expect(localStorage.getItem('test-key')).toBe('final')
+
+      // Advancing should not overwrite with the old debounced value
+      act(() => {
+        timers.advance(300)
+      })
+      expect(localStorage.getItem('test-key')).toBe('final')
+    })
+
+    it('removes key when debounced value matches default', () => {
+      localStorage.setItem('test-key', 'old')
+      const timers = fakeTimers()
+      const { result } = renderHook(() => useLocalStorage('test-key', '', { debounceMs: 300 }))
+
+      act(() => {
+        result.current[1]('')
+      })
+      act(() => {
+        timers.advance(300)
+      })
+      expect(localStorage.getItem('test-key')).toBeNull()
+    })
+
+    it('flushes pending write on key change', () => {
+      fakeTimers()
+      const { result, rerender } = renderHook(({ key }) => useLocalStorage(key, '', { debounceMs: 300 }), {
+        initialProps: { key: 'key-1' },
+      })
+
+      act(() => {
+        result.current[1]('pending value')
+      })
+
+      // Key changes before debounce fires
+      rerender({ key: 'key-2' })
+
+      // Pending value for key-1 should have been flushed
+      expect(localStorage.getItem('key-1')).toBe('pending value')
+    })
+  })
+
+  describe('key changes', () => {
+    it('loads new value when key changes', () => {
+      localStorage.setItem('key-1', 'value one')
+      localStorage.setItem('key-2', 'value two')
+
+      const { result, rerender } = renderHook(({ key }) => useLocalStorage(key, ''), {
+        initialProps: { key: 'key-1' },
+      })
+
+      expect(result.current[0]).toBe('value one')
+
+      rerender({ key: 'key-2' })
+
+      expect(result.current[0]).toBe('value two')
+    })
+
+    it('returns default when new key has no stored value', () => {
+      localStorage.setItem('key-1', 'value one')
+
+      const { result, rerender } = renderHook(({ key }) => useLocalStorage(key, 'fallback'), {
+        initialProps: { key: 'key-1' },
+      })
+
+      expect(result.current[0]).toBe('value one')
+
+      rerender({ key: 'key-2' })
+
+      expect(result.current[0]).toBe('fallback')
+    })
+  })
+})

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const defaultDebounceMs = 0
+
+/**
+ * React hook that syncs state to localStorage with optional debounced writes.
+ * Removes the key when value equals the default, keeping localStorage clean.
+ *
+ * @param key - localStorage key
+ * @param defaultValue - returned when key is absent; also used to detect "empty" state for cleanup
+ * @param options.debounceMs - debounce writes by this many ms (0 = immediate)
+ */
+export const useLocalStorage = (key: string, defaultValue: string, options?: { debounceMs?: number }) => {
+  const debounceMs = options?.debounceMs ?? defaultDebounceMs
+  const [value, setValueState] = useState(() => localStorage.getItem(key) ?? defaultValue)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingValueRef = useRef<string | null>(null)
+  const keyRef = useRef(key)
+
+  // When key changes, load the new key's value and flush any pending write for the old key
+  useEffect(() => {
+    // Capture current key before updating — cleanup needs to flush writes to THIS key,
+    // not the next one (keyRef.current will already point to the new key by cleanup time)
+    const currentKey = key
+    keyRef.current = key
+    setValueState(localStorage.getItem(key) ?? defaultValue)
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      if (pendingValueRef.current !== null) {
+        writeToStorage(currentKey, pendingValueRef.current, defaultValue)
+        pendingValueRef.current = null
+      }
+    }
+  }, [key, defaultValue])
+
+  const setValue = useCallback(
+    (next: string, setOptions?: { immediate?: boolean }) => {
+      setValueState(next)
+
+      if (debounceMs === 0 || setOptions?.immediate) {
+        if (timerRef.current) {
+          clearTimeout(timerRef.current)
+          timerRef.current = null
+        }
+        pendingValueRef.current = null
+        writeToStorage(keyRef.current, next, defaultValue)
+        return
+      }
+
+      pendingValueRef.current = next
+
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+
+      timerRef.current = setTimeout(() => {
+        writeToStorage(keyRef.current, next, defaultValue)
+        timerRef.current = null
+        pendingValueRef.current = null
+      }, debounceMs)
+    },
+    [debounceMs, defaultValue],
+  )
+
+  return [value, setValue] as const
+}
+
+/** Write to localStorage, removing the key when value matches the default. */
+const writeToStorage = (key: string, value: string, defaultValue: string) => {
+  if (value === defaultValue) {
+    localStorage.removeItem(key)
+  } else {
+    localStorage.setItem(key, value)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `useDraftInput` hook that persists chat prompt text to localStorage (debounced, keyed per chat thread)
- On submit, the draft is cleared immediately
- Restores draft when navigating back to a chat thread

## Linear
[THU-331](https://linear.app/mozilla-thunderbolt/issue/THU-331/persist-prompt-input-to-disk-so-that-user-doesnt-lose-their-place-if)

## Test Plan
- [x] Type in prompt, navigate away, come back — text is restored
- [x] Submit a message — draft is cleared
- [x] Switch between chat threads — each has its own draft
- [x] 7 unit tests for `useDraftInput` hook
- [x] All 9 existing `ChatPromptInput` tests still pass

## Changes
- `src/hooks/use-draft-input.ts` — New hook with debounced localStorage persistence
- `src/hooks/use-draft-input.test.ts` — 7 tests covering init, save, debounce, clear, thread switching
- `src/components/chat/chat-prompt-input.tsx` — Replace `useState('')` with `useDraftInput(chatThreadId)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX change that adds debounced localStorage persistence for chat prompt drafts; main risk is subtle draft key/cleanup behavior causing stale or missing drafts across thread switches.
> 
> **Overview**
> Chat prompt drafts are now persisted to `localStorage` per chat thread via a new debounced `useLocalStorage` hook and a `useDraftInput` wrapper, so typed text is restored when navigating away/back or switching threads.
> 
> `ChatPromptInput` switches from `useState` to `useDraftInput` (including a stable `'new'` key for unsaved chats) and clears the persisted draft immediately on submit. Adds unit tests for both new hooks. Updates `.thunderbot/thunderfix.md` to include replying to questions/suggestions before resolving threads and minimizing comments, and fetches comment IDs needed for replies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2861478cddddd5518e5e6965177d7fc74c8fddd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->