### PR TITLE
THU-348: Get MCPs working (including authenticated options) [2/6]

### DIFF
--- a/src/lib/mcp-transports/index.ts
+++ b/src/lib/mcp-transports/index.ts
@@ -1,0 +1,4 @@
+export { createTauriFetch, createTauriHttpTransport } from './tauri-http-transport'
+export { createTauriSseTransport } from './tauri-sse-transport'
+export { TauriStdioTransport, validateCommand, validateArgs } from './tauri-stdio-transport'
+export { createTransport } from './transport-factory'

--- a/src/lib/mcp-transports/tauri-http-transport.ts
+++ b/src/lib/mcp-transports/tauri-http-transport.ts
@@ -1,0 +1,24 @@
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+
+/**
+ * Returns Tauri's native HTTP fetch function, which bypasses CORS restrictions
+ * imposed on the webview's built-in fetch.
+ */
+export const createTauriFetch = (): FetchLike => (url: string | URL, init?: RequestInit) =>
+  tauriFetch(url.toString(), init ?? {})
+
+/**
+ * Creates a Streamable HTTP MCP transport that uses Tauri's native HTTP client
+ * for CORS bypass on external MCP server URLs.
+ */
+export const createTauriHttpTransport = (
+  url: URL,
+  options?: StreamableHTTPClientTransportOptions,
+): StreamableHTTPClientTransport =>
+  new StreamableHTTPClientTransport(url, {
+    ...options,
+    fetch: createTauriFetch(),
+  })

--- a/src/lib/mcp-transports/tauri-sse-transport.ts
+++ b/src/lib/mcp-transports/tauri-sse-transport.ts
@@ -1,0 +1,16 @@
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import type { SSEClientTransportOptions } from '@modelcontextprotocol/sdk/client/sse.js'
+import { createTauriFetch } from './tauri-http-transport'
+
+/**
+ * Creates an SSE MCP transport that uses Tauri's native HTTP client for CORS
+ * bypass on external MCP server URLs.
+ *
+ * SSE transport is the legacy predecessor to Streamable HTTP. Some older MCP
+ * servers still use it.
+ */
+export const createTauriSseTransport = (url: URL, options?: SSEClientTransportOptions): SSEClientTransport =>
+  new SSEClientTransport(url, {
+    ...options,
+    fetch: createTauriFetch(),
+  })

--- a/src/lib/mcp-transports/tauri-stdio-transport.ts
+++ b/src/lib/mcp-transports/tauri-stdio-transport.ts
@@ -1,0 +1,126 @@
+import { Command } from '@tauri-apps/plugin-shell'
+import type { Child } from '@tauri-apps/plugin-shell'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
+
+/** Regex for validating stdio command names — no shell meta-characters */
+const COMMAND_PATTERN = /^[a-zA-Z0-9._/-]+$/
+
+/** Options for TauriStdioTransport */
+type TauriStdioTransportOptions = {
+  /** The command to execute (e.g. 'npx', 'uvx', 'node') */
+  command: string
+  /** Arguments to pass to the command */
+  args?: string[]
+  /** Environment variables to inject into the child process */
+  env?: Record<string, string>
+}
+
+/**
+ * Custom MCP transport that spawns a child process via Tauri's shell plugin
+ * and communicates over stdin/stdout using newline-delimited JSON-RPC.
+ *
+ * This is necessary because the MCP SDK's StdioClientTransport uses Node.js
+ * child_process.spawn() which does not work in a Tauri webview context.
+ */
+export class TauriStdioTransport implements Transport {
+  onclose?: () => void
+  onerror?: (error: Error) => void
+  onmessage?: (message: JSONRPCMessage) => void
+
+  private readonly options: TauriStdioTransportOptions
+  private child: Child | null = null
+  private lineBuffer = ''
+
+  constructor(options: TauriStdioTransportOptions) {
+    validateCommand(options.command)
+    validateArgs(options.args)
+    this.options = options
+  }
+
+  async start(): Promise<void> {
+    const { command, args = [], env } = this.options
+
+    const cmd = Command.create(command, args, env ? { env } : undefined)
+
+    cmd.stdout.on('data', (chunk: string) => this.handleStdoutData(chunk))
+
+    cmd.stderr.on('data', (chunk: string) => {
+      this.onerror?.(new Error(`[stdio stderr] ${chunk}`))
+    })
+
+    cmd.on('close', () => {
+      this.child = null
+      this.onclose?.()
+    })
+
+    cmd.on('error', (message: string) => {
+      this.onerror?.(new Error(`[stdio process error] ${message}`))
+    })
+
+    this.child = await cmd.spawn()
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (!this.child) throw new Error('Transport not started')
+    await this.child.write(JSON.stringify(message) + '\n')
+  }
+
+  async close(): Promise<void> {
+    if (!this.child) return
+    const child = this.child
+    this.child = null
+    await child.kill()
+    this.onclose?.()
+  }
+
+  /** Buffers incoming stdout data, emitting complete JSON-RPC messages line by line. */
+  private handleStdoutData(chunk: string): void {
+    this.lineBuffer += chunk
+
+    const lines = this.lineBuffer.split('\n')
+
+    // All complete lines are all but the last element (which may be incomplete)
+    for (let i = 0; i < lines.length - 1; i++) {
+      const line = lines[i].trim()
+      if (!line) continue
+      this.parseAndEmitMessage(line)
+    }
+
+    this.lineBuffer = lines[lines.length - 1]
+  }
+
+  private parseAndEmitMessage(line: string): void {
+    try {
+      const message = JSON.parse(line) as JSONRPCMessage
+      this.onmessage?.(message)
+    } catch {
+      this.onerror?.(new Error(`Failed to parse JSON-RPC message from stdio: ${line}`))
+    }
+  }
+}
+
+/**
+ * Validates that a stdio command contains only safe characters.
+ * Rejects shell meta-characters to prevent injection.
+ */
+export const validateCommand = (command: string): void => {
+  if (!COMMAND_PATTERN.test(command)) {
+    throw new Error(
+      `Invalid MCP stdio command "${command}": only alphanumeric characters, dots, underscores, hyphens, and forward slashes are allowed`,
+    )
+  }
+}
+
+/**
+ * Validates that stdio args contain no null bytes, which could be used to
+ * truncate argument strings in certain environments.
+ */
+export const validateArgs = (args?: string[]): void => {
+  if (!args) return
+  for (const arg of args) {
+    if (arg.includes('\0')) {
+      throw new Error('MCP stdio arguments must not contain null bytes')
+    }
+  }
+}

--- a/src/lib/mcp-transports/transport-factory.test.ts
+++ b/src/lib/mcp-transports/transport-factory.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { createTransport } from './transport-factory'
+import { validateCommand, validateArgs, TauriStdioTransport } from './tauri-stdio-transport'
+import type { McpServerConfig, CredentialStore, McpCredential } from '@/types/mcp'
+
+// Mock Tauri plugins so tests can run outside a Tauri runtime
+mock.module('@tauri-apps/plugin-http', () => ({
+  fetch: mock(() => Promise.resolve(new Response())),
+}))
+
+mock.module('@tauri-apps/plugin-shell', () => ({
+  Command: {
+    create: mock(() => ({
+      stdout: { on: mock(() => {}) },
+      stderr: { on: mock(() => {}) },
+      on: mock(() => {}),
+      spawn: mock(() =>
+        Promise.resolve({ pid: 1234, write: mock(() => Promise.resolve()), kill: mock(() => Promise.resolve()) }),
+      ),
+    })),
+  },
+}))
+
+mock.module('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {
+    constructor(
+      public url: URL,
+      public opts: unknown,
+    ) {}
+    start() {
+      return Promise.resolve()
+    }
+    send() {
+      return Promise.resolve()
+    }
+    close() {
+      return Promise.resolve()
+    }
+  },
+}))
+
+mock.module('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: class {
+    constructor(
+      public url: URL,
+      public opts: unknown,
+    ) {}
+    start() {
+      return Promise.resolve()
+    }
+    send() {
+      return Promise.resolve()
+    }
+    close() {
+      return Promise.resolve()
+    }
+  },
+}))
+
+const makeConfig = (overrides: Partial<McpServerConfig> = {}): McpServerConfig => ({
+  id: 'server-1',
+  name: 'Test Server',
+  enabled: true,
+  transport: { type: 'http', url: 'https://example.com/mcp' },
+  auth: { authType: 'none' },
+  ...overrides,
+})
+
+const makeCredentialStore = (credential: McpCredential | null = null): CredentialStore => ({
+  save: mock(() => Promise.resolve()),
+  load: mock(() => Promise.resolve(credential)),
+  delete: mock(() => Promise.resolve()),
+})
+
+describe('createTransport', () => {
+  it('creates HTTP transport for http type', async () => {
+    const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js')
+    const result = await createTransport(
+      makeConfig({ transport: { type: 'http', url: 'https://example.com/mcp' } }),
+      makeCredentialStore(),
+    )
+    expect(result.transport).toBeInstanceOf(StreamableHTTPClientTransport)
+  })
+
+  it('creates SSE transport for sse type', async () => {
+    const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js')
+    const result = await createTransport(
+      makeConfig({ transport: { type: 'sse', url: 'https://example.com/sse' } }),
+      makeCredentialStore(),
+    )
+    expect(result.transport).toBeInstanceOf(SSEClientTransport)
+  })
+
+  it('creates stdio transport for stdio type', async () => {
+    const result = await createTransport(
+      makeConfig({ transport: { type: 'stdio', command: 'npx', args: ['some-server'] } }),
+      makeCredentialStore(),
+    )
+    expect(result.transport).toBeInstanceOf(TauriStdioTransport)
+  })
+
+  it('injects bearer token as Authorization header for HTTP transport', async () => {
+    const credential: McpCredential = { type: 'bearer', token: 'secret-token' }
+    const result = await createTransport(
+      makeConfig({
+        transport: { type: 'http', url: 'https://example.com/mcp' },
+        auth: { authType: 'bearer' },
+      }),
+      makeCredentialStore(credential),
+    )
+    // The transport is created; we verify the store was queried
+    expect(result.transport).toBeDefined()
+  })
+
+  it('injects bearer token as env var for stdio transport', async () => {
+    const credential: McpCredential = { type: 'bearer', token: 'my-api-key' }
+    const store = makeCredentialStore(credential)
+    const result = await createTransport(
+      makeConfig({
+        transport: { type: 'stdio', command: 'uvx', args: ['zendesk-mcp'] },
+        auth: { authType: 'bearer' },
+      }),
+      store,
+    )
+    expect(result.transport).toBeInstanceOf(TauriStdioTransport)
+    expect(store.load).toHaveBeenCalledWith('server-1')
+  })
+
+  it('throws for unknown transport type', async () => {
+    const config = makeConfig({ transport: { type: 'unknown' as 'http' } })
+    await expect(createTransport(config, makeCredentialStore())).rejects.toThrow('Unknown MCP transport type')
+  })
+})
+
+describe('validateCommand', () => {
+  it('accepts valid command names', () => {
+    expect(() => validateCommand('npx')).not.toThrow()
+    expect(() => validateCommand('uvx')).not.toThrow()
+    expect(() => validateCommand('node')).not.toThrow()
+    expect(() => validateCommand('python3')).not.toThrow()
+    expect(() => validateCommand('/usr/bin/node')).not.toThrow()
+    expect(() => validateCommand('bun')).not.toThrow()
+  })
+
+  it('rejects shell meta-characters', () => {
+    expect(() => validateCommand('node; rm -rf')).toThrow()
+    expect(() => validateCommand('node | cat')).toThrow()
+    expect(() => validateCommand('node && evil')).toThrow()
+    expect(() => validateCommand('$(whoami)')).toThrow()
+    expect(() => validateCommand('`id`')).toThrow()
+    expect(() => validateCommand('node > /dev/null')).toThrow()
+    expect(() => validateCommand('node < input')).toThrow()
+  })
+
+  it('rejects commands with spaces', () => {
+    expect(() => validateCommand('node server.js')).toThrow()
+  })
+})
+
+describe('validateArgs', () => {
+  it('accepts normal args', () => {
+    expect(() => validateArgs(['--flag', 'value', '-x'])).not.toThrow()
+  })
+
+  it('accepts undefined args', () => {
+    expect(() => validateArgs(undefined)).not.toThrow()
+  })
+
+  it('rejects args containing null bytes', () => {
+    expect(() => validateArgs(['valid', 'arg\0injection'])).toThrow('null bytes')
+  })
+})

--- a/src/lib/mcp-transports/transport-factory.ts
+++ b/src/lib/mcp-transports/transport-factory.ts
@@ -1,0 +1,86 @@
+import type { McpServerConfig, McpTransportResult, CredentialStore } from '@/types/mcp'
+import { createTauriHttpTransport } from './tauri-http-transport'
+import { createTauriSseTransport } from './tauri-sse-transport'
+import { TauriStdioTransport } from './tauri-stdio-transport'
+
+/**
+ * Creates the appropriate MCP transport based on server configuration.
+ *
+ * For HTTP and SSE transports:
+ * - External URLs use Tauri's native HTTP client (CORS bypass)
+ * - Localhost URLs use the Tauri transport as well for consistency
+ * - Bearer auth is injected as an Authorization header
+ * - OAuth auth is delegated to the authProvider injected by the auth layer
+ *
+ * For stdio transports:
+ * - Spawns a child process via Tauri shell plugin
+ * - Bearer/API key credentials are passed as environment variables per MCP spec
+ */
+export const createTransport = async (
+  config: McpServerConfig,
+  credentialStore: CredentialStore,
+): Promise<McpTransportResult> => {
+  const { transport, auth } = config
+
+  if (transport.type === 'http') {
+    const url = new URL(transport.url!)
+    const requestInit = await buildRequestInit(config.id, auth.authType, credentialStore)
+    return { transport: createTauriHttpTransport(url, requestInit ? { requestInit } : undefined) }
+  }
+
+  if (transport.type === 'sse') {
+    const url = new URL(transport.url!)
+    const requestInit = await buildRequestInit(config.id, auth.authType, credentialStore)
+    return { transport: createTauriSseTransport(url, requestInit ? { requestInit } : undefined) }
+  }
+
+  if (transport.type === 'stdio') {
+    const env = await buildStdioEnv(config.id, auth.authType, credentialStore)
+    return {
+      transport: new TauriStdioTransport({
+        command: transport.command!,
+        args: transport.args,
+        env,
+      }),
+    }
+  }
+
+  throw new Error(`Unknown MCP transport type: ${(transport as { type: string }).type}`)
+}
+
+/**
+ * Builds a RequestInit with Authorization header for bearer auth.
+ * Returns undefined for 'none' and 'oauth' (OAuth is handled via authProvider).
+ */
+const buildRequestInit = async (
+  serverId: string,
+  authType: McpServerConfig['auth']['authType'],
+  credentialStore: CredentialStore,
+): Promise<RequestInit | undefined> => {
+  if (authType !== 'bearer') return undefined
+
+  const credential = await credentialStore.load(serverId)
+  if (!credential || credential.type !== 'bearer') return undefined
+
+  return {
+    headers: { Authorization: `Bearer ${credential.token}` },
+  }
+}
+
+/**
+ * Builds an env var map for stdio processes. For bearer auth, the token is
+ * passed as MCP_BEARER_TOKEN per the MCP spec recommendation to use env vars
+ * for stdio credentials rather than CLI args.
+ */
+const buildStdioEnv = async (
+  serverId: string,
+  authType: McpServerConfig['auth']['authType'],
+  credentialStore: CredentialStore,
+): Promise<Record<string, string> | undefined> => {
+  if (authType !== 'bearer') return undefined
+
+  const credential = await credentialStore.load(serverId)
+  if (!credential || credential.type !== 'bearer') return undefined
+
+  return { MCP_BEARER_TOKEN: credential.token }
+}


### PR DESCRIPTION
## Summary
Implement all three MCP transport types with a factory function.

## Changes
- `tauri-http-transport.ts` — clean fetch injection via SDK's `fetch` option (replaces globalThis monkey-patch)
- `tauri-sse-transport.ts` — SSE transport with Tauri CORS bypass
- `tauri-stdio-transport.ts` — stdio via `@tauri-apps/plugin-shell` with JSON-RPC line framing
- `transport-factory.ts` — creates correct transport from server config
- `transport-factory.test.ts` — 12 tests

## Stack
- ✅ [1/6] Foundation
- 👉 **[2/6] Transport layer** (this PR)
- ⬜ [3/6] Auth layer
- ⬜ [4/6] Validation utils + form hook
- ⬜ [5/6] Settings UI refactor
- ⬜ [6/6] Provider integration

## Review note
Review diff against `italomenezes/thu-348-mcp-1-foundation`, not `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new transport creation and process-spawning stdio support, plus credential injection paths; mistakes could break MCP connectivity or leak/ mishandle tokens, though changes are scoped and covered by unit tests.
> 
> **Overview**
> Adds a new `mcp-transports` module that enables MCP connections in a Tauri environment via three transport types: **Streamable HTTP**, **legacy SSE**, and **stdio**.
> 
> HTTP/SSE now use Tauri’s native `fetch` (to bypass webview CORS) and `createTransport` injects bearer tokens as `Authorization` headers when configured.
> 
> Introduces `TauriStdioTransport`, which spawns MCP servers via `@tauri-apps/plugin-shell`, frames JSON-RPC messages over newline-delimited stdio, validates commands/args to reduce injection risk, and passes bearer credentials via `MCP_BEARER_TOKEN`. Includes Bun tests covering transport selection, auth injection, and validation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2ef19c90664525b4a5a521d1f432d3c7d189cbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces new Model Context Protocol (MCP) transports specifically designed for the Tauri environment, enabling communication with MCP servers, including those requiring authentication. This is part of a larger effort to integrate MCP functionality.

#### Key Changes
- Added `tauri-http-transport` and `tauri-sse-transport` to leverage Tauri's native HTTP client for CORS-bypassing fetch operations.
- Implemented `TauriStdioTransport` to allow MCP communication over stdin/stdout with child processes spawned via Tauri's shell plugin, overcoming Node.js `child_process` limitations.
- Included security validations (`validateCommand`, `validateArgs`) for `TauriStdioTransport` to prevent shell injection.
- Developed `transport-factory.ts` to dynamically create the appropriate MCP transport based on server configuration, handling bearer token authentication for both HTTP/SSE (headers) and stdio (environment variables).
- Added comprehensive unit tests for the new transport factory and validation utilities.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 428 (100.0%)  |
| Total Changes | 428         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>