### PR TITLE
fix: PowerSync sync not connecting on page refresh

### DIFF
--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -1,5 +1,4 @@
 import { getSettings } from '@/dal'
-import { getDb } from '@/db/database'
 import { defaultSettingCloudUrl } from '@/defaults/settings'
 import type { AbstractPowerSyncDatabase } from '@powersync/common'
 import { PowerSyncDatabase, SyncStreamConnectionMethod, WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web'
@@ -180,7 +179,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
    * Call this when user enables sync.
    */
   async connectToSync(): Promise<void> {
-    if (!this.powerSync) {
+    if (!this.powerSync || !this._db) {
       return
     }
 
@@ -189,8 +188,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
     }
 
     try {
-      const db = getDb()
-      const { cloudUrl } = await getSettings(db, { cloud_url: defaultSettingCloudUrl.value })
+      const { cloudUrl } = await getSettings(this._db, { cloud_url: defaultSettingCloudUrl.value })
       const connector = new ThunderboltConnector(cloudUrl ?? defaultSettingCloudUrl.value)
       // Use HTTP streaming to avoid WebSocket "invalid opcode 7" with self-hosted service (ws library).
       await this.powerSync.connect(connector, {


### PR DESCRIPTION
## Summary

- **Fixes sync showing "Offline" after page refresh** even though the sync toggle shows enabled
- Root cause: `connectToSync()` called `getDb()` during `PowerSyncDatabaseImpl.initialize()`, but `setDatabase()` hadn't been called yet — the module-level singleton wasn't registered, so the call threw silently and the connection never established
- Fix: use `this._db` (already set on the instance before `connectToSync()` is called) instead of going through the module-level `getDb()` accessor
- Regression from #426 (DI refactor)

## Test plan

- [ ] Enable sync, refresh the page — status indicator should show "Connected" (not "Offline")
- [ ] Disable sync, refresh — should stay disabled
- [ ] Toggle sync off and back on without refresh — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change limited to PowerSync sync initialization logic; main risk is missing sync connection if `_db` is unexpectedly null, but it now guards against that explicitly.
> 
> **Overview**
> Fixes PowerSync sync failing to reconnect after a page refresh by removing the `getDb()` singleton dependency in `connectToSync()` and instead reading settings via the instance’s initialized `this._db`.
> 
> Also adds an early-return guard when either `powerSync` or `_db` is not available, preventing silent failures during initialization ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f16a7916180445e5eebb5f638bcdaa443cdf7615. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a bug where PowerSync synchronization failed to connect upon page refresh. The fix ensures that the internal database instance is properly initialized and used when attempting to establish a sync connection.

#### Key Changes
- Removed the redundant `getDb()` import and usage, relying instead on the class's internal `_db` instance.
- Added a check for `!this._db` in the `connectToSync` method to ensure the database is initialized before attempting to connect.
- Updated the `getSettings` call to directly use `this._db` for retrieving cloud settings.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Churn       | 2 (50.0%)     |
| Rework      | 2 (50.0%)     |
| Total Changes | 4             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>