### PR TITLE
THU-330: Keep header fixed and sticky when keyboard opens on mobile web

### DIFF
--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -5,17 +5,12 @@ import { useEffect } from 'react'
  * can stay pinned above the software keyboard on mobile.
  *
  * Sets on `<html>`:
- * - `--vv-top`:    visual viewport scroll offset (px) — on iOS Safari the
- *                  browser scrolls the layout viewport when the keyboard opens,
- *                  so fixed elements drift off-screen unless compensated.
- * - `--vv-height`: visual viewport height (px) — shrinks to the area above
- *                  the keyboard.
- * - `--kb`:        keyboard inset height (px) — kept for consumers that need
- *                  the raw keyboard height (e.g. positioned dialogs).
+ * - `--vv-top`:    visual viewport scroll offset (px)
+ * - `--vv-height`: visual viewport height (px)
+ * - `--kb`:        keyboard inset height (px)
  *
- * Uses `requestAnimationFrame` polling while the viewport is animating
- * (keyboard slide) so the values update every frame instead of only when
- * the browser fires `resize`/`scroll` events.
+ * Starts `requestAnimationFrame` polling on `focusin` (before the keyboard
+ * animation begins) so the values track every frame from the start.
  */
 export const useKeyboardInset = (): void => {
   useEffect(() => {
@@ -34,7 +29,6 @@ export const useKeyboardInset = (): void => {
       el.setProperty('--kb', `${Math.max(0, window.innerHeight - vv.height - vv.offsetTop)}px`)
     }
 
-    /** Poll every frame until the viewport stops moving. */
     const poll = () => {
       apply()
 
@@ -49,15 +43,14 @@ export const useKeyboardInset = (): void => {
         stableFrames++
       }
 
-      // Keep polling until 10 consecutive stable frames (~160ms)
-      if (stableFrames < 10) {
+      if (stableFrames < 20) {
         rafId = requestAnimationFrame(poll)
       } else {
         rafId = 0
       }
     }
 
-    const onViewportChange = () => {
+    const startPolling = () => {
       stableFrames = 0
       if (!rafId) {
         rafId = requestAnimationFrame(poll)
@@ -66,12 +59,17 @@ export const useKeyboardInset = (): void => {
 
     apply()
 
-    vv.addEventListener('resize', onViewportChange)
-    vv.addEventListener('scroll', onViewportChange)
+    // Start polling on focusin — fires BEFORE the keyboard animation starts
+    document.addEventListener('focusin', startPolling)
+    document.addEventListener('focusout', startPolling)
+    vv.addEventListener('resize', startPolling)
+    vv.addEventListener('scroll', startPolling)
 
     return () => {
-      vv.removeEventListener('resize', onViewportChange)
-      vv.removeEventListener('scroll', onViewportChange)
+      document.removeEventListener('focusin', startPolling)
+      document.removeEventListener('focusout', startPolling)
+      vv.removeEventListener('resize', startPolling)
+      vv.removeEventListener('scroll', startPolling)
       if (rafId) cancelAnimationFrame(rafId)
     }
   }, [])

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -1,34 +1,55 @@
-import { useEffect } from 'react'
+import { useLayoutEffect } from 'react'
 
 /**
- * Tracks the visual viewport and sets CSS custom properties on `<html>`:
- * - `--vv-top`:  visual viewport offset (px) — how far iOS Safari has scrolled
- *                the layout viewport when the keyboard opens.
- * - `--kb`:      keyboard inset height (px).
+ * Keeps `#root` pinned to the visual viewport on iOS Safari when the virtual
+ * keyboard opens.
  *
- * The header uses `--vv-top` via a CSS transform to float in place while iOS
- * natively scrolls everything else.
+ * iOS Safari scrolls the layout viewport instead of resizing it when the
+ * keyboard appears. Fixed-position elements follow the layout viewport and
+ * scroll off screen. This hook compensates by directly setting `#root`'s
+ * `top` and `height` to match the visual viewport.
+ *
+ * To prevent the flash caused by Safari's native scroll-to-focused-input
+ * behavior, we override `HTMLElement.prototype.focus` to always use
+ * `preventScroll: true` (technique from Adobe React Spectrum).
+ *
+ * Uses `useLayoutEffect` for synchronous-before-paint updates and rAF
+ * polling to track the keyboard animation.
  */
 export const useKeyboardInset = (): void => {
-  useEffect(() => {
+  useLayoutEffect(() => {
     const vv = window.visualViewport
     if (!vv) return
 
+    const root = document.getElementById('root')
+    if (!root) return
+
+    // Override focus to prevent Safari's native scroll-to-input behavior.
+    // This is the key to eliminating the flash — without it, Safari scrolls
+    // the layout viewport before our JS can compensate.
+    const originalFocus = HTMLElement.prototype.focus
+    HTMLElement.prototype.focus = function (opts) {
+      originalFocus.call(this, { ...opts, preventScroll: true })
+    }
+
     let rafId = 0
-    let prevTop = vv.offsetTop
+    let prevHeight = vv.height
+    let prevOffsetTop = vv.offsetTop
     let stableFrames = 0
 
     const apply = () => {
-      const el = document.documentElement.style
-      el.setProperty('--vv-top', `${vv.offsetTop}px`)
-      el.setProperty('--kb', `${Math.max(0, window.innerHeight - vv.height - vv.offsetTop)}px`)
+      root.style.top = `${vv.offsetTop}px`
+      root.style.height = `${vv.height}px`
+      // Force layout viewport back to origin
+      window.scrollTo(0, 0)
     }
 
     const poll = () => {
       apply()
 
-      const changed = vv.offsetTop !== prevTop
-      prevTop = vv.offsetTop
+      const changed = vv.height !== prevHeight || vv.offsetTop !== prevOffsetTop
+      prevHeight = vv.height
+      prevOffsetTop = vv.offsetTop
 
       stableFrames = changed ? 0 : stableFrames + 1
 
@@ -46,6 +67,7 @@ export const useKeyboardInset = (): void => {
       }
     }
 
+    // Initial apply
     apply()
 
     document.addEventListener('focusin', startPolling)
@@ -54,11 +76,14 @@ export const useKeyboardInset = (): void => {
     vv.addEventListener('scroll', startPolling)
 
     return () => {
+      HTMLElement.prototype.focus = originalFocus
       document.removeEventListener('focusin', startPolling)
       document.removeEventListener('focusout', startPolling)
       vv.removeEventListener('resize', startPolling)
       vv.removeEventListener('scroll', startPolling)
       if (rafId) cancelAnimationFrame(rafId)
+      root.style.top = ''
+      root.style.height = ''
     }
   }, [])
 }

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -8,9 +8,8 @@ import { useEffect } from 'react'
  * - `--vv-height`: visual viewport height (px)
  * - `--kb`:        keyboard inset height (px)
  *
- * Prevents iOS Safari's native viewport scroll (which pushes the header
- * offscreen) by locking `window.scrollTo(0, 0)` on every animation frame
- * while the viewport is changing.
+ * Prevents iOS Safari's native viewport scroll by locking html/body to
+ * position:fixed (via CSS) and resetting any scroll that sneaks through.
  */
 export const useKeyboardInset = (): void => {
   useEffect(() => {
@@ -21,12 +20,15 @@ export const useKeyboardInset = (): void => {
     let prevHeight = vv.height
     let stableFrames = 0
 
-    const apply = () => {
-      // Prevent iOS Safari from scrolling the layout viewport
+    // Immediately kill any viewport scroll iOS tries to do
+    const lockScroll = () => {
       if (window.scrollY !== 0 || window.scrollX !== 0) {
         window.scrollTo(0, 0)
       }
+    }
 
+    const apply = () => {
+      lockScroll()
       const el = document.documentElement.style
       el.setProperty('--vv-height', `${vv.height}px`)
       el.setProperty('--kb', `${Math.max(0, window.innerHeight - vv.height - vv.offsetTop)}px`)
@@ -60,12 +62,15 @@ export const useKeyboardInset = (): void => {
 
     apply()
 
+    // Synchronous scroll listener — fires before next paint
+    window.addEventListener('scroll', lockScroll, { passive: false })
     document.addEventListener('focusin', startPolling)
     document.addEventListener('focusout', startPolling)
     vv.addEventListener('resize', startPolling)
     vv.addEventListener('scroll', startPolling)
 
     return () => {
+      window.removeEventListener('scroll', lockScroll)
       document.removeEventListener('focusin', startPolling)
       document.removeEventListener('focusout', startPolling)
       vv.removeEventListener('resize', startPolling)

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -6,7 +6,9 @@ import { useLayoutEffect } from 'react'
  * desktop signatures that also include "Safari" in the UA string.
  */
 const isMobileWebKit = (): boolean => {
-  if (typeof navigator === 'undefined' || typeof window === 'undefined') return false
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return false
+  }
   const ua = navigator.userAgent
   const isMobileViewport = window.innerWidth <= 768
   const isWebKit = /AppleWebKit/.test(ua) && /Mobile/.test(ua)
@@ -34,13 +36,19 @@ const isMobileWebKit = (): boolean => {
  */
 export const useKeyboardInset = (): void => {
   useLayoutEffect(() => {
-    if (!isMobileWebKit()) return
+    if (!isMobileWebKit()) {
+      return
+    }
 
     const vv = window.visualViewport
-    if (!vv) return
+    if (!vv) {
+      return
+    }
 
     const root = document.getElementById('root')
-    if (!root) return
+    if (!root) {
+      return
+    }
 
     // Add class so CSS can scope fixed-positioning styles
     root.classList.add('keyboard-inset-active')

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -1,51 +1,78 @@
 import { useEffect } from 'react'
 
 /**
- * React hook that maintains the `--kb` CSS custom property on the root `<html>` element.
- * The property reflects the height (in pixels) of the area currently covered by the
- * software keyboard. When the keyboard is hidden, the value is `0px`.
+ * Keeps CSS custom properties in sync with the visual viewport so `#root`
+ * can stay pinned above the software keyboard on mobile.
  *
- * It relies on the Visual Viewport API, which is supported by all major mobile browsers
- * (Safari iOS, Chrome/Edge/Opera/Samsung Internet, Firefox Android) and desktop Chromium.
+ * Sets on `<html>`:
+ * - `--vv-top`:    visual viewport scroll offset (px) — on iOS Safari the
+ *                  browser scrolls the layout viewport when the keyboard opens,
+ *                  so fixed elements drift off-screen unless compensated.
+ * - `--vv-height`: visual viewport height (px) — shrinks to the area above
+ *                  the keyboard.
+ * - `--kb`:        keyboard inset height (px) — kept for consumers that need
+ *                  the raw keyboard height (e.g. positioned dialogs).
  *
- * The hook is safe to use on older engines that don’t expose `window.visualViewport` –
- * it simply becomes a no-op, leaving `--kb` at its initial `0px`.
- *
- * Usage:
- *   // Call it once at the top level of your app
- *   useKeyboardInset()
+ * Uses `requestAnimationFrame` polling while the viewport is animating
+ * (keyboard slide) so the values update every frame instead of only when
+ * the browser fires `resize`/`scroll` events.
  */
 export const useKeyboardInset = (): void => {
   useEffect(() => {
     const vv = window.visualViewport
-    if (!vv) {
-      return
-    } // VisualViewport API not supported
+    if (!vv) return
 
-    /**
-     * Calculates and sets the CSS variable based on the difference between the
-     * layout viewport (`window.innerHeight`) and the visual viewport (`vv.height`).
-     * On iOS the layout viewport stays constant and the visual viewport shrinks
-     * when the keyboard appears. On Android/Chromium both shrink, but the math
-     * still produces a non-negative inset that matches the covered area.
-     */
-    const update = () => {
+    let rafId = 0
+    let prevTop = vv.offsetTop
+    let prevHeight = vv.height
+    let stableFrames = 0
+
+    const apply = () => {
       const el = document.documentElement.style
       el.setProperty('--vv-top', `${vv.offsetTop}px`)
       el.setProperty('--vv-height', `${vv.height}px`)
       el.setProperty('--kb', `${Math.max(0, window.innerHeight - vv.height - vv.offsetTop)}px`)
     }
 
-    // Initial run
-    update()
+    /** Poll every frame until the viewport stops moving. */
+    const poll = () => {
+      apply()
 
-    // iOS fires `scroll` when the viewport pans, Android fires `resize`
-    vv.addEventListener('resize', update)
-    vv.addEventListener('scroll', update)
+      const topChanged = vv.offsetTop !== prevTop
+      const heightChanged = vv.height !== prevHeight
+      prevTop = vv.offsetTop
+      prevHeight = vv.height
+
+      if (topChanged || heightChanged) {
+        stableFrames = 0
+      } else {
+        stableFrames++
+      }
+
+      // Keep polling until 10 consecutive stable frames (~160ms)
+      if (stableFrames < 10) {
+        rafId = requestAnimationFrame(poll)
+      } else {
+        rafId = 0
+      }
+    }
+
+    const onViewportChange = () => {
+      stableFrames = 0
+      if (!rafId) {
+        rafId = requestAnimationFrame(poll)
+      }
+    }
+
+    apply()
+
+    vv.addEventListener('resize', onViewportChange)
+    vv.addEventListener('scroll', onViewportChange)
 
     return () => {
-      vv.removeEventListener('resize', update)
-      vv.removeEventListener('scroll', update)
+      vv.removeEventListener('resize', onViewportChange)
+      vv.removeEventListener('scroll', onViewportChange)
+      if (rafId) cancelAnimationFrame(rafId)
     }
   }, [])
 }

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -1,15 +1,13 @@
 import { useEffect } from 'react'
 
 /**
- * Keeps CSS custom properties in sync with the visual viewport so `#root`
- * can stay pinned above the software keyboard on mobile.
+ * Tracks the visual viewport and sets CSS custom properties on `<html>`:
+ * - `--vv-top`:  visual viewport offset (px) — how far iOS Safari has scrolled
+ *                the layout viewport when the keyboard opens.
+ * - `--kb`:      keyboard inset height (px).
  *
- * Sets on `<html>`:
- * - `--vv-height`: visual viewport height (px)
- * - `--kb`:        keyboard inset height (px)
- *
- * Prevents iOS Safari's native viewport scroll by locking html/body to
- * position:fixed (via CSS) and resetting any scroll that sneaks through.
+ * The header uses `--vv-top` via a CSS transform to float in place while iOS
+ * natively scrolls everything else.
  */
 export const useKeyboardInset = (): void => {
   useEffect(() => {
@@ -17,34 +15,22 @@ export const useKeyboardInset = (): void => {
     if (!vv) return
 
     let rafId = 0
-    let prevHeight = vv.height
+    let prevTop = vv.offsetTop
     let stableFrames = 0
 
-    // Immediately kill any viewport scroll iOS tries to do
-    const lockScroll = () => {
-      if (window.scrollY !== 0 || window.scrollX !== 0) {
-        window.scrollTo(0, 0)
-      }
-    }
-
     const apply = () => {
-      lockScroll()
       const el = document.documentElement.style
-      el.setProperty('--vv-height', `${vv.height}px`)
+      el.setProperty('--vv-top', `${vv.offsetTop}px`)
       el.setProperty('--kb', `${Math.max(0, window.innerHeight - vv.height - vv.offsetTop)}px`)
     }
 
     const poll = () => {
       apply()
 
-      const heightChanged = vv.height !== prevHeight
-      prevHeight = vv.height
+      const changed = vv.offsetTop !== prevTop
+      prevTop = vv.offsetTop
 
-      if (heightChanged) {
-        stableFrames = 0
-      } else {
-        stableFrames++
-      }
+      stableFrames = changed ? 0 : stableFrames + 1
 
       if (stableFrames < 20) {
         rafId = requestAnimationFrame(poll)
@@ -62,15 +48,12 @@ export const useKeyboardInset = (): void => {
 
     apply()
 
-    // Synchronous scroll listener — fires before next paint
-    window.addEventListener('scroll', lockScroll, { passive: false })
     document.addEventListener('focusin', startPolling)
     document.addEventListener('focusout', startPolling)
     vv.addEventListener('resize', startPolling)
     vv.addEventListener('scroll', startPolling)
 
     return () => {
-      window.removeEventListener('scroll', lockScroll)
       document.removeEventListener('focusin', startPolling)
       document.removeEventListener('focusout', startPolling)
       vv.removeEventListener('resize', startPolling)

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -19,10 +19,14 @@ import { useLayoutEffect } from 'react'
 export const useKeyboardInset = (): void => {
   useLayoutEffect(() => {
     const vv = window.visualViewport
-    if (!vv) return
+    if (!vv) {
+      return
+    }
 
     const root = document.getElementById('root')
-    if (!root) return
+    if (!root) {
+      return
+    }
 
     // Override focus to prevent Safari's native scroll-to-input behavior.
     // This is the key to eliminating the flash — without it, Safari scrolls
@@ -81,7 +85,9 @@ export const useKeyboardInset = (): void => {
       document.removeEventListener('focusout', startPolling)
       vv.removeEventListener('resize', startPolling)
       vv.removeEventListener('scroll', startPolling)
-      if (rafId) cancelAnimationFrame(rafId)
+      if (rafId) {
+        cancelAnimationFrame(rafId)
+      }
       root.style.top = ''
       root.style.height = ''
     }

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -5,12 +5,12 @@ import { useEffect } from 'react'
  * can stay pinned above the software keyboard on mobile.
  *
  * Sets on `<html>`:
- * - `--vv-top`:    visual viewport scroll offset (px)
  * - `--vv-height`: visual viewport height (px)
  * - `--kb`:        keyboard inset height (px)
  *
- * Starts `requestAnimationFrame` polling on `focusin` (before the keyboard
- * animation begins) so the values track every frame from the start.
+ * Prevents iOS Safari's native viewport scroll (which pushes the header
+ * offscreen) by locking `window.scrollTo(0, 0)` on every animation frame
+ * while the viewport is changing.
  */
 export const useKeyboardInset = (): void => {
   useEffect(() => {
@@ -18,13 +18,16 @@ export const useKeyboardInset = (): void => {
     if (!vv) return
 
     let rafId = 0
-    let prevTop = vv.offsetTop
     let prevHeight = vv.height
     let stableFrames = 0
 
     const apply = () => {
+      // Prevent iOS Safari from scrolling the layout viewport
+      if (window.scrollY !== 0 || window.scrollX !== 0) {
+        window.scrollTo(0, 0)
+      }
+
       const el = document.documentElement.style
-      el.setProperty('--vv-top', `${vv.offsetTop}px`)
       el.setProperty('--vv-height', `${vv.height}px`)
       el.setProperty('--kb', `${Math.max(0, window.innerHeight - vv.height - vv.offsetTop)}px`)
     }
@@ -32,12 +35,10 @@ export const useKeyboardInset = (): void => {
     const poll = () => {
       apply()
 
-      const topChanged = vv.offsetTop !== prevTop
       const heightChanged = vv.height !== prevHeight
-      prevTop = vv.offsetTop
       prevHeight = vv.height
 
-      if (topChanged || heightChanged) {
+      if (heightChanged) {
         stableFrames = 0
       } else {
         stableFrames++
@@ -59,7 +60,6 @@ export const useKeyboardInset = (): void => {
 
     apply()
 
-    // Start polling on focusin — fires BEFORE the keyboard animation starts
     document.addEventListener('focusin', startPolling)
     document.addEventListener('focusout', startPolling)
     vv.addEventListener('resize', startPolling)

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -1,6 +1,19 @@
 import { useLayoutEffect } from 'react'
 
 /**
+ * Detects mobile WebKit (iOS Safari and iOS Chrome/Firefox which all use WebKit).
+ * We check for a small viewport (mobile) + WebKit UA signature + no Chrome/Firefox
+ * desktop signatures that also include "Safari" in the UA string.
+ */
+const isMobileWebKit = (): boolean => {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') return false
+  const ua = navigator.userAgent
+  const isMobileViewport = window.innerWidth <= 768
+  const isWebKit = /AppleWebKit/.test(ua) && /Mobile/.test(ua)
+  return isMobileViewport && isWebKit
+}
+
+/**
  * Keeps `#root` pinned to the visual viewport on iOS Safari when the virtual
  * keyboard opens.
  *
@@ -15,18 +28,22 @@ import { useLayoutEffect } from 'react'
  *
  * Uses `useLayoutEffect` for synchronous-before-paint updates and rAF
  * polling to track the keyboard animation.
+ *
+ * Guarded to only run on mobile WebKit — desktop browsers and non-WebKit
+ * mobile browsers are unaffected.
  */
 export const useKeyboardInset = (): void => {
   useLayoutEffect(() => {
+    if (!isMobileWebKit()) return
+
     const vv = window.visualViewport
-    if (!vv) {
-      return
-    }
+    if (!vv) return
 
     const root = document.getElementById('root')
-    if (!root) {
-      return
-    }
+    if (!root) return
+
+    // Add class so CSS can scope fixed-positioning styles
+    root.classList.add('keyboard-inset-active')
 
     // Override focus to prevent Safari's native scroll-to-input behavior.
     // This is the key to eliminating the flash — without it, Safari scrolls
@@ -44,6 +61,12 @@ export const useKeyboardInset = (): void => {
     const apply = () => {
       root.style.top = `${vv.offsetTop}px`
       root.style.height = `${vv.height}px`
+
+      // Set --kb on documentElement so portaled components (e.g. onboarding
+      // dialog) that live outside #root can still react to keyboard height.
+      const kbHeight = window.innerHeight - vv.height
+      document.documentElement.style.setProperty('--kb', `${kbHeight}px`)
+
       // Force layout viewport back to origin
       window.scrollTo(0, 0)
     }
@@ -81,6 +104,7 @@ export const useKeyboardInset = (): void => {
 
     return () => {
       HTMLElement.prototype.focus = originalFocus
+      root.classList.remove('keyboard-inset-active')
       document.removeEventListener('focusin', startPolling)
       document.removeEventListener('focusout', startPolling)
       vv.removeEventListener('resize', startPolling)
@@ -90,6 +114,7 @@ export const useKeyboardInset = (): void => {
       }
       root.style.top = ''
       root.style.height = ''
+      document.documentElement.style.removeProperty('--kb')
     }
   }, [])
 }

--- a/src/hooks/use-keyboard-inset.ts
+++ b/src/hooks/use-keyboard-inset.ts
@@ -30,8 +30,10 @@ export const useKeyboardInset = (): void => {
      * still produces a non-negative inset that matches the covered area.
      */
     const update = () => {
-      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
-      document.documentElement.style.setProperty('--kb', `${inset}px`)
+      const el = document.documentElement.style
+      el.setProperty('--vv-top', `${vv.offsetTop}px`)
+      el.setProperty('--vv-height', `${vv.height}px`)
+      el.setProperty('--kb', `${Math.max(0, window.innerHeight - vv.height - vv.offsetTop)}px`)
     }
 
     // Initial run

--- a/src/index.css
+++ b/src/index.css
@@ -157,22 +157,17 @@ body {
 }
 
 @media (max-width: 768px) {
-  html,
   body {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    width: 100%;
+    height: 100%;
     overflow: hidden;
   }
 
-  #root {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: var(--vv-height, 100svh);
+  header {
+    transform: translateY(var(--vv-top, 0px));
+    position: relative;
+    z-index: 50;
+    background-color: var(--color-background);
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -157,9 +157,13 @@ body {
 }
 
 @media (max-width: 768px) {
+  html,
   body {
-    width: 100%;
-    height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     overflow: hidden;
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -157,18 +157,23 @@ body {
 }
 
 @media (max-width: 768px) {
+  html,
   body {
-    width: 100%;
-    height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     overflow: hidden;
   }
 
-  header {
-    transform: translateY(var(--vv-top, 0px));
-    transition: transform 0.25s ease-out;
-    position: relative;
-    z-index: 50;
-    background-color: var(--color-background);
+  #root {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    overflow: hidden;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -165,7 +165,7 @@ body {
 
   #root {
     position: fixed;
-    top: var(--vv-top, 0px);
+    top: 0;
     left: 0;
     right: 0;
     height: var(--vv-height, 100svh);

--- a/src/index.css
+++ b/src/index.css
@@ -157,8 +157,8 @@ body {
 }
 
 @media (max-width: 768px) {
-  html,
-  body {
+  html:has(.keyboard-inset-active),
+  html:has(.keyboard-inset-active) body {
     position: fixed;
     top: 0;
     left: 0;
@@ -167,7 +167,7 @@ body {
     overflow: hidden;
   }
 
-  #root {
+  #root.keyboard-inset-active {
     position: fixed;
     top: 0;
     left: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -162,6 +162,14 @@ body {
     height: 100%;
     overflow: hidden;
   }
+
+  #root {
+    position: fixed;
+    top: var(--vv-top, 0px);
+    left: 0;
+    right: 0;
+    height: var(--vv-height, 100svh);
+  }
 }
 
 /* Subtle table borders for markdown content */

--- a/src/index.css
+++ b/src/index.css
@@ -165,6 +165,7 @@ body {
 
   header {
     transform: translateY(var(--vv-top, 0px));
+    transition: transform 0.25s ease-out;
     position: relative;
     z-index: 50;
     background-color: var(--color-background);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces iOS-specific viewport pinning by mutating global `HTMLElement.prototype.focus` and forcing fixed positioning/scroll resets, which could affect focus/scroll behavior across the app on mobile WebKit.
> 
> **Overview**
> Improves iOS mobile-web keyboard behavior by refactoring `useKeyboardInset` to **only run on mobile WebKit** and to keep the app UI pinned while the virtual keyboard animates.
> 
> The hook now uses `useLayoutEffect`, toggles a `keyboard-inset-active` class on `#root`, overrides `HTMLElement.prototype.focus` to enforce `preventScroll: true`, and uses rAF polling to continuously sync `#root` `top`/`height` (plus the `--kb` CSS var) to `visualViewport`.
> 
> Mobile CSS is updated so when `keyboard-inset-active` is present, `html`/`body` and `#root` are fixed and overflow-hidden, preventing the header/layout from scrolling off-screen during keyboard open/close.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b16c79fe06f42d3e61fe097afcc75320d35c6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

 
 
 
 
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses an issue on mobile web, particularly iOS Safari, where fixed headers and other elements scroll off-screen when the virtual keyboard opens. It introduces a new mechanism to keep the `#root` element pinned to the visual viewport, ensuring fixed elements remain visible.

#### Key Changes
- Refactored the `useKeyboardInset` hook to use `useLayoutEffect` and specifically target mobile WebKit browsers.
- Implemented a strategy to directly manipulate `#root`'s `top` and `height` based on the visual viewport, and override `HTMLElement.prototype.focus` to prevent native scroll behavior.
- Added a `keyboard-inset-active` class to `#root` and corresponding CSS rules in `index.css` to manage fixed positioning and overflow when the keyboard is active.
- Utilized `requestAnimationFrame` for polling to smoothly track keyboard animation and set a `--kb` CSS variable for keyboard height.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 97 (74.6%)    |
| Churn       | 5 (3.8%)      |
| Rework      | 28 (21.5%)    |
| Total Changes | 130           | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>