### PR TITLE
⚡ THU-334: Fix mobile scrolling whitespace below chat input

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -162,6 +162,12 @@ body {
     height: 100%;
     overflow: hidden;
   }
+
+  #root {
+    position: fixed;
+    inset: 0;
+    height: auto;
+  }
 }
 
 /* Subtle table borders for markdown content */


### PR DESCRIPTION
## Summary
- On mobile web, scrolling up created whitespace between the bottom of the browser and the chat input area
- Root cause: `#root` uses `height: 100svh` which is the "small viewport height" (with address bar visible). When the address bar auto-hides, the viewport grows taller than `100svh`, creating a gap
- Fix: add `position: fixed; inset: 0; height: auto` to `#root` on mobile (≤768px), pinning it to the viewport edges so the browser can't create a gap. `height: auto` overrides the base `100svh` so `inset: 0` determines the height

## Linear
[THU-334](https://linear.app/mozilla-thunderbolt/issue/THU-334/scrolling-up-causes-whitespace-between-the-bottom-of-browser-and-chat)

## Previous Attempt
PR #438 was closed because it didn't override `height: 100svh`, causing CSS to ignore `bottom` from `inset: 0`. This PR adds `height: auto` to resolve that conflict.

## Test Plan
- [ ] Mobile Safari: pull up from bottom of chat — no whitespace appears
- [ ] Mobile Chrome: same test — no whitespace
- [ ] Desktop: layout unchanged, no regressions
- [ ] Mobile: keyboard open/close behavior unaffected

## Changes
- `src/index.css` — Added `position: fixed; inset: 0; height: auto` to `#root` within mobile media query

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, CSS-only change scoped to the mobile media query; potential risk is unintended layout/positioning side effects on small screens due to `#root` becoming `position: fixed`.
> 
> **Overview**
> Fixes mobile scrolling whitespace under the chat input by changing `#root` styles for screens ≤768px to be `position: fixed` with `inset: 0`, and overriding the base `height: 100svh` with `height: auto` so the app always fills the visible viewport as the browser chrome shows/hides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c94abfb01674ef998b6b55632469b8ff9d3a13fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a mobile display issue where unwanted whitespace appeared below the chat input. The fix ensures the main application container (`#root`) correctly fills the viewport on mobile devices.

#### Key Changes
- Modified `src/index.css` to apply new CSS rules for the `#root` element within a media query for `body`.
- Added `position: fixed`, `inset: 0`, and `height: auto` to `#root` to resolve the mobile scrolling whitespace.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 6 (100.0%)    |
| Total Changes | 6             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>