### PR TITLE
Fix intermittent Android build failures due to disk space

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -54,6 +54,17 @@ jobs:
       build_version: ${{ steps.determine_version.outputs.build_version }}
 
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android/sdk/ndk/27*
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/share/boost
+          sudo docker system prune -af || true
+          df -h
+
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:


### PR DESCRIPTION
## Summary

- The `build_and_deploy_android` pipeline fails intermittently with `No space left on device (os error 28)` when compiling Rust for the 4th Android target
- Adds a disk cleanup step as the first action in the job, removing unused pre-installed software (dotnet, CodeQL, Swift, boost, old NDK versions, Docker images) to free ~10-15 GB on the GitHub Actions runner

## Root cause

The `ubuntu-latest` runner has ~14 GB free. Compiling Rust release builds for 4 Android targets (aarch64, armv7, i686, x86_64) plus the restored cargo cache exhausts disk space. The failure is intermittent because cache size and runner image contents vary between runs.

## Test plan

- [ ] Trigger the Android release workflow and verify it completes successfully
- [ ] Verify `df -h` output in the "Free disk space" step logs shows sufficient free space
- [ ] Confirm the build no longer fails with "No space left on device"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main risk is accidentally removing runner tooling the Android build relies on, which would fail the workflow early rather than affecting shipped code.
> 
> **Overview**
> Reduces intermittent Android release CI failures by adding an initial **disk cleanup** step that removes large preinstalled runner components (e.g., dotnet/Swift/CodeQL/old NDKs) and prunes Docker before building.
> 
> Also bumps the application version from `0.1.66` to `0.1.67` across `package.json`, Tauri config, and Rust crate metadata (`Cargo.toml`/`Cargo.lock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 738cb91bfb21107f5abf665e3039888f9529d2ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses intermittent Android build failures in the CI/CD pipeline by adding a step to free up disk space. It also includes a minor version bump across various project configuration files.

#### Key Changes
- Added a "Free disk space" step to the `android-release.yml` GitHub Actions workflow, which removes large cached directories and prunes Docker data.
- Updated the project version from `0.1.66` to `0.1.67` in `package.json`, `src-tauri/Cargo.lock`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 11 (73.3%)    |
| Rework      | 4 (26.7%)     |
| Total Changes | 15            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>