### PR TITLE
THU-351: Automation text cannot scroll with mouse wheel (only by dragging/arrow keys)

### DIFF
--- a/src/automations/automation-form-modal.tsx
+++ b/src/automations/automation-form-modal.tsx
@@ -3,8 +3,8 @@ import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { PromptInput } from '@/components/ui/prompt-input'
+import { Dialog } from '@/components/ui/dialog'
 import {
-  ResponsiveModal,
   ResponsiveModalContentComposable,
   ResponsiveModalHeader,
   ResponsiveModalTitle,
@@ -283,7 +283,7 @@ export default function AutomationFormModal({
   const isLoading = createPromptMutation.isPending || updatePromptMutation.isPending
 
   return (
-    <ResponsiveModal open={isOpen} onOpenChange={onOpenChange}>
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <ResponsiveModalContentComposable className="sm:max-w-[600px] p-0">
         <ResponsiveModalHeader className="px-6 pt-6">
           <ResponsiveModalTitle>{prompt ? 'Edit Automation' : 'Create Automation'}</ResponsiveModalTitle>
@@ -394,6 +394,6 @@ export default function AutomationFormModal({
           </form>
         </Form>
       </ResponsiveModalContentComposable>
-    </ResponsiveModal>
+    </Dialog>
   )
 }

--- a/src/automations/automation-form-modal.tsx
+++ b/src/automations/automation-form-modal.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
+import { Dialog } from '@/components/ui/dialog'
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { PromptInput } from '@/components/ui/prompt-input'
-import { Dialog } from '@/components/ui/dialog'
 import {
   ResponsiveModalContentComposable,
   ResponsiveModalHeader,

--- a/src/components/ui/autosize-textarea.tsx
+++ b/src/components/ui/autosize-textarea.tsx
@@ -39,8 +39,10 @@ export const useAutosizeTextArea = ({
       const scrollHeight = textAreaElement.scrollHeight
       if (scrollHeight > maxHeight) {
         textAreaElement.style.height = `${maxHeight}px`
+        textAreaElement.style.overflowY = 'auto'
       } else {
         textAreaElement.style.height = `${scrollHeight + offsetBorder}px`
+        textAreaElement.style.overflowY = 'hidden'
       }
     }
   }, [textAreaRef.current, triggerAutoSize, minHeight, maxHeight])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: adjusts textarea overflow behavior and swaps the automation form modal root to `Dialog`, which could subtly affect modal focus/scroll handling but doesn’t touch data or auth.
> 
> **Overview**
> Fixes the automation prompt editor so long text can be scrolled normally (e.g., via mouse wheel).
> 
> This updates `AutosizeTextarea` to toggle `overflowY` between `auto` and `hidden` based on whether content exceeds `maxHeight`, and switches `AutomationFormModal` from `ResponsiveModal` to the base `Dialog` wrapper to improve modal scrolling behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e59b2af7c2cffbeba51d6ceef4ce5ac3aa7f907. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses an issue where automation text could not be scrolled using the mouse wheel, only by dragging or arrow keys. The changes involve adjusting the modal component used and explicitly managing the `overflowY` style for the autosizing textarea to enable proper scrolling.

#### Key Changes
- Replaced the `ResponsiveModal` component with `Dialog` in `automation-form-modal.tsx`.
- Modified `autosize-textarea.tsx` to set `overflowY: 'auto'` when content exceeds `maxHeight` and `overflowY: 'hidden'` otherwise, enabling mouse wheel scrolling for overflowing text.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 3 (50.0%)     |
| Churn       | 1 (16.7%)     |
| Rework      | 2 (33.3%)     |
| Total Changes | 6             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>