### PR TITLE
THU-341: Desktop crash on update and restart

### DIFF
--- a/docs/local-cdn-for-app-update-testing.md
+++ b/docs/local-cdn-for-app-update-testing.md
@@ -1,0 +1,79 @@
+# Testing in-app updates with a local CDN
+
+The Tauri updater downloads from CrabNebula CDN in production. To test the full update flow locally (download, install, relaunch), you can run a local server that mimics the CDN.
+
+## Prerequisites
+
+- Two copies of the repo: the **old version** (simulates what the user has installed) and the **new version** (simulates what they're updating to)
+- A signing keypair for update bundles
+
+## 1. Generate a test signing keypair
+
+```bash
+bun tauri signer generate -w ~/.tauri/test-update.key
+# Press Enter twice for empty password
+```
+
+This creates `~/.tauri/test-update.key` (private) and `~/.tauri/test-update.key.pub` (public).
+
+## 2. Configure the old build to use localhost
+
+In the old build's `src-tauri/tauri.conf.json`, point the updater at your local server:
+
+```json
+"updater": {
+  "endpoints": [
+    "http://localhost:8888/update/{{target}}-{{arch}}/{{current_version}}"
+  ],
+  "pubkey": "<contents of ~/.tauri/test-update.key.pub>"
+}
+```
+
+## 3. Build the new version with test signing
+
+From your current repo (the version you want to update *to*):
+
+```bash
+TAURI_PRIVATE_KEY="$(cat ~/.tauri/test-update.key)" TAURI_PRIVATE_KEY_PASSWORD="" bun tauri build
+```
+
+If the build doesn't generate a `.sig` file alongside the bundle, sign it manually:
+
+```bash
+TAURI_PRIVATE_KEY_PASSWORD="" bun tauri signer sign -f ~/.tauri/test-update.key \
+  src-tauri/target/release/bundle/macos/Thunderbolt.app.tar.gz
+```
+
+## 4. Build the old version
+
+From the old repo checkout:
+
+```bash
+bun tauri build --debug
+```
+
+## 5. Start the local update server
+
+```bash
+bun run scripts/local-update-server.ts
+```
+
+This serves on port 8888. When the old build's updater checks for updates, the server:
+- Reads the new version from `src-tauri/tauri.conf.json`
+- Returns a 204 (no update) if versions match, or an update manifest pointing at the local bundle
+- Serves the `.tar.gz` bundle and its signature when the updater downloads it
+
+## 6. Run the old build and trigger the update
+
+```bash
+open path/to/old-build/src-tauri/target/debug/bundle/macos/Thunderbolt.app
+```
+
+Don't drag it to `/Applications` — run it directly from the build output. Log in, wait for the update notification, click Download, then Restart.
+
+## Troubleshooting
+
+- **No bundles found**: Make sure step 3 completed and `src-tauri/target/release/bundle/macos/` contains a `.tar.gz` file
+- **Signature mismatch**: The pubkey in the old build's `tauri.conf.json` must match the private key used to sign the new build
+- **No update offered (204)**: The version in the new build's `tauri.conf.json` must be higher than the old build's version
+- **Server not reachable**: Check that nothing else is using port 8888

--- a/scripts/local-update-server.ts
+++ b/scripts/local-update-server.ts
@@ -1,0 +1,96 @@
+/**
+ * Local update server for testing Tauri updater flow.
+ *
+ * Serves update manifests and bundles from the release build output.
+ * Point the old build's updater endpoint to http://localhost:8888/update/{{target}}-{{arch}}/{{current_version}}
+ *
+ * Usage:
+ *   1. Build the new version: TAURI_SIGNING_PRIVATE_KEY=~/.tauri/test-update.key bun tauri build
+ *   2. Start this server: bun run scripts/local-update-server.ts
+ *   3. Open the old build and trigger the update
+ */
+
+const BUNDLE_DIR = new URL('../src-tauri/target/release/bundle', import.meta.url).pathname
+const PORT = 8888
+
+const server = Bun.serve({
+  port: PORT,
+  async fetch(req) {
+    const url = new URL(req.url)
+    console.log(`${req.method} ${url.pathname}`)
+
+    // Tauri updater hits: GET /update/{target}-{arch}/{current_version}
+    // It expects a JSON response with the update info, or 204 if no update
+    if (url.pathname.startsWith('/update/')) {
+      const parts = url.pathname.split('/')
+      const platform = parts[2] // e.g. "darwin-aarch64"
+      const currentVersion = parts[3]
+
+      // Find the .tar.gz update bundle and its .sig file
+      const glob = new Bun.Glob('macos/*.tar.gz')
+      const bundles = Array.from(glob.scanSync(BUNDLE_DIR))
+
+      if (bundles.length === 0) {
+        console.error('No update bundles found in', BUNDLE_DIR + '/macos/')
+        return new Response('No bundles found', { status: 500 })
+      }
+
+      const bundleName = bundles[0]
+      const bundlePath = `${BUNDLE_DIR}/${bundleName}`
+      const sigPath = `${bundlePath}.sig`
+
+      // Read signature
+      let signature: string
+      try {
+        signature = await Bun.file(sigPath).text()
+      } catch {
+        console.error('Signature file not found:', sigPath)
+        return new Response('Signature not found', { status: 500 })
+      }
+
+      // Read version from tauri.conf.json
+      const confPath = new URL('../src-tauri/tauri.conf.json', import.meta.url).pathname
+      const conf = await Bun.file(confPath).json()
+      const newVersion = conf.version
+
+      console.log(`Current: ${currentVersion}, Available: ${newVersion}, Bundle: ${bundleName}`)
+
+      if (currentVersion === newVersion) {
+        return new Response(null, { status: 204 })
+      }
+
+      const manifest = {
+        version: newVersion,
+        notes: `Update to ${newVersion}`,
+        pub_date: new Date().toISOString(),
+        url: `http://localhost:${PORT}/bundle/${bundleName}`,
+        signature,
+      }
+
+      console.log('Serving update manifest:', JSON.stringify(manifest, null, 2))
+      return Response.json(manifest)
+    }
+
+    // Serve the actual bundle file
+    if (url.pathname.startsWith('/bundle/')) {
+      const filePath = `${BUNDLE_DIR}/${url.pathname.replace('/bundle/', '')}`
+      const file = Bun.file(filePath)
+
+      if (!(await file.exists())) {
+        console.error('Bundle not found:', filePath)
+        return new Response('Not found', { status: 404 })
+      }
+
+      console.log('Serving bundle:', filePath, `(${(file.size / 1024 / 1024).toFixed(1)}MB)`)
+      return new Response(file, {
+        headers: { 'Content-Type': 'application/gzip' },
+      })
+    }
+
+    return new Response('Not found', { status: 404 })
+  },
+})
+
+console.log(`Local update server running at http://localhost:${PORT}`)
+console.log(`Bundle dir: ${BUNDLE_DIR}`)
+console.log(`\nWaiting for update requests...`)

--- a/scripts/local-update-server.ts
+++ b/scripts/local-update-server.ts
@@ -73,7 +73,12 @@ const server = Bun.serve({
 
     // Serve the actual bundle file
     if (url.pathname.startsWith('/bundle/')) {
-      const filePath = `${BUNDLE_DIR}/${url.pathname.replace('/bundle/', '')}`
+      const relativePath = url.pathname.substring('/bundle/'.length)
+      if (relativePath.includes('..')) {
+        console.error(`Path traversal attempt blocked: ${relativePath}`)
+        return new Response('Forbidden', { status: 403 })
+      }
+      const filePath = `${BUNDLE_DIR}/${relativePath}`
       const file = Bun.file(filePath)
 
       if (!(await file.exists())) {

--- a/src/hooks/use-desktop-update.ts
+++ b/src/hooks/use-desktop-update.ts
@@ -2,6 +2,7 @@ import { useReducer, useEffect, useCallback } from 'react'
 import { check, type Update } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
 import { isDesktop } from '@/lib/platform'
+import { getPowerSyncInstance } from '@/db/powersync'
 
 export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error'
 
@@ -112,6 +113,11 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
 
   const restartApp = useCallback(async () => {
     try {
+      // Disconnect PowerSync (without clearing data) before relaunching so
+      // the new process doesn't compete for locks/connections (see THU-341).
+      await getPowerSyncInstance()?.disconnect()
+      // Signal the new process to reset navigation (WebView may restore stale route)
+      localStorage.setItem('thunderbolt_post_update', '1')
       await relaunch()
     } catch (err) {
       console.error('Failed to restart app:', err)

--- a/src/hooks/use-desktop-update.ts
+++ b/src/hooks/use-desktop-update.ts
@@ -3,6 +3,7 @@ import { check, type Update } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
 import { isDesktop } from '@/lib/platform'
 import { getPowerSyncInstance } from '@/db/powersync'
+import { setPostUpdateFlag } from '@/lib/post-update-redirect'
 
 export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error'
 
@@ -116,11 +117,11 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
       // Best-effort disconnect — don't block the relaunch if PowerSync fails
       try {
         await getPowerSyncInstance()?.disconnect()
-      } catch {
-        /* proceed anyway */
+      } catch (err) {
+        console.error('Failed to disconnect PowerSync before relaunch:', err)
       }
       // Signal the new process to reset navigation (WebView may restore stale route)
-      localStorage.setItem('thunderbolt_post_update', '1')
+      setPostUpdateFlag()
       await relaunch()
     } catch (err) {
       console.error('Failed to restart app:', err)

--- a/src/hooks/use-desktop-update.ts
+++ b/src/hooks/use-desktop-update.ts
@@ -113,9 +113,12 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
 
   const restartApp = useCallback(async () => {
     try {
-      // Disconnect PowerSync (without clearing data) before relaunching so
-      // the new process doesn't compete for locks/connections (see THU-341).
-      await getPowerSyncInstance()?.disconnect()
+      // Best-effort disconnect — don't block the relaunch if PowerSync fails
+      try {
+        await getPowerSyncInstance()?.disconnect()
+      } catch {
+        /* proceed anyway */
+      }
       // Signal the new process to reset navigation (WebView may restore stale route)
       localStorage.setItem('thunderbolt_post_update', '1')
       await relaunch()

--- a/src/hooks/use-desktop-update.ts
+++ b/src/hooks/use-desktop-update.ts
@@ -3,7 +3,7 @@ import { check, type Update } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
 import { isDesktop } from '@/lib/platform'
 import { getPowerSyncInstance } from '@/db/powersync'
-import { setPostUpdateFlag } from '@/lib/post-update-redirect'
+import { setPostUpdateFlag, clearPostUpdateFlag } from '@/lib/post-update-redirect'
 
 export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error'
 
@@ -124,6 +124,8 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
       setPostUpdateFlag()
       await relaunch()
     } catch (err) {
+      // Clear the flag so a stale flag doesn't force-redirect on next manual launch
+      clearPostUpdateFlag()
       console.error('Failed to restart app:', err)
       dispatch({ type: 'ERROR', error: err instanceof Error ? err.message : 'Failed to restart app' })
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,15 @@ import './polyfills'
 import './index.css'
 import { initializeLinkInterception } from './lib/intercept-links'
 
+// After an update+relaunch, the WebView may restore a stale route (e.g. /waitlist
+// verify screen). Detect this and force a clean start at root.
+if (localStorage.getItem('thunderbolt_post_update')) {
+  localStorage.removeItem('thunderbolt_post_update')
+  if (window.location.pathname !== '/') {
+    window.location.replace('/')
+  }
+}
+
 initializeLinkInterception()
 
 const root = document.getElementById('root') as HTMLElement

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,20 +4,13 @@ import './polyfills'
 
 import './index.css'
 import { initializeLinkInterception } from './lib/intercept-links'
+import { handlePostUpdateRedirect } from './lib/post-update-redirect'
 
 // After an update+relaunch, the WebView may restore a stale route (e.g. /waitlist
 // verify screen). Detect this and force a clean start at root.
-const postUpdateFlag = localStorage.getItem('thunderbolt_post_update')
-const shouldRedirectToRoot = Boolean(postUpdateFlag) && window.location.pathname !== '/'
+const redirecting = handlePostUpdateRedirect()
 
-if (postUpdateFlag) {
-  localStorage.removeItem('thunderbolt_post_update')
-  if (shouldRedirectToRoot) {
-    window.location.replace('/')
-  }
-}
-
-if (!shouldRedirectToRoot) {
+if (!redirecting) {
   initializeLinkInterception()
 
   const root = document.getElementById('root') as HTMLElement

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,15 +7,20 @@ import { initializeLinkInterception } from './lib/intercept-links'
 
 // After an update+relaunch, the WebView may restore a stale route (e.g. /waitlist
 // verify screen). Detect this and force a clean start at root.
-if (localStorage.getItem('thunderbolt_post_update')) {
+const postUpdateFlag = localStorage.getItem('thunderbolt_post_update')
+const shouldRedirectToRoot = Boolean(postUpdateFlag) && window.location.pathname !== '/'
+
+if (postUpdateFlag) {
   localStorage.removeItem('thunderbolt_post_update')
-  if (window.location.pathname !== '/') {
+  if (shouldRedirectToRoot) {
     window.location.replace('/')
   }
 }
 
-initializeLinkInterception()
+if (!shouldRedirectToRoot) {
+  initializeLinkInterception()
 
-const root = document.getElementById('root') as HTMLElement
+  const root = document.getElementById('root') as HTMLElement
 
-ReactDOM.createRoot(root).render(<App />)
+  ReactDOM.createRoot(root).render(<App />)
+}

--- a/src/lib/post-update-redirect.test.ts
+++ b/src/lib/post-update-redirect.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
 import { setPostUpdateFlag, handlePostUpdateRedirect } from './post-update-redirect'
 
 const mockLocation = (pathname: string) => {
-  const replaceSpy = vi.fn()
+  const replaceSpy = mock()
   Object.defineProperty(window, 'location', {
     value: { ...window.location, pathname, replace: replaceSpy },
     writable: true,

--- a/src/lib/post-update-redirect.test.ts
+++ b/src/lib/post-update-redirect.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setPostUpdateFlag, handlePostUpdateRedirect } from './post-update-redirect'
+
+const mockLocation = (pathname: string) => {
+  const replaceSpy = vi.fn()
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, pathname, replace: replaceSpy },
+    writable: true,
+    configurable: true,
+  })
+  return replaceSpy
+}
+
+describe('setPostUpdateFlag', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('sets the post-update flag in localStorage', () => {
+    setPostUpdateFlag()
+    expect(localStorage.getItem('thunderbolt_post_update')).toBe('1')
+  })
+})
+
+describe('handlePostUpdateRedirect', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('returns false when no flag is set', () => {
+    mockLocation('/')
+    expect(handlePostUpdateRedirect()).toBe(false)
+  })
+
+  it('removes the flag and returns false when already on root', () => {
+    localStorage.setItem('thunderbolt_post_update', '1')
+    mockLocation('/')
+    expect(handlePostUpdateRedirect()).toBe(false)
+    expect(localStorage.getItem('thunderbolt_post_update')).toBeNull()
+  })
+
+  it('removes the flag, redirects to root, and returns true when on a non-root path', () => {
+    localStorage.setItem('thunderbolt_post_update', '1')
+    const replaceSpy = mockLocation('/waitlist/verify')
+
+    expect(handlePostUpdateRedirect()).toBe(true)
+    expect(replaceSpy).toHaveBeenCalledWith('/')
+    expect(localStorage.getItem('thunderbolt_post_update')).toBeNull()
+  })
+
+  it('returns false without flag even on a non-root path', () => {
+    mockLocation('/settings')
+    expect(handlePostUpdateRedirect()).toBe(false)
+  })
+})

--- a/src/lib/post-update-redirect.ts
+++ b/src/lib/post-update-redirect.ts
@@ -9,6 +9,14 @@ export const setPostUpdateFlag = () => {
 }
 
 /**
+ * Clears the post-update flag. Called when relaunch fails so a stale flag
+ * doesn't force-redirect on the next manual app launch.
+ */
+export const clearPostUpdateFlag = () => {
+  localStorage.removeItem(postUpdateKey)
+}
+
+/**
  * Checks for and consumes the post-update flag. If the flag is present and the
  * current pathname isn't "/", redirects to root via `window.location.replace`
  * and returns true (caller should skip normal initialization). Otherwise returns false.

--- a/src/lib/post-update-redirect.ts
+++ b/src/lib/post-update-redirect.ts
@@ -1,11 +1,11 @@
-const POST_UPDATE_KEY = 'thunderbolt_post_update'
+const postUpdateKey = 'thunderbolt_post_update'
 
 /**
  * Sets a flag in localStorage to signal that the app should redirect to root
  * after an update+relaunch. Called before restarting the app.
  */
 export const setPostUpdateFlag = () => {
-  localStorage.setItem(POST_UPDATE_KEY, '1')
+  localStorage.setItem(postUpdateKey, '1')
 }
 
 /**
@@ -14,10 +14,12 @@ export const setPostUpdateFlag = () => {
  * and returns true (caller should skip normal initialization). Otherwise returns false.
  */
 export const handlePostUpdateRedirect = (): boolean => {
-  const flag = localStorage.getItem(POST_UPDATE_KEY)
-  if (!flag) return false
+  const flag = localStorage.getItem(postUpdateKey)
+  if (!flag) {
+    return false
+  }
 
-  localStorage.removeItem(POST_UPDATE_KEY)
+  localStorage.removeItem(postUpdateKey)
 
   if (window.location.pathname !== '/') {
     window.location.replace('/')

--- a/src/lib/post-update-redirect.ts
+++ b/src/lib/post-update-redirect.ts
@@ -1,0 +1,28 @@
+const POST_UPDATE_KEY = 'thunderbolt_post_update'
+
+/**
+ * Sets a flag in localStorage to signal that the app should redirect to root
+ * after an update+relaunch. Called before restarting the app.
+ */
+export const setPostUpdateFlag = () => {
+  localStorage.setItem(POST_UPDATE_KEY, '1')
+}
+
+/**
+ * Checks for and consumes the post-update flag. If the flag is present and the
+ * current pathname isn't "/", redirects to root via `window.location.replace`
+ * and returns true (caller should skip normal initialization). Otherwise returns false.
+ */
+export const handlePostUpdateRedirect = (): boolean => {
+  const flag = localStorage.getItem(POST_UPDATE_KEY)
+  if (!flag) return false
+
+  localStorage.removeItem(POST_UPDATE_KEY)
+
+  if (window.location.pathname !== '/') {
+    window.location.replace('/')
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the desktop update/relaunch path and app bootstrap logic; mistakes could block startup or regress the in-app update flow, though changes are small and localized.
> 
> **Overview**
> Fixes desktop update relaunch issues by doing a best-effort PowerSync disconnect before `relaunch()` and setting a `localStorage` flag to force a clean post-update navigation state.
> 
> Adds `post-update-redirect` logic (with tests) that, on next startup, consumes the flag and redirects to `/` to avoid the WebView restoring a stale route; `src/index.tsx` now skips normal initialization when redirecting.
> 
> Introduces a Bun-based local Tauri update server plus documentation for end-to-end testing of in-app updates against a localhost “CDN” (manifest + bundle + `.sig`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be009beb392a0cfd54734bc7ccd98c047db38e8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

 
 
 
 
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a desktop crash on update and restart by introducing a robust mechanism for handling post-update redirects and providing tools for local update testing. The changes ensure a clean application state after an update and relaunch, preventing issues caused by stale routes.

#### Key Changes
- Added comprehensive documentation (`docs/local-cdn-for-app-update-testing.md`) for setting up a local CDN to test in-app updates.
- Implemented a local update server script (`scripts/local-update-server.ts`) to simulate the production CDN for testing purposes.
- Modified the `useDesktopUpdate` hook to disconnect PowerSync gracefully before relaunch and to set a flag signaling a post-update redirect.
- Introduced `post-update-redirect.ts` to manage a flag in local storage, which forces a redirect to the root path after an update and relaunch if the WebView restores a stale route.
- Updated `src/index.tsx` to utilize the new post-update redirect logic, ensuring the app starts cleanly after an update.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 302 (99.0%)   |
| Rework      | 3 (1.0%)      |
| Total Changes | 305         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>