### PR TITLE
THU-348: Get MCPs working (including authenticated options) [4/6]

### DIFF
--- a/src/hooks/use-mcp-server-form.test.ts
+++ b/src/hooks/use-mcp-server-form.test.ts
@@ -1,0 +1,277 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+import { useMcpServerFormState } from './use-mcp-server-form'
+
+describe('useMcpServerFormState', () => {
+  describe('initial state', () => {
+    it('starts with http transport', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      expect(result.current.state.transportType).toBe('http')
+    })
+
+    it('starts with empty url and command', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      expect(result.current.state.url).toBe('')
+      expect(result.current.state.command).toBe('')
+    })
+
+    it('starts with no auth', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      expect(result.current.state.authType).toBe('none')
+      expect(result.current.state.bearerToken).toBe('')
+    })
+
+    it('starts with idle connection status', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      expect(result.current.state.connectionStatus).toBe('idle')
+      expect(result.current.state.connectionError).toBeNull()
+    })
+
+    it('starts with empty capabilities and args', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      expect(result.current.state.serverCapabilities).toEqual([])
+      expect(result.current.state.args).toEqual([])
+    })
+  })
+
+  describe('SET_TRANSPORT_TYPE', () => {
+    it('changes transport type', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+      })
+      expect(result.current.state.transportType).toBe('stdio')
+    })
+
+    it('resets url, command, args and connection state on transport change', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'http://example.com' })
+        result.current.dispatch({ type: 'SET_CONNECTION_STATUS', payload: 'success' })
+        result.current.dispatch({ type: 'SET_CONNECTION_ERROR', payload: 'some error' })
+      })
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'sse' })
+      })
+      expect(result.current.state.url).toBe('')
+      expect(result.current.state.command).toBe('')
+      expect(result.current.state.args).toEqual([])
+      expect(result.current.state.connectionStatus).toBe('idle')
+      expect(result.current.state.connectionError).toBeNull()
+    })
+  })
+
+  describe('SET_URL', () => {
+    it('sets the url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'http://localhost:8000/mcp/' })
+      })
+      expect(result.current.state.url).toBe('http://localhost:8000/mcp/')
+    })
+  })
+
+  describe('SET_COMMAND', () => {
+    it('sets the command', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx' })
+      })
+      expect(result.current.state.command).toBe('npx')
+    })
+  })
+
+  describe('SET_ARGS', () => {
+    it('sets the args array', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_ARGS', payload: ['mcp-server', '--port', '8080'] })
+      })
+      expect(result.current.state.args).toEqual(['mcp-server', '--port', '8080'])
+    })
+  })
+
+  describe('SET_AUTH_TYPE', () => {
+    it('sets the auth type', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_AUTH_TYPE', payload: 'bearer' })
+      })
+      expect(result.current.state.authType).toBe('bearer')
+    })
+
+    it('clears bearer token when auth type changes', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_AUTH_TYPE', payload: 'bearer' })
+        result.current.dispatch({ type: 'SET_BEARER_TOKEN', payload: 'secret-token' })
+      })
+      act(() => {
+        result.current.dispatch({ type: 'SET_AUTH_TYPE', payload: 'none' })
+      })
+      expect(result.current.state.bearerToken).toBe('')
+    })
+  })
+
+  describe('SET_BEARER_TOKEN', () => {
+    it('sets the bearer token', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_BEARER_TOKEN', payload: 'my-api-key' })
+      })
+      expect(result.current.state.bearerToken).toBe('my-api-key')
+    })
+  })
+
+  describe('SET_CONNECTION_STATUS', () => {
+    it('updates connection status to testing', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_CONNECTION_STATUS', payload: 'testing' })
+      })
+      expect(result.current.state.connectionStatus).toBe('testing')
+    })
+
+    it('updates connection status to success', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_CONNECTION_STATUS', payload: 'success' })
+      })
+      expect(result.current.state.connectionStatus).toBe('success')
+    })
+
+    it('updates connection status to error', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_CONNECTION_STATUS', payload: 'error' })
+      })
+      expect(result.current.state.connectionStatus).toBe('error')
+    })
+  })
+
+  describe('SET_CONNECTION_ERROR', () => {
+    it('sets the connection error message', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_CONNECTION_ERROR', payload: 'Connection refused' })
+      })
+      expect(result.current.state.connectionError).toBe('Connection refused')
+    })
+
+    it('clears the connection error', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_CONNECTION_ERROR', payload: 'some error' })
+        result.current.dispatch({ type: 'SET_CONNECTION_ERROR', payload: null })
+      })
+      expect(result.current.state.connectionError).toBeNull()
+    })
+  })
+
+  describe('SET_CAPABILITIES', () => {
+    it('sets server capabilities', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_CAPABILITIES', payload: ['tool_a', 'tool_b'] })
+      })
+      expect(result.current.state.serverCapabilities).toEqual(['tool_a', 'tool_b'])
+    })
+  })
+
+  describe('RESET', () => {
+    it('resets all state to initial values', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx' })
+        result.current.dispatch({ type: 'SET_AUTH_TYPE', payload: 'bearer' })
+        result.current.dispatch({ type: 'SET_BEARER_TOKEN', payload: 'secret' })
+        result.current.dispatch({ type: 'SET_CONNECTION_STATUS', payload: 'success' })
+      })
+      act(() => {
+        result.current.dispatch({ type: 'RESET' })
+      })
+      expect(result.current.state.transportType).toBe('http')
+      expect(result.current.state.command).toBe('')
+      expect(result.current.state.authType).toBe('none')
+      expect(result.current.state.bearerToken).toBe('')
+      expect(result.current.state.connectionStatus).toBe('idle')
+    })
+  })
+
+  describe('isValid', () => {
+    it('returns false when http transport has empty url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns true when http transport has valid url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'http://localhost:8000/mcp/' })
+      })
+      expect(result.current.isValid()).toBe(true)
+    })
+
+    it('returns false when http transport has invalid url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'not-a-url' })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns false when http transport has javascript: url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'javascript:alert(1)' })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns true when sse transport has valid url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'sse' })
+        result.current.dispatch({ type: 'SET_URL', payload: 'https://example.com/sse' })
+      })
+      expect(result.current.isValid()).toBe(true)
+    })
+
+    it('returns false when stdio transport has empty command', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns true when stdio transport has valid command', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx' })
+      })
+      expect(result.current.isValid()).toBe(true)
+    })
+
+    it('returns false when stdio transport has invalid command', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx; rm -rf /' })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns false when stdio args contain null byte', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx' })
+        result.current.dispatch({ type: 'SET_ARGS', payload: ['arg\0'] })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+  })
+})

--- a/src/hooks/use-mcp-server-form.ts
+++ b/src/hooks/use-mcp-server-form.ts
@@ -1,0 +1,70 @@
+import { useCallback, useReducer } from 'react'
+import type { McpServerFormAction, McpServerFormState } from '@/types/mcp'
+import { validateMcpUrl, validateStdioArgs, validateStdioCommand } from '@/lib/mcp-utils'
+
+const initialFormState: McpServerFormState = {
+  transportType: 'http',
+  url: '',
+  command: '',
+  args: [],
+  authType: 'none',
+  bearerToken: '',
+  connectionStatus: 'idle',
+  connectionError: null,
+  serverCapabilities: [],
+}
+
+const formReducer = (state: McpServerFormState, action: McpServerFormAction): McpServerFormState => {
+  switch (action.type) {
+    case 'SET_TRANSPORT_TYPE':
+      return {
+        ...state,
+        transportType: action.payload,
+        url: '',
+        command: '',
+        args: [],
+        connectionStatus: 'idle',
+        connectionError: null,
+      }
+    case 'SET_URL':
+      return { ...state, url: action.payload }
+    case 'SET_COMMAND':
+      return { ...state, command: action.payload }
+    case 'SET_ARGS':
+      return { ...state, args: action.payload }
+    case 'SET_AUTH_TYPE':
+      return { ...state, authType: action.payload, bearerToken: '' }
+    case 'SET_BEARER_TOKEN':
+      return { ...state, bearerToken: action.payload }
+    case 'SET_CONNECTION_STATUS':
+      return { ...state, connectionStatus: action.payload }
+    case 'SET_CONNECTION_ERROR':
+      return { ...state, connectionError: action.payload }
+    case 'SET_CAPABILITIES':
+      return { ...state, serverCapabilities: action.payload }
+    case 'RESET':
+      return initialFormState
+    default:
+      return state
+  }
+}
+
+export const useMcpServerFormState = () => {
+  const [state, dispatch] = useReducer(formReducer, initialFormState)
+
+  const isValid = useCallback(() => {
+    try {
+      if (state.transportType === 'stdio') {
+        validateStdioCommand(state.command)
+        validateStdioArgs(state.args)
+        return true
+      }
+      validateMcpUrl(state.url)
+      return true
+    } catch {
+      return false
+    }
+  }, [state])
+
+  return { state, dispatch, isValid }
+}

--- a/src/lib/mcp-utils.test.ts
+++ b/src/lib/mcp-utils.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test'
+import { validateMcpUrl, validateStdioArgs, validateStdioCommand } from './mcp-utils'
+
+describe('validateMcpUrl', () => {
+  it('accepts http URLs', () => {
+    const result = validateMcpUrl('http://localhost:8000/mcp/')
+    expect(result.hostname).toBe('localhost')
+  })
+
+  it('accepts https URLs', () => {
+    const result = validateMcpUrl('https://api.example.com/mcp')
+    expect(result.hostname).toBe('api.example.com')
+  })
+
+  it('returns a URL object', () => {
+    const result = validateMcpUrl('http://localhost:8000/mcp/')
+    expect(result).toBeInstanceOf(URL)
+  })
+
+  it('throws on invalid URL string', () => {
+    expect(() => validateMcpUrl('not a url')).toThrow()
+  })
+
+  it('throws on ftp protocol', () => {
+    expect(() => validateMcpUrl('ftp://example.com/mcp')).toThrow('URL must use http: or https: protocol')
+  })
+
+  it('throws on javascript: protocol', () => {
+    expect(() => validateMcpUrl('javascript:alert(1)')).toThrow('URL must use http: or https: protocol')
+  })
+
+  it('throws on data: protocol', () => {
+    expect(() => validateMcpUrl('data:text/html,<h1>hello</h1>')).toThrow('URL must use http: or https: protocol')
+  })
+
+  it('throws on empty string', () => {
+    expect(() => validateMcpUrl('')).toThrow()
+  })
+})
+
+describe('validateStdioCommand', () => {
+  it('accepts simple binary names', () => {
+    expect(() => validateStdioCommand('npx')).not.toThrow()
+    expect(() => validateStdioCommand('uvx')).not.toThrow()
+    expect(() => validateStdioCommand('node')).not.toThrow()
+    expect(() => validateStdioCommand('python3')).not.toThrow()
+    expect(() => validateStdioCommand('bun')).not.toThrow()
+  })
+
+  it('accepts paths with slashes', () => {
+    expect(() => validateStdioCommand('/usr/local/bin/mcp-server')).not.toThrow()
+    expect(() => validateStdioCommand('./bin/server')).not.toThrow()
+  })
+
+  it('accepts names with dots and hyphens', () => {
+    expect(() => validateStdioCommand('mcp-server.sh')).not.toThrow()
+  })
+
+  it('throws on empty command', () => {
+    expect(() => validateStdioCommand('')).toThrow('Command is required')
+  })
+
+  it('throws on whitespace-only command', () => {
+    expect(() => validateStdioCommand('   ')).toThrow('Command is required')
+  })
+
+  it('throws on command with semicolon', () => {
+    expect(() => validateStdioCommand('npx; rm -rf /')).toThrow('Command contains invalid characters')
+  })
+
+  it('throws on command with pipe', () => {
+    expect(() => validateStdioCommand('npx | cat')).toThrow('Command contains invalid characters')
+  })
+
+  it('throws on command with dollar sign', () => {
+    expect(() => validateStdioCommand('$PATH')).toThrow('Command contains invalid characters')
+  })
+
+  it('throws on command with backtick', () => {
+    expect(() => validateStdioCommand('`whoami`')).toThrow('Command contains invalid characters')
+  })
+
+  it('throws on command with spaces', () => {
+    expect(() => validateStdioCommand('node server')).toThrow('Command contains invalid characters')
+  })
+})
+
+describe('validateStdioArgs', () => {
+  it('accepts normal args', () => {
+    expect(() => validateStdioArgs(['--port', '8080', '--verbose'])).not.toThrow()
+  })
+
+  it('accepts args with special characters (non-null)', () => {
+    expect(() => validateStdioArgs(['--key=value', '-x', 'some/path'])).not.toThrow()
+  })
+
+  it('accepts empty array', () => {
+    expect(() => validateStdioArgs([])).not.toThrow()
+  })
+
+  it('throws when any arg contains null byte', () => {
+    expect(() => validateStdioArgs(['--port', 'val\0ue'])).toThrow('Arguments must not contain null bytes')
+  })
+
+  it('throws on null byte at start of arg', () => {
+    expect(() => validateStdioArgs(['\0malicious'])).toThrow('Arguments must not contain null bytes')
+  })
+
+  it('throws on null byte at end of arg', () => {
+    expect(() => validateStdioArgs(['arg\0'])).toThrow('Arguments must not contain null bytes')
+  })
+})

--- a/src/lib/mcp-utils.ts
+++ b/src/lib/mcp-utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Validates an MCP server URL for HTTP/SSE transport.
+ * Throws with a descriptive message on invalid input.
+ */
+export const validateMcpUrl = (url: string): URL => {
+  const parsed = new URL(url)
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('URL must use http: or https: protocol')
+  }
+  return parsed
+}
+
+/**
+ * Validates a stdio command against the allowlist pattern.
+ * Rejects shell meta-characters.
+ */
+export const validateStdioCommand = (command: string): void => {
+  if (!command.trim()) throw new Error('Command is required')
+  if (!/^[a-zA-Z0-9._/-]+$/.test(command)) {
+    throw new Error('Command contains invalid characters')
+  }
+}
+
+/**
+ * Validates stdio args array for injection safety.
+ * Rejects args containing null bytes.
+ */
+export const validateStdioArgs = (args: string[]): void => {
+  for (const arg of args) {
+    if (arg.includes('\0')) {
+      throw new Error('Arguments must not contain null bytes')
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add URL/command validation utilities and extract form state into a `useReducer`-based hook.

## Changes
- `mcp-utils.ts` — `validateMcpUrl()`, `validateStdioCommand()`, `validateStdioArgs()`
- `mcp-utils.test.ts` — 24 tests
- `use-mcp-server-form.ts` — `useMcpServerFormState()` hook with `useReducer` (replaces 9 `useState` calls)
- `use-mcp-server-form.test.ts` — 29 tests

## Stack
- ✅ [1/6] Foundation
- ✅ [2/6] Transport layer
- ✅ [3/6] Auth layer
- 👉 **[4/6] Validation utils + form hook** (this PR)
- ⬜ [5/6] Settings UI refactor
- ⬜ [6/6] Provider integration

## Review note
Review diff against \`italomenezes/thu-348-mcp-3-auth\`, not \`main\`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new input-validation logic for MCP server URLs/stdio commands and centralizes form state management; mistakes here could block valid configs or allow unsafe strings through.
> 
> **Overview**
> Introduces shared MCP input validation via `validateMcpUrl`, `validateStdioCommand`, and `validateStdioArgs`, enforcing http/https-only URLs and basic stdio injection safeguards.
> 
> Extracts MCP server add/edit dialog state into a `useReducer`-based hook (`useMcpServerFormState`) with a single `dispatch` API, transport-change resets, and an `isValid()` helper that runs the new validators.
> 
> Adds comprehensive unit coverage for both the validators and the new form reducer/validation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a256d0ac8fb672cbaa1255a20a78918fde3edeff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces state management and validation logic for configuring Multi-Client Protocol (MCP) server connections, including authenticated options. It establishes the foundational client-side components for handling various MCP transport types and their respective connection parameters.

#### Key Changes
- Added a new `useMcpServerFormState` React hook to manage the form state for MCP server connections, encompassing transport type, URL, command, arguments, authentication details, and connection status.
- Implemented `mcp-utils.ts` with validation functions (`validateMcpUrl`, `validateStdioCommand`, `validateStdioArgs`) to ensure secure and correct input for MCP server configurations.
- Integrated an `isValid` function within the `useMcpServerFormState` hook to perform real-time validation of the form based on the selected transport type and input values.
- Included comprehensive unit tests for both the `useMcpServerFormState` hook and the `mcp-utils` validation functions to ensure reliability and correctness.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 493 (100.0%)  |
| Total Changes | 493         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>