### PR TITLE
⚡ THU-342: Add cursor[bot] to Claude PR review allowed bots

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -112,7 +112,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CI_ANTHROPIC_API_KEY }}
-          allowed_bots: 'dependabot[bot],renovate[bot]'
+          allowed_bots: 'dependabot[bot],renovate[bot],cursor[bot]'
           include_fix_links: true
           prompt: |
             Your goal is HIGH-SIGNAL, LOW-NOISE feedback.


### PR DESCRIPTION
## Summary
- Add `cursor[bot]` to the `allowed_bots` list in the Claude Code PR review workflow
- Fixes Cursor autofix pushes (e.g. `@cursor push`) being rejected by the review action

## Linear
[THU-342](https://linear.app/mozilla-thunderbolt/issue/THU-342/claude-code-automatic-pr-review-rejects-cursor-autofix)

## Test Plan
- [ ] Create a PR with a Cursor bot push and verify Claude review triggers successfully
- [ ] Verify dependabot/renovate PRs still get reviewed

## Changes
- `.github/workflows/claude.yml`: Added `cursor[bot]` to `allowed_bots` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to GitHub Actions configuration and only broadens the allowlist for which bots can trigger the Claude review action; minimal impact beyond CI behavior.
> 
> **Overview**
> Updates the Claude PR review GitHub Actions workflow to include `cursor[bot]` in the `allowed_bots` allowlist, so Cursor-driven autofix pushes are eligible for automatic Claude reviews alongside Dependabot/Renovate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 569cbc9af1227a15e3f0a1d18e7a59bae482c818. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->