### PR TITLE
fix: replace ky with fetch in PowerSync connector to fix CI

### DIFF
--- a/src/db/powersync/connector.test.ts
+++ b/src/db/powersync/connector.test.ts
@@ -148,9 +148,8 @@ describe('ThunderboltConnector', () => {
       expiresAt: new Date(tokenData.expiresAt),
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [request] = fetchMock.mock.calls[0] as [Request]
-    expect(request.url).toContain('/powersync/token')
-    expect(request.method).toBe('GET')
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain('/powersync/token')
   })
 
   it('fetchCredentials returns null and dispatches event when backend returns 410', async () => {

--- a/src/db/powersync/connector.ts
+++ b/src/db/powersync/connector.ts
@@ -134,9 +134,11 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
 
       console.info(`Uploading ${operations.length} operations to backend`)
 
+      const headers = new Headers(buildHeaders())
+      headers.set('Content-Type', 'application/json')
       const response = await fetch(`${this.backendUrl}/powersync/upload`, {
         method: 'PUT',
-        headers: { ...buildHeaders(), 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({ operations }),
       })
 

--- a/src/db/powersync/connector.ts
+++ b/src/db/powersync/connector.ts
@@ -1,6 +1,5 @@
 import { getDeviceId, getAuthToken } from '@/lib/auth-token'
 import { getDeviceDisplayName } from '@/lib/platform'
-import ky from 'ky'
 import type { AbstractPowerSyncDatabase, PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web'
 
 /** Dispatched when backend returns 410 (account deleted), 403 + DEVICE_DISCONNECTED, or 409 + DEVICE_ID_TAKEN. App should reset and reload. */
@@ -81,9 +80,8 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
         return null
       }
 
-      const response = await ky.get(`${this.backendUrl}/powersync/token`, {
+      const response = await fetch(`${this.backendUrl}/powersync/token`, {
         headers: buildHeaders(),
-        throwHttpErrors: false,
       })
 
       if (!response.ok) {
@@ -136,10 +134,10 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
 
       console.info(`Uploading ${operations.length} operations to backend`)
 
-      const response = await ky.put(`${this.backendUrl}/powersync/upload`, {
-        headers: buildHeaders(),
-        json: { operations },
-        throwHttpErrors: false,
+      const response = await fetch(`${this.backendUrl}/powersync/upload`, {
+        method: 'PUT',
+        headers: { ...buildHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ operations }),
       })
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- Replaced `ky` with native `fetch` in the PowerSync connector (`connector.ts`)
- `ky` was caching the `fetch` reference internally, so test mocks of `globalThis.fetch` were not intercepted in CI (bun latest on Linux), causing 10 consistent test failures
- Updated test assertions to match `fetch` call signature (URL string instead of Request object)

## Test plan
- [x] All 9400 tests pass locally with `--rerun-each 5 --randomize` (same as CI)
- [x] Type check passes
- [x] Lint passes (0 errors)
- [ ] CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the HTTP client used for PowerSync token retrieval and upload paths, which could subtly affect request semantics (headers/body handling) and sync behavior. Scope is small and covered by existing tests, but it touches auth-backed networking.
> 
> **Overview**
> Switches PowerSync backend calls from `ky` to native `fetch` for both credential fetching (`/powersync/token`) and upload (`/powersync/upload`), including manual JSON body/header handling for uploads.
> 
> Updates `connector.test.ts` expectations to assert against the `fetch` URL argument (string) rather than a `Request` object, aligning tests with the new implementation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e51275e74aaa59678c39b1767718d9abfadf0ada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a CI failure by replacing the `ky` HTTP client with the native `fetch` API within the PowerSync connector. This change ensures compatibility and stability in the continuous integration environment.

#### Key Changes
- Replaced `ky` with `fetch` for all HTTP requests in `src/db/powersync/connector.ts`, including token retrieval and operation uploads.
- Adjusted `fetch` call parameters to correctly set headers and request bodies for `PUT` requests.
- Updated the corresponding test file `src/db/powersync/connector.test.ts` to reflect the change in how `fetchMock` receives arguments, specifically checking the URL directly.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 2 (16.7%)     |
| Churn       | 3 (25.0%)     |
| Rework      | 7 (58.3%)     |
| Total Changes | 12            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>