### PR TITLE
⚡ THU-337: Add haptic feedback on keyboard key press

### DIFF
--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -1,5 +1,6 @@
 import { AutosizeTextarea } from '@/components/ui/autosize-textarea'
 import { Button } from '@/components/ui/button'
+import { useKeyboardHaptics } from '@/hooks/use-keyboard-haptics'
 import { type ChatThread } from '@/layout/sidebar/types'
 import type { Model } from '@/types'
 import { ArrowUp, Square } from 'lucide-react'
@@ -64,9 +65,12 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
       }
     }
 
+    const { onKeyDown: onKeyDownHaptic } = useKeyboardHaptics()
+
     const handleTextareaChange = (e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)
 
     const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      onKeyDownHaptic(e)
       if (!isStreaming && submitOnEnter && e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault()
         onSubmit?.()
@@ -103,7 +107,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <AutosizeTextarea
           value={value}
           onChange={handleTextareaChange}
-          onKeyDown={submitOnEnter ? handleKeyDown : undefined}
+          onKeyDown={handleKeyDown}
           placeholder={placeholder}
           minHeight={28}
           maxHeight={240}
@@ -136,7 +140,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <AutosizeTextarea
           value={value}
           onChange={handleTextareaChange}
-          onKeyDown={submitOnEnter ? handleKeyDown : undefined}
+          onKeyDown={handleKeyDown}
           placeholder={placeholder}
           minHeight={52}
           maxHeight={240}

--- a/src/hooks/use-keyboard-haptics.test.ts
+++ b/src/hooks/use-keyboard-haptics.test.ts
@@ -1,0 +1,32 @@
+import '@/testing-library'
+import { describe, expect, mock, test } from 'bun:test'
+import { renderHook } from '@testing-library/react'
+
+const triggerImpact = mock(() => {})
+
+mock.module('@/hooks/use-haptics', () => ({
+  useHaptics: () => ({
+    triggerSelection: () => {},
+    triggerImpact,
+    triggerNotification: () => {},
+  }),
+  HapticsProvider: ({ children }: { children: unknown }) => children,
+}))
+
+const { useKeyboardHaptics } = await import('./use-keyboard-haptics')
+
+describe('useKeyboardHaptics', () => {
+  test('returns an onKeyDown handler', () => {
+    const { result } = renderHook(() => useKeyboardHaptics())
+    expect(typeof result.current.onKeyDown).toBe('function')
+  })
+
+  test('triggers soft impact haptic on keydown', () => {
+    const { result } = renderHook(() => useKeyboardHaptics())
+    const fakeEvent = { key: 'a' } as React.KeyboardEvent<HTMLTextAreaElement>
+
+    result.current.onKeyDown(fakeEvent)
+
+    expect(triggerImpact).toHaveBeenCalledWith('soft')
+  })
+})

--- a/src/hooks/use-keyboard-haptics.ts
+++ b/src/hooks/use-keyboard-haptics.ts
@@ -1,0 +1,19 @@
+import { useCallback, type KeyboardEvent } from 'react'
+import { useHaptics } from './use-haptics'
+
+/**
+ * Returns an `onKeyDown` handler that triggers a soft impact haptic on every keystroke.
+ * Designed for text inputs on mobile — no-ops on desktop or when haptics are disabled.
+ */
+export const useKeyboardHaptics = () => {
+  const { triggerImpact } = useHaptics()
+
+  const onKeyDown = useCallback(
+    (_e: KeyboardEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+      triggerImpact('soft')
+    },
+    [triggerImpact],
+  )
+
+  return { onKeyDown }
+}


### PR DESCRIPTION
## Summary
- Adds a `useKeyboardHaptics` hook that triggers soft impact haptic feedback on every keystroke
- Integrates the hook into `PromptInput` so typing in the chat textarea triggers haptics on mobile
- Uses `triggerImpact('soft')` for a subtle per-keystroke feel — respects the existing haptics_enabled setting

## Linear
[THU-337](https://linear.app/mozilla-thunderbolt/issue/THU-337/add-haptic-feedback-on-keyboard-key-press-on-mobile)

## Test Plan
- [ ] On Tauri mobile (iOS/Android): verify typing in the prompt triggers subtle haptic feedback per keystroke
- [ ] Toggle haptics off in Settings > Preferences — verify no haptics on keypress
- [ ] On desktop: verify no vibration/errors (web-haptics no-ops on desktop)
- [ ] Verify Enter-to-submit still works correctly

## Changes
- `src/hooks/use-keyboard-haptics.ts` — New reusable hook returning an `onKeyDown` handler
- `src/hooks/use-keyboard-haptics.test.ts` — Tests for the hook
- `src/components/ui/prompt-input.tsx` — Always attaches `handleKeyDown` (was conditional on `submitOnEnter`), calls haptic trigger on every keystroke

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `PromptInput` keydown handling (core chat UX) to run per-keystroke haptics, which could affect typing/Enter-to-submit behavior or introduce noisy feedback/perf issues on some platforms.
> 
> **Overview**
> Adds a new `useKeyboardHaptics` hook that triggers `triggerImpact('soft')` on every `keydown`, plus unit tests mocking `useHaptics`.
> 
> Integrates the hook into `PromptInput` by always wiring an `onKeyDown` handler to the chat textarea (previously only attached when `submitOnEnter`), while keeping Enter-to-submit gated behind `submitOnEnter` and `isStreaming` checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ec95938f60202b13cbd1c82e667f77339fd7d98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->