### PR TITLE
Simplify DAL: remove mapModel and introduce DrizzleQueryWithPromise type

### DIFF
--- a/src/automations/automation-form-modal.tsx
+++ b/src/automations/automation-form-modal.tsx
@@ -70,7 +70,7 @@ export default function AutomationFormModal({
     query: toCompilableQuery(getSelectedModelQuery(db)),
   })
 
-  const selectedModel = selectedModelRows[0]
+  const selectedModel = selectedModelRows?.[0]
 
   const { isTriggersEnabled } = useSettings({
     is_triggers_enabled: false,

--- a/src/automations/automation-form-modal.tsx
+++ b/src/automations/automation-form-modal.tsx
@@ -19,7 +19,6 @@ import {
   getAllTriggersForPrompt,
   getAvailableModels,
   getSelectedModelQuery,
-  mapModel,
   updateAutomation,
 } from '@/dal'
 import { useSettings } from '@/hooks/use-settings'
@@ -61,19 +60,17 @@ export default function AutomationFormModal({
 }: AutomationFormModalProps) {
   const db = useDatabase()
 
-  const { data = [] } = useQuery({
+  const { data: models = [] } = useQuery({
     queryKey: ['models', 'availableModels'],
     query: toCompilableQuery(getAvailableModels(db)),
   })
-
-  const models = useMemo(() => data.map(mapModel), [data])
 
   const { data: selectedModelRows = [] } = useQuery({
     queryKey: ['models', 'selectedModel'],
     query: toCompilableQuery(getSelectedModelQuery(db)),
   })
 
-  const selectedModel = selectedModelRows[0] ? mapModel(selectedModelRows[0]) : undefined
+  const selectedModel = useMemo(() => selectedModelRows[0], [selectedModelRows])
 
   const { isTriggersEnabled } = useSettings({
     is_triggers_enabled: false,

--- a/src/automations/automation-form-modal.tsx
+++ b/src/automations/automation-form-modal.tsx
@@ -30,7 +30,7 @@ import { useMutation } from '@tanstack/react-query'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { eq } from 'drizzle-orm'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { v7 as uuidv7 } from 'uuid'
 import { z } from 'zod'
@@ -70,7 +70,7 @@ export default function AutomationFormModal({
     query: toCompilableQuery(getSelectedModelQuery(db)),
   })
 
-  const selectedModel = useMemo(() => selectedModelRows[0], [selectedModelRows])
+  const selectedModel = selectedModelRows[0]
 
   const { isTriggersEnabled } = useSettings({
     is_triggers_enabled: false,

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -15,7 +15,7 @@ import { getOrCreateChatThread, updateChatThread } from '@/dal/chat-threads'
 import { useMCP } from '@/lib/mcp-provider'
 import { generateTitle } from '@/lib/title-generator'
 import { convertDbChatMessageToUIMessage } from '@/lib/utils'
-import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
+import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useChatStore } from './chat-store'
@@ -101,7 +101,7 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
 
       setMcpClients(mcpClients)
       setModes(modes)
-      setModels(models as Model[])
+      setModels(models)
 
       setIsReady(true)
 
@@ -150,7 +150,7 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
 
     setMcpClients(mcpClients)
     setModes(modes)
-    setModels(models as Model[])
+    setModels(models)
 
     setIsReady(true)
   }

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -9,14 +9,13 @@ import {
   getSettings,
   getTriggerPromptForThread,
   isChatThreadDeleted,
-  mapModel,
   saveMessagesWithContextUpdate,
 } from '@/dal'
 import { getOrCreateChatThread, updateChatThread } from '@/dal/chat-threads'
 import { useMCP } from '@/lib/mcp-provider'
 import { generateTitle } from '@/lib/title-generator'
 import { convertDbChatMessageToUIMessage } from '@/lib/utils'
-import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
+import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useChatStore } from './chat-store'
@@ -102,7 +101,7 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
 
       setMcpClients(mcpClients)
       setModes(modes)
-      setModels(models.map(mapModel))
+      setModels(models as Model[])
 
       setIsReady(true)
 
@@ -151,7 +150,7 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
 
     setMcpClients(mcpClients)
     setModes(modes)
-    setModels(models.map(mapModel))
+    setModels(models as Model[])
 
     setIsReady(true)
   }

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -4,6 +4,7 @@ import { chatMessagesTable, chatThreadsTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
 import { type ChatThread, type Model } from '@/types'
 import { getModel } from './models'
+import type { DrizzleQueryWithPromise } from '@/types'
 
 /**
  * Checks if a chat thread ID exists as a soft-deleted record.
@@ -27,8 +28,7 @@ export const getAllChatThreads = (db: AnyDrizzleDatabase) => {
     .from(chatThreadsTable)
     .where(isNull(chatThreadsTable.deletedAt))
     .orderBy(desc(chatThreadsTable.id))
-
-  return query as typeof query & { execute: () => Promise<ChatThread[]> }
+  return query as typeof query & DrizzleQueryWithPromise<ChatThread>
 }
 
 /**
@@ -106,10 +106,11 @@ export const getOrCreateChatThread = async (
  * @returns The context size in tokens, or null if not found/not known
  */
 export const getContextSizeForThread = (db: AnyDrizzleDatabase, threadId: string) => {
-  return db
+  const query = db
     .select({ contextSize: chatThreadsTable.contextSize })
     .from(chatThreadsTable)
     .where(and(eq(chatThreadsTable.id, threadId), isNull(chatThreadsTable.deletedAt)))
+  return query as typeof query & DrizzleQueryWithPromise<{ contextSize: number | null }>
 }
 
 /**

--- a/src/dal/devices.ts
+++ b/src/dal/devices.ts
@@ -1,6 +1,7 @@
 import { desc, eq } from 'drizzle-orm'
 import type { AnyDrizzleDatabase } from '@/db/database-interface'
 import { devicesTable } from '@/db/tables'
+import type { DrizzleQueryWithPromise } from '@/types'
 
 export type Device = {
   id: string
@@ -15,7 +16,8 @@ export type Device = {
  * Gets a single device by id from the local DB (synced via PowerSync).
  */
 export const getDevice = (db: AnyDrizzleDatabase, deviceId: string) => {
-  return db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+  const query = db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+  return query as typeof query & DrizzleQueryWithPromise<Device>
 }
 
 /**
@@ -23,6 +25,5 @@ export const getDevice = (db: AnyDrizzleDatabase, deviceId: string) => {
  */
 export const getAllDevices = (db: AnyDrizzleDatabase) => {
   const query = db.select().from(devicesTable).orderBy(desc(devicesTable.lastSeen))
-
-  return query as typeof query & { execute: () => Promise<Device[]> }
+  return query as typeof query & DrizzleQueryWithPromise<Device>
 }

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -12,7 +12,6 @@ export {
   getSystemModel,
   resetModelToDefault,
   updateModel,
-  mapModel,
 } from './models'
 
 // Settings

--- a/src/dal/mcp-servers.ts
+++ b/src/dal/mcp-servers.ts
@@ -3,14 +3,14 @@ import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { mcpServersTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
 import { type McpServer } from '@/types'
+import type { DrizzleQueryWithPromise } from '@/types'
 
 /**
  * Gets all MCP servers from the database (excluding soft-deleted)
  */
 export const getAllMcpServers = (db: AnyDrizzleDatabase) => {
   const query = db.select().from(mcpServersTable).where(isNull(mcpServersTable.deletedAt))
-
-  return query as typeof query & { execute: () => Promise<McpServer[]> }
+  return query as typeof query & DrizzleQueryWithPromise<McpServer>
 }
 
 /**
@@ -21,8 +21,7 @@ export const getHttpMcpServers = (db: AnyDrizzleDatabase) => {
     .select()
     .from(mcpServersTable)
     .where(and(eq(mcpServersTable.type, 'http'), isNotNull(mcpServersTable.url), isNull(mcpServersTable.deletedAt)))
-
-  return query as typeof query & { execute: () => Promise<McpServer[]> }
+  return query as typeof query & DrizzleQueryWithPromise<McpServer>
 }
 
 /**

--- a/src/dal/models.test.ts
+++ b/src/dal/models.test.ts
@@ -11,6 +11,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import { defaultModelGptOss120b } from '@/defaults/models'
+import type { Model } from '@/types'
 import {
   createModel,
   deleteModel,
@@ -21,7 +22,6 @@ import {
   getSelectedModel,
   getSelectedModelQuery,
   getSystemModel,
-  mapModel,
   updateModel,
 } from './models'
 import { getAllPrompts, getPrompt } from './prompts'
@@ -205,7 +205,7 @@ describe('Models DAL', () => {
 
       const asyncResult = await getSelectedModel(getDb())
       const queryResult = await getSelectedModelQuery(getDb()).all()
-      const queryModel = queryResult[0] ? mapModel(queryResult[0]) : undefined
+      const queryModel = queryResult[0] ? (queryResult[0] as Model) : undefined
 
       expect(queryModel?.id).toBe(asyncResult.id)
       expect(queryModel?.name).toBe(asyncResult.name)
@@ -237,7 +237,7 @@ describe('Models DAL', () => {
       await updateSettings(getDb(), { selected_model: disabledModelId })
 
       const queryResult = await getSelectedModelQuery(getDb()).all()
-      const queryModel = queryResult[0] ? mapModel(queryResult[0]) : undefined
+      const queryModel = queryResult[0] ? (queryResult[0] as Model) : undefined
 
       expect(queryModel?.id).toBe(systemModelId)
       expect(queryModel?.name).toBe('System Model')

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -2,10 +2,9 @@ import { and, desc, eq, getTableColumns, isNotNull, isNull, or, sql } from 'driz
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { modelsTable, settingsTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
-import type { Model } from '../types'
+import type { DrizzleQueryWithPromise, Model } from '@/types'
 import { getLastMessage } from './chat-messages'
 import { createDefaultModelProfile, deleteModelProfileForModel } from './model-profiles'
-import type { DrizzleQueryWithPromise } from '@/types'
 
 /**
  * Gets all models from the database (excluding soft-deleted)

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -5,6 +5,7 @@ import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { Model } from '../types'
 import { getLastMessage } from './chat-messages'
 import { createDefaultModelProfile, deleteModelProfileForModel } from './model-profiles'
+import type { DrizzleQueryWithPromise } from '@/types'
 
 /**
  * Gets all models from the database (excluding soft-deleted)
@@ -17,7 +18,7 @@ export const getAllModels = (db: AnyDrizzleDatabase) => {
     .where(isNull(modelsTable.deletedAt))
     .orderBy(desc(modelsTable.isSystem), modelsTable.name)
 
-  return query as typeof query & { execute: () => Promise<Model[]> }
+  return query as typeof query & DrizzleQueryWithPromise<Model>
 }
 
 /**
@@ -31,7 +32,7 @@ export const getAvailableModels = (db: AnyDrizzleDatabase) => {
     .where(and(eq(modelsTable.enabled, 1), isNull(modelsTable.deletedAt)))
     .orderBy(desc(modelsTable.isSystem), modelsTable.name)
 
-  return query as typeof query & { execute: () => Promise<Model[]> }
+  return query as typeof query & DrizzleQueryWithPromise<Model>
 }
 
 export const getModelQuery = (db: AnyDrizzleDatabase, id: string) => {
@@ -40,7 +41,7 @@ export const getModelQuery = (db: AnyDrizzleDatabase, id: string) => {
     .from(modelsTable)
     .where(and(eq(modelsTable.id, id), isNull(modelsTable.deletedAt)))
 
-  return query as typeof query & { execute: () => Promise<Model[]> }
+  return query as typeof query & DrizzleQueryWithPromise<Model>
 }
 
 /**
@@ -60,7 +61,7 @@ export const getSelectedModelQuery = (db: AnyDrizzleDatabase) => {
     .orderBy(sql`CASE WHEN ${settingsTable.value} IS NOT NULL THEN 0 ELSE 1 END`, modelsTable.name)
     .limit(1)
 
-  return query as typeof query & { execute: () => Promise<Model[]> }
+  return query as typeof query & DrizzleQueryWithPromise<Model>
 }
 
 /**

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -2,28 +2,22 @@ import { and, desc, eq, getTableColumns, isNotNull, isNull, or, sql } from 'driz
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { modelsTable, settingsTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
-import type { Model, ModelRow } from '../types'
+import type { Model } from '../types'
 import { getLastMessage } from './chat-messages'
 import { createDefaultModelProfile, deleteModelProfileForModel } from './model-profiles'
-
-export const mapModel = (row: ModelRow): Model => {
-  return {
-    ...row,
-    api_key: row.apiKey ?? undefined,
-    is_system: row.isSystem ?? undefined,
-  } as Model
-}
 
 /**
  * Gets all models from the database (excluding soft-deleted)
  * Sorted with system models first, then alphabetically by name
  */
 export const getAllModels = (db: AnyDrizzleDatabase) => {
-  return db
+  const query = db
     .select()
     .from(modelsTable)
     .where(isNull(modelsTable.deletedAt))
     .orderBy(desc(modelsTable.isSystem), modelsTable.name)
+
+  return query as typeof query & { execute: () => Promise<Model[]> }
 }
 
 /**
@@ -31,18 +25,22 @@ export const getAllModels = (db: AnyDrizzleDatabase) => {
  * Sorted with system models first, then alphabetically by name
  */
 export const getAvailableModels = (db: AnyDrizzleDatabase) => {
-  return db
+  const query = db
     .select()
     .from(modelsTable)
     .where(and(eq(modelsTable.enabled, 1), isNull(modelsTable.deletedAt)))
     .orderBy(desc(modelsTable.isSystem), modelsTable.name)
+
+  return query as typeof query & { execute: () => Promise<Model[]> }
 }
 
 export const getModelQuery = (db: AnyDrizzleDatabase, id: string) => {
-  return db
+  const query = db
     .select()
     .from(modelsTable)
     .where(and(eq(modelsTable.id, id), isNull(modelsTable.deletedAt)))
+
+  return query as typeof query & { execute: () => Promise<Model[]> }
 }
 
 /**
@@ -50,8 +48,8 @@ export const getModelQuery = (db: AnyDrizzleDatabase, id: string) => {
  * Use with PowerSync's toCompilableQuery, or await the result to execute.
  * Returns the selected model if it exists and is enabled; otherwise the system model.
  */
-export const getSelectedModelQuery = (db: AnyDrizzleDatabase) =>
-  db
+export const getSelectedModelQuery = (db: AnyDrizzleDatabase) => {
+  const query = db
     .select(getTableColumns(modelsTable))
     .from(modelsTable)
     .leftJoin(
@@ -62,12 +60,15 @@ export const getSelectedModelQuery = (db: AnyDrizzleDatabase) =>
     .orderBy(sql`CASE WHEN ${settingsTable.value} IS NOT NULL THEN 0 ELSE 1 END`, modelsTable.name)
     .limit(1)
 
+  return query as typeof query & { execute: () => Promise<Model[]> }
+}
+
 /**
  * Gets a specific model by ID (excluding soft-deleted)
  */
 export const getModel = async (db: AnyDrizzleDatabase, id: string): Promise<Model | null> => {
   const model = await getModelQuery(db, id).get()
-  return model ? mapModel(model) : null
+  return model ? (model as Model) : null
 }
 
 export const getSystemModel = async (db: AnyDrizzleDatabase): Promise<Model | null> => {
@@ -77,7 +78,7 @@ export const getSystemModel = async (db: AnyDrizzleDatabase): Promise<Model | nu
     .where(and(eq(modelsTable.isSystem, 1), isNull(modelsTable.deletedAt)))
     .orderBy(modelsTable.name)
     .get()
-  return systemModel ? mapModel(systemModel) : null
+  return systemModel ? (systemModel as Model) : null
 }
 
 /**
@@ -90,7 +91,7 @@ export const getSelectedModel = async (db: AnyDrizzleDatabase): Promise<Model> =
   if (!row) {
     throw new Error('No system model found')
   }
-  return mapModel(row)
+  return row as Model
 }
 
 /**

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -7,6 +7,7 @@ import { clearNullableColumns, convertUIMessageToDbChatMessage, nowIso } from '.
 import { getModel } from './models'
 import { createChatThread } from './chat-threads'
 import { deleteTriggersForPrompt, deleteTriggersForPrompts } from './triggers'
+import type { DrizzleQueryWithPromise } from '@/types'
 
 /**
  * Returns a Drizzle query for all prompts, optionally filtered by search query (excluding soft-deleted).
@@ -24,7 +25,7 @@ export const getAllPrompts = (db: AnyDrizzleDatabase, searchQuery?: string) => {
     .orderBy(asc(promptsTable.id))
     .limit(50)
 
-  return query as typeof query & { execute: () => Promise<Prompt[]> }
+  return query as typeof query & DrizzleQueryWithPromise<Prompt>
 }
 
 /**

--- a/src/dal/settings.ts
+++ b/src/dal/settings.ts
@@ -5,8 +5,7 @@ import { settingsTable } from '../db/tables'
 import { hashSetting } from '../defaults/settings'
 import { serializeValue } from '../lib/serialization'
 import { camelCased, hashValues } from '../lib/utils'
-import type { Setting } from '../types'
-import type { DrizzleQueryWithPromise } from '@/types'
+import type { DrizzleQueryWithPromise, Setting } from '@/types'
 
 /**
  * Gets all settings from the database

--- a/src/dal/settings.ts
+++ b/src/dal/settings.ts
@@ -6,6 +6,7 @@ import { hashSetting } from '../defaults/settings'
 import { serializeValue } from '../lib/serialization'
 import { camelCased, hashValues } from '../lib/utils'
 import type { Setting } from '../types'
+import type { DrizzleQueryWithPromise } from '@/types'
 
 /**
  * Gets all settings from the database
@@ -29,11 +30,13 @@ type SettingSchema = Record<
  * When keys is empty, uses sql`1=0` instead of inArray -- inArray(column, [])
  * produces invalid SQL (WHERE col IN ()) in SQLite.
  */
-export const getSettingsRecords = (db: AnyDrizzleDatabase, keys: string[]) =>
-  db
+export const getSettingsRecords = (db: AnyDrizzleDatabase, keys: string[]) => {
+  const query = db
     .select()
     .from(settingsTable)
     .where(keys.length > 0 ? inArray(settingsTable.key, keys) : sql`1=0`)
+  return query as typeof query & DrizzleQueryWithPromise<Setting>
+}
 
 /**
  * Helper type to convert snake_case to camelCase

--- a/src/dal/tasks.ts
+++ b/src/dal/tasks.ts
@@ -3,6 +3,7 @@ import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { tasksTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { Task } from '../types'
+import type { DrizzleQueryWithPromise } from '@/types'
 
 /**
  * Gets all tasks (excluding soft-deleted)
@@ -17,8 +18,8 @@ const itemNotEmpty = and(isNotNull(tasksTable.item), sql`trim(${tasksTable.item}
  * Returns a Drizzle query for incomplete tasks, optionally filtered by search query (excluding soft-deleted).
  * Use with PowerSync's toCompilableQuery, or await the result to execute.
  */
-export const getIncompleteTasks = (db: AnyDrizzleDatabase, searchQuery?: string) =>
-  db
+export const getIncompleteTasks = (db: AnyDrizzleDatabase, searchQuery?: string) => {
+  const query = db
     .select()
     .from(tasksTable)
     .where(
@@ -33,16 +34,20 @@ export const getIncompleteTasks = (db: AnyDrizzleDatabase, searchQuery?: string)
     )
     .orderBy(asc(tasksTable.order), desc(tasksTable.id))
     .limit(50)
+  return query as typeof query & DrizzleQueryWithPromise<Task>
+}
 
 /**
  * Returns a Drizzle query for the count of incomplete tasks (excluding soft-deleted).
  * Use with PowerSync's toCompilableQuery, or await the result to execute.
  */
-export const getIncompleteTasksCount = (db: AnyDrizzleDatabase) =>
-  db
+export const getIncompleteTasksCount = (db: AnyDrizzleDatabase) => {
+  const query = db
     .select({ count: sql<number>`count(*)` })
     .from(tasksTable)
     .where(and(eq(tasksTable.isComplete, 0), isNull(tasksTable.deletedAt), itemNotEmpty))
+  return query as typeof query & DrizzleQueryWithPromise<{ count: number }>
+}
 
 /**
  * Update a task (preserves defaultHash for modification tracking)

--- a/src/dal/triggers.ts
+++ b/src/dal/triggers.ts
@@ -3,6 +3,7 @@ import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { triggersTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { Trigger } from '../types'
+import type { DrizzleQueryWithPromise } from '@/types'
 
 /**
  * Returns a Drizzle query for all triggers for a prompt (excluding soft-deleted).
@@ -13,7 +14,7 @@ export const getAllTriggersForPrompt = (db: AnyDrizzleDatabase, promptId: string
     .select()
     .from(triggersTable)
     .where(and(eq(triggersTable.promptId, promptId), isNull(triggersTable.deletedAt)))
-  return query as typeof query & { execute: () => Promise<Trigger[]> }
+  return query as typeof query & DrizzleQueryWithPromise<Trigger>
 }
 
 /**

--- a/src/settings/models/detail.tsx
+++ b/src/settings/models/detail.tsx
@@ -22,7 +22,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { useDatabase } from '@/contexts'
-import { deleteModel, updateModel, getModelQuery, mapModel } from '@/dal'
+import { deleteModel, updateModel, getModelQuery } from '@/dal'
 import type { Model } from '@/types'
 import { Trash2 } from 'lucide-react'
 
@@ -74,7 +74,7 @@ export default function ModelDetailPage() {
     enabled: !!modelId,
   })
 
-  const model = useMemo(() => data.map(mapModel)[0], [data])
+  const model = useMemo(() => data[0], [data])
 
   const updateModelMutation = useMutation({
     mutationFn: async (model: Partial<Model> & { id: string }) => {

--- a/src/settings/models/detail.tsx
+++ b/src/settings/models/detail.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation } from '@tanstack/react-query'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useParams } from 'react-router'
 import { z } from 'zod'
@@ -74,7 +74,7 @@ export default function ModelDetailPage() {
     enabled: !!modelId,
   })
 
-  const model = useMemo(() => data[0], [data])
+  const model = data[0]
 
   const updateModelMutation = useMutation({
     mutationFn: async (model: Partial<Model> & { id: string }) => {

--- a/src/settings/models/detail.tsx
+++ b/src/settings/models/detail.tsx
@@ -74,7 +74,7 @@ export default function ModelDetailPage() {
     enabled: !!modelId,
   })
 
-  const model = data[0]
+  const model = data?.[0]
 
   const updateModelMutation = useMutation({
     mutationFn: async (model: Partial<Model> & { id: string }) => {

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -20,14 +20,7 @@ import { StatusCard } from '@/components/ui/status-card'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useDatabase } from '@/contexts'
-import {
-  createModel as createModelDAL,
-  deleteModel,
-  getAllModels,
-  mapModel,
-  resetModelToDefault,
-  updateModel,
-} from '@/dal'
+import { createModel as createModelDAL, deleteModel, getAllModels, resetModelToDefault, updateModel } from '@/dal'
 import { defaultModels } from '@/defaults/models'
 import { isModelModified } from '@/defaults/utils'
 import { fetch } from '@/lib/fetch'
@@ -248,12 +241,10 @@ export default function ModelsPage() {
     }
   }, [isAddDialogOpen])
 
-  const { data = [] } = useQuery({
+  const { data: models = [] } = useQuery({
     queryKey: ['models'],
     query: toCompilableQuery(getAllModels(db)),
   })
-
-  const models = useMemo(() => data.map(mapModel), [data])
 
   const toggleModelMutation = useMutation({
     mutationFn: async ({ id, enabled }: { id: string; enabled: boolean }) => {

--- a/src/settings/models/layout.tsx
+++ b/src/settings/models/layout.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Plus } from 'lucide-react'
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import { Outlet, useNavigate, useParams } from 'react-router'
 import { useDatabase } from '@/contexts'
-import { getAllModels, mapModel } from '@/dal'
+import { getAllModels } from '@/dal'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
 
@@ -13,12 +13,10 @@ export default function ModelsLayout() {
   const navigate = useNavigate()
   const { modelId } = useParams()
 
-  const { data = [] } = useQuery({
+  const { data: models = [] } = useQuery({
     queryKey: ['models'],
     query: toCompilableQuery(getAllModels(db)),
   })
-
-  const models = useMemo(() => data.map(mapModel), [data])
 
   // Find the currently selected model
   const currentModel = models.find((model) => model.id === modelId)

--- a/src/tasks/index.tsx
+++ b/src/tasks/index.tsx
@@ -34,7 +34,6 @@ import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { CheckCircle2, GripVertical, Plus, Square } from 'lucide-react'
 import { type KeyboardEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { v7 as uuidv7 } from 'uuid'
-import { type CompilableQuery } from '@powersync/web'
 
 // Task Item Component - Memoized for performance
 type TaskItemProps = {
@@ -279,7 +278,7 @@ export default function TasksPage() {
     isPlaceholderData,
   } = useQuery({
     queryKey: ['tasks', debouncedSearchQuery],
-    query: toCompilableQuery(getIncompleteTasks(db, debouncedSearchQuery)) as CompilableQuery<Task>,
+    query: toCompilableQuery(getIncompleteTasks(db, debouncedSearchQuery)),
     placeholderData: (previousData) => previousData,
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { TrayIcon } from '@tauri-apps/api/tray'
 import type { SourceMetadata } from './types/source'
 import type { Window } from '@tauri-apps/api/window'
 import type { UIDataTypes, UIMessage, UITools } from 'ai'
+import type { DrizzleQuery } from '@powersync/drizzle-driver'
 import type { InferSelectModel } from 'drizzle-orm'
 import { type PostHog } from 'posthog-js'
 import type { z } from 'zod'
@@ -75,6 +76,12 @@ export type McpServer = WithRequired<McpServerRow, 'name' | 'type' | 'enabled'>
 export type Prompt = WithRequired<PromptRow, 'prompt' | 'modelId'>
 export type Trigger = WithRequired<TriggerRow, 'triggerType' | 'isEnabled' | 'promptId'>
 export type ModelProfile = WithRequired<ModelProfileRow, 'modelId'>
+
+/**
+ * Query usable with PowerSync's toCompilableQuery and direct await.
+ * When awaited, resolves to T[] without manual cast.
+ */
+export type DrizzleQueryWithPromise<T> = DrizzleQuery<T> & PromiseLike<T[]>
 
 export type AutomationRun = {
   prompt: Prompt | null


### PR DESCRIPTION
## Summary

- Remove `mapModel` function and use Drizzle rows as the `Model` type directly across components (automation form, chat hydration, model settings)
- Introduce `DrizzleQueryWithPromise<T>` type in `src/types.ts` for consistent, awaitable Drizzle query returns
- Update DAL functions (models, tasks, settings, prompts, triggers, devices, chat threads, MCP servers) to return `DrizzleQueryWithPromise<T>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple DAL query helpers and all call sites that consume model rows, so type/shape mismatches could surface at runtime if any code relied on `mapModel` field normalization. Changes are mostly typing/casting and should be low behavioral risk if DB rows already match the `Model` shape.
> 
> **Overview**
> Simplifies model handling by removing `mapModel` and treating Drizzle `modelsTable` rows as the app `Model` type throughout the UI (automation modal, chat store hydration, and model settings pages).
> 
> Introduces a shared `DrizzleQueryWithPromise<T>` type and updates many DAL query builders (models, tasks, settings, prompts, triggers, devices, chat threads, MCP servers) to return this awaitable query type, reducing repeated `execute()` casting and tightening PowerSync `toCompilableQuery` usage (e.g., tasks list no longer needs a manual `CompilableQuery` cast).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b596ff54787a68298a1f0fe12841f18c804b36d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR simplifies the Data Access Layer (DAL) by removing the `mapModel` utility function and introducing a new `DrizzleQueryWithPromise` type. These changes aim to streamline data handling, reduce boilerplate, and enhance type safety for Drizzle queries.

#### Key Changes
- The `mapModel` function and its imports have been removed from various components and DAL files, indicating that Drizzle's `ModelRow` type is now directly compatible with the `Model` type.
- A new `DrizzleQueryWithPromise<T>` type was introduced in `src/types.ts` to allow Drizzle queries to be directly awaited and provide better type inference for their results.
- Numerous Drizzle query functions across the DAL (e.g., `chat-threads.ts`, `models.ts`, `tasks.ts`) have been updated to utilize and return the new `DrizzleQueryWithPromise` type, improving consistency and developer experience.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 31 (30.7%)    |
| Churn       | 30 (29.7%)    |
| Rework      | 40 (39.6%)    |
| Total Changes | 101         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>