### PR TITLE
THU-311: Link preview + citation widget bugs

### DIFF
--- a/src/ai/widget-parser.test.ts
+++ b/src/ai/widget-parser.test.ts
@@ -801,4 +801,51 @@ describe('parseContentParts', () => {
       expect(result).toEqual([{ type: 'text', content: 'Normal text without any brackets.' }])
     })
   })
+
+  describe('text with [N] citations and widget tags', () => {
+    it('produces both text parts with [N] citations and widget parts', () => {
+      const text =
+        "Here's a demo:\n\n- Inline link [1]\n\n" + '<widget:link-preview url="https://example.com" source="1" />'
+      const result = parseContentParts(text)
+
+      const textParts = result.filter((p) => p.type === 'text')
+      const widgetParts = result.filter((p) => p.type === 'widget')
+
+      expect(textParts.length).toBeGreaterThanOrEqual(1)
+      expect(widgetParts.length).toBeGreaterThanOrEqual(1)
+
+      expect(textParts.some((p) => p.type === 'text' && p.content.includes('[1]'))).toBe(true)
+      expect(widgetParts.some((p) => p.type === 'widget' && p.widget.widget === 'link-preview')).toBe(true)
+    })
+
+    it('preserves multiple widget parts after text with multiple [N] citations', () => {
+      const text = [
+        'Sources [1] and [2] confirm this.',
+        '<widget:link-preview url="https://a.com" source="1" />',
+        '<widget:link-preview url="https://b.com" source="2" />',
+      ].join('\n\n')
+      const result = parseContentParts(text)
+
+      const textParts = result.filter((p) => p.type === 'text')
+      const widgetParts = result.filter((p) => p.type === 'widget')
+
+      expect(textParts.length).toBeGreaterThanOrEqual(1)
+      expect(widgetParts).toHaveLength(2)
+    })
+
+    it('preserves widget order relative to text when citations are present', () => {
+      const text =
+        'First point [1].\n\n' +
+        '<widget:link-preview url="https://first.com" source="1" />\n\n' +
+        'Second point [2].\n\n' +
+        '<widget:link-preview url="https://second.com" source="2" />'
+      const result = parseContentParts(text)
+
+      expect(result.length).toBeGreaterThanOrEqual(4)
+      expect(result[0].type).toBe('text')
+      expect(result[1].type).toBe('widget')
+      expect(result[2].type).toBe('text')
+      expect(result[3].type).toBe('widget')
+    })
+  })
 })

--- a/src/components/chat/citation-badge.tsx
+++ b/src/components/chat/citation-badge.tsx
@@ -52,21 +52,21 @@ const ManagedBadge = memo(({ sources, citationId }: { sources: CitationSource[];
   const isOpen = ctx.popover?.citationId === citationId
   const { displayName, additionalCount, ariaLabel } = getBadgeLabel(sources)
 
-  const toggle = (rect: DOMRect) => {
+  const toggle = (element: HTMLElement) => {
     if (isOpen) {
       ctx.close()
     } else {
-      ctx.open(citationId, sources, rect)
+      ctx.open(citationId, sources, element)
     }
   }
 
   return (
     <button
-      onClick={(e) => toggle(e.currentTarget.getBoundingClientRect())}
+      onClick={(e) => toggle(e.currentTarget)}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
-          toggle(e.currentTarget.getBoundingClientRect())
+          toggle(e.currentTarget)
         }
       }}
       className={badgeClass}

--- a/src/components/chat/citation-popover.tsx
+++ b/src/components/chat/citation-popover.tsx
@@ -3,18 +3,28 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useSettings } from '@/hooks/use-settings'
 import type { CitationSource } from '@/types/citation'
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
 import { SourceList } from './source-list'
 
 type PopoverData = {
   citationId: number
   sources: CitationSource[]
-  anchorRect: DOMRect
+  anchorElement: HTMLElement
 }
 
 type CitationPopoverState = {
   popover: PopoverData | null
-  open: (id: number, sources: CitationSource[], rect: DOMRect) => void
+  open: (id: number, sources: CitationSource[], element: HTMLElement) => void
   close: () => void
 }
 
@@ -30,8 +40,8 @@ export const useCitationPopover = () => useContext(CitationPopoverContext)
 export const CitationPopoverProvider = ({ children }: { children: ReactNode }) => {
   const [popover, setPopover] = useState<PopoverData | null>(null)
 
-  const open = useCallback((id: number, sources: CitationSource[], rect: DOMRect) => {
-    setPopover({ citationId: id, sources, anchorRect: rect })
+  const open = useCallback((id: number, sources: CitationSource[], element: HTMLElement) => {
+    setPopover({ citationId: id, sources, anchorElement: element })
   }, [])
 
   const close = useCallback(() => setPopover(null), [])
@@ -48,25 +58,54 @@ export const CitationPopoverProvider = ({ children }: { children: ReactNode }) =
 
 // --- Overlay (rendered automatically by the provider, outside the markdown tree) ---
 
-const CitationOverlay = ({ popover, close }: { popover: PopoverData | null; close: () => void }) => {
+const CitationOverlay = memo(({ popover, close }: { popover: PopoverData | null; close: () => void }) => {
   const { isMobile } = useIsMobile()
   const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
+  const anchorRef = useRef<HTMLSpanElement>(null)
 
-  // Close popover on scroll — the fixed-positioned anchor can't track the badge after scroll
   useEffect(() => {
     if (!popover) {
       return
     }
-    const handler = () => close()
-    window.addEventListener('scroll', handler, { capture: true })
-    return () => window.removeEventListener('scroll', handler, { capture: true })
+    const { anchorElement } = popover
+    const anchorSpan = anchorRef.current
+    if (!anchorSpan) {
+      return
+    }
+
+    const updatePosition = () => {
+      if (!document.contains(anchorElement)) {
+        close()
+        return
+      }
+      const rect = anchorElement.getBoundingClientRect()
+      anchorSpan.style.left = `${rect.left}px`
+      anchorSpan.style.top = `${rect.bottom}px`
+      anchorSpan.style.width = `${rect.width}px`
+    }
+
+    updatePosition()
+
+    let rafId = 0
+    const onScroll = () => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(updatePosition)
+    }
+
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onScroll)
+      cancelAnimationFrame(rafId)
+    }
   }, [popover, close])
 
   if (!popover) {
     return null
   }
 
-  const { sources, anchorRect } = popover
+  const { sources } = popover
 
   if (isMobile) {
     return (
@@ -90,19 +129,22 @@ const CitationOverlay = ({ popover, close }: { popover: PopoverData | null; clos
     <Popover open onOpenChange={(open) => !open && close()}>
       <PopoverAnchor asChild>
         <span
+          ref={anchorRef}
           style={{
             position: 'fixed',
-            left: anchorRect.left,
-            top: anchorRect.bottom,
-            width: anchorRect.width,
             height: 1,
             pointerEvents: 'none',
           }}
         />
       </PopoverAnchor>
-      <PopoverContent align="start" side="bottom" className="w-[420px] overflow-hidden rounded-2xl p-0">
+      <PopoverContent
+        hideWhenDetached
+        align="start"
+        side="bottom"
+        className="w-[420px] overflow-hidden rounded-2xl p-0"
+      >
         <SourceList sources={sources} proxyBase={cloudUrl.value} />
       </PopoverContent>
     </Popover>
   )
-}
+})

--- a/src/components/chat/citation-popover.tsx
+++ b/src/components/chat/citation-popover.tsx
@@ -84,21 +84,15 @@ const CitationOverlay = memo(({ popover, close }: { popover: PopoverData | null;
       anchorSpan.style.width = `${rect.width}px`
     }
 
-    updatePosition()
-
-    let rafId = 0
-    const onScroll = () => {
-      cancelAnimationFrame(rafId)
-      rafId = requestAnimationFrame(updatePosition)
+    // Continuous position tracking — covers scroll, resize, AND streaming content shifts
+    let rafId: number
+    const track = () => {
+      updatePosition()
+      rafId = requestAnimationFrame(track)
     }
+    rafId = requestAnimationFrame(track)
 
-    window.addEventListener('scroll', onScroll, true)
-    window.addEventListener('resize', onScroll)
-    return () => {
-      window.removeEventListener('scroll', onScroll, true)
-      window.removeEventListener('resize', onScroll)
-      cancelAnimationFrame(rafId)
-    }
+    return () => cancelAnimationFrame(rafId)
   }, [popover, close])
 
   if (!popover) {
@@ -141,6 +135,7 @@ const CitationOverlay = memo(({ popover, close }: { popover: PopoverData | null;
         hideWhenDetached
         align="start"
         side="bottom"
+        collisionPadding={{ top: 35, bottom: 150 }}
         className="w-[420px] overflow-hidden rounded-2xl p-0"
       >
         <SourceList sources={sources} proxyBase={cloudUrl.value} />

--- a/src/components/chat/citation-popover.tsx
+++ b/src/components/chat/citation-popover.tsx
@@ -73,26 +73,14 @@ const CitationOverlay = memo(({ popover, close }: { popover: PopoverData | null;
       return
     }
 
-    const updatePosition = () => {
-      if (!document.contains(anchorElement)) {
-        close()
-        return
-      }
-      const rect = anchorElement.getBoundingClientRect()
-      anchorSpan.style.left = `${rect.left}px`
-      anchorSpan.style.top = `${rect.bottom}px`
-      anchorSpan.style.width = `${rect.width}px`
-    }
+    const rect = anchorElement.getBoundingClientRect()
+    anchorSpan.style.left = `${rect.left}px`
+    anchorSpan.style.top = `${rect.bottom}px`
+    anchorSpan.style.width = `${rect.width}px`
 
-    // Continuous position tracking — covers scroll, resize, AND streaming content shifts
-    let rafId: number
-    const track = () => {
-      updatePosition()
-      rafId = requestAnimationFrame(track)
-    }
-    rafId = requestAnimationFrame(track)
-
-    return () => cancelAnimationFrame(rafId)
+    const handler = () => close()
+    window.addEventListener('scroll', handler, { capture: true })
+    return () => window.removeEventListener('scroll', handler, { capture: true })
   }, [popover, close])
 
   if (!popover) {
@@ -131,13 +119,7 @@ const CitationOverlay = memo(({ popover, close }: { popover: PopoverData | null;
           }}
         />
       </PopoverAnchor>
-      <PopoverContent
-        hideWhenDetached
-        align="start"
-        side="bottom"
-        collisionPadding={{ top: 35, bottom: 150 }}
-        className="w-[420px] overflow-hidden rounded-2xl p-0"
-      >
+      <PopoverContent align="start" side="bottom" className="w-[420px] overflow-hidden rounded-2xl p-0">
         <SourceList sources={sources} proxyBase={cloudUrl.value} />
       </PopoverContent>
     </Popover>

--- a/src/components/chat/citation-popover.tsx
+++ b/src/components/chat/citation-popover.tsx
@@ -148,3 +148,5 @@ const CitationOverlay = memo(({ popover, close }: { popover: PopoverData | null;
     </Popover>
   )
 })
+
+CitationOverlay.displayName = 'CitationOverlay'

--- a/src/components/chat/citation-popover.tsx
+++ b/src/components/chat/citation-popover.tsx
@@ -3,7 +3,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useSettings } from '@/hooks/use-settings'
 import type { CitationSource } from '@/types/citation'
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { SourceList } from './source-list'
 
 type PopoverData = {
@@ -51,6 +51,16 @@ export const CitationPopoverProvider = ({ children }: { children: ReactNode }) =
 const CitationOverlay = ({ popover, close }: { popover: PopoverData | null; close: () => void }) => {
   const { isMobile } = useIsMobile()
   const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
+
+  // Close popover on scroll — the fixed-positioned anchor can't track the badge after scroll
+  useEffect(() => {
+    if (!popover) {
+      return
+    }
+    const handler = () => close()
+    window.addEventListener('scroll', handler, { capture: true })
+    return () => window.removeEventListener('scroll', handler, { capture: true })
+  }, [popover, close])
 
   if (!popover) {
     return null

--- a/src/components/chat/text-part.test.ts
+++ b/src/components/chat/text-part.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { ContentPart } from '@/ai/widget-parser'
+import { parseContentParts } from '@/ai/widget-parser'
 import type { SourceMetadata } from '@/types/source'
 import { buildSourceCitationPlaceholders, deduplicateLinkPreviews } from './text-part'
 
@@ -263,5 +264,71 @@ describe('deduplicateLinkPreviews', () => {
   test('treats different paths as unique even for same domain', () => {
     const parts = [makeLinkPreview('https://apnews.com/article/one'), makeLinkPreview('https://apnews.com/article/two')]
     expect(deduplicateLinkPreviews(parts)).toHaveLength(2)
+  })
+
+  test('preserves widget parts when text parts contain [N] citation patterns', () => {
+    const parts: ContentPart[] = [
+      makeText('Here is a demo:\n\n- Inline link [1]'),
+      makeLinkPreview('https://example.com'),
+    ]
+    const result = deduplicateLinkPreviews(parts)
+    expect(result).toHaveLength(2)
+    expect(result[0].type).toBe('text')
+    expect(result[1].type).toBe('widget')
+  })
+
+  test('deduplicates link-previews but keeps text parts with citations intact', () => {
+    const parts: ContentPart[] = [
+      makeText('Sources [1] and [2] confirm this.'),
+      makeLinkPreview('https://example.com'),
+      makeLinkPreview('https://example.com'),
+      makeLinkPreview('https://other.com'),
+    ]
+    const result = deduplicateLinkPreviews(parts)
+    expect(result).toHaveLength(3)
+    expect(result[0].type).toBe('text')
+    expect(result[0]).toEqual(makeText('Sources [1] and [2] confirm this.'))
+    expect(result[1]).toEqual(makeLinkPreview('https://example.com'))
+    expect(result[2]).toEqual(makeLinkPreview('https://other.com'))
+  })
+})
+
+describe('parseContentParts preserves widgets alongside citation text', () => {
+  test('produces both text and widget parts when input has [N] citations and widget tags', () => {
+    const input = 'Here\'s a demo:\n\n- Inline link [1]\n\n<widget:link-preview url="https://example.com" source="1" />'
+    const parts = parseContentParts(input)
+
+    const textParts = parts.filter((p) => p.type === 'text')
+    const widgetParts = parts.filter((p) => p.type === 'widget')
+
+    expect(textParts.length).toBeGreaterThanOrEqual(1)
+    expect(widgetParts.length).toBeGreaterThanOrEqual(1)
+    expect(textParts.some((p) => p.type === 'text' && p.content.includes('[1]'))).toBe(true)
+  })
+
+  test('widget parts survive filtering when combined with citation text via deduplicateLinkPreviews', () => {
+    const input = 'According to [1], AI is advancing.\n\n<widget:link-preview url="https://example.com" source="1" />'
+    const parts = parseContentParts(input)
+    const deduped = deduplicateLinkPreviews(parts)
+
+    const widgetParts = deduped.filter((p) => p.type === 'widget')
+    expect(widgetParts).toHaveLength(1)
+    expect((widgetParts[0] as Extract<ContentPart, { type: 'widget' }>).widget.widget).toBe('link-preview')
+  })
+
+  test('multiple widget parts are preserved alongside citation text after dedup', () => {
+    const input = [
+      'Results: [1] and [2].',
+      '<widget:link-preview url="https://a.com" source="1" />',
+      '<widget:link-preview url="https://b.com" source="2" />',
+    ].join('\n\n')
+    const parts = parseContentParts(input)
+    const deduped = deduplicateLinkPreviews(parts)
+
+    const textParts = deduped.filter((p) => p.type === 'text')
+    const widgetParts = deduped.filter((p) => p.type === 'widget')
+
+    expect(textParts.length).toBeGreaterThanOrEqual(1)
+    expect(widgetParts).toHaveLength(2)
   })
 })

--- a/src/components/chat/text-part.test.ts
+++ b/src/components/chat/text-part.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import type { ContentPart } from '@/ai/widget-parser'
 import { parseContentParts } from '@/ai/widget-parser'
+import type { CitationMap } from '@/types/citation'
 import type { SourceMetadata } from '@/types/source'
 import { buildSourceCitationPlaceholders, deduplicateLinkPreviews } from './text-part'
 
@@ -185,6 +186,37 @@ describe('buildSourceCitationPlaceholders', () => {
     expect(citations.get(0)).toHaveLength(1)
     expect(citations.get(1)).toHaveLength(1)
     expect(fullText).toContain('[text](https://x.com)')
+  })
+
+  test('startKey offsets citation map keys', () => {
+    const twoSources = [makeSource(1), makeSource(2)]
+    const { fullText, citations } = buildSourceCitationPlaceholders('See [1] and [2].', twoSources, 5)
+
+    expect(fullText).toBe('See {{CITE:5}} and {{CITE:6}}.')
+    expect(citations.get(5)).toBeDefined()
+    expect(citations.get(6)).toBeDefined()
+    expect(citations.get(0)).toBeUndefined()
+  })
+
+  test('processes multiple text segments with unique keys across segments', () => {
+    const threeSources = [makeSource(1), makeSource(2), makeSource(3)]
+    let keyOffset = 0
+    const merged: CitationMap = new Map()
+
+    // Segment 1: has [1] and [2] adjacent (grouped into one entry)
+    const seg1 = buildSourceCitationPlaceholders('First [1] [2].', threeSources, keyOffset)
+    for (const [k, v] of seg1.citations) merged.set(k, v)
+    keyOffset += seg1.citations.size
+
+    // Segment 2: has [3] alone
+    const seg2 = buildSourceCitationPlaceholders('Second [3].', threeSources, keyOffset)
+    for (const [k, v] of seg2.citations) merged.set(k, v)
+
+    expect(seg1.fullText).toBe('First {{CITE:0}}.')
+    expect(seg2.fullText).toBe('Second {{CITE:1}}.')
+    expect(merged.size).toBe(2)
+    expect(merged.get(0)).toHaveLength(2)
+    expect(merged.get(1)).toHaveLength(1)
   })
 })
 

--- a/src/components/chat/text-part.test.ts
+++ b/src/components/chat/text-part.test.ts
@@ -205,12 +205,16 @@ describe('buildSourceCitationPlaceholders', () => {
 
     // Segment 1: has [1] and [2] adjacent (grouped into one entry)
     const seg1 = buildSourceCitationPlaceholders('First [1] [2].', threeSources, keyOffset)
-    for (const [k, v] of seg1.citations) merged.set(k, v)
+    for (const [k, v] of seg1.citations) {
+      merged.set(k, v)
+    }
     keyOffset += seg1.citations.size
 
     // Segment 2: has [3] alone
     const seg2 = buildSourceCitationPlaceholders('Second [3].', threeSources, keyOffset)
-    for (const [k, v] of seg2.citations) merged.set(k, v)
+    for (const [k, v] of seg2.citations) {
+      merged.set(k, v)
+    }
 
     expect(seg1.fullText).toBe('First {{CITE:0}}.')
     expect(seg2.fullText).toBe('Second {{CITE:1}}.')

--- a/src/components/chat/text-part.test.ts
+++ b/src/components/chat/text-part.test.ts
@@ -294,18 +294,6 @@ describe('deduplicateLinkPreviews', () => {
 })
 
 describe('parseContentParts preserves widgets alongside citation text', () => {
-  test('produces both text and widget parts when input has [N] citations and widget tags', () => {
-    const input = 'Here\'s a demo:\n\n- Inline link [1]\n\n<widget:link-preview url="https://example.com" source="1" />'
-    const parts = parseContentParts(input)
-
-    const textParts = parts.filter((p) => p.type === 'text')
-    const widgetParts = parts.filter((p) => p.type === 'widget')
-
-    expect(textParts.length).toBeGreaterThanOrEqual(1)
-    expect(widgetParts.length).toBeGreaterThanOrEqual(1)
-    expect(textParts.some((p) => p.type === 'text' && p.content.includes('[1]'))).toBe(true)
-  })
-
   test('widget parts survive filtering when combined with citation text via deduplicateLinkPreviews', () => {
     const input = 'According to [1], AI is advancing.\n\n<widget:link-preview url="https://example.com" source="1" />'
     const parts = parseContentParts(input)

--- a/src/components/chat/text-part.tsx
+++ b/src/components/chat/text-part.tsx
@@ -129,19 +129,30 @@ export const TextPart = memo(({ part, messageId, sources }: TextPartProps) => {
   }
 
   if (hasCitations && hasText) {
+    const widgetParts = deduplicateLinkPreviews(contentParts).filter(
+      (p): p is Extract<ContentPart, { type: 'widget' }> => p.type === 'widget',
+    )
+
     return (
-      <div className="p-4 rounded-md my-2">
-        <CitationPopoverProvider>
-          <CitationContext.Provider value={citations}>
-            <MemoizedMarkdown
-              key={`${messageId}-text`}
-              id={messageId}
-              content={fullText}
-              components={citationMarkdownComponents}
-            />
-          </CitationContext.Provider>
-        </CitationPopoverProvider>
-      </div>
+      <>
+        <div className="p-4 rounded-md my-2">
+          <CitationPopoverProvider>
+            <CitationContext.Provider value={citations}>
+              <MemoizedMarkdown
+                key={`${messageId}-text`}
+                id={messageId}
+                content={fullText}
+                components={citationMarkdownComponents}
+              />
+            </CitationContext.Provider>
+          </CitationPopoverProvider>
+        </div>
+        {widgetParts.map((widgetPart, index) => (
+          <div key={`widget-${index}`} className="animate-in slide-in-from-bottom-2 fade-in duration-300 ease-out">
+            <WidgetRenderer widget={widgetPart.widget} messageId={messageId} sources={sources} />
+          </div>
+        ))}
+      </>
     )
   }
 

--- a/src/components/chat/text-part.tsx
+++ b/src/components/chat/text-part.tsx
@@ -148,7 +148,14 @@ export const TextPart = memo(({ part, messageId, sources }: TextPartProps) => {
           </CitationPopoverProvider>
         </div>
         {widgetParts.map((widgetPart, index) => (
-          <div key={`widget-${index}`} className="animate-in slide-in-from-bottom-2 fade-in duration-300 ease-out">
+          <div
+            key={
+              widgetPart.widget.widget === 'link-preview'
+                ? (widgetPart.widget.args as { url: string }).url
+                : `widget-${index}`
+            }
+            className="animate-in slide-in-from-bottom-2 fade-in duration-300 ease-out"
+          >
             <WidgetRenderer widget={widgetPart.widget} messageId={messageId} sources={sources} />
           </div>
         ))}

--- a/src/components/chat/text-part.tsx
+++ b/src/components/chat/text-part.tsx
@@ -54,14 +54,16 @@ export const deduplicateLinkPreviews = (parts: ContentPart[]): ContentPart[] => 
  * Detects `[N]` citation patterns in text and builds a CitationMap from SourceMetadata[].
  * Each `[N]` where `N-1` is a valid index into `sources` becomes a `{{CITE:mapKey}}` placeholder.
  * Out-of-range references are left as-is in the text.
+ * @param startKey - Initial key value for the citation map (default 0). Use to avoid key collisions when processing multiple segments.
  * @returns fullText with placeholders, and the corresponding CitationMap
  */
 export const buildSourceCitationPlaceholders = (
   text: string,
   sources: SourceMetadata[],
+  startKey = 0,
 ): { fullText: string; citations: CitationMap } => {
   const citations: CitationMap = new Map()
-  let nextKey = 0
+  let nextKey = startKey
 
   const fullText = text.replace(groupedCitationRegex, (match) => {
     const validSources: CitationSource[] = []
@@ -89,11 +91,10 @@ export const TextPart = memo(({ part, messageId, sources }: TextPartProps) => {
   const hasNewSources = !!sources && sources.length > 0
 
   // Build citation data upfront so the hook is always called in the same order
-  const { contentParts, fullText, citations, hasCitations, hasText } = useMemo(() => {
+  const { processedParts, citations, hasCitations, hasText } = useMemo(() => {
     if (!part.text) {
       return {
-        contentParts: [],
-        fullText: '',
+        processedParts: [] as ContentPart[],
         citations: new Map() as CitationMap,
         hasCitations: false,
         hasText: false,
@@ -103,24 +104,34 @@ export const TextPart = memo(({ part, messageId, sources }: TextPartProps) => {
     const parts = parseContentParts(part.text)
 
     if (hasNewSources) {
-      const textContent = parts
-        .filter((p) => p.type === 'text')
-        .map((p) => p.content)
-        .join('\n\n')
+      let keyOffset = 0
+      const mergedCitations: CitationMap = new Map()
+      const processedParts: ContentPart[] = parts.map((p) => {
+        if (p.type !== 'text') {
+          return p
+        }
+        const { fullText, citations } = buildSourceCitationPlaceholders(p.content, sources, keyOffset)
+        for (const [key, value] of citations) {
+          mergedCitations.set(key, value)
+        }
+        keyOffset += citations.size
+        return { type: 'text' as const, content: fullText }
+      })
 
-      const result = buildSourceCitationPlaceholders(textContent, sources)
-      const hasCit = result.citations.size > 0
-      return { contentParts: parts, ...result, hasCitations: hasCit, hasText: textContent.length > 0 }
+      const hasCit = mergedCitations.size > 0
+      return {
+        processedParts,
+        citations: mergedCitations,
+        hasCitations: hasCit,
+        hasText: parts.some((p) => p.type === 'text' && p.content.length > 0),
+      }
     }
 
-    const hasTxt = parts.some((p) => p.type === 'text')
-
     return {
-      contentParts: parts,
-      fullText: '',
+      processedParts: parts,
       citations: new Map() as CitationMap,
       hasCitations: false,
-      hasText: hasTxt,
+      hasText: parts.some((p) => p.type === 'text'),
     }
   }, [part.text, hasNewSources, sources])
 
@@ -129,44 +140,44 @@ export const TextPart = memo(({ part, messageId, sources }: TextPartProps) => {
   }
 
   if (hasCitations && hasText) {
-    const widgetParts = deduplicateLinkPreviews(contentParts).filter(
-      (p): p is Extract<ContentPart, { type: 'widget' }> => p.type === 'widget',
-    )
+    const dedupedParts = deduplicateLinkPreviews(processedParts)
 
     return (
-      <>
-        <div className="p-4 rounded-md my-2">
-          <CitationPopoverProvider>
-            <CitationContext.Provider value={citations}>
-              <MemoizedMarkdown
-                key={`${messageId}-text`}
-                id={messageId}
-                content={fullText}
-                components={citationMarkdownComponents}
-              />
-            </CitationContext.Provider>
-          </CitationPopoverProvider>
-        </div>
-        {widgetParts.map((widgetPart, index) => (
-          <div
-            key={
-              widgetPart.widget.widget === 'link-preview'
-                ? (widgetPart.widget.args as { url: string }).url
-                : `widget-${index}`
+      <CitationPopoverProvider>
+        <CitationContext.Provider value={citations}>
+          {dedupedParts.map((part, index) => {
+            if (part.type === 'text') {
+              return (
+                <div key={`text-${index}`} className="p-4 rounded-md my-2">
+                  <MemoizedMarkdown
+                    key={`${messageId}-text-${index}`}
+                    id={`${messageId}-${index}`}
+                    content={part.content}
+                    components={citationMarkdownComponents}
+                  />
+                </div>
+              )
             }
-            className="animate-in slide-in-from-bottom-2 fade-in duration-300 ease-out"
-          >
-            <WidgetRenderer widget={widgetPart.widget} messageId={messageId} sources={sources} />
-          </div>
-        ))}
-      </>
+            return (
+              <div
+                key={
+                  part.widget.widget === 'link-preview' ? (part.widget.args as { url: string }).url : `widget-${index}`
+                }
+                className="animate-in slide-in-from-bottom-2 fade-in duration-300 ease-out"
+              >
+                <WidgetRenderer widget={part.widget} messageId={messageId} sources={sources} />
+              </div>
+            )
+          })}
+        </CitationContext.Provider>
+      </CitationPopoverProvider>
     )
   }
 
   // Default behavior for block-level widgets or no citations
   return (
     <>
-      {deduplicateLinkPreviews(contentParts).map((contentPart, index) => {
+      {deduplicateLinkPreviews(processedParts).map((contentPart, index) => {
         if (contentPart.type === 'text') {
           return (
             <div key={`text-${index}`} className="p-4 rounded-md my-2">

--- a/src/defaults/model-profiles/mistral.ts
+++ b/src/defaults/model-profiles/mistral.ts
@@ -10,7 +10,11 @@ export const defaultModelProfileMistralMedium31: ModelProfile = {
   useSystemMessageModeDeveloper: 0,
   providerOptions: null,
   toolsOverride: `CITATION RULE: After EVERY tool call, you MUST add [N] citations to your response. This is mandatory, not optional. Each [N] corresponds to the source number from the tool result. If you used 3 different sources, your response must contain at least [1], [2], and [3].
-Do NOT stop after just 1-2 tool calls. For requests involving link previews, you need at minimum: 1 search + 1 aggregate fetch + 3 individual page fetches = 5 tool calls.`,
+Do NOT stop after just 1-2 tool calls. For requests involving link previews, you need at minimum: 1 search + 1 aggregate fetch + 3 individual page fetches = 5 tool calls.
+CRITICAL — use fetch_content source numbers, not search source numbers:
+  WRONG: search returns [Source 1] apnews.com → you cite [1] → badge shows apnews.com (homepage)
+  RIGHT: fetch_content returns [Source 5] apnews.com/article/abc123 → you cite [5] → badge shows the article
+Always cite the [Source N] assigned by fetch_content, not the one assigned by search.`,
   linkPreviewsOverride: `SIMPLIFIED LINK PREVIEW WORKFLOW (follow these exact steps):
 1. Search for the topic (e.g. "top news today apnews")
 2. Fetch the FIRST aggregate/homepage result to discover article URLs
@@ -20,7 +24,7 @@ Do NOT stop after just 1-2 tool calls. For requests involving link previews, you
 NEVER show a URL whose path is "/" or a short section like "/ai/", "/news/", "/technology/" — these are NOT individual pages.
 NEVER show the same URL twice.
 NEVER link to review-site aggregates (pcmag.com/picks, cnet.com/best, wirecutter.com).`,
-  chatModeAddendum: `MANDATORY: Every fact in your response that came from a tool result MUST have a [N] citation at the end of the sentence. Do not skip citations — a response without [N] markers is considered incomplete. If you used tools, your response MUST contain at least one [N].`,
+  chatModeAddendum: `MANDATORY: Every fact in your response that came from a tool result MUST have a [N] citation at the end of the sentence. Do not skip citations — a response without [N] markers is considered incomplete. If you used tools, your response MUST contain at least one [N]. When citing, prefer the [Source N] number from fetch_content results over search results — fetch_content gives the specific article URL, search gives the homepage.`,
   searchModeAddendum: `Before responding, verify EACH link you plan to show:
 - Did you fetch the page and find substantive content (an article, product page, or detailed guide)?
 - If the fetched content is just a navigation menu, list of links, or generic landing page, REMOVE that link and search for a better one.
@@ -30,11 +34,12 @@ NEVER link to review-site aggregates (pcmag.com/picks, cnet.com/best, wirecutter
 2. If fewer than 5, go back through your text and add [N] after every fact that came from a tool result
 3. Every paragraph MUST have at least one [N] citation
 4. Use a different number for each distinct source — [1], [2], [3], etc.
+5. Use [Source N] numbers from fetch_content results, not from search results — fetch_content sources point to specific article URLs.
 Do NOT submit a response with zero citations — this is a hard requirement.`,
   citationReinforcementEnabled: 1,
-  citationReinforcementPrompt: `\n\n<citation-format>\nWhen writing your response, place [N] after each fact from a tool result.\nN = the source number shown in the tool result as [Source N].\nEvery paragraph must contain at least one [N] reference.\n</citation-format>`,
-  nudgeFinalStep: `Respond now with the information gathered. Every fact from a tool result must have [N] at the end of its sentence, where N matches the source number.`,
-  nudgePreventive: `Synthesize your tool results and respond now. Remember: cite every fact with [N] at end of sentence.`,
+  citationReinforcementPrompt: `\n\n<citation-format>\nWhen writing your response, place [N] after each fact from a tool result.\nN = the source number shown in the tool result as [Source N].\nEvery paragraph must contain at least one [N] reference.\nPriority: use [Source N] from fetch_content results — they point to specific article URLs. Search result source numbers refer to homepages and should not be cited.\n</citation-format>`,
+  nudgeFinalStep: `Respond now with the information gathered. Every fact from a tool result must have [N] at the end of its sentence, where N matches the source number. Use the [Source N] from fetch_content results, not from search results.`,
+  nudgePreventive: `Synthesize your tool results and respond now. Remember: cite every fact with [N] at end of sentence. Use the [Source N] from fetch_content results, not from search results.`,
   nudgeRetry: `Respond now with the information gathered. Add [N] citations after every sourced fact. No more tools.`,
   nudgeSearchFinalStep: `Respond now with link preview widgets. Use <widget:link-preview url="https://full-url-here" /> for each result. No duplicate URLs. No homepages.`,
   nudgeSearchPreventive: `You have enough results. Respond with <widget:link-preview url="https://..." /> widgets now.`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches chat rendering for citations/widgets and popover positioning; regressions could affect message formatting or citation UX, but changes are scoped and covered by added tests.
> 
> **Overview**
> Fixes chat rendering when **`[N]` citations appear alongside `<widget:link-preview>` tags** by processing citations per text segment (with a new `startKey` offset) and then rendering interleaved text+widget parts instead of collapsing all text into one markdown block.
> 
> Updates the citation popover anchoring to track the triggering `HTMLElement` (not a one-time `DOMRect`), positioning a fixed anchor span via `getBoundingClientRect()` and closing on scroll to avoid stale placement during streaming/scrolling.
> 
> Adds targeted tests to ensure `parseContentParts` and `deduplicateLinkPreviews` preserve widget order/presence with citation-like `[N]` patterns, and updates the Mistral model profile prompts to **prefer `fetch_content` source numbers** over search results for citations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 639431e277d603582f30151195571ab2d72fc5f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses several bugs related to the rendering and parsing of link previews and citations within chat messages. It refactors how text and widget content are processed and displayed, ensuring that citations and link previews coexist correctly and that citation popovers are positioned reliably.

#### Key Changes
- Enhanced `parseContentParts` and `deduplicateLinkPreviews` to correctly handle and preserve both text with `[N]` citations and widget parts, maintaining their order.
- Modified citation popover logic to anchor to an `HTMLElement` instead of a `DOMRect`, improving popover positioning and adding scroll-aware closing.
- Refactored `buildSourceCitationPlaceholders` to support `startKey` offsets and process multiple text segments independently, merging citations across parts.
- Updated `TextPart` component to iterate and render processed text and widget parts separately, fixing issues where link previews and citations were not displayed together.
- Adjusted AI model prompts in `mistral.ts` to prioritize citing `fetch_content` source numbers over `search` source numbers for more accurate article references.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 208 (80.6%)   |
| Churn       | 5 (1.9%)      |
| Rework      | 45 (17.4%)    |
| Total Changes | 258         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>