### PR TITLE
⚡ THU-343: Fix CI glob to match branch names with slashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   # Run CI for all PR updates without duplication from push events
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    branches: ['*']
+    branches: ['**']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- Change `pull_request.branches` filter from `['*']` to `['**']` in CI workflow
- `*` doesn't cross `/` boundaries in GitHub Actions glob patterns, so PRs targeting branches like `username/thu-123-feature` silently skipped CI

## Linear
[THU-343](https://linear.app/mozilla-thunderbolt/issue/THU-343/tests-should-run-even-if-not-merging-into-main)

## Test Plan
- [x] This PR itself should trigger CI (it targets `main`, which already matched)
- [x] Verify PR #389 (targets `italomenezes/thu-302-01-core`) gets CI after merge

## Changes
- `.github/workflows/ci.yml`: `['*']` → `['**']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that expands which PR targets trigger CI; main risk is slightly increased CI load from previously-excluded PRs.
> 
> **Overview**
> Ensures CI runs for PRs targeting branch names containing `/` by changing the `pull_request.branches` filter in `.github/workflows/ci.yml` from `['*']` to `['**']`.
> 
> This prevents PRs to namespaced/feature branches from silently skipping the CI workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe18319716fe1faf80387b94661921cfe82422ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->