### PR TITLE
THU-148: Increase mobile font + button sizes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ When adding new custom headers to API requests (e.g. `X-Device-ID`, `X-Device-Na
 
 - Heights: `h-[var(--touch-height-default)]`, `h-[var(--touch-height-sm)]`, `h-[var(--touch-height-lg)]`, `h-[var(--touch-height-xl)]`
 - Icons: `size-[var(--icon-size-default)]`, `size-[var(--icon-size-sm)]`
-- Text: `text-[var(--font-size-body)]`, `text-[var(--font-size-sm)]`, `text-[var(--font-size-xs)]`
+- Text: `text-[length:var(--font-size-body)]`, `text-[length:var(--font-size-sm)]`, `text-[length:var(--font-size-xs)]`
 - Padding X: `px-[var(--spacing-x-default)]`, `px-[var(--spacing-x-md)]`, `px-[var(--spacing-x-sm)]`, `px-[var(--spacing-x-lg)]`
 - Padding Y: `py-[var(--spacing-y-default)]`, `py-[var(--spacing-y-md)]`, `py-[var(--spacing-y-sm)]`
 - Gaps: `gap-[var(--gap-default)]`, `gap-[var(--gap-lg)]`, `gap-[var(--gap-sm)]`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,19 @@ See [docs/powersync-account-devices.md](docs/powersync-account-devices.md#pr-flo
 ## CORS and API headers
 
 When adding new custom headers to API requests (e.g. `X-Device-ID`, `X-Device-Name`), update `backend/src/config/settings.ts` so `corsAllowHeaders` includes them. Otherwise CORS preflight will fail and requests from the browser will be blocked.
+
+## Responsive Sizing
+
+**NEVER** use manual responsive classes like `h-11 md:h-9`, `size-5 md:size-4`, or `text-base md:text-sm`.
+
+**ALWAYS** use CSS custom properties that automatically respond to breakpoints:
+
+- Heights: `h-[var(--touch-height-default)]`, `h-[var(--touch-height-sm)]`, `h-[var(--touch-height-lg)]`, `h-[var(--touch-height-xl)]`
+- Icons: `size-[var(--icon-size-default)]`, `size-[var(--icon-size-sm)]`
+- Text: `text-[var(--font-size-body)]`, `text-[var(--font-size-sm)]`, `text-[var(--font-size-xs)]`
+- Padding X: `px-[var(--spacing-x-default)]`, `px-[var(--spacing-x-md)]`, `px-[var(--spacing-x-sm)]`, `px-[var(--spacing-x-lg)]`
+- Padding Y: `py-[var(--spacing-y-default)]`, `py-[var(--spacing-y-md)]`, `py-[var(--spacing-y-sm)]`
+- Gaps: `gap-[var(--gap-default)]`, `gap-[var(--gap-lg)]`, `gap-[var(--gap-sm)]`
+- Minimum heights: `min-h-[var(--min-touch-height)]`
+
+All variables are defined in `/src/index.css` with mobile (larger) and desktop (smaller) values that switch at 768px breakpoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,7 @@ When adding new custom headers to API requests (e.g. `X-Device-ID`, `X-Device-Na
 
 ## Responsive Sizing
 
-**NEVER** use manual responsive classes like `h-11 md:h-9`, `size-5 md:size-4`, or `text-base md:text-sm`.
-
-**ALWAYS** use CSS custom properties that automatically respond to breakpoints:
+**Prefer** CSS custom properties that automatically respond to breakpoints over manual responsive classes like `h-11 md:h-9`, `size-5 md:size-4`, or `text-base md:text-sm`:
 
 - Heights: `h-[var(--touch-height-default)]`, `h-[var(--touch-height-sm)]`, `h-[var(--touch-height-lg)]`, `h-[var(--touch-height-xl)]`
 - Icons: `size-[var(--icon-size-default)]`, `size-[var(--icon-size-sm)]`

--- a/src/components/chat/chat-prompt-input.test.tsx
+++ b/src/components/chat/chat-prompt-input.test.tsx
@@ -103,7 +103,7 @@ describe('ChatPromptInput', () => {
 
       const form = container.querySelector('form')
       expect(form?.className).toContain('gap-0')
-      expect(form?.className).toContain('p-4')
+      expect(form?.className).toContain('p-2')
     })
 
     it('should apply desktop class names when not mobile', () => {

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -154,7 +154,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
           submitOnEnter={!isStreaming && !shouldInsertNewlineOnEnter}
           className={cn(
             'flex flex-col bg-background dark:bg-input/30 border dark:border-input rounded-2xl w-full',
-            isMobile ? 'gap-0 p-4' : 'gap-2 p-3',
+            isMobile ? 'gap-0 p-2' : 'gap-2 p-3',
           )}
           footerStartElements={footerStartElements}
           isMobile={isMobile}

--- a/src/components/powersync-status.tsx
+++ b/src/components/powersync-status.tsx
@@ -74,7 +74,7 @@ export const PowerSyncStatus = () => {
           <button
             type="button"
             className={cn(
-              'flex items-center gap-2 px-[var(--spacing-x-sm)] py-2 md:py-1 rounded-md transition-colors min-h-[var(--min-touch-height)]',
+              'flex items-center gap-2 px-[var(--spacing-x-sm)] py-[var(--spacing-y-sm)] rounded-md transition-colors min-h-[var(--min-touch-height)]',
               'hover:bg-accent cursor-pointer select-none outline-none',
             )}
             aria-label="Sync status"

--- a/src/components/powersync-status.tsx
+++ b/src/components/powersync-status.tsx
@@ -50,15 +50,15 @@ export const PowerSyncStatus = () => {
 
   const getIcon = () => {
     if (!syncEnabled) {
-      return <CloudOff className="size-5 md:size-4 text-muted-foreground" />
+      return <CloudOff className="size-[var(--icon-size-default)] text-muted-foreground" />
     }
     if (isConnecting) {
-      return <Loader2 className="size-5 md:size-4 animate-spin text-muted-foreground" />
+      return <Loader2 className="size-[var(--icon-size-default)] animate-spin text-muted-foreground" />
     }
     if (!isConnected) {
-      return <CloudOff className="size-5 md:size-4 text-muted-foreground" />
+      return <CloudOff className="size-[var(--icon-size-default)] text-muted-foreground" />
     }
-    return <Cloud className="size-5 md:size-4 text-green-500" />
+    return <Cloud className="size-[var(--icon-size-default)] text-green-500" />
   }
 
   const statusNote = !isAuthenticated
@@ -74,14 +74,14 @@ export const PowerSyncStatus = () => {
           <button
             type="button"
             className={cn(
-              'flex items-center gap-2 px-3 md:px-2 py-2 md:py-1 rounded-md transition-colors min-h-10 md:min-h-0',
+              'flex items-center gap-2 px-[var(--spacing-x-sm)] py-2 md:py-1 rounded-md transition-colors min-h-[var(--min-touch-height)]',
               'hover:bg-accent cursor-pointer select-none outline-none',
             )}
             aria-label="Sync status"
             aria-haspopup="dialog"
           >
             {getIcon()}
-            <span className="text-sm md:text-xs text-muted-foreground hidden sm:inline">{getStatusText()}</span>
+            <span className="text-xs text-muted-foreground hidden sm:inline">{getStatusText()}</span>
           </button>
         </PopoverTrigger>
         <PopoverContent align="end" side="bottom">

--- a/src/components/powersync-status.tsx
+++ b/src/components/powersync-status.tsx
@@ -50,15 +50,15 @@ export const PowerSyncStatus = () => {
 
   const getIcon = () => {
     if (!syncEnabled) {
-      return <CloudOff className="h-4 w-4 text-muted-foreground" />
+      return <CloudOff className="size-5 md:size-4 text-muted-foreground" />
     }
     if (isConnecting) {
-      return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      return <Loader2 className="size-5 md:size-4 animate-spin text-muted-foreground" />
     }
     if (!isConnected) {
-      return <CloudOff className="h-4 w-4 text-muted-foreground" />
+      return <CloudOff className="size-5 md:size-4 text-muted-foreground" />
     }
-    return <Cloud className="h-4 w-4 text-green-500" />
+    return <Cloud className="size-5 md:size-4 text-green-500" />
   }
 
   const statusNote = !isAuthenticated
@@ -74,14 +74,14 @@ export const PowerSyncStatus = () => {
           <button
             type="button"
             className={cn(
-              'flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors',
+              'flex items-center gap-2 px-3 md:px-2 py-2 md:py-1 rounded-md transition-colors min-h-10 md:min-h-0',
               'hover:bg-accent cursor-pointer select-none outline-none',
             )}
             aria-label="Sync status"
             aria-haspopup="dialog"
           >
             {getIcon()}
-            <span className="text-xs text-muted-foreground hidden sm:inline">{getStatusText()}</span>
+            <span className="text-sm md:text-xs text-muted-foreground hidden sm:inline">{getStatusText()}</span>
           </button>
         </PopoverTrigger>
         <PopoverContent align="end" side="bottom">

--- a/src/components/sidebar-footer.tsx
+++ b/src/components/sidebar-footer.tsx
@@ -59,7 +59,7 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
                 <Loader2 className="size-[var(--icon-size-default)] animate-spin text-muted-foreground" />
               </div>
               {isExpanded && (
-                <div className="grid flex-1 text-left text-[var(--font-size-body)] leading-tight">
+                <div className="grid flex-1 text-left text-[length:var(--font-size-body)] leading-tight">
                   <span className="truncate text-muted-foreground">Loading...</span>
                 </div>
               )}
@@ -71,7 +71,7 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
                 <Sparkles className="size-[var(--icon-size-default)] text-muted-foreground" />
               </div>
               {isExpanded && (
-                <div className="flex flex-1 flex-col justify-center text-left text-[var(--font-size-body)] leading-tight">
+                <div className="flex flex-1 flex-col justify-center text-left text-[length:var(--font-size-body)] leading-tight">
                   <span className="truncate font-semibold">Sign In</span>
                   <span className="truncate text-xs text-muted-foreground">Sync chats between devices</span>
                 </div>
@@ -90,7 +90,7 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
                   </div>
                   {isExpanded && (
                     <>
-                      <div className="flex flex-1 flex-col justify-center text-left text-[var(--font-size-body)] leading-tight">
+                      <div className="flex flex-1 flex-col justify-center text-left text-[length:var(--font-size-body)] leading-tight">
                         {displayName && <span className="truncate font-semibold">{displayName}</span>}
                         <span className="truncate text-xs">{displayEmail}</span>
                       </div>
@@ -106,11 +106,11 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
                 sideOffset={4}
               >
                 <DropdownMenuLabel className="p-0 font-normal">
-                  <div className="flex items-center gap-2 px-1 py-[var(--spacing-y-md)] text-left text-[var(--font-size-body)]">
+                  <div className="flex items-center gap-2 px-1 py-[var(--spacing-y-md)] text-left text-[length:var(--font-size-body)]">
                     <div className="flex size-[var(--touch-height-sm)] items-center justify-center rounded-lg border border-border">
                       <Sparkles className="size-[var(--icon-size-default)] text-muted-foreground" />
                     </div>
-                    <div className="flex flex-1 flex-col justify-center text-left text-[var(--font-size-body)] leading-tight">
+                    <div className="flex flex-1 flex-col justify-center text-left text-[length:var(--font-size-body)] leading-tight">
                       {displayName && <span className="truncate font-semibold">{displayName}</span>}
                       <span className="truncate text-xs">{displayEmail}</span>
                     </div>

--- a/src/components/sidebar-footer.tsx
+++ b/src/components/sidebar-footer.tsx
@@ -55,11 +55,11 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
           {isPending ? (
             // Loading state
             <SidebarMenuButton size="lg" className="cursor-default">
-              <div className="flex h-8 w-8 items-center justify-center rounded-lg">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              <div className="flex h-10 w-10 md:h-8 md:w-8 items-center justify-center rounded-lg">
+                <Loader2 className="size-5 md:size-4 animate-spin text-muted-foreground" />
               </div>
               {isExpanded && (
-                <div className="grid flex-1 text-left text-sm leading-tight">
+                <div className="grid flex-1 text-left text-base md:text-sm leading-tight">
                   <span className="truncate text-muted-foreground">Loading...</span>
                 </div>
               )}
@@ -67,11 +67,11 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
           ) : !user ? (
             // Not logged in - show "Sign In" button
             <SidebarMenuButton size="lg" className="cursor-pointer" onClick={handleSignInClick}>
-              <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-border">
-                <Sparkles className="h-4 w-4 text-muted-foreground" />
+              <div className="flex h-10 w-10 md:h-8 md:w-8 items-center justify-center rounded-lg border border-border">
+                <Sparkles className="size-5 md:size-4 text-muted-foreground" />
               </div>
               {isExpanded && (
-                <div className="flex flex-1 flex-col justify-center text-left text-sm leading-tight">
+                <div className="flex flex-1 flex-col justify-center text-left text-base md:text-sm leading-tight">
                   <span className="truncate font-semibold">Sign In</span>
                   <span className="truncate text-xs text-muted-foreground">Sync chats between devices</span>
                 </div>
@@ -85,16 +85,16 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
                   size="lg"
                   className="cursor-pointer data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                 >
-                  <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-border">
-                    <Sparkles className="h-4 w-4 text-muted-foreground" />
+                  <div className="flex h-10 w-10 md:h-8 md:w-8 items-center justify-center rounded-lg border border-border">
+                    <Sparkles className="size-5 md:size-4 text-muted-foreground" />
                   </div>
                   {isExpanded && (
                     <>
-                      <div className="flex flex-1 flex-col justify-center text-left text-sm leading-tight">
+                      <div className="flex flex-1 flex-col justify-center text-left text-base md:text-sm leading-tight">
                         {displayName && <span className="truncate font-semibold">{displayName}</span>}
                         <span className="truncate text-xs">{displayEmail}</span>
                       </div>
-                      <ChevronsUpDown className="ml-auto size-4" />
+                      <ChevronsUpDown className="ml-auto size-5 md:size-4" />
                     </>
                   )}
                 </SidebarMenuButton>
@@ -106,11 +106,11 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
                 sideOffset={4}
               >
                 <DropdownMenuLabel className="p-0 font-normal">
-                  <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-border">
-                      <Sparkles className="h-4 w-4 text-muted-foreground" />
+                  <div className="flex items-center gap-2 px-1 py-2 md:py-1.5 text-left text-base md:text-sm">
+                    <div className="flex h-10 w-10 md:h-8 md:w-8 items-center justify-center rounded-lg border border-border">
+                      <Sparkles className="size-5 md:size-4 text-muted-foreground" />
                     </div>
-                    <div className="flex flex-1 flex-col justify-center text-left text-sm leading-tight">
+                    <div className="flex flex-1 flex-col justify-center text-left text-base md:text-sm leading-tight">
                       {displayName && <span className="truncate font-semibold">{displayName}</span>}
                       <span className="truncate text-xs">{displayEmail}</span>
                     </div>

--- a/src/components/sidebar-footer.tsx
+++ b/src/components/sidebar-footer.tsx
@@ -55,11 +55,11 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
           {isPending ? (
             // Loading state
             <SidebarMenuButton size="lg" className="cursor-default">
-              <div className="flex h-10 w-10 md:h-8 md:w-8 items-center justify-center rounded-lg">
-                <Loader2 className="size-5 md:size-4 animate-spin text-muted-foreground" />
+              <div className="flex size-[var(--touch-height-sm)] items-center justify-center rounded-lg">
+                <Loader2 className="size-[var(--icon-size-default)] animate-spin text-muted-foreground" />
               </div>
               {isExpanded && (
-                <div className="grid flex-1 text-left text-base md:text-sm leading-tight">
+                <div className="grid flex-1 text-left text-[var(--font-size-body)] leading-tight">
                   <span className="truncate text-muted-foreground">Loading...</span>
                 </div>
               )}
@@ -67,11 +67,11 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
           ) : !user ? (
             // Not logged in - show "Sign In" button
             <SidebarMenuButton size="lg" className="cursor-pointer" onClick={handleSignInClick}>
-              <div className="flex h-10 w-10 md:h-8 md:w-8 items-center justify-center rounded-lg border border-border">
-                <Sparkles className="size-5 md:size-4 text-muted-foreground" />
+              <div className="flex size-[var(--touch-height-sm)] items-center justify-center rounded-lg border border-border">
+                <Sparkles className="size-[var(--icon-size-default)] text-muted-foreground" />
               </div>
               {isExpanded && (
-                <div className="flex flex-1 flex-col justify-center text-left text-base md:text-sm leading-tight">
+                <div className="flex flex-1 flex-col justify-center text-left text-[var(--font-size-body)] leading-tight">
                   <span className="truncate font-semibold">Sign In</span>
                   <span className="truncate text-xs text-muted-foreground">Sync chats between devices</span>
                 </div>
@@ -85,16 +85,16 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
                   size="lg"
                   className="cursor-pointer data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                 >
-                  <div className="flex h-10 w-10 md:h-8 md:w-8 items-center justify-center rounded-lg border border-border">
-                    <Sparkles className="size-5 md:size-4 text-muted-foreground" />
+                  <div className="flex size-[var(--touch-height-sm)] items-center justify-center rounded-lg border border-border">
+                    <Sparkles className="size-[var(--icon-size-default)] text-muted-foreground" />
                   </div>
                   {isExpanded && (
                     <>
-                      <div className="flex flex-1 flex-col justify-center text-left text-base md:text-sm leading-tight">
+                      <div className="flex flex-1 flex-col justify-center text-left text-[var(--font-size-body)] leading-tight">
                         {displayName && <span className="truncate font-semibold">{displayName}</span>}
                         <span className="truncate text-xs">{displayEmail}</span>
                       </div>
-                      <ChevronsUpDown className="ml-auto size-5 md:size-4" />
+                      <ChevronsUpDown className="ml-auto size-[var(--icon-size-default)]" />
                     </>
                   )}
                 </SidebarMenuButton>
@@ -106,11 +106,11 @@ export const SidebarFooter = ({ className }: SidebarFooterProps) => {
                 sideOffset={4}
               >
                 <DropdownMenuLabel className="p-0 font-normal">
-                  <div className="flex items-center gap-2 px-1 py-2 md:py-1.5 text-left text-base md:text-sm">
-                    <div className="flex h-10 w-10 md:h-8 md:w-8 items-center justify-center rounded-lg border border-border">
-                      <Sparkles className="size-5 md:size-4 text-muted-foreground" />
+                  <div className="flex items-center gap-2 px-1 py-[var(--spacing-y-md)] text-left text-[var(--font-size-body)]">
+                    <div className="flex size-[var(--touch-height-sm)] items-center justify-center rounded-lg border border-border">
+                      <Sparkles className="size-[var(--icon-size-default)] text-muted-foreground" />
                     </div>
-                    <div className="flex flex-1 flex-col justify-center text-left text-base md:text-sm leading-tight">
+                    <div className="flex flex-1 flex-col justify-center text-left text-[var(--font-size-body)] leading-tight">
                       {displayName && <span className="truncate font-semibold">{displayName}</span>}
                       <span className="truncate text-xs">{displayEmail}</span>
                     </div>

--- a/src/components/ui/autosize-textarea.tsx
+++ b/src/components/ui/autosize-textarea.tsx
@@ -96,7 +96,7 @@ export const AutosizeTextarea = forwardRef<AutosizeTextAreaRef, AutosizeTextArea
         value={value}
         ref={textAreaRef}
         className={cn(
-          'flex w-full rounded-md border border-input bg-background px-4 md:px-3 py-2.5 md:py-2 text-base md:text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex w-full rounded-md border border-input bg-background px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[var(--font-size-body)] ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         onChange={(e) => {

--- a/src/components/ui/autosize-textarea.tsx
+++ b/src/components/ui/autosize-textarea.tsx
@@ -96,7 +96,7 @@ export const AutosizeTextarea = forwardRef<AutosizeTextAreaRef, AutosizeTextArea
         value={value}
         ref={textAreaRef}
         className={cn(
-          'flex w-full rounded-md border border-input bg-background px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[var(--font-size-body)] ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex w-full rounded-md border border-input bg-background px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[length:var(--font-size-body)] ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         onChange={(e) => {

--- a/src/components/ui/autosize-textarea.tsx
+++ b/src/components/ui/autosize-textarea.tsx
@@ -96,7 +96,7 @@ export const AutosizeTextarea = forwardRef<AutosizeTextAreaRef, AutosizeTextArea
         value={value}
         ref={textAreaRef}
         className={cn(
-          'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex w-full rounded-md border border-input bg-background px-4 md:px-3 py-2.5 md:py-2 text-base md:text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         onChange={(e) => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { useHaptics } from '@/hooks/use-haptics'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2.5 md:gap-2 whitespace-nowrap rounded-md text-base md:text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-[var(--gap-lg)] whitespace-nowrap rounded-md text-[var(--font-size-body)] font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -20,10 +20,11 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-11 md:h-9 px-5 md:px-4 py-2.5 md:py-2 has-[>svg]:px-4 md:has-[>svg]:px-3',
-        sm: 'h-10 md:h-8 rounded-md gap-2 md:gap-1.5 px-4 md:px-3 has-[>svg]:px-3 md:has-[>svg]:px-2.5',
-        lg: 'h-12 md:h-10 rounded-md px-7 md:px-6 has-[>svg]:px-5 md:has-[>svg]:px-4',
-        icon: 'size-11 md:size-9',
+        default:
+          'h-[var(--touch-height-default)] px-[var(--spacing-x-default)] py-[var(--spacing-y-default)] has-[>svg]:px-[var(--spacing-x-md)]',
+        sm: 'h-[var(--touch-height-sm)] rounded-md gap-[var(--gap-default)] px-[var(--spacing-x-md)] has-[>svg]:px-[var(--spacing-x-sm)]',
+        lg: 'h-[var(--touch-height-lg)] rounded-md px-[var(--spacing-x-lg)] has-[>svg]:px-[var(--spacing-x-default)]',
+        icon: 'size-[var(--touch-height-default)]',
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { useHaptics } from '@/hooks/use-haptics'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-[var(--gap-lg)] whitespace-nowrap rounded-md text-[var(--font-size-body)] font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-[var(--gap-lg)] whitespace-nowrap rounded-md text-[length:var(--font-size-body)] font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { useHaptics } from '@/hooks/use-haptics'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2.5 md:gap-2 whitespace-nowrap rounded-md text-base md:text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -20,10 +20,10 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        icon: 'size-9',
+        default: 'h-11 md:h-9 px-5 md:px-4 py-2.5 md:py-2 has-[>svg]:px-4 md:has-[>svg]:px-3',
+        sm: 'h-10 md:h-8 rounded-md gap-2 md:gap-1.5 px-4 md:px-3 has-[>svg]:px-3 md:has-[>svg]:px-2.5',
+        lg: 'h-12 md:h-10 rounded-md px-7 md:px-6 has-[>svg]:px-5 md:has-[>svg]:px-4',
+        icon: 'size-11 md:size-9',
       },
     },
     defaultVariants: {

--- a/src/components/ui/chat-nav-button.tsx
+++ b/src/components/ui/chat-nav-button.tsx
@@ -40,7 +40,7 @@ export const ChatNavButton = ({ chatTitle, threadId, className, asChild = false,
         <div className="flex items-center w-full">
           <Button
             variant="ghost"
-            className="flex items-center justify-between gap-2 h-10 px-3 w-full"
+            className="flex items-center justify-between gap-2 h-12 md:h-10 px-4 md:px-3 w-full"
             onClick={handleButtonClick}
           >
             <div className="flex items-center gap-2">

--- a/src/components/ui/chat-nav-button.tsx
+++ b/src/components/ui/chat-nav-button.tsx
@@ -40,7 +40,7 @@ export const ChatNavButton = ({ chatTitle, threadId, className, asChild = false,
         <div className="flex items-center w-full">
           <Button
             variant="ghost"
-            className="flex items-center justify-between gap-2 h-12 md:h-10 px-4 md:px-3 w-full"
+            className="flex items-center justify-between gap-2 h-[var(--touch-height-lg)] px-[var(--spacing-x-md)] w-full"
             onClick={handleButtonClick}
           >
             <div className="flex items-center gap-2">

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -23,7 +23,7 @@ const Checkbox = forwardRef<
     <CheckboxPrimitive.Root
       ref={ref}
       className={cn(
-        'peer h-5 w-5 md:h-4 md:w-4 shrink-0 rounded-[4px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground cursor-pointer',
+        'peer size-[var(--icon-size-default)] shrink-0 rounded-[4px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground cursor-pointer',
         className,
       )}
       onCheckedChange={handleCheckedChange}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -23,7 +23,7 @@ const Checkbox = forwardRef<
     <CheckboxPrimitive.Root
       ref={ref}
       className={cn(
-        'peer h-4 w-4 shrink-0 rounded-[4px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground cursor-pointer',
+        'peer h-5 w-5 md:h-4 md:w-4 shrink-0 rounded-[4px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground cursor-pointer',
         className,
       )}
       onCheckedChange={handleCheckedChange}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -48,7 +48,7 @@ const CommandDialog = ({
 
 const CommandInput = ({ className, ...props }: ComponentProps<typeof CommandPrimitive.Input>) => {
   return (
-    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
+    <div data-slot="command-input-wrapper" className="flex h-11 md:h-9 items-center gap-2 border-b px-4 md:px-3">
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"
@@ -104,7 +104,7 @@ const CommandItem = ({ className, ...props }: ComponentProps<typeof CommandPrimi
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-3 md:px-2 py-2 md:py-1.5 text-base md:text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -48,7 +48,10 @@ const CommandDialog = ({
 
 const CommandInput = ({ className, ...props }: ComponentProps<typeof CommandPrimitive.Input>) => {
   return (
-    <div data-slot="command-input-wrapper" className="flex h-11 md:h-9 items-center gap-2 border-b px-4 md:px-3">
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-[var(--touch-height-default)] items-center gap-2 border-b px-[var(--spacing-x-md)]"
+    >
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"
@@ -104,7 +107,7 @@ const CommandItem = ({ className, ...props }: ComponentProps<typeof CommandPrimi
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-3 md:px-2 py-2 md:py-1.5 text-base md:text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[var(--font-size-body)] outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -107,7 +107,7 @@ const CommandItem = ({ className, ...props }: ComponentProps<typeof CommandPrimi
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[var(--font-size-body)] outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[length:var(--font-size-body)] outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -68,7 +68,7 @@ const DialogContent = ({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring absolute right-4 flex h-10 w-10 md:h-8 md:w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring absolute right-4 flex size-[var(--touch-height-sm)] cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
             style={{ top: fullScreen ? 'calc(var(--safe-area-top-padding, 0px) + 16px)' : '16px' }}
           >
             <XIcon />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -68,7 +68,7 @@ const DialogContent = ({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring absolute right-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring absolute right-4 flex h-10 w-10 md:h-8 md:w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
             style={{ top: fullScreen ? 'calc(var(--safe-area-top-padding, 0px) + 16px)' : '16px' }}
           >
             <XIcon />

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -55,7 +55,7 @@ const DropdownMenuItem = ({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-3 md:px-2 py-2 md:py-1.5 text-base md:text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-9 md:data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -73,7 +73,7 @@ const DropdownMenuCheckboxItem = ({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-2 md:py-1.5 pr-3 md:pr-2 pl-9 md:pl-8 text-base md:text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -102,7 +102,7 @@ const DropdownMenuRadioItem = ({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-2 md:py-1.5 pr-3 md:pr-2 pl-9 md:pl-8 text-base md:text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -171,7 +171,7 @@ const DropdownMenuSubTrigger = ({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-3 md:px-2 py-2 md:py-1.5 text-base md:text-sm outline-hidden select-none data-[inset]:pl-9 md:data-[inset]:pl-8',
         className,
       )}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -55,7 +55,7 @@ const DropdownMenuItem = ({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-3 md:px-2 py-2 md:py-1.5 text-base md:text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-9 md:data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-9 md:data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -73,7 +73,7 @@ const DropdownMenuCheckboxItem = ({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-2 md:py-1.5 pr-3 md:pr-2 pl-9 md:pl-8 text-base md:text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-[var(--spacing-x-sm)] pl-9 md:pl-8 text-[var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -102,7 +102,7 @@ const DropdownMenuRadioItem = ({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-2 md:py-1.5 pr-3 md:pr-2 pl-9 md:pl-8 text-base md:text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-[var(--spacing-x-sm)] pl-9 md:pl-8 text-[var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -171,7 +171,7 @@ const DropdownMenuSubTrigger = ({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-3 md:px-2 py-2 md:py-1.5 text-base md:text-sm outline-hidden select-none data-[inset]:pl-9 md:data-[inset]:pl-8',
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[var(--font-size-body)] outline-hidden select-none data-[inset]:pl-9 md:data-[inset]:pl-8',
         className,
       )}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -55,7 +55,7 @@ const DropdownMenuItem = ({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-9 md:data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[length:var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-9 md:data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -73,7 +73,7 @@ const DropdownMenuCheckboxItem = ({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-[var(--spacing-x-sm)] pl-9 md:pl-8 text-[var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-[var(--spacing-x-sm)] pl-9 md:pl-8 text-[length:var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -102,7 +102,7 @@ const DropdownMenuRadioItem = ({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-[var(--spacing-x-sm)] pl-9 md:pl-8 text-[var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-[var(--spacing-x-sm)] pl-9 md:pl-8 text-[length:var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -171,7 +171,7 @@ const DropdownMenuSubTrigger = ({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[var(--font-size-body)] outline-hidden select-none data-[inset]:pl-9 md:data-[inset]:pl-8',
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-[var(--spacing-x-sm)] py-[var(--spacing-y-md)] text-[length:var(--font-size-body)] outline-hidden select-none data-[inset]:pl-9 md:data-[inset]:pl-8',
         className,
       )}
       {...props}

--- a/src/components/ui/expandable.tsx
+++ b/src/components/ui/expandable.tsx
@@ -58,7 +58,7 @@ export const Expandable = ({
         <AccordionPrimitive.Header className="flex">
           <AccordionPrimitive.Trigger
             className={cn(
-              'flex flex-1 items-center justify-between gap-2 px-4 py-[var(--spacing-y-default)] text-left transition-all outline-none min-h-12 md:min-h-10',
+              'flex flex-1 items-center justify-between gap-2 px-4 py-[var(--spacing-y-default)] text-left transition-all outline-none min-h-[var(--min-touch-height)]',
               'hover:bg-secondary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
               'rounded-lg data-[state=open]:rounded-b-none',
               'disabled:pointer-events-none disabled:opacity-50',

--- a/src/components/ui/expandable.tsx
+++ b/src/components/ui/expandable.tsx
@@ -58,7 +58,7 @@ export const Expandable = ({
         <AccordionPrimitive.Header className="flex">
           <AccordionPrimitive.Trigger
             className={cn(
-              'flex flex-1 items-center justify-between gap-2 px-4 py-2 text-left transition-all outline-none min-h-10',
+              'flex flex-1 items-center justify-between gap-2 px-4 py-2.5 md:py-2 text-left transition-all outline-none min-h-12 md:min-h-10',
               'hover:bg-secondary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
               'rounded-lg data-[state=open]:rounded-b-none',
               'disabled:pointer-events-none disabled:opacity-50',

--- a/src/components/ui/expandable.tsx
+++ b/src/components/ui/expandable.tsx
@@ -58,7 +58,7 @@ export const Expandable = ({
         <AccordionPrimitive.Header className="flex">
           <AccordionPrimitive.Trigger
             className={cn(
-              'flex flex-1 items-center justify-between gap-2 px-4 py-2.5 md:py-2 text-left transition-all outline-none min-h-12 md:min-h-10',
+              'flex flex-1 items-center justify-between gap-2 px-4 py-[var(--spacing-y-default)] text-left transition-all outline-none min-h-12 md:min-h-10',
               'hover:bg-secondary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
               'rounded-lg data-[state=open]:rounded-b-none',
               'disabled:pointer-events-none disabled:opacity-50',

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -88,6 +88,7 @@ export const Header = () => {
               <span className="sr-only">New Chat</span>
             </Button>
           )}
+          <PowerSyncStatus />
         </div>
       </header>
     )

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -62,7 +62,7 @@ export const Header = () => {
 
     return (
       <header className="flex h-[var(--touch-height-xl)] w-full items-center justify-between px-[var(--spacing-x-sm)] flex-shrink-0 border-b border-border">
-        <div className="flex items-center w-10 md:w-7">
+        <div className="flex flex-1 items-center">
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -61,7 +61,7 @@ export const Header = () => {
     const showNewChatButton = isChatRoute && location.pathname !== '/chats/new'
 
     return (
-      <header className="flex h-14 md:h-12 w-full items-center justify-between px-3 md:px-2 flex-shrink-0 border-b border-border">
+      <header className="flex h-[var(--touch-height-xl)] w-full items-center justify-between px-[var(--spacing-x-sm)] flex-shrink-0 border-b border-border">
         <div className="flex items-center w-10 md:w-7">
           <Button
             variant="ghost"
@@ -69,7 +69,7 @@ export const Header = () => {
             className="h-10 w-10 md:h-7 md:w-7 cursor-pointer"
             onClick={toggleSidebar}
           >
-            <Menu className="size-5 md:size-4" />
+            <Menu className="size-[var(--icon-size-default)]" />
             <span className="sr-only">Toggle Sidebar</span>
           </Button>
         </div>
@@ -84,7 +84,7 @@ export const Header = () => {
               className="h-10 w-10 md:h-7 md:w-7 cursor-pointer"
               onClick={handleNewChat}
             >
-              <MessageCirclePlus className="size-5 md:size-4" />
+              <MessageCirclePlus className="size-[var(--icon-size-default)]" />
               <span className="sr-only">New Chat</span>
             </Button>
           )}
@@ -95,7 +95,7 @@ export const Header = () => {
 
   // Desktop: Left-aligned with PowerSync status on the right
   return (
-    <header className="flex h-14 md:h-12 w-full items-center justify-between px-3 md:px-2 flex-shrink-0 border-b border-border">
+    <header className="flex h-[var(--touch-height-xl)] w-full items-center justify-between px-[var(--spacing-x-sm)] flex-shrink-0 border-b border-border">
       <div className="flex items-center">{modelSelector}</div>
       <PowerSyncStatus />
     </header>

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -66,7 +66,7 @@ export const Header = () => {
           <Button
             variant="ghost"
             size="icon"
-            className="h-10 w-10 md:h-7 md:w-7 cursor-pointer"
+            className="size-[var(--touch-height-sm)] cursor-pointer"
             onClick={toggleSidebar}
           >
             <Menu className="size-[var(--icon-size-default)]" />
@@ -81,7 +81,7 @@ export const Header = () => {
             <Button
               variant="ghost"
               size="icon"
-              className="h-10 w-10 md:h-7 md:w-7 cursor-pointer"
+              className="size-[var(--touch-height-sm)] cursor-pointer"
               onClick={handleNewChat}
             >
               <MessageCirclePlus className="size-[var(--icon-size-default)]" />

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -61,10 +61,15 @@ export const Header = () => {
     const showNewChatButton = isChatRoute && location.pathname !== '/chats/new'
 
     return (
-      <header className="flex h-12 w-full items-center px-2 flex-shrink-0 border-b border-border">
-        <div className="flex flex-1 items-center">
-          <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={toggleSidebar}>
-            <Menu className="h-5 w-5" />
+      <header className="flex h-14 md:h-12 w-full items-center justify-between px-3 md:px-2 flex-shrink-0 border-b border-border">
+        <div className="flex items-center w-10 md:w-7">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-10 w-10 md:h-7 md:w-7 cursor-pointer"
+            onClick={toggleSidebar}
+          >
+            <Menu className="size-5 md:size-4" />
             <span className="sr-only">Toggle Sidebar</span>
           </Button>
         </div>
@@ -73,8 +78,13 @@ export const Header = () => {
 
         <div className="flex flex-1 items-center gap-1 justify-end">
           {showNewChatButton && (
-            <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer" onClick={handleNewChat}>
-              <MessageCirclePlus className="h-5 w-5" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 md:h-7 md:w-7 cursor-pointer"
+              onClick={handleNewChat}
+            >
+              <MessageCirclePlus className="size-5 md:size-4" />
               <span className="sr-only">New Chat</span>
             </Button>
           )}
@@ -85,7 +95,7 @@ export const Header = () => {
 
   // Desktop: Left-aligned with PowerSync status on the right
   return (
-    <header className="flex h-12 w-full items-center justify-between px-2 flex-shrink-0 border-b border-border">
+    <header className="flex h-14 md:h-12 w-full items-center justify-between px-3 md:px-2 flex-shrink-0 border-b border-border">
       <div className="flex items-center">{modelSelector}</div>
       <PowerSyncStatus />
     </header>

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -40,7 +40,7 @@ const InputOTPSlot = ({
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border text-sm shadow-xs transition-all outline-none first:rounded-l-md last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
+        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-11 w-11 md:h-9 md:w-9 items-center justify-center border text-base md:text-sm shadow-xs transition-all outline-none first:rounded-l-md last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
         className,
       )}
       {...props}

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -40,7 +40,7 @@ const InputOTPSlot = ({
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-11 w-11 md:h-9 md:w-9 items-center justify-center border text-base md:text-sm shadow-xs transition-all outline-none first:rounded-l-md last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
+        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-[var(--touch-height-default)] w-[var(--touch-height-default)] items-center justify-center border text-[length:var(--font-size-body)] shadow-xs transition-all outline-none first:rounded-l-md last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
         className,
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -16,9 +16,9 @@ const inputVariants = cva(
       },
       inputSize: {
         default: 'h-[var(--touch-height-default)] w-full',
-        sm: 'h-[var(--touch-height-sm)] text-xs px-[var(--spacing-x-sm)] py-1 md:py-0.5 rounded-md',
+        sm: 'h-[var(--touch-height-sm)] text-xs px-[var(--spacing-x-sm)] py-[var(--spacing-y-sm)] rounded-md',
         lg: 'h-[var(--touch-height-lg)] text-base px-[var(--spacing-x-default)] py-[var(--spacing-y-default)] rounded-md',
-        xl: 'h-[var(--touch-height-xl)] text-lg px-6 md:px-5 py-3 md:py-2.5 rounded-lg',
+        xl: 'h-[var(--touch-height-xl)] text-lg px-[var(--spacing-x-lg)] py-[var(--spacing-y-md)] rounded-lg',
       },
       state: {
         default: '',

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { forwardRef, type InputHTMLAttributes } from 'react'
 import { cn } from '@/lib/utils'
 
 const inputVariants = cva(
-  'border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex min-w-0 rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-sm)] text-[var(--font-size-body)] outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+  'border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex min-w-0 rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-sm)] text-[length:var(--font-size-body)] outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { forwardRef, type InputHTMLAttributes } from 'react'
 import { cn } from '@/lib/utils'
 
 const inputVariants = cva(
-  'border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex min-w-0 rounded-md border bg-transparent px-4 md:px-3 py-1.5 md:py-1 text-base outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+  'border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex min-w-0 rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-sm)] text-[var(--font-size-body)] outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
   {
     variants: {
       variant: {
@@ -15,10 +15,10 @@ const inputVariants = cva(
         ghost: 'border-none focus-visible:bg-accent/50 focus-visible:ring-0',
       },
       inputSize: {
-        default: 'h-11 md:h-9 w-full',
-        sm: 'h-10 md:h-8 text-xs px-3 md:px-2.5 py-1 md:py-0.5 rounded-md',
-        lg: 'h-12 md:h-10 text-base px-5 md:px-4 py-2.5 md:py-2 rounded-md',
-        xl: 'h-14 md:h-12 text-lg px-6 md:px-5 py-3 md:py-2.5 rounded-lg',
+        default: 'h-[var(--touch-height-default)] w-full',
+        sm: 'h-[var(--touch-height-sm)] text-xs px-[var(--spacing-x-sm)] py-1 md:py-0.5 rounded-md',
+        lg: 'h-[var(--touch-height-lg)] text-base px-[var(--spacing-x-default)] py-[var(--spacing-y-default)] rounded-md',
+        xl: 'h-[var(--touch-height-xl)] text-lg px-6 md:px-5 py-3 md:py-2.5 rounded-lg',
       },
       state: {
         default: '',

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { forwardRef, type InputHTMLAttributes } from 'react'
 import { cn } from '@/lib/utils'
 
 const inputVariants = cva(
-  'border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex min-w-0 rounded-md border bg-transparent px-3 py-1 text-base outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+  'border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex min-w-0 rounded-md border bg-transparent px-4 md:px-3 py-1.5 md:py-1 text-base outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
   {
     variants: {
       variant: {
@@ -15,10 +15,10 @@ const inputVariants = cva(
         ghost: 'border-none focus-visible:bg-accent/50 focus-visible:ring-0',
       },
       inputSize: {
-        default: 'h-9 w-full',
-        sm: 'h-8 text-xs px-2.5 py-0.5 rounded-md',
-        lg: 'h-10 text-base px-4 py-2 rounded-md',
-        xl: 'h-12 text-lg px-5 py-2.5 rounded-lg',
+        default: 'h-11 md:h-9 w-full',
+        sm: 'h-10 md:h-8 text-xs px-3 md:px-2.5 py-1 md:py-0.5 rounded-md',
+        lg: 'h-12 md:h-10 text-base px-5 md:px-4 py-2.5 md:py-2 rounded-md',
+        xl: 'h-14 md:h-12 text-lg px-6 md:px-5 py-3 md:py-2.5 rounded-lg',
       },
       state: {
         default: '',

--- a/src/components/ui/mode-selector/mode-selector.tsx
+++ b/src/components/ui/mode-selector/mode-selector.tsx
@@ -47,7 +47,9 @@ export const ModeSelector = ({ modes, selectedMode, onModeChange, iconOnly = fal
     <div
       className={cn(
         'flex items-center rounded-lg cursor-pointer transition-colors text-sm border border-border',
-        iconOnly ? 'size-11 md:size-[34px] justify-center' : 'gap-1 px-3 md:px-2 py-2 md:py-1.5',
+        iconOnly
+          ? 'size-[var(--touch-height-default)] justify-center'
+          : 'gap-1 px-[var(--spacing-x-sm)] py-[var(--spacing-y-sm)]',
         isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
       )}
     >
@@ -62,7 +64,7 @@ export const ModeSelector = ({ modes, selectedMode, onModeChange, iconOnly = fal
     return (
       <div
         className={cn(
-          'w-full flex items-center gap-2 px-4 md:px-3 py-3 md:py-2.5 rounded-xl transition-colors text-left cursor-pointer',
+          'w-full flex items-center gap-2 px-[var(--spacing-x-md)] py-[var(--spacing-y-md)] rounded-xl transition-colors text-left cursor-pointer',
           isSelected ? 'bg-muted' : 'hover:bg-accent/50',
         )}
       >

--- a/src/components/ui/mode-selector/mode-selector.tsx
+++ b/src/components/ui/mode-selector/mode-selector.tsx
@@ -45,7 +45,7 @@ export const ModeSelector = ({ modes, selectedMode, onModeChange, iconOnly = fal
     <div
       className={cn(
         'flex items-center rounded-lg cursor-pointer transition-colors text-sm border border-border',
-        iconOnly ? 'size-[34px] justify-center' : 'gap-1 px-2 py-1.5',
+        iconOnly ? 'size-11 md:size-[34px] justify-center' : 'gap-1 px-3 md:px-2 py-2 md:py-1.5',
         isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
       )}
     >
@@ -60,7 +60,7 @@ export const ModeSelector = ({ modes, selectedMode, onModeChange, iconOnly = fal
     return (
       <div
         className={cn(
-          'w-full flex items-center gap-2 px-3 py-2.5 rounded-xl transition-colors text-left cursor-pointer',
+          'w-full flex items-center gap-2 px-4 md:px-3 py-3 md:py-2.5 rounded-xl transition-colors text-left cursor-pointer',
           isSelected ? 'bg-muted' : 'hover:bg-accent/50',
         )}
       >

--- a/src/components/ui/mode-selector/mode-selector.tsx
+++ b/src/components/ui/mode-selector/mode-selector.tsx
@@ -46,7 +46,7 @@ export const ModeSelector = ({ modes, selectedMode, onModeChange, iconOnly = fal
   const renderTrigger = (selected: SearchableMenuItem<ModeItemData> | undefined, isOpen: boolean) => (
     <div
       className={cn(
-        'flex items-center rounded-lg cursor-pointer transition-colors text-sm border border-border',
+        'flex items-center rounded-lg cursor-pointer transition-colors text-[length:var(--font-size-sm)] border border-border',
         iconOnly
           ? 'size-[var(--touch-height-default)] justify-center'
           : 'gap-1 px-[var(--spacing-x-sm)] py-[var(--spacing-y-sm)]',
@@ -70,7 +70,7 @@ export const ModeSelector = ({ modes, selectedMode, onModeChange, iconOnly = fal
       >
         {item.icon}
         <span>{item.label}</span>
-        {isDefault && <span className="text-muted-foreground text-sm">Default</span>}
+        {isDefault && <span className="text-muted-foreground text-[length:var(--font-size-sm)]">Default</span>}
       </div>
     )
   }

--- a/src/components/ui/mode-selector/mode-selector.tsx
+++ b/src/components/ui/mode-selector/mode-selector.tsx
@@ -11,14 +11,16 @@ export type ModeSelectorProps = {
   iconOnly?: boolean
 }
 
+const iconSize = 'size-[var(--icon-size-default)]'
+
 const iconMap: Record<string, ReactNode> = {
-  'message-square': <MessageSquare className="size-4" />,
-  globe: <Globe className="size-4" />,
-  microscope: <Microscope className="size-4" />,
+  'message-square': <MessageSquare className={iconSize} />,
+  globe: <Globe className={iconSize} />,
+  microscope: <Microscope className={iconSize} />,
 }
 
 const getModeIcon = (iconName: string): ReactNode => {
-  return iconMap[iconName] ?? <MessageSquare className="size-4" />
+  return iconMap[iconName] ?? <MessageSquare className={iconSize} />
 }
 
 type ModeItemData = {
@@ -49,7 +51,7 @@ export const ModeSelector = ({ modes, selectedMode, onModeChange, iconOnly = fal
         isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
       )}
     >
-      {selected?.icon ?? <MessageSquare className="size-4" />}
+      {selected?.icon ?? <MessageSquare className={iconSize} />}
       {!iconOnly && <span className="font-medium text-muted-foreground">{selected?.label ?? 'Chat'}</span>}
     </div>
   )

--- a/src/components/ui/model-select.tsx
+++ b/src/components/ui/model-select.tsx
@@ -39,7 +39,7 @@ export const ModelSelect = memo(({ chatThread, models, selectedModelId, onModelC
   const renderTrigger = (selected: SearchableMenuItem<ModelItemData> | undefined, isOpen: boolean) => (
     <div
       className={cn(
-        'flex items-center justify-between gap-2 px-4 md:px-3 py-2 md:py-1.5 rounded-full cursor-pointer transition-colors text-base md:text-sm border h-11 md:h-9 min-w-[140px]',
+        'flex items-center justify-between gap-2 px-[var(--spacing-x-md)] py-[var(--spacing-y-md)] rounded-full cursor-pointer transition-colors text-[length:var(--font-size-body)] border h-[var(--touch-height-default)] min-w-[140px]',
         isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
       )}
     >

--- a/src/components/ui/model-select.tsx
+++ b/src/components/ui/model-select.tsx
@@ -39,7 +39,7 @@ export const ModelSelect = memo(({ chatThread, models, selectedModelId, onModelC
   const renderTrigger = (selected: SearchableMenuItem<ModelItemData> | undefined, isOpen: boolean) => (
     <div
       className={cn(
-        'flex items-center justify-between gap-2 px-3 py-1.5 rounded-full cursor-pointer transition-colors text-sm border h-9 min-w-[140px]',
+        'flex items-center justify-between gap-2 px-4 md:px-3 py-2 md:py-1.5 rounded-full cursor-pointer transition-colors text-base md:text-sm border h-11 md:h-9 min-w-[140px]',
         isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
       )}
     >

--- a/src/components/ui/model-selector/model-selector.tsx
+++ b/src/components/ui/model-selector/model-selector.tsx
@@ -94,7 +94,7 @@ export const ModelSelector = ({
   const renderTrigger = (selected: SearchableMenuItem<ModelItemData> | undefined, isOpen: boolean) => (
     <div
       className={cn(
-        'flex items-center gap-2 px-4 md:px-3 py-2 md:py-1.5 rounded-full cursor-pointer transition-colors text-base md:text-sm',
+        'flex items-center gap-2 px-[var(--spacing-x-md)] py-[var(--spacing-y-sm)] rounded-full cursor-pointer transition-colors text-[length:var(--font-size-body)]',
         isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
       )}
     >
@@ -107,7 +107,7 @@ export const ModelSelector = ({
   const renderItem = (item: SearchableMenuItem<ModelItemData>, isSelected: boolean) => (
     <div
       className={cn(
-        'w-full flex items-center justify-between px-4 md:px-3 py-2.5 md:py-2 rounded-lg transition-colors text-left cursor-pointer',
+        'w-full flex items-center justify-between px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] rounded-lg transition-colors text-left cursor-pointer',
         'hover:bg-accent/50',
         isSelected && 'bg-accent',
         item.disabled && 'opacity-50 cursor-not-allowed',

--- a/src/components/ui/model-selector/model-selector.tsx
+++ b/src/components/ui/model-selector/model-selector.tsx
@@ -94,7 +94,7 @@ export const ModelSelector = ({
   const renderTrigger = (selected: SearchableMenuItem<ModelItemData> | undefined, isOpen: boolean) => (
     <div
       className={cn(
-        'flex items-center gap-2 px-3 py-1.5 rounded-full cursor-pointer transition-colors text-sm',
+        'flex items-center gap-2 px-4 md:px-3 py-2 md:py-1.5 rounded-full cursor-pointer transition-colors text-base md:text-sm',
         isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
       )}
     >
@@ -107,7 +107,7 @@ export const ModelSelector = ({
   const renderItem = (item: SearchableMenuItem<ModelItemData>, isSelected: boolean) => (
     <div
       className={cn(
-        'w-full flex items-center justify-between px-3 py-2 rounded-lg transition-colors text-left cursor-pointer',
+        'w-full flex items-center justify-between px-4 md:px-3 py-2.5 md:py-2 rounded-lg transition-colors text-left cursor-pointer',
         'hover:bg-accent/50',
         isSelected && 'bg-accent',
         item.disabled && 'opacity-50 cursor-not-allowed',

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -81,7 +81,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <Button
           type="button"
           variant="default"
-          className="size-8 rounded-lg flex items-center justify-center flex-shrink-0"
+          className="size-10 md:size-8 rounded-lg flex items-center justify-center flex-shrink-0"
           onClick={onStop}
         >
           <Square className="size-4" />
@@ -90,7 +90,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <Button
           type="submit"
           variant="default"
-          className="size-8 rounded-lg flex items-center justify-center flex-shrink-0"
+          className="size-10 md:size-8 rounded-lg flex items-center justify-center flex-shrink-0"
           disabled={isLoading || !value.trim()}
         >
           <ArrowUp className="size-4" />

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -81,7 +81,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <Button
           type="button"
           variant="default"
-          className="size-10 md:size-8 rounded-lg flex items-center justify-center flex-shrink-0"
+          className="size-[var(--touch-height-sm)] rounded-lg flex items-center justify-center flex-shrink-0"
           onClick={onStop}
         >
           <Square className="size-4" />
@@ -90,7 +90,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <Button
           type="submit"
           variant="default"
-          className="size-10 md:size-8 rounded-lg flex items-center justify-center flex-shrink-0"
+          className="size-[var(--touch-height-sm)] rounded-lg flex items-center justify-center flex-shrink-0"
           disabled={isLoading || !value.trim()}
         >
           <ArrowUp className="size-4" />

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -84,7 +84,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
           className="size-[var(--touch-height-sm)] rounded-lg flex items-center justify-center flex-shrink-0"
           onClick={onStop}
         >
-          <Square className="size-4" />
+          <Square className="size-[var(--icon-size-default)]" />
         </Button>
       ) : (
         <Button
@@ -93,7 +93,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
           className="size-[var(--touch-height-sm)] rounded-lg flex items-center justify-center flex-shrink-0"
           disabled={isLoading || !value.trim()}
         >
-          <ArrowUp className="size-4" />
+          <ArrowUp className="size-[var(--icon-size-default)]" />
         </Button>
       ))
 

--- a/src/components/ui/responsive-modal.tsx
+++ b/src/components/ui/responsive-modal.tsx
@@ -123,7 +123,7 @@ export const ResponsiveModal = ({
               <>
                 {children}
                 {showCloseButton && (
-                  <DialogPrimitive.Close className="ring-offset-background focus:ring-ring absolute right-4 top-4 flex h-10 w-10 md:h-8 md:w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+                  <DialogPrimitive.Close className="ring-offset-background focus:ring-ring absolute right-4 top-4 flex h-[var(--touch-height-sm)] w-[var(--touch-height-sm)] cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
                     <XIcon className="h-4 w-4" />
                     <span className="sr-only">Close</span>
                   </DialogPrimitive.Close>
@@ -235,7 +235,7 @@ export const ResponsiveModalContentComposable = ({
         {children}
         {showCloseButton && (
           <DialogClose
-            className="ring-offset-background focus:ring-ring absolute right-4 flex h-10 w-10 md:h-8 md:w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+            className="ring-offset-background focus:ring-ring absolute right-4 flex h-[var(--touch-height-sm)] w-[var(--touch-height-sm)] cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
             style={{ top: isMobile ? 'calc(var(--safe-area-top-padding, 0px) + 16px)' : 16 }}
           >
             <XIcon className="h-4 w-4" />

--- a/src/components/ui/responsive-modal.tsx
+++ b/src/components/ui/responsive-modal.tsx
@@ -123,7 +123,7 @@ export const ResponsiveModal = ({
               <>
                 {children}
                 {showCloseButton && (
-                  <DialogPrimitive.Close className="ring-offset-background focus:ring-ring absolute right-4 top-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+                  <DialogPrimitive.Close className="ring-offset-background focus:ring-ring absolute right-4 top-4 flex h-10 w-10 md:h-8 md:w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
                     <XIcon className="h-4 w-4" />
                     <span className="sr-only">Close</span>
                   </DialogPrimitive.Close>
@@ -235,7 +235,7 @@ export const ResponsiveModalContentComposable = ({
         {children}
         {showCloseButton && (
           <DialogClose
-            className="ring-offset-background focus:ring-ring absolute right-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+            className="ring-offset-background focus:ring-ring absolute right-4 flex h-10 w-10 md:h-8 md:w-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
             style={{ top: isMobile ? 'calc(var(--safe-area-top-padding, 0px) + 16px)' : 16 }}
           >
             <XIcon className="h-4 w-4" />

--- a/src/components/ui/responsive-modal.tsx
+++ b/src/components/ui/responsive-modal.tsx
@@ -124,7 +124,7 @@ export const ResponsiveModal = ({
                 {children}
                 {showCloseButton && (
                   <DialogPrimitive.Close className="ring-offset-background focus:ring-ring absolute right-4 top-4 flex h-[var(--touch-height-sm)] w-[var(--touch-height-sm)] cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-                    <XIcon className="h-4 w-4" />
+                    <XIcon className="size-[var(--icon-size-default)]" />
                     <span className="sr-only">Close</span>
                   </DialogPrimitive.Close>
                 )}
@@ -238,7 +238,7 @@ export const ResponsiveModalContentComposable = ({
             className="ring-offset-background focus:ring-ring absolute right-4 flex h-[var(--touch-height-sm)] w-[var(--touch-height-sm)] cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
             style={{ top: isMobile ? 'calc(var(--safe-area-top-padding, 0px) + 16px)' : 16 }}
           >
-            <XIcon className="h-4 w-4" />
+            <XIcon className="size-[var(--icon-size-default)]" />
             <span className="sr-only">Close</span>
           </DialogClose>
         )}

--- a/src/components/ui/searchable-menu/searchable-menu.tsx
+++ b/src/components/ui/searchable-menu/searchable-menu.tsx
@@ -30,7 +30,7 @@ const ItemButton = memo(<T,>({ item, isSelected, onClick, renderItem }: ItemButt
       disabled={item.disabled}
       onClick={onClick}
       className={cn(
-        'w-full flex items-center gap-3 px-4 md:px-3 py-2.5 md:py-2 rounded-lg transition-colors text-left cursor-pointer',
+        'w-full flex items-center gap-3 px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] rounded-lg transition-colors text-left cursor-pointer',
         'hover:bg-accent/50 focus:bg-accent/50 focus:outline-none',
         isSelected && 'bg-accent',
         item.disabled && 'opacity-50 cursor-not-allowed',
@@ -93,7 +93,7 @@ const DefaultTrigger = <T,>({
 }) => (
   <div
     className={cn(
-      'flex items-center gap-2 px-4 md:px-3 py-2 md:py-1.5 rounded-full cursor-pointer transition-colors text-base md:text-sm border',
+      'flex items-center gap-2 px-[var(--spacing-x-md)] py-[var(--spacing-y-md)] rounded-full cursor-pointer transition-colors text-[var(--font-size-body)] border',
       isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
     )}
   >

--- a/src/components/ui/searchable-menu/searchable-menu.tsx
+++ b/src/components/ui/searchable-menu/searchable-menu.tsx
@@ -93,7 +93,7 @@ const DefaultTrigger = <T,>({
 }) => (
   <div
     className={cn(
-      'flex items-center gap-2 px-[var(--spacing-x-md)] py-[var(--spacing-y-md)] rounded-full cursor-pointer transition-colors text-[var(--font-size-body)] border',
+      'flex items-center gap-2 px-[var(--spacing-x-md)] py-[var(--spacing-y-md)] rounded-full cursor-pointer transition-colors text-[length:var(--font-size-body)] border',
       isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
     )}
   >

--- a/src/components/ui/searchable-menu/searchable-menu.tsx
+++ b/src/components/ui/searchable-menu/searchable-menu.tsx
@@ -30,7 +30,7 @@ const ItemButton = memo(<T,>({ item, isSelected, onClick, renderItem }: ItemButt
       disabled={item.disabled}
       onClick={onClick}
       className={cn(
-        'w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-left cursor-pointer',
+        'w-full flex items-center gap-3 px-4 md:px-3 py-2.5 md:py-2 rounded-lg transition-colors text-left cursor-pointer',
         'hover:bg-accent/50 focus:bg-accent/50 focus:outline-none',
         isSelected && 'bg-accent',
         item.disabled && 'opacity-50 cursor-not-allowed',
@@ -93,7 +93,7 @@ const DefaultTrigger = <T,>({
 }) => (
   <div
     className={cn(
-      'flex items-center gap-2 px-3 py-1.5 rounded-full cursor-pointer transition-colors text-sm border',
+      'flex items-center gap-2 px-4 md:px-3 py-2 md:py-1.5 rounded-full cursor-pointer transition-colors text-base md:text-sm border',
       isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
     )}
   >

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -29,7 +29,7 @@ const SelectTrigger = ({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-4 md:px-3 py-2.5 md:py-2 text-base md:text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-11 md:data-[size=default]:h-9 data-[size=sm]:h-10 md:data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[var(--font-size-body)] whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[var(--touch-height-default)] data-[size=sm]:h-[var(--touch-height-sm)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -92,7 +92,7 @@ const SelectItem = ({ className, children, ...props }: ComponentProps<typeof Sel
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-2 md:py-1.5 pr-9 md:pr-8 pl-3 md:pl-2 text-base md:text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-9 md:pr-8 pl-[var(--spacing-x-sm)] text-[var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -29,7 +29,7 @@ const SelectTrigger = ({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[var(--font-size-body)] whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[var(--touch-height-default)] data-[size=sm]:h-[var(--touch-height-sm)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[length:var(--font-size-body)] whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[var(--touch-height-default)] data-[size=sm]:h-[var(--touch-height-sm)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -92,7 +92,7 @@ const SelectItem = ({ className, children, ...props }: ComponentProps<typeof Sel
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-9 md:pr-8 pl-[var(--spacing-x-sm)] text-[var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-[var(--spacing-y-md)] pr-9 md:pr-8 pl-[var(--spacing-x-sm)] text-[length:var(--font-size-body)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -29,7 +29,7 @@ const SelectTrigger = ({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-4 md:px-3 py-2.5 md:py-2 text-base md:text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-11 md:data-[size=default]:h-9 data-[size=sm]:h-10 md:data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -92,7 +92,7 @@ const SelectItem = ({ className, children, ...props }: ComponentProps<typeof Sel
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-2 md:py-1.5 pr-9 md:pr-8 pl-3 md:pl-2 text-base md:text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/src/components/ui/sidebar-close-button.tsx
+++ b/src/components/ui/sidebar-close-button.tsx
@@ -3,7 +3,13 @@ import { type ComponentProps } from 'react'
 import { Button } from './button'
 
 export const SidebarCloseButton = ({ onClick, ...props }: ComponentProps<typeof Button> & { onClick: () => void }) => (
-  <Button onClick={onClick} variant="ghost" size="icon" className="h-10 w-10 md:h-8 md:w-8 rounded-full" {...props}>
-    <X className="size-5 md:size-4" />
+  <Button
+    onClick={onClick}
+    variant="ghost"
+    size="icon"
+    className="size-[var(--touch-height-sm)] rounded-full"
+    {...props}
+  >
+    <X className="size-[var(--icon-size-default)]" />
   </Button>
 )

--- a/src/components/ui/sidebar-close-button.tsx
+++ b/src/components/ui/sidebar-close-button.tsx
@@ -3,7 +3,7 @@ import { type ComponentProps } from 'react'
 import { Button } from './button'
 
 export const SidebarCloseButton = ({ onClick, ...props }: ComponentProps<typeof Button> & { onClick: () => void }) => (
-  <Button onClick={onClick} variant="ghost" size="icon" className="h-8 w-8 rounded-full" {...props}>
-    <X className="size-4" />
+  <Button onClick={onClick} variant="ghost" size="icon" className="h-10 w-10 md:h-8 md:w-8 rounded-full" {...props}>
+    <X className="size-5 md:size-4" />
   </Button>
 )

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -459,7 +459,7 @@ const SidebarGroup = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ classN
     <div
       ref={ref}
       data-sidebar="group"
-      className={cn('relative flex w-full min-w-0 flex-col p-3 md:p-2', className)}
+      className={cn('relative flex w-full min-w-0 flex-col p-[var(--spacing-x-sm)]', className)}
       {...props}
     />
   )

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -533,7 +533,7 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-[var(--touch-height-default)] text-[length:var(--font-size-body)]',
+        default: 'h-[var(--touch-height-sm)] text-[length:var(--font-size-body)]',
         sm: 'h-[var(--touch-height-sm)] text-xs',
         lg: 'h-[var(--touch-height-xl)] text-[length:var(--font-size-body)] group-data-[collapsible=icon]:p-0!',
       },

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -391,7 +391,7 @@ const SidebarInput = forwardRef<ElementRef<typeof Input>, ComponentProps<typeof 
         ref={ref}
         data-sidebar="input"
         className={cn(
-          'h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring',
+          'h-10 md:h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring',
           className,
         )}
         {...props}
@@ -402,12 +402,12 @@ const SidebarInput = forwardRef<ElementRef<typeof Input>, ComponentProps<typeof 
 SidebarInput.displayName = 'SidebarInput'
 
 const SidebarHeader = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ className, ...props }, ref) => {
-  return <div ref={ref} data-sidebar="header" className={cn('flex flex-col gap-2 p-2', className)} {...props} />
+  return <div ref={ref} data-sidebar="header" className={cn('flex flex-col gap-2 p-3 md:p-2', className)} {...props} />
 })
 SidebarHeader.displayName = 'SidebarHeader'
 
 const SidebarFooter = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ className, ...props }, ref) => {
-  return <div ref={ref} data-sidebar="footer" className={cn('flex flex-col gap-2 p-2', className)} {...props} />
+  return <div ref={ref} data-sidebar="footer" className={cn('flex flex-col gap-2 p-3 md:p-2', className)} {...props} />
 })
 SidebarFooter.displayName = 'SidebarFooter'
 
@@ -445,7 +445,7 @@ const SidebarGroup = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ classN
     <div
       ref={ref}
       data-sidebar="group"
-      className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
+      className={cn('relative flex w-full min-w-0 flex-col p-3 md:p-2', className)}
       {...props}
     />
   )
@@ -461,7 +461,7 @@ const SidebarGroupLabel = forwardRef<HTMLDivElement, ComponentProps<'div'> & { a
         ref={ref}
         data-sidebar="group-label"
         className={cn(
-          'duration-200 flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+          'duration-200 flex h-10 md:h-8 shrink-0 items-center rounded-md px-3 md:px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0',
           'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
           className,
         )}
@@ -481,7 +481,7 @@ const SidebarGroupAction = forwardRef<HTMLButtonElement, ComponentProps<'button'
         ref={ref}
         data-sidebar="group-action"
         className={cn(
-          'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+          'absolute right-3 top-3.5 flex aspect-square w-6 md:w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0',
           // Increases the hit area of the button on mobile.
           'after:absolute after:-inset-2 md:after:hidden',
           'group-data-[collapsible=icon]:hidden',
@@ -510,7 +510,7 @@ const SidebarMenuItem = forwardRef<HTMLLIElement, ComponentProps<'li'>>(({ class
 SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2.5 md:p-2 text-left text-base md:text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-9 md:group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -519,9 +519,9 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-8 text-sm',
-        sm: 'h-7 text-xs',
-        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+        default: 'h-11 md:h-8 text-base md:text-sm',
+        sm: 'h-10 md:h-7 text-xs',
+        lg: 'h-14 md:h-12 text-base md:text-sm group-data-[collapsible=icon]:p-0!',
       },
     },
     defaultVariants: {
@@ -601,12 +601,12 @@ const SidebarMenuAction = forwardRef<
       ref={ref}
       data-sidebar="menu-action"
       className={cn(
-        'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0',
+        'absolute right-1.5 md:right-1 top-2 md:top-1.5 flex aspect-square w-6 md:w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 md:after:hidden',
-        'peer-data-[size=sm]/menu-button:top-1',
-        'peer-data-[size=default]/menu-button:top-1.5',
-        'peer-data-[size=lg]/menu-button:top-2.5',
+        'peer-data-[size=sm]/menu-button:top-1.5 md:peer-data-[size=sm]/menu-button:top-1',
+        'peer-data-[size=default]/menu-button:top-2 md:peer-data-[size=default]/menu-button:top-1.5',
+        'peer-data-[size=lg]/menu-button:top-3 md:peer-data-[size=lg]/menu-button:top-2.5',
         'group-data-[collapsible=icon]:hidden',
         showOnHover &&
           'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
@@ -623,11 +623,11 @@ const SidebarMenuBadge = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ cl
     ref={ref}
     data-sidebar="menu-badge"
     className={cn(
-      'absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground select-none pointer-events-none',
+      'absolute right-1.5 md:right-1 flex h-6 min-w-6 md:h-5 md:min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground select-none pointer-events-none',
       'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
-      'peer-data-[size=sm]/menu-button:top-1',
-      'peer-data-[size=default]/menu-button:top-1.5',
-      'peer-data-[size=lg]/menu-button:top-2.5',
+      'peer-data-[size=sm]/menu-button:top-1.5 md:peer-data-[size=sm]/menu-button:top-1',
+      'peer-data-[size=default]/menu-button:top-2 md:peer-data-[size=default]/menu-button:top-1.5',
+      'peer-data-[size=lg]/menu-button:top-3 md:peer-data-[size=lg]/menu-button:top-2.5',
       'group-data-[collapsible=icon]:hidden',
       className,
     )}
@@ -651,10 +651,10 @@ const SidebarMenuSkeleton = forwardRef<
     <div
       ref={ref}
       data-sidebar="menu-skeleton"
-      className={cn('rounded-md h-8 flex gap-2 px-2 items-center', className)}
+      className={cn('rounded-md h-11 md:h-8 flex gap-2 px-3 md:px-2 items-center', className)}
       {...props}
     >
-      {showIcon && <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
+      {showIcon && <Skeleton className="size-5 md:size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
       <Skeleton
         className="h-4 flex-1 max-w-(--skeleton-width)"
         data-sidebar="menu-skeleton-text"
@@ -705,7 +705,7 @@ const SidebarMenuSubButton = forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -533,7 +533,7 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-[var(--touch-height-sm)] text-[length:var(--font-size-body)]',
+        default: 'h-[var(--touch-height-default)] text-[length:var(--font-size-body)]',
         sm: 'h-[var(--touch-height-sm)] text-xs',
         lg: 'h-[var(--touch-height-xl)] text-[length:var(--font-size-body)] group-data-[collapsible=icon]:p-0!',
       },

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -391,7 +391,7 @@ const SidebarInput = forwardRef<ElementRef<typeof Input>, ComponentProps<typeof 
         ref={ref}
         data-sidebar="input"
         className={cn(
-          'h-10 md:h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring',
+          'h-[var(--touch-height-sm)] w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring',
           className,
         )}
         {...props}
@@ -402,12 +402,26 @@ const SidebarInput = forwardRef<ElementRef<typeof Input>, ComponentProps<typeof 
 SidebarInput.displayName = 'SidebarInput'
 
 const SidebarHeader = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ className, ...props }, ref) => {
-  return <div ref={ref} data-sidebar="header" className={cn('flex flex-col gap-2 p-3 md:p-2', className)} {...props} />
+  return (
+    <div
+      ref={ref}
+      data-sidebar="header"
+      className={cn('flex flex-col gap-2 p-[var(--spacing-x-sm)]', className)}
+      {...props}
+    />
+  )
 })
 SidebarHeader.displayName = 'SidebarHeader'
 
 const SidebarFooter = forwardRef<HTMLDivElement, ComponentProps<'div'>>(({ className, ...props }, ref) => {
-  return <div ref={ref} data-sidebar="footer" className={cn('flex flex-col gap-2 p-3 md:p-2', className)} {...props} />
+  return (
+    <div
+      ref={ref}
+      data-sidebar="footer"
+      className={cn('flex flex-col gap-2 p-[var(--spacing-x-sm)]', className)}
+      {...props}
+    />
+  )
 })
 SidebarFooter.displayName = 'SidebarFooter'
 
@@ -461,7 +475,7 @@ const SidebarGroupLabel = forwardRef<HTMLDivElement, ComponentProps<'div'> & { a
         ref={ref}
         data-sidebar="group-label"
         className={cn(
-          'duration-200 flex h-10 md:h-8 shrink-0 items-center rounded-md px-3 md:px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0',
+          'duration-200 flex h-[var(--touch-height-sm)] shrink-0 items-center rounded-md px-[var(--spacing-x-sm)] text-xs font-medium text-sidebar-foreground/70 outline-hidden ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-[var(--icon-size-default)] [&>svg]:shrink-0',
           'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
           className,
         )}
@@ -481,7 +495,7 @@ const SidebarGroupAction = forwardRef<HTMLButtonElement, ComponentProps<'button'
         ref={ref}
         data-sidebar="group-action"
         className={cn(
-          'absolute right-3 top-3.5 flex aspect-square w-6 md:w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0',
+          'absolute right-3 top-3.5 flex aspect-square w-6 md:w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-[var(--icon-size-default)] [&>svg]:shrink-0',
           // Increases the hit area of the button on mobile.
           'after:absolute after:-inset-2 md:after:hidden',
           'group-data-[collapsible=icon]:hidden',
@@ -510,7 +524,7 @@ const SidebarMenuItem = forwardRef<HTMLLIElement, ComponentProps<'li'>>(({ class
 SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2.5 md:p-2 text-left text-base md:text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-9 md:group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-[var(--spacing-y-default)] text-left text-[var(--font-size-body)] outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-9 md:group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-[var(--icon-size-default)] [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -519,9 +533,9 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-11 md:h-8 text-base md:text-sm',
-        sm: 'h-10 md:h-7 text-xs',
-        lg: 'h-14 md:h-12 text-base md:text-sm group-data-[collapsible=icon]:p-0!',
+        default: 'h-[var(--touch-height-default)] text-[var(--font-size-body)]',
+        sm: 'h-[var(--touch-height-sm)] text-xs',
+        lg: 'h-[var(--touch-height-xl)] text-[var(--font-size-body)] group-data-[collapsible=icon]:p-0!',
       },
     },
     defaultVariants: {
@@ -601,7 +615,7 @@ const SidebarMenuAction = forwardRef<
       ref={ref}
       data-sidebar="menu-action"
       className={cn(
-        'absolute right-1.5 md:right-1 top-2 md:top-1.5 flex aspect-square w-6 md:w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-5 md:[&>svg]:size-4 [&>svg]:shrink-0',
+        'absolute right-1.5 md:right-1 top-2 md:top-1.5 flex aspect-square w-6 md:w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-[var(--icon-size-default)] [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 md:after:hidden',
         'peer-data-[size=sm]/menu-button:top-1.5 md:peer-data-[size=sm]/menu-button:top-1',
@@ -651,10 +665,15 @@ const SidebarMenuSkeleton = forwardRef<
     <div
       ref={ref}
       data-sidebar="menu-skeleton"
-      className={cn('rounded-md h-11 md:h-8 flex gap-2 px-3 md:px-2 items-center', className)}
+      className={cn(
+        'rounded-md h-[var(--touch-height-default)] flex gap-2 px-[var(--spacing-x-sm)] items-center',
+        className,
+      )}
       {...props}
     >
-      {showIcon && <Skeleton className="size-5 md:size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
+      {showIcon && (
+        <Skeleton className="size-[var(--icon-size-default)] rounded-md" data-sidebar="menu-skeleton-icon" />
+      )}
       <Skeleton
         className="h-4 flex-1 max-w-(--skeleton-width)"
         data-sidebar="menu-skeleton-text"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -524,7 +524,7 @@ const SidebarMenuItem = forwardRef<HTMLLIElement, ComponentProps<'li'>>(({ class
 SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-[var(--spacing-y-default)] text-left text-[var(--font-size-body)] outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-9 md:group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-[var(--icon-size-default)] [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-[var(--spacing-y-default)] text-left text-[length:var(--font-size-body)] outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-9 md:group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-[var(--icon-size-default)] [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -533,9 +533,9 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-[var(--touch-height-default)] text-[var(--font-size-body)]',
+        default: 'h-[var(--touch-height-default)] text-[length:var(--font-size-body)]',
         sm: 'h-[var(--touch-height-sm)] text-xs',
-        lg: 'h-[var(--touch-height-xl)] text-[var(--font-size-body)] group-data-[collapsible=icon]:p-0!',
+        lg: 'h-[var(--touch-height-xl)] text-[length:var(--font-size-body)] group-data-[collapsible=icon]:p-0!',
       },
     },
     defaultVariants: {

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -19,7 +19,7 @@ const Switch = ({ className, onCheckedChange, ...props }: ComponentProps<typeof 
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        'cursor-pointer peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'cursor-pointer peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-5 w-10 md:h-[1.15rem] md:w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       onCheckedChange={handleCheckedChange}
@@ -28,7 +28,7 @@ const Switch = ({ className, onCheckedChange, ...props }: ComponentProps<typeof 
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
+          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(2.5rem-1rem-2px)] md:data-[state=checked]:translate-x-[calc(2rem-1rem-2px)] data-[state=unchecked]:translate-x-0',
         )}
       />
     </SwitchPrimitive.Root>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -19,7 +19,7 @@ const Switch = ({ className, onCheckedChange, ...props }: ComponentProps<typeof 
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        'cursor-pointer peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-5 w-10 md:h-[1.15rem] md:w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'cursor-pointer peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[var(--switch-track-height)] w-[var(--switch-track-width)] shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       onCheckedChange={handleCheckedChange}
@@ -28,7 +28,7 @@ const Switch = ({ className, onCheckedChange, ...props }: ComponentProps<typeof 
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[var(--switch-thumb-translate)] data-[state=unchecked]:translate-x-0',
+          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-[var(--switch-thumb-size)] rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[var(--switch-thumb-translate)] data-[state=unchecked]:translate-x-0',
         )}
       />
     </SwitchPrimitive.Root>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -28,7 +28,7 @@ const Switch = ({ className, onCheckedChange, ...props }: ComponentProps<typeof 
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(2.5rem-1rem-2px)] md:data-[state=checked]:translate-x-[calc(2rem-1rem-2px)] data-[state=unchecked]:translate-x-0',
+          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[var(--switch-thumb-translate)] data-[state=unchecked]:translate-x-0',
         )}
       />
     </SwitchPrimitive.Root>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = ({ className, ...props }: ComponentProps<'textarea'>) => {
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-20 md:min-h-16 w-full rounded-md border bg-transparent px-4 md:px-3 py-2.5 md:py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-20 md:min-h-16 w-full rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[var(--font-size-body)] shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = ({ className, ...props }: ComponentProps<'textarea'>) => {
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-20 md:min-h-16 w-full rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[var(--font-size-body)] shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-20 md:min-h-16 w-full rounded-md border bg-transparent px-[var(--spacing-x-md)] py-[var(--spacing-y-default)] text-[length:var(--font-size-body)] shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = ({ className, ...props }: ComponentProps<'textarea'>) => {
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-20 md:min-h-16 w-full rounded-md border bg-transparent px-4 md:px-3 py-2.5 md:py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className,
       )}
       {...props}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -14,9 +14,9 @@ const toggleVariants = cva(
         outline: 'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
       },
       size: {
-        default: 'h-9 px-2 min-w-9',
-        sm: 'h-8 px-1.5 min-w-8',
-        lg: 'h-10 px-2.5 min-w-10',
+        default: 'h-11 md:h-9 px-2.5 md:px-2 min-w-11 md:min-w-9',
+        sm: 'h-10 md:h-8 px-2 md:px-1.5 min-w-10 md:min-w-8',
+        lg: 'h-12 md:h-10 px-3 md:px-2.5 min-w-12 md:min-w-10',
       },
     },
     defaultVariants: {

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -14,9 +14,9 @@ const toggleVariants = cva(
         outline: 'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
       },
       size: {
-        default: 'h-11 md:h-9 px-2.5 md:px-2 min-w-11 md:min-w-9',
-        sm: 'h-10 md:h-8 px-2 md:px-1.5 min-w-10 md:min-w-8',
-        lg: 'h-12 md:h-10 px-3 md:px-2.5 min-w-12 md:min-w-10',
+        default: 'h-[var(--touch-height-default)] px-[var(--spacing-y-default)] min-w-[var(--touch-height-default)]',
+        sm: 'h-[var(--touch-height-sm)] px-[var(--spacing-y-md)] min-w-[var(--touch-height-sm)]',
+        lg: 'h-[var(--touch-height-lg)] px-[var(--spacing-x-sm)] min-w-[var(--touch-height-lg)]',
       },
     },
     defaultVariants: {

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -14,8 +14,8 @@ const toggleVariants = cva(
         outline: 'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
       },
       size: {
-        default: 'h-[var(--touch-height-default)] px-[var(--spacing-y-default)] min-w-[var(--touch-height-default)]',
-        sm: 'h-[var(--touch-height-sm)] px-[var(--spacing-y-md)] min-w-[var(--touch-height-sm)]',
+        default: 'h-[var(--touch-height-default)] px-[var(--spacing-x-sm)] min-w-[var(--touch-height-default)]',
+        sm: 'h-[var(--touch-height-sm)] px-[var(--spacing-x-sm)] min-w-[var(--touch-height-sm)]',
         lg: 'h-[var(--touch-height-lg)] px-[var(--spacing-x-sm)] min-w-[var(--touch-height-lg)]',
       },
     },

--- a/src/index.css
+++ b/src/index.css
@@ -82,7 +82,10 @@
   --min-touch-height: 2.5rem; /* 40px mobile */
 
   /* Switch component specific */
-  --switch-thumb-translate: calc(2.5rem - 1rem - 2px); /* mobile */
+  --switch-track-height: 1.5rem; /* 24px mobile - slightly larger for touch */
+  --switch-track-width: 2.75rem; /* 44px mobile */
+  --switch-thumb-size: 1.125rem; /* 18px mobile */
+  --switch-thumb-translate: calc(var(--switch-track-width) - var(--switch-thumb-size) - 2px);
 }
 
 @media (min-width: 768px) {
@@ -122,7 +125,10 @@
     --min-touch-height: 0; /* No min on desktop */
 
     /* Switch component specific */
-    --switch-thumb-translate: calc(2rem - 1rem - 2px); /* desktop */
+    --switch-track-height: 1.15rem; /* desktop */
+    --switch-track-width: 2rem; /* desktop */
+    --switch-thumb-size: 1rem; /* desktop */
+    --switch-thumb-translate: calc(var(--switch-track-width) - var(--switch-thumb-size) - 2px);
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,89 @@
   --color-card-border: #dee8df;
 }
 
+/* ===========================
+   Responsive Touch Target System
+   =========================== */
+:root {
+  /* Heights - Touch targets */
+  --touch-height-xl: 3.5rem; /* 56px mobile */
+  --touch-height-lg: 3rem; /* 48px mobile */
+  --touch-height-default: 2.75rem; /* 44px mobile - primary touch target */
+  --touch-height-sm: 2.5rem; /* 40px mobile */
+
+  /* Icon sizes */
+  --icon-size-default: 1.25rem; /* 20px mobile */
+  --icon-size-sm: 1rem; /* 16px mobile */
+
+  /* Font sizes */
+  --font-size-body: 1rem; /* 16px mobile */
+  --font-size-sm: 0.875rem; /* 14px mobile */
+  --font-size-xs: 0.75rem; /* 12px mobile */
+
+  /* Spacing - Horizontal padding */
+  --spacing-x-lg: 1.75rem; /* 28px mobile */
+  --spacing-x-default: 1.25rem; /* 20px mobile */
+  --spacing-x-md: 1rem; /* 16px mobile */
+  --spacing-x-sm: 0.75rem; /* 12px mobile */
+
+  /* Spacing - Vertical padding */
+  --spacing-y-default: 0.625rem; /* 10px mobile */
+  --spacing-y-md: 0.5rem; /* 8px mobile */
+  --spacing-y-sm: 0.375rem; /* 6px mobile */
+
+  /* Gaps */
+  --gap-lg: 0.625rem; /* 10px mobile */
+  --gap-default: 0.5rem; /* 8px mobile */
+  --gap-sm: 0.375rem; /* 6px mobile */
+
+  /* Minimum sizes */
+  --min-touch-height: 2.5rem; /* 40px mobile */
+
+  /* Switch component specific */
+  --switch-thumb-translate: calc(2.5rem - 1rem - 2px); /* mobile */
+}
+
+@media (min-width: 768px) {
+  :root {
+    /* Heights - Desktop values */
+    --touch-height-xl: 3rem; /* 48px desktop */
+    --touch-height-lg: 2.5rem; /* 40px desktop */
+    --touch-height-default: 2.25rem; /* 36px desktop */
+    --touch-height-sm: 2rem; /* 32px desktop */
+
+    /* Icon sizes */
+    --icon-size-default: 1rem; /* 16px desktop */
+    --icon-size-sm: 0.875rem; /* 14px desktop */
+
+    /* Font sizes */
+    --font-size-body: 0.875rem; /* 14px desktop */
+    --font-size-sm: 0.75rem; /* 12px desktop */
+    --font-size-xs: 0.625rem; /* 10px desktop */
+
+    /* Spacing - Horizontal padding */
+    --spacing-x-lg: 1.5rem; /* 24px desktop */
+    --spacing-x-default: 1rem; /* 16px desktop */
+    --spacing-x-md: 0.75rem; /* 12px desktop */
+    --spacing-x-sm: 0.5rem; /* 8px desktop */
+
+    /* Spacing - Vertical padding */
+    --spacing-y-default: 0.5rem; /* 8px desktop */
+    --spacing-y-md: 0.375rem; /* 6px desktop */
+    --spacing-y-sm: 0.25rem; /* 4px desktop */
+
+    /* Gaps */
+    --gap-lg: 0.5rem; /* 8px desktop */
+    --gap-default: 0.375rem; /* 6px desktop */
+    --gap-sm: 0.25rem; /* 4px desktop */
+
+    /* Minimum sizes */
+    --min-touch-height: 0; /* No min on desktop */
+
+    /* Switch component specific */
+    --switch-thumb-translate: calc(2rem - 1rem - 2px); /* desktop */
+  }
+}
+
 .dark {
   --color-background: oklch(0.145 0 0);
   --color-foreground: oklch(0.985 0 0);

--- a/src/layout/sidebar/chat-list-item.tsx
+++ b/src/layout/sidebar/chat-list-item.tsx
@@ -40,9 +40,9 @@ export const ChatListItem = ({
           tooltip={thread.title ?? undefined}
         >
           {status === 'streaming' ? (
-            <Loader2 className={`h-4 w-4 animate-spin text-muted-foreground`} />
+            <Loader2 className="size-5 md:size-4 animate-spin text-muted-foreground" />
           ) : (
-            <MessageCircle className="size-4 shrink-0" />
+            <MessageCircle className="size-5 md:size-4 shrink-0" />
           )}
         </SidebarMenuButton>
       </SidebarMenuItem>
@@ -67,7 +67,7 @@ export const ChatListItem = ({
                   exit={{ opacity: 0, width: 0 }}
                   className="flex-shrink-0"
                 >
-                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                  <Loader2 className="size-5 md:size-4 animate-spin text-muted-foreground" />
                 </motion.div>
               )}
             </AnimatePresence>
@@ -76,7 +76,7 @@ export const ChatListItem = ({
           <DropdownMenuTrigger asChild>
             <MoreHorizontal
               className={cn(
-                'shrink-0 size-4',
+                'shrink-0 size-5 md:size-4',
                 !isMobile &&
                   'opacity-0 group-hover/item:opacity-100 group-data-[state=open]/item:opacity-100 transition-opacity',
               )}
@@ -92,7 +92,7 @@ export const ChatListItem = ({
             disabled={deleteChatMutation.isPending}
             className="text-destructive cursor-pointer"
           >
-            {deleteChatMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : 'Delete'}
+            {deleteChatMutation.isPending ? <Loader2 className="size-5 md:size-4 animate-spin" /> : 'Delete'}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </SidebarMenuItem>

--- a/src/layout/sidebar/chat-list-item.tsx
+++ b/src/layout/sidebar/chat-list-item.tsx
@@ -40,9 +40,9 @@ export const ChatListItem = ({
           tooltip={thread.title ?? undefined}
         >
           {status === 'streaming' ? (
-            <Loader2 className="size-5 md:size-4 animate-spin text-muted-foreground" />
+            <Loader2 className="size-[var(--icon-size-default)] animate-spin text-muted-foreground" />
           ) : (
-            <MessageCircle className="size-5 md:size-4 shrink-0" />
+            <MessageCircle className="size-[var(--icon-size-default)] shrink-0" />
           )}
         </SidebarMenuButton>
       </SidebarMenuItem>
@@ -67,7 +67,7 @@ export const ChatListItem = ({
                   exit={{ opacity: 0, width: 0 }}
                   className="flex-shrink-0"
                 >
-                  <Loader2 className="size-5 md:size-4 animate-spin text-muted-foreground" />
+                  <Loader2 className="size-[var(--icon-size-default)] animate-spin text-muted-foreground" />
                 </motion.div>
               )}
             </AnimatePresence>
@@ -76,7 +76,7 @@ export const ChatListItem = ({
           <DropdownMenuTrigger asChild>
             <MoreHorizontal
               className={cn(
-                'shrink-0 size-5 md:size-4',
+                'shrink-0 size-[var(--icon-size-default)]',
                 !isMobile &&
                   'opacity-0 group-hover/item:opacity-100 group-data-[state=open]/item:opacity-100 transition-opacity',
               )}
@@ -92,7 +92,11 @@ export const ChatListItem = ({
             disabled={deleteChatMutation.isPending}
             className="text-destructive cursor-pointer"
           >
-            {deleteChatMutation.isPending ? <Loader2 className="size-5 md:size-4 animate-spin" /> : 'Delete'}
+            {deleteChatMutation.isPending ? (
+              <Loader2 className="size-[var(--icon-size-default)] animate-spin" />
+            ) : (
+              'Delete'
+            )}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </SidebarMenuItem>

--- a/src/layout/sidebar/chat-list.tsx
+++ b/src/layout/sidebar/chat-list.tsx
@@ -66,7 +66,7 @@ export const ChatList = ({
             <>
               <SidebarMenuItem>
                 <SidebarMenuButton onClick={(e) => onSearchClick(e)} tooltip="Search chats" className="cursor-pointer">
-                  <Search className={`size-4 ${debouncedSearchQuery ? 'text-blue-500' : ''}`} />
+                  <Search className={`size-5 md:size-4 ${debouncedSearchQuery ? 'text-blue-500' : ''}`} />
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>
@@ -77,9 +77,9 @@ export const ChatList = ({
                   className="cursor-pointer"
                 >
                   {deleteAllChatsMutation.isPending ? (
-                    <Loader2 className="size-4 animate-spin" />
+                    <Loader2 className="size-5 md:size-4 animate-spin" />
                   ) : (
-                    <Flame className="size-4" />
+                    <Flame className="size-5 md:size-4" />
                   )}
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/src/layout/sidebar/chat-list.tsx
+++ b/src/layout/sidebar/chat-list.tsx
@@ -66,7 +66,9 @@ export const ChatList = ({
             <>
               <SidebarMenuItem>
                 <SidebarMenuButton onClick={(e) => onSearchClick(e)} tooltip="Search chats" className="cursor-pointer">
-                  <Search className={`size-5 md:size-4 ${debouncedSearchQuery ? 'text-blue-500' : ''}`} />
+                  <Search
+                    className={`size-[var(--icon-size-default)] ${debouncedSearchQuery ? 'text-blue-500' : ''}`}
+                  />
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>
@@ -77,9 +79,9 @@ export const ChatList = ({
                   className="cursor-pointer"
                 >
                   {deleteAllChatsMutation.isPending ? (
-                    <Loader2 className="size-5 md:size-4 animate-spin" />
+                    <Loader2 className="size-[var(--icon-size-default)] animate-spin" />
                   ) : (
-                    <Flame className="size-5 md:size-4" />
+                    <Flame className="size-[var(--icon-size-default)]" />
                   )}
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/src/layout/sidebar/navigation-menu.tsx
+++ b/src/layout/sidebar/navigation-menu.tsx
@@ -26,7 +26,7 @@ export const NavigationMenu = ({
           className="cursor-pointer"
           isActive={currentPath === '/chats/new'}
         >
-          <MessageCirclePlus className="size-5 md:size-4" />
+          <MessageCirclePlus className="size-[var(--icon-size-default)]" />
           <span>New Chat</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
@@ -34,7 +34,7 @@ export const NavigationMenu = ({
         <SidebarMenuItem>
           <SidebarMenuButton asChild tooltip="Tasks" isActive={currentPath.startsWith('/tasks')}>
             <NavLink to="/tasks">
-              <CheckSquare className="size-5 md:size-4" />
+              <CheckSquare className="size-[var(--icon-size-default)]" />
               <span>Tasks</span>
             </NavLink>
           </SidebarMenuButton>
@@ -43,7 +43,7 @@ export const NavigationMenu = ({
       <SidebarMenuItem>
         <SidebarMenuButton asChild tooltip="Automations" isActive={currentPath.startsWith('/automations')}>
           <NavLink to="/automations">
-            <Zap className="size-5 md:size-4" />
+            <Zap className="size-[var(--icon-size-default)]" />
             <span>Automations</span>
           </NavLink>
         </SidebarMenuButton>
@@ -55,13 +55,13 @@ export const NavigationMenu = ({
             isActive={currentPath.startsWith('/settings')}
             className="cursor-pointer"
           >
-            <Settings className="size-5 md:size-4" />
+            <Settings className="size-[var(--icon-size-default)]" />
             <span>Settings</span>
           </SidebarMenuButton>
         ) : (
           <SidebarMenuButton asChild tooltip="Settings" isActive={currentPath.startsWith('/settings')}>
             <NavLink to="/settings/preferences">
-              <Settings className="size-5 md:size-4" />
+              <Settings className="size-[var(--icon-size-default)]" />
               <span>Settings</span>
             </NavLink>
           </SidebarMenuButton>

--- a/src/layout/sidebar/navigation-menu.tsx
+++ b/src/layout/sidebar/navigation-menu.tsx
@@ -26,7 +26,7 @@ export const NavigationMenu = ({
           className="cursor-pointer"
           isActive={currentPath === '/chats/new'}
         >
-          <MessageCirclePlus className="size-4" />
+          <MessageCirclePlus className="size-5 md:size-4" />
           <span>New Chat</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
@@ -34,7 +34,7 @@ export const NavigationMenu = ({
         <SidebarMenuItem>
           <SidebarMenuButton asChild tooltip="Tasks" isActive={currentPath.startsWith('/tasks')}>
             <NavLink to="/tasks">
-              <CheckSquare className="size-4" />
+              <CheckSquare className="size-5 md:size-4" />
               <span>Tasks</span>
             </NavLink>
           </SidebarMenuButton>
@@ -43,7 +43,7 @@ export const NavigationMenu = ({
       <SidebarMenuItem>
         <SidebarMenuButton asChild tooltip="Automations" isActive={currentPath.startsWith('/automations')}>
           <NavLink to="/automations">
-            <Zap className="size-4" />
+            <Zap className="size-5 md:size-4" />
             <span>Automations</span>
           </NavLink>
         </SidebarMenuButton>
@@ -55,13 +55,13 @@ export const NavigationMenu = ({
             isActive={currentPath.startsWith('/settings')}
             className="cursor-pointer"
           >
-            <Settings className="size-4" />
+            <Settings className="size-5 md:size-4" />
             <span>Settings</span>
           </SidebarMenuButton>
         ) : (
           <SidebarMenuButton asChild tooltip="Settings" isActive={currentPath.startsWith('/settings')}>
             <NavLink to="/settings/preferences">
-              <Settings className="size-4" />
+              <Settings className="size-5 md:size-4" />
               <span>Settings</span>
             </NavLink>
           </SidebarMenuButton>

--- a/src/layout/sidebar/sidebar-header.tsx
+++ b/src/layout/sidebar/sidebar-header.tsx
@@ -7,7 +7,6 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 import { SidebarCloseButton } from '@/components/ui/sidebar-close-button'
-import { PowerSyncStatus } from '@/components/powersync-status'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { PanelLeft } from 'lucide-react'
 import { useState } from 'react'
@@ -55,10 +54,7 @@ export const SidebarHeader = ({ onToggle }: SidebarHeaderProps) => {
       {isExpanded && (
         <div className="flex items-center">
           {isMobile ? (
-            <>
-              <PowerSyncStatus />
-              <SidebarCloseButton onClick={onToggle} />
-            </>
+            <SidebarCloseButton onClick={onToggle} />
           ) : (
             <SidebarGroup className="p-0 w-auto">
               <SidebarGroupContent>

--- a/src/layout/sidebar/sidebar-header.tsx
+++ b/src/layout/sidebar/sidebar-header.tsx
@@ -25,7 +25,7 @@ export const SidebarHeader = ({ onToggle }: SidebarHeaderProps) => {
   const isExpanded = isMobile || state === 'expanded'
 
   return (
-    <div className="h-12 border-b border-border flex items-center justify-between px-2 flex-shrink-0">
+    <div className="h-[var(--touch-height-xl)] border-b border-border flex items-center justify-between px-[var(--spacing-x-sm)] flex-shrink-0">
       <div
         className="flex items-center gap-2 h-8 px-2 relative flex-1"
         onMouseEnter={() => !isMobile && !isExpanded && setShowExpandButton(true)}

--- a/src/layout/sidebar/sidebar-header.tsx
+++ b/src/layout/sidebar/sidebar-header.tsx
@@ -38,7 +38,7 @@ export const SidebarHeader = ({ onToggle }: SidebarHeaderProps) => {
               <SidebarMenu>
                 <SidebarMenuItem>
                   <SidebarMenuButton onClick={onToggle} tooltip="Expand Sidebar" className="cursor-pointer">
-                    <PanelLeft className="size-5 md:size-4" />
+                    <PanelLeft className="size-[var(--icon-size-default)]" />
                     <span className="sr-only">Expand Sidebar</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
@@ -65,7 +65,7 @@ export const SidebarHeader = ({ onToggle }: SidebarHeaderProps) => {
                 <SidebarMenu>
                   <SidebarMenuItem className="w-auto">
                     <SidebarMenuButton onClick={onToggle} tooltip="Toggle Sidebar" className="cursor-pointer w-8">
-                      <PanelLeft className="size-5 md:size-4" />
+                      <PanelLeft className="size-[var(--icon-size-default)]" />
                       <span className="sr-only">Toggle Sidebar</span>
                     </SidebarMenuButton>
                   </SidebarMenuItem>

--- a/src/layout/sidebar/sidebar-header.tsx
+++ b/src/layout/sidebar/sidebar-header.tsx
@@ -38,7 +38,7 @@ export const SidebarHeader = ({ onToggle }: SidebarHeaderProps) => {
               <SidebarMenu>
                 <SidebarMenuItem>
                   <SidebarMenuButton onClick={onToggle} tooltip="Expand Sidebar" className="cursor-pointer">
-                    <PanelLeft className="size-4" />
+                    <PanelLeft className="size-5 md:size-4" />
                     <span className="sr-only">Expand Sidebar</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
@@ -65,7 +65,7 @@ export const SidebarHeader = ({ onToggle }: SidebarHeaderProps) => {
                 <SidebarMenu>
                   <SidebarMenuItem className="w-auto">
                     <SidebarMenuButton onClick={onToggle} tooltip="Toggle Sidebar" className="cursor-pointer w-8">
-                      <PanelLeft className="size-4" />
+                      <PanelLeft className="size-5 md:size-4" />
                       <span className="sr-only">Toggle Sidebar</span>
                     </SidebarMenuButton>
                   </SidebarMenuItem>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad UI styling refactor across shared components may cause layout/spacing regressions, especially on mobile/desktop breakpoints, but does not touch data, auth, or backend logic.
> 
> **Overview**
> Introduces a *responsive touch-target sizing system* via new CSS custom properties in `src/index.css` (mobile-first values with a 768px desktop override) for heights, icon sizes, font sizes, spacing, gaps, and switch dimensions.
> 
> Refactors many shared UI components (`Button`, `Input`, `Textarea`, `Switch`, menus/dialogs/sidebar/header, and various icons) to use these variables instead of hard-coded Tailwind sizes, increasing mobile hit areas and standardizing typography/spacing. Mobile header/sidebars also adjust layout (e.g., `PowerSyncStatus` shown in the mobile header, removed from the mobile sidebar header), and the `ChatPromptInput` mobile padding change updates its unit test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96656ebd654e8b2fa713b7aee19ffe9fe0220659. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces a new responsive sizing system using CSS custom properties to improve the mobile user experience by increasing font and button sizes. It centralizes responsive design logic, making UI elements more consistent and maintainable across different screen sizes.

#### Key Changes
- Added a new section to `AGENTS.md` documenting the preferred use of CSS custom properties for responsive sizing.
- Defined a comprehensive set of CSS variables in `src/index.css` for heights, icon sizes, font sizes, spacing, and gaps, with distinct values for mobile and desktop breakpoints.
- Refactored numerous UI components (e.g., `Button`, `Input`, `Textarea`, `DropdownMenu`, `Sidebar`, `Header`) to utilize these new CSS custom properties instead of hardcoded Tailwind classes for sizing and spacing.
- Adjusted padding in `ChatPromptInput` for mobile and updated icon and button sizing in `PowerSyncStatus` and `SidebarFooter`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 153 (55.4%)   |
| Churn       | 4 (1.4%)      |
| Rework      | 119 (43.1%)   |
| Total Changes | 276         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>