### PR TITLE
THU-348: Get MCPs working (including authenticated options) [3/6]

### DIFF
--- a/src/lib/mcp-auth/bearer-token-provider.ts
+++ b/src/lib/mcp-auth/bearer-token-provider.ts
@@ -1,0 +1,9 @@
+/**
+ * Creates HTTP Authorization headers for bearer token authentication.
+ * Used to inject auth into Streamable HTTP and SSE transport requests.
+ */
+const createBearerAuthHeaders = (token: string): HeadersInit => ({
+  Authorization: `Bearer ${token}`,
+})
+
+export { createBearerAuthHeaders }

--- a/src/lib/mcp-auth/credential-store.test.ts
+++ b/src/lib/mcp-auth/credential-store.test.ts
@@ -1,0 +1,214 @@
+import { getDb } from '@/db/database'
+import { mcpServersTable } from '@/db/tables'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { v7 as uuidv7 } from 'uuid'
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { createCredentialStore, resetKeyCache } from './credential-store'
+import { createBearerAuthHeaders } from './bearer-token-provider'
+import type { McpCredential } from '@/types/mcp'
+
+// Mock @tauri-apps/plugin-fs so getDeviceId returns a stable test value
+mock.module('@tauri-apps/plugin-fs', () => ({
+  readTextFile: async () => 'test-device-id',
+  writeTextFile: async () => {},
+  BaseDirectory: { AppData: 0 },
+}))
+
+beforeAll(async () => {
+  await setupTestDatabase()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+const seedServer = async (serverId: string) => {
+  const db = getDb()
+  await db.insert(mcpServersTable).values({
+    id: serverId,
+    name: 'Test Server',
+    type: 'http',
+    url: 'http://localhost:3000',
+    enabled: 1,
+  })
+}
+
+describe('CredentialStore', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+    resetKeyCache()
+  })
+
+  describe('save and load roundtrip', () => {
+    it('roundtrips a bearer credential', async () => {
+      const db = getDb()
+      const serverId = uuidv7()
+      await seedServer(serverId)
+
+      const store = createCredentialStore(db)
+      const credential: McpCredential = { type: 'bearer', token: 'my-secret-api-key' }
+
+      await store.save(serverId, credential)
+      const loaded = await store.load(serverId)
+
+      expect(loaded).toEqual(credential)
+    })
+
+    it('roundtrips an OAuth credential', async () => {
+      const db = getDb()
+      const serverId = uuidv7()
+      await seedServer(serverId)
+
+      const store = createCredentialStore(db)
+      const credential: McpCredential = {
+        type: 'oauth',
+        accessToken: 'access-token-abc',
+        refreshToken: 'refresh-token-xyz',
+        expiresAt: '2026-12-31T00:00:00.000Z',
+        tokenType: 'bearer',
+        scope: 'read write',
+      }
+
+      await store.save(serverId, credential)
+      const loaded = await store.load(serverId)
+
+      expect(loaded).toEqual(credential)
+    })
+
+    it('roundtrips an OAuth credential without optional fields', async () => {
+      const db = getDb()
+      const serverId = uuidv7()
+      await seedServer(serverId)
+
+      const store = createCredentialStore(db)
+      const credential: McpCredential = {
+        type: 'oauth',
+        accessToken: 'access-token-only',
+        tokenType: 'bearer',
+      }
+
+      await store.save(serverId, credential)
+      const loaded = await store.load(serverId)
+
+      expect(loaded).toEqual(credential)
+    })
+
+    it('does not store plaintext in the database column', async () => {
+      const db = getDb()
+      const serverId = uuidv7()
+      await seedServer(serverId)
+
+      const store = createCredentialStore(db)
+      const token = 'super-secret-token'
+      await store.save(serverId, { type: 'bearer', token })
+
+      const rows = await db.select({ encryptedCredential: mcpServersTable.encryptedCredential }).from(mcpServersTable)
+
+      const raw = rows[0]?.encryptedCredential ?? ''
+      expect(raw).not.toContain(token)
+      expect(raw).toContain('"iv"')
+      expect(raw).toContain('"ciphertext"')
+    })
+
+    it('produces different ciphertexts for identical inputs (unique IV per call)', async () => {
+      const db = getDb()
+      const serverId1 = uuidv7()
+      const serverId2 = uuidv7()
+      await seedServer(serverId1)
+      await seedServer(serverId2)
+
+      const store = createCredentialStore(db)
+      const credential: McpCredential = { type: 'bearer', token: 'same-token' }
+      await store.save(serverId1, credential)
+      await store.save(serverId2, credential)
+
+      const rows = await db.select({ encryptedCredential: mcpServersTable.encryptedCredential }).from(mcpServersTable)
+
+      const [enc1, enc2] = rows.map((r) => r.encryptedCredential)
+      expect(enc1).not.toEqual(enc2)
+    })
+  })
+
+  describe('load', () => {
+    it('returns null for a server with no credential', async () => {
+      const db = getDb()
+      const serverId = uuidv7()
+      await seedServer(serverId)
+
+      const store = createCredentialStore(db)
+      const result = await store.load(serverId)
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null for a non-existent server ID', async () => {
+      const db = getDb()
+      const store = createCredentialStore(db)
+      const result = await store.load('non-existent-server-id')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('delete', () => {
+    it('removes the credential from the server record', async () => {
+      const db = getDb()
+      const serverId = uuidv7()
+      await seedServer(serverId)
+
+      const store = createCredentialStore(db)
+      await store.save(serverId, { type: 'bearer', token: 'to-be-deleted' })
+
+      const beforeDelete = await store.load(serverId)
+      expect(beforeDelete).not.toBeNull()
+
+      await store.delete(serverId)
+
+      const afterDelete = await store.load(serverId)
+      expect(afterDelete).toBeNull()
+    })
+
+    it('does not throw when deleting a credential that does not exist', async () => {
+      const db = getDb()
+      const serverId = uuidv7()
+      await seedServer(serverId)
+
+      const store = createCredentialStore(db)
+      await expect(store.delete(serverId)).resolves.toBeUndefined()
+    })
+
+    it('does not affect other servers when deleting', async () => {
+      const db = getDb()
+      const serverId1 = uuidv7()
+      const serverId2 = uuidv7()
+      await seedServer(serverId1)
+      await seedServer(serverId2)
+
+      const store = createCredentialStore(db)
+      const credential: McpCredential = { type: 'bearer', token: 'keep-this' }
+      await store.save(serverId1, credential)
+      await store.save(serverId2, { type: 'bearer', token: 'delete-this' })
+
+      await store.delete(serverId2)
+
+      const server1Cred = await store.load(serverId1)
+      const server2Cred = await store.load(serverId2)
+
+      expect(server1Cred).toEqual(credential)
+      expect(server2Cred).toBeNull()
+    })
+  })
+})
+
+describe('createBearerAuthHeaders', () => {
+  it('produces correct Authorization header format', () => {
+    const headers = createBearerAuthHeaders('my-token')
+    expect(headers).toEqual({ Authorization: 'Bearer my-token' })
+  })
+
+  it('handles tokens with special characters', () => {
+    const token = 'eyJhbGciOiJSUzI1NiJ9.payload.signature'
+    const headers = createBearerAuthHeaders(token)
+    expect((headers as Record<string, string>)['Authorization']).toBe(`Bearer ${token}`)
+  })
+})

--- a/src/lib/mcp-auth/credential-store.ts
+++ b/src/lib/mcp-auth/credential-store.ts
@@ -1,0 +1,144 @@
+import { eq } from 'drizzle-orm'
+import type { AnyDrizzleDatabase } from '@/db/database-interface'
+import { mcpServersTable } from '@/db/tables'
+import type { CredentialStore, McpCredential } from '@/types/mcp'
+
+/** Application-specific salt prefix mixed with the device hostname */
+const APP_SALT_PREFIX = 'thunderbolt-mcp-v1:'
+
+/** PBKDF2 iteration count — must be >= 100,000 per security requirements */
+const PBKDF2_ITERATIONS = 100_000
+
+/** Encrypts a credential using AES-GCM with a derived key */
+type EncryptedBlob = {
+  iv: string
+  ciphertext: string
+}
+
+/**
+ * Derives a 256-bit AES-GCM key from the device hostname using PBKDF2.
+ * The key is bound to the hostname so credentials are device-local.
+ */
+const deriveKey = async (hostname: string): Promise<CryptoKey> => {
+  const encoder = new TextEncoder()
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(APP_SALT_PREFIX + hostname),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  )
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: encoder.encode('thunderbolt-mcp-credential-salt'),
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+/**
+ * Encrypts a JSON-serializable value using AES-GCM.
+ * Each call generates a unique random IV, so identical inputs produce different ciphertexts.
+ */
+const encrypt = async (key: CryptoKey, plaintext: string): Promise<string> => {
+  const encoder = new TextEncoder()
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoder.encode(plaintext))
+
+  const blob: EncryptedBlob = {
+    iv: btoa(String.fromCharCode(...iv)),
+    ciphertext: btoa(String.fromCharCode(...new Uint8Array(ciphertext))),
+  }
+  return JSON.stringify(blob)
+}
+
+/**
+ * Decrypts a value previously encrypted with `encrypt`.
+ */
+const decrypt = async (key: CryptoKey, encryptedJson: string): Promise<string> => {
+  const blob: EncryptedBlob = JSON.parse(encryptedJson)
+  const iv = Uint8Array.from(atob(blob.iv), (c) => c.charCodeAt(0))
+  const ciphertext = Uint8Array.from(atob(blob.ciphertext), (c) => c.charCodeAt(0))
+
+  const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext)
+  return new TextDecoder().decode(plaintext)
+}
+
+/**
+ * Returns a persistent device-unique identifier for key derivation.
+ * Generates a random UUID on first run and stores it in the app data directory.
+ * Falls back to a static identifier in non-Tauri environments (tests).
+ */
+const getDeviceId = async (): Promise<string> => {
+  try {
+    const { readTextFile, writeTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs')
+    try {
+      return await readTextFile('mcp-device-id', { baseDir: BaseDirectory.AppData })
+    } catch {
+      const id = crypto.randomUUID()
+      await writeTextFile('mcp-device-id', id, { baseDir: BaseDirectory.AppData })
+      return id
+    }
+  } catch {
+    return 'thunderbolt-local'
+  }
+}
+
+/** Promise-based singleton prevents concurrent PBKDF2 derivations */
+let keyPromise: Promise<CryptoKey> | null = null
+
+const getEncryptionKey = (): Promise<CryptoKey> => {
+  keyPromise ??= getDeviceId().then(deriveKey)
+  return keyPromise
+}
+
+/**
+ * Creates an encrypted credential store that persists credentials
+ * in the `mcp_servers.encrypted_credential` column using AES-GCM encryption.
+ *
+ * Key derivation: PBKDF2(APP_SALT_PREFIX + hostname) -> 256-bit AES-GCM key.
+ * Storage format: `{ iv: base64, ciphertext: base64 }` serialized as JSON.
+ *
+ * Credentials are never stored in plaintext — only the encrypted blob reaches SQLite.
+ */
+const createCredentialStore = (db: AnyDrizzleDatabase): CredentialStore => {
+  const save = async (serverId: string, credential: McpCredential): Promise<void> => {
+    const key = await getEncryptionKey()
+    const encryptedCredential = await encrypt(key, JSON.stringify(credential))
+    await db.update(mcpServersTable).set({ encryptedCredential }).where(eq(mcpServersTable.id, serverId))
+  }
+
+  const load = async (serverId: string): Promise<McpCredential | null> => {
+    const rows = await db
+      .select({ encryptedCredential: mcpServersTable.encryptedCredential })
+      .from(mcpServersTable)
+      .where(eq(mcpServersTable.id, serverId))
+
+    const row = rows[0]
+    if (!row?.encryptedCredential) return null
+
+    const key = await getEncryptionKey()
+    const plaintext = await decrypt(key, row.encryptedCredential)
+    return JSON.parse(plaintext) as McpCredential
+  }
+
+  const deleteCredential = async (serverId: string): Promise<void> => {
+    await db.update(mcpServersTable).set({ encryptedCredential: null }).where(eq(mcpServersTable.id, serverId))
+  }
+
+  return { save, load, delete: deleteCredential }
+}
+
+export { createCredentialStore }
+/** Exported for testing only — resets the in-memory key cache */
+export const resetKeyCache = () => {
+  keyPromise = null
+}

--- a/src/lib/mcp-auth/index.ts
+++ b/src/lib/mcp-auth/index.ts
@@ -1,0 +1,3 @@
+export { createCredentialStore } from './credential-store'
+export { McpOAuthClientProvider } from './oauth-client-provider'
+export { createBearerAuthHeaders } from './bearer-token-provider'

--- a/src/lib/mcp-auth/oauth-client-provider.ts
+++ b/src/lib/mcp-auth/oauth-client-provider.ts
@@ -1,0 +1,112 @@
+import { invoke } from '@tauri-apps/api/core'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import type {
+  OAuthClientInformation,
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js'
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
+import type { CredentialStore } from '@/types/mcp'
+
+/**
+ * Static client ID for Thunderbolt published as a Client ID Metadata Document (CIMD).
+ * Authorization servers that support CIMD will fetch this to verify the client.
+ */
+const THUNDERBOLT_CLIENT_ID = 'https://thunderbolt.io/.well-known/oauth-client/thunderbolt'
+
+/**
+ * OAuth 2.1 client provider for MCP servers.
+ *
+ * Implements the MCP SDK's `OAuthClientProvider` interface for a single MCP server.
+ * Uses the existing loopback OAuth server (Rust command `start_oauth_server`) to capture
+ * the authorization code callback on localhost:17421-17423.
+ *
+ * The code verifier is held in memory only (never persisted) per security requirements.
+ * Tokens are stored encrypted via the `CredentialStore`.
+ */
+class McpOAuthClientProvider implements OAuthClientProvider {
+  private readonly serverId: string
+  private readonly credentialStore: CredentialStore
+  private codeVerifierValue: string | null = null
+  private clientInfo: OAuthClientInformationFull | null = null
+
+  constructor(serverId: string, credentialStore: CredentialStore) {
+    this.serverId = serverId
+    this.credentialStore = credentialStore
+  }
+
+  get redirectUrl(): string {
+    return 'http://localhost:17421'
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      client_name: 'Thunderbolt',
+      redirect_uris: ['http://localhost:17421', 'http://localhost:17422', 'http://localhost:17423'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    }
+  }
+
+  clientInformation(): OAuthClientInformation | undefined {
+    if (this.clientInfo) return this.clientInfo
+    // Return static client ID for CIMD-based registration
+    return { client_id: THUNDERBOLT_CLIENT_ID }
+  }
+
+  async saveClientInformation(clientInformation: OAuthClientInformationFull): Promise<void> {
+    this.clientInfo = clientInformation
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const cred = await this.credentialStore.load(this.serverId)
+    if (!cred || cred.type !== 'oauth') return undefined
+
+    return {
+      access_token: cred.accessToken,
+      refresh_token: cred.refreshToken,
+      token_type: cred.tokenType,
+    }
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await this.credentialStore.save(this.serverId, {
+      type: 'oauth',
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: tokens.expires_in ? new Date(Date.now() + tokens.expires_in * 1000).toISOString() : undefined,
+      tokenType: tokens.token_type ?? 'bearer',
+      scope: tokens.scope,
+    })
+  }
+
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    await invoke('start_oauth_server')
+    await openUrl(authorizationUrl.toString())
+  }
+
+  async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    this.codeVerifierValue = codeVerifier
+  }
+
+  async codeVerifier(): Promise<string> {
+    if (!this.codeVerifierValue) throw new Error('codeVerifier called before saveCodeVerifier')
+    return this.codeVerifierValue
+  }
+
+  async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier'): Promise<void> {
+    if (scope === 'tokens' || scope === 'all') {
+      await this.credentialStore.delete(this.serverId)
+    }
+    if (scope === 'client' || scope === 'all') {
+      this.clientInfo = null
+    }
+    if (scope === 'verifier' || scope === 'all') {
+      this.codeVerifierValue = null
+    }
+  }
+}
+
+export { McpOAuthClientProvider }


### PR DESCRIPTION
## Summary
Implement encrypted credential storage, OAuth 2.1 client provider, and bearer token utilities.

## Changes
- `credential-store.ts` — AES-GCM encryption with PBKDF2 device-derived key, persistent device UUID
- `credential-store.test.ts` — 12 tests (encrypt/decrypt roundtrip, isolation, deletion)
- `oauth-client-provider.ts` — implements MCP SDK `OAuthClientProvider` using existing loopback server
- `bearer-token-provider.ts` — `createBearerAuthHeaders()` utility
- `index.ts` — barrel exports

## Stack
- ✅ [1/6] Foundation
- ✅ [2/6] Transport layer
- 👉 **[3/6] Auth layer** (this PR)
- ⬜ [4/6] Validation utils + form hook
- ⬜ [5/6] Settings UI refactor
- ⬜ [6/6] Provider integration

## Review note
Review diff against `italomenezes/thu-348-mcp-2-transport`, not `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces new credential encryption/key-derivation and OAuth token persistence logic, which is security-sensitive and could affect access to authenticated MCP servers if incorrect.
> 
> **Overview**
> Adds an MCP auth layer with **encrypted per-server credential persistence** and **OAuth 2.1 client-provider integration**.
> 
> Credentials are now saved/loaded/deleted via a new `createCredentialStore()` that encrypts `McpCredential` blobs into `mcp_servers.encrypted_credential` using AES-GCM with a PBKDF2-derived, device-bound key (with a cached derived key and a persistent device ID for derivation). The new `McpOAuthClientProvider` implements the MCP SDK `OAuthClientProvider`, launching the existing loopback OAuth server and persisting tokens through the encrypted store.
> 
> Also adds a small `createBearerAuthHeaders()` helper for Bearer auth injection, exports the new auth utilities via `src/lib/mcp-auth/index.ts`, and includes a comprehensive test suite validating roundtrips, non-plaintext storage, IV uniqueness, and deletion behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59fbcd73f57840d6536dbf3dcdfe407b071c4cab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces secure credential management and OAuth 2.1 authentication capabilities for Model Context Protocol (MCP) servers. It focuses on enabling authenticated options by providing mechanisms to store and retrieve sensitive tokens safely and handle OAuth flows.

#### Key Changes
- Added `createBearerAuthHeaders` utility for generating bearer token authorization headers.
- Implemented `createCredentialStore` for encrypted storage (AES-GCM with PBKDF2-derived keys) of MCP credentials (bearer and OAuth) in the database.
- Introduced `McpOAuthClientProvider` to manage OAuth 2.1 client interactions, including token handling, client metadata, and redirecting to an authorization server.
- Included comprehensive unit tests for the credential store, verifying encryption, decryption, and credential lifecycle management.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 482 (100.0%)  |
| Total Changes | 482         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>