### PR TITLE
[Experiment] ACP - Phase 2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
         "@chromatic-com/storybook": "^4.1.1",
         "@emotion/is-prop-valid": "^1.4.0",
         "@eslint/js": "^9.33.0",
-        "@happy-dom/global-registrator": "^20.0.8",
+        "@happy-dom/global-registrator": "^20.8.4",
         "@libsql/client": "^0.15.12",
         "@sinonjs/fake-timers": "^15.0.0",
         "@size-limit/file": "^12.0.1",
@@ -314,7 +314,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.8", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.8" } }, "sha512-6XJ7BGO3tz3yLZcrQF1JIQAEZ6u3mJ2EYfLSZDuZPC5EVdGtz5O2R/RlWgLYATc2tbkPnuxb9qHWHdT4TlzeOw=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.4", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.4" } }, "sha512-cXGYd3xIAcviiGO6lPXdG6Yg244xwRgtY2dicAQ6HiB87E2IL2ekgfR5QIos18UtjiAsnCpLS3m78JfDorJcYg=="],
 
     "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
@@ -1010,7 +1010,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -2056,7 +2056,7 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "@happy-dom/global-registrator/@types/node": ["@types/node@20.19.24", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA=="],
+    "@happy-dom/global-registrator/happy-dom": ["happy-dom@20.8.4", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
@@ -2156,6 +2156,8 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -2243,8 +2245,6 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
-
-    "@happy-dom/global-registrator/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@chromatic-com/storybook": "^4.1.1",
     "@emotion/is-prop-valid": "^1.4.0",
     "@eslint/js": "^9.33.0",
-    "@happy-dom/global-registrator": "^20.0.8",
+    "@happy-dom/global-registrator": "^20.8.4",
     "@libsql/client": "^0.15.12",
     "@sinonjs/fake-timers": "^15.0.0",
     "@size-limit/file": "^12.0.1",

--- a/src/acp/discovery.test.ts
+++ b/src/acp/discovery.test.ts
@@ -87,7 +87,9 @@ describe('discoverLocalAgents', () => {
 
   it('should handle commandExists throwing errors gracefully', async () => {
     const faultyChecker: CommandExistsChecker = async (command) => {
-      if (command === 'codex') throw new Error('Command check failed')
+      if (command === 'codex') {
+        throw new Error('Command check failed')
+      }
       return command === 'claude'
     }
 

--- a/src/acp/discovery.test.ts
+++ b/src/acp/discovery.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'bun:test'
+import type { CommandExistsChecker } from './discovery'
+import { discoverLocalAgents, knownCliAgents } from './discovery'
+
+const noCommandsExist: CommandExistsChecker = async () => false
+const allCommandsExist: CommandExistsChecker = async () => true
+
+const onlyCommand = (target: string): CommandExistsChecker => {
+  return async (command) => command === target
+}
+
+describe('discoverLocalAgents', () => {
+  it('should return empty array when no commands are found', async () => {
+    const agents = await discoverLocalAgents(noCommandsExist)
+    expect(agents).toEqual([])
+  })
+
+  it('should discover all agents when all commands exist', async () => {
+    const agents = await discoverLocalAgents(allCommandsExist)
+    expect(agents).toHaveLength(knownCliAgents.length)
+  })
+
+  it('should discover only claude when only claude command exists', async () => {
+    const agents = await discoverLocalAgents(onlyCommand('claude'))
+    expect(agents).toHaveLength(1)
+    expect(agents[0]?.name).toBe('Claude Code')
+    expect(agents[0]?.command).toBe('claude')
+  })
+
+  it('should discover only codex when only codex command exists', async () => {
+    const agents = await discoverLocalAgents(onlyCommand('codex'))
+    expect(agents).toHaveLength(1)
+    expect(agents[0]?.name).toBe('Codex')
+    expect(agents[0]?.command).toBe('codex')
+  })
+
+  it('should discover only goose when only goose command exists', async () => {
+    const agents = await discoverLocalAgents(onlyCommand('goose'))
+    expect(agents).toHaveLength(1)
+    expect(agents[0]?.name).toBe('Goose')
+  })
+
+  it('should return agents with correct type and transport', async () => {
+    const agents = await discoverLocalAgents(allCommandsExist)
+    for (const agent of agents) {
+      expect(agent.type).toBe('local')
+      expect(agent.transport).toBe('stdio')
+    }
+  })
+
+  it('should return agents with deterministic IDs based on command name', async () => {
+    const agents = await discoverLocalAgents(allCommandsExist)
+    const claudeAgent = agents.find((a) => a.command === 'claude')
+    expect(claudeAgent?.id).toBe('agent-local-claude')
+  })
+
+  it('should return agents marked as system and enabled', async () => {
+    const agents = await discoverLocalAgents(allCommandsExist)
+    for (const agent of agents) {
+      expect(agent.isSystem).toBe(1)
+      expect(agent.enabled).toBe(1)
+    }
+  })
+
+  it('should return agents with args for ACP mode', async () => {
+    const agents = await discoverLocalAgents(allCommandsExist)
+    for (const agent of agents) {
+      expect(agent.args).toBe('["--acp"]')
+    }
+  })
+
+  it('should return agents with null url and authMethod', async () => {
+    const agents = await discoverLocalAgents(allCommandsExist)
+    for (const agent of agents) {
+      expect(agent.url).toBeNull()
+      expect(agent.authMethod).toBeNull()
+    }
+  })
+
+  it('should handle multiple commands found', async () => {
+    const checker: CommandExistsChecker = async (command) => command === 'claude' || command === 'goose'
+    const agents = await discoverLocalAgents(checker)
+    expect(agents).toHaveLength(2)
+    expect(agents.map((a) => a.command)).toContain('claude')
+    expect(agents.map((a) => a.command)).toContain('goose')
+  })
+
+  it('should handle commandExists throwing errors gracefully', async () => {
+    const faultyChecker: CommandExistsChecker = async (command) => {
+      if (command === 'codex') throw new Error('Command check failed')
+      return command === 'claude'
+    }
+
+    // When commandExists throws, the individual promise rejects and
+    // discoverLocalAgents propagates it (caller should handle)
+    await expect(discoverLocalAgents(faultyChecker)).rejects.toThrow('Command check failed')
+  })
+})
+
+describe('knownCliAgents', () => {
+  it('should contain claude, codex, and goose', () => {
+    const commands = knownCliAgents.map((a) => a.command)
+    expect(commands).toContain('claude')
+    expect(commands).toContain('codex')
+    expect(commands).toContain('goose')
+  })
+
+  it('should have names for all entries', () => {
+    for (const agent of knownCliAgents) {
+      expect(agent.name).toBeTruthy()
+    }
+  })
+
+  it('should have icons for all entries', () => {
+    for (const agent of knownCliAgents) {
+      expect(agent.icon).toBeTruthy()
+    }
+  })
+})

--- a/src/acp/discovery.ts
+++ b/src/acp/discovery.ts
@@ -25,8 +25,6 @@ export const knownCliAgents = [
   },
 ] as const
 
-export type KnownCliAgent = (typeof knownCliAgents)[number]
-
 /**
  * Function signature for checking if a command exists on the system.
  * Abstracted so it can be mocked in tests and implemented via Tauri shell in production.

--- a/src/acp/discovery.ts
+++ b/src/acp/discovery.ts
@@ -41,16 +41,20 @@ export type CommandExistsChecker = (command: string) => Promise<boolean>
  * @returns Array of discovered agents (empty if none found or not on desktop)
  */
 export const discoverLocalAgents = async (commandExists: CommandExistsChecker): Promise<Agent[]> => {
-  const results = await Promise.all(
+  const agents: Agent[] = []
+
+  await Promise.all(
     knownCliAgents.map(async (known) => {
       const exists = await commandExists(known.command)
-      if (!exists) return null
+      if (!exists) {
+        return
+      }
 
-      return {
+      agents.push({
         id: `agent-local-${known.command}`,
         name: known.name,
-        type: 'local' as const,
-        transport: 'stdio' as const,
+        type: 'local',
+        transport: 'stdio',
         command: known.command,
         args: known.args,
         url: null,
@@ -61,9 +65,9 @@ export const discoverLocalAgents = async (commandExists: CommandExistsChecker): 
         deletedAt: null,
         userId: null,
         defaultHash: null,
-      } satisfies Agent
+      })
     }),
   )
 
-  return results.filter((agent): agent is Agent => agent !== null)
+  return agents
 }

--- a/src/acp/discovery.ts
+++ b/src/acp/discovery.ts
@@ -1,0 +1,69 @@
+import type { Agent } from '@/types'
+
+/**
+ * Known CLI agents that can be auto-discovered on desktop.
+ * Each entry maps a command name to its agent metadata.
+ */
+export const knownCliAgents = [
+  {
+    command: 'claude',
+    name: 'Claude Code',
+    icon: 'terminal',
+    args: '["--acp"]',
+  },
+  {
+    command: 'codex',
+    name: 'Codex',
+    icon: 'terminal',
+    args: '["--acp"]',
+  },
+  {
+    command: 'goose',
+    name: 'Goose',
+    icon: 'terminal',
+    args: '["--acp"]',
+  },
+] as const
+
+export type KnownCliAgent = (typeof knownCliAgents)[number]
+
+/**
+ * Function signature for checking if a command exists on the system.
+ * Abstracted so it can be mocked in tests and implemented via Tauri shell in production.
+ */
+export type CommandExistsChecker = (command: string) => Promise<boolean>
+
+/**
+ * Discovers installed CLI agents by checking known commands against the system PATH.
+ * Returns Agent objects for each detected CLI tool.
+ *
+ * @param commandExists - Function that checks if a command is available on the system
+ * @returns Array of discovered agents (empty if none found or not on desktop)
+ */
+export const discoverLocalAgents = async (commandExists: CommandExistsChecker): Promise<Agent[]> => {
+  const results = await Promise.all(
+    knownCliAgents.map(async (known) => {
+      const exists = await commandExists(known.command)
+      if (!exists) return null
+
+      return {
+        id: `agent-local-${known.command}`,
+        name: known.name,
+        type: 'local' as const,
+        transport: 'stdio' as const,
+        command: known.command,
+        args: known.args,
+        url: null,
+        authMethod: null,
+        icon: known.icon,
+        isSystem: 1,
+        enabled: 1,
+        deletedAt: null,
+        userId: null,
+        defaultHash: null,
+      } satisfies Agent
+    }),
+  )
+
+  return results.filter((agent): agent is Agent => agent !== null)
+}

--- a/src/chats/chat-store.test.ts
+++ b/src/chats/chat-store.test.ts
@@ -3,6 +3,7 @@ import { setupTestDatabase, teardownTestDatabase, resetTestDatabase } from '@/da
 import { getDb } from '@/db/database'
 import type { Mode } from '@/types'
 import {
+  createMockAgent,
   createMockAutomationRun,
   createMockChatInstanceWithValidation,
   createMockChatThread,
@@ -316,6 +317,91 @@ describe('chat-store', () => {
 
       const session = getCurrentSession()
       expect(session?.selectedModel?.id).toBe('tracked-model')
+    })
+  })
+
+  describe('setSelectedAgent', () => {
+    it('should throw error when agent is not found', async () => {
+      const agent1 = createMockAgent({ id: 'agent-1' })
+      const model = createMockModel()
+
+      hydrateStore({
+        chatInstance: createMockChatInstanceWithValidation(),
+        chatThread: null,
+        id: 'test-id',
+        mcpClients: [],
+        agents: [agent1],
+        models: [model],
+        selectedAgent: agent1,
+        selectedModel: model,
+        triggerData: null,
+      })
+
+      await expect(useChatStore.getState().setSelectedAgent('test-id', 'nonexistent-agent')).rejects.toThrow(
+        'Agent not found',
+      )
+    })
+
+    it('should set selected agent and update settings', async () => {
+      const agent1 = createMockAgent({ id: 'agent-1', name: 'Agent 1' })
+      const agent2 = createMockAgent({ id: 'agent-2', name: 'Agent 2', type: 'local', transport: 'stdio' })
+      const model = createMockModel()
+
+      hydrateStore({
+        chatInstance: createMockChatInstanceWithValidation(),
+        chatThread: null,
+        id: 'test-id',
+        mcpClients: [],
+        agents: [agent1, agent2],
+        models: [model],
+        selectedAgent: agent1,
+        selectedModel: model,
+        triggerData: null,
+      })
+
+      await useChatStore.getState().setSelectedAgent('test-id', 'agent-2')
+
+      const session = getCurrentSession()
+      expect(session?.selectedAgent).toBe(agent2)
+      expect(session?.selectedAgent?.id).toBe('agent-2')
+
+      const settings = await getSettings(getDb(), { selected_agent: String })
+      expect(settings.selectedAgent).toBe('agent-2')
+    })
+
+    it('should throw error when session is not found', async () => {
+      const agent = createMockAgent()
+      useChatStore.getState().setAgents([agent])
+
+      await expect(useChatStore.getState().setSelectedAgent('nonexistent-session', 'agent-built-in')).rejects.toThrow(
+        'No session found',
+      )
+    })
+  })
+
+  describe('setAgents', () => {
+    it('should set agents in the store', () => {
+      const agent1 = createMockAgent({ id: 'agent-1' })
+      const agent2 = createMockAgent({ id: 'agent-2' })
+
+      useChatStore.getState().setAgents([agent1, agent2])
+
+      const { agents } = useChatStore.getState()
+      expect(agents).toHaveLength(2)
+      expect(agents[0]).toBe(agent1)
+      expect(agents[1]).toBe(agent2)
+    })
+
+    it('should replace existing agents', () => {
+      const agent1 = createMockAgent({ id: 'agent-1' })
+      const agent2 = createMockAgent({ id: 'agent-2' })
+
+      useChatStore.getState().setAgents([agent1])
+      useChatStore.getState().setAgents([agent2])
+
+      const { agents } = useChatStore.getState()
+      expect(agents).toHaveLength(1)
+      expect(agents[0]).toBe(agent2)
     })
   })
 })

--- a/src/chats/chat-store.test.ts
+++ b/src/chats/chat-store.test.ts
@@ -113,6 +113,7 @@ describe('chat-store', () => {
               chatInstance,
               chatThread: null,
               id: 'test-id',
+              selectedAgent: null,
               selectedMode: null as unknown as Mode,
               retryCount: 0,
               retriesExhausted: false,

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -3,7 +3,7 @@ import { updateSettings } from '@/dal'
 import { getDb } from '@/db/database'
 import { type MCPClient } from '@/lib/mcp-provider'
 import { trackEvent } from '@/lib/posthog'
-import type { AutomationRun, ChatThread, Mode, Model, ThunderboltUIMessage } from '@/types'
+import type { Agent, AutomationRun, ChatThread, Mode, Model, ThunderboltUIMessage } from '@/types'
 import { create } from 'zustand'
 import type { Chat } from '@ai-sdk/react'
 import { useShallow } from 'zustand/react/shallow'
@@ -15,12 +15,14 @@ type ChatSession = {
   id: string
   retryCount: number
   retriesExhausted: boolean
+  selectedAgent: Agent | null
   selectedMode: Mode
   selectedModel: Model
   triggerData: AutomationRun | null
 }
 
 type ChatStoreState = {
+  agents: Agent[]
   currentSessionId: string | null
   mcpClients: MCPClient[]
   modes: Mode[]
@@ -30,10 +32,12 @@ type ChatStoreState = {
 
 type ChatStoreActions = {
   createSession(session: ChatSession): void
+  setAgents(agents: Agent[]): void
   setCurrentSessionId(id: string): void
   setMcpClients(mcpClients: MCPClient[]): void
   setModes(modes: Mode[]): void
   setModels(models: Model[]): void
+  setSelectedAgent(id: string, agentId: string | null): Promise<void>
   setSelectedMode(id: string, modeId: string | null): Promise<void>
   setSelectedModel(id: string, modelId: string | null): Promise<void>
   updateSession(id: string, session: Partial<Omit<ChatSession, 'id'>>): void
@@ -42,6 +46,7 @@ type ChatStoreActions = {
 type ChatStore = ChatStoreState & ChatStoreActions
 
 const initialState: ChatStoreState = {
+  agents: [],
   currentSessionId: null,
   mcpClients: [],
   modes: [],
@@ -65,6 +70,10 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
     set({ sessions: nextSessions })
   },
 
+  setAgents: (agents) => {
+    set({ agents })
+  },
+
   setCurrentSessionId: (id) => {
     set({ currentSessionId: id })
   },
@@ -79,6 +88,32 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
 
   setModels: (models) => {
     set({ models })
+  },
+
+  setSelectedAgent: async (id, agentId) => {
+    const { agents, sessions } = get()
+
+    const agent = agents.find((a) => a.id === agentId)
+
+    if (!agent) {
+      throw new Error('Agent not found')
+    }
+
+    const session = sessions.get(id)
+
+    if (!session) {
+      throw new Error('No session found')
+    }
+
+    const nextSessions = new Map(sessions)
+    nextSessions.set(id, { ...session, selectedAgent: agent })
+
+    set({ sessions: nextSessions })
+
+    const db = getDb()
+    await updateSettings(db, { selected_agent: agent.id })
+
+    trackEvent('agent_select', { agent: agent.id })
   },
 
   setSelectedMode: async (id, modeId) => {

--- a/src/chats/use-hydrate-chat-store.test.tsx
+++ b/src/chats/use-hydrate-chat-store.test.tsx
@@ -6,7 +6,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { useHydrateChatStore } from './use-hydrate-chat-store'
 import { useChatStore } from './chat-store'
 import { getDb } from '@/db/database'
-import { modelsTable, modesTable } from '@/db/tables'
+import { agentsTable, modelsTable, modesTable } from '@/db/tables'
 import { v7 as uuidv7 } from 'uuid'
 import { createChatThread } from '@/dal/chat-threads'
 import { getModel } from '@/dal/models'
@@ -61,6 +61,24 @@ const createSystemModel = async () => {
   })
 
   return modelId
+}
+
+/**
+ * Helper function to create a system agent (required for getSelectedAgent)
+ */
+const createSystemAgent = async () => {
+  const db = getDb()
+
+  await db.insert(agentsTable).values({
+    id: 'agent-built-in',
+    name: 'Built-in',
+    type: 'built-in',
+    transport: 'in-process',
+    isSystem: 1,
+    enabled: 1,
+    icon: 'bot',
+    deletedAt: null,
+  })
 }
 
 /**
@@ -147,9 +165,11 @@ describe('useHydrateChatStore', () => {
     // Reset store state before each test
     resetStore()
     await resetTestDatabase()
-    // Create default mode (required for getSelectedMode) and system model (required for getDefaultModelForThread)
+    // Create default mode (required for getSelectedMode), system model (required for getDefaultModelForThread),
+    // and system agent (required for getSelectedAgent)
     await createDefaultMode()
     await createSystemModel()
+    await createSystemAgent()
   })
 
   afterEach(async () => {

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -4,11 +4,13 @@ import { createInProcessStream } from '@/acp/streams'
 import { createBuiltInInference } from '@/acp/built-in-inference'
 import { useDatabase } from '@/contexts'
 import {
+  getEnabledAgents,
   getAllModes,
   getAvailableModels,
   getChatMessages,
   getChatThread,
   getDefaultModelForThread,
+  getSelectedAgent,
   getSelectedMode,
   getSettings,
   getTriggerPromptForThread,
@@ -84,7 +86,8 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
   }
 
   const hydrateChatStore = async () => {
-    const { createSession, sessions, setCurrentSessionId, setMcpClients, setModes, setModels } = useChatStore.getState()
+    const { createSession, sessions, setAgents, setCurrentSessionId, setMcpClients, setModes, setModels } =
+      useChatStore.getState()
 
     // Check if this ID belongs to a deleted chat - redirect to 404 if so
     const isDeleted = await isChatThreadDeleted(db, id)
@@ -97,12 +100,14 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
     if (sessions.has(id)) {
       setCurrentSessionId(id)
 
-      const [modes, models, mcpClients] = await Promise.all([
+      const [agents, modes, models, mcpClients] = await Promise.all([
+        getEnabledAgents(db),
         getAllModes(db),
         getAvailableModels(db),
         getEnabledClients(),
       ])
 
+      setAgents(agents)
       setMcpClients(mcpClients)
       setModes(modes)
       setModels(models)
@@ -115,17 +120,29 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
     // If the session does not exist, create it below
     const settings = await getSettings(db, { selected_model: String })
 
-    const [defaultModel, selectedMode, chatThread, initialMessages, modes, models, triggerData, mcpClients] =
-      await Promise.all([
-        getDefaultModelForThread(db, id, settings.selectedModel ?? undefined),
-        getSelectedMode(db),
-        getChatThread(db, id),
-        getChatMessages(db, id),
-        getAllModes(db),
-        getAvailableModels(db),
-        getTriggerPromptForThread(db, id),
-        getEnabledClients(),
-      ])
+    const [
+      agents,
+      defaultModel,
+      selectedAgent,
+      selectedMode,
+      chatThread,
+      initialMessages,
+      modes,
+      models,
+      triggerData,
+      mcpClients,
+    ] = await Promise.all([
+      getEnabledAgents(db),
+      getDefaultModelForThread(db, id, settings.selectedModel ?? undefined),
+      getSelectedAgent(db),
+      getSelectedMode(db),
+      getChatThread(db, id),
+      getChatMessages(db, id),
+      getAllModes(db),
+      getAvailableModels(db),
+      getTriggerPromptForThread(db, id),
+      getEnabledClients(),
+    ])
 
     // If chat doesn't exist and this isn't a new chat, redirect to 404
     if (!chatThread && !isNew) {
@@ -146,6 +163,7 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
       id,
       retryCount: 0,
       retriesExhausted: false,
+      selectedAgent,
       selectedMode,
       selectedModel: defaultModel,
       triggerData,
@@ -153,6 +171,7 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
 
     setCurrentSessionId(id)
 
+    setAgents(agents)
     setMcpClients(mcpClients)
     setModes(modes)
     setModels(models)

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -44,7 +44,14 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
 
     const { isMobile } = useIsMobile()
 
-    const { chatInstance, chatThread, id: chatThreadId, selectedMode, selectedModel } = useCurrentChatSession()
+    const {
+      chatInstance,
+      chatThread,
+      id: chatThreadId,
+      selectedAgent,
+      selectedMode,
+      selectedModel,
+    } = useCurrentChatSession()
 
     const { messages, status, stop, sendMessage } = useChat({ chat: chatInstance })
 
@@ -126,9 +133,13 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
       setInput,
     }))
 
+    // Mode selector is only shown for built-in agents (which declare modes via ACP).
+    // External agents may not have modes, so the selector hides.
+    const showModeSelector = modes.length > 0 && selectedAgent?.type === 'built-in'
+
     const footerStartElements = (
       <div className="flex items-center gap-2">
-        {modes.length > 0 && (
+        {showModeSelector && (
           <ModeSelector modes={modes} selectedMode={selectedMode} onModeChange={handleModeChange} iconOnly={isMobile} />
         )}
         {isContextKnown && !isMobile && (

--- a/src/components/ui/agent-selector/agent-selector.test.ts
+++ b/src/components/ui/agent-selector/agent-selector.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test'
+import { categorizeAgents } from './agent-selector'
+import type { Agent } from '@/types'
+
+const makeAgent = (overrides: Partial<Agent> & { id: string; name: string }): Agent =>
+  ({
+    type: 'built-in',
+    transport: 'in-process',
+    enabled: 1,
+    isSystem: 1,
+    command: null,
+    args: null,
+    url: null,
+    authMethod: null,
+    icon: 'bot',
+    deletedAt: null,
+    userId: null,
+    defaultHash: null,
+    ...overrides,
+  }) as Agent
+
+const builtInAgent = makeAgent({ id: 'agent-built-in', name: 'Built-in', type: 'built-in', icon: 'bot' })
+const localAgent = makeAgent({
+  id: 'agent-local-claude',
+  name: 'Claude Code',
+  type: 'local',
+  transport: 'stdio',
+  icon: 'terminal',
+  command: 'claude',
+})
+const remoteAgent = makeAgent({
+  id: 'agent-remote-1',
+  name: 'Haystack',
+  type: 'remote',
+  transport: 'websocket',
+  icon: 'globe',
+  url: 'wss://haystack.example.com',
+})
+
+describe('categorizeAgents', () => {
+  test('empty agents returns empty groups', () => {
+    const groups = categorizeAgents([])
+    expect(groups).toHaveLength(0)
+  })
+
+  test('single built-in agent creates one group without label', () => {
+    const groups = categorizeAgents([builtInAgent])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].id).toBe('built-in')
+    expect(groups[0].label).toBeUndefined()
+    expect(groups[0].items).toHaveLength(1)
+    expect(groups[0].items[0].id).toBe('agent-built-in')
+    expect(groups[0].items[0].label).toBe('Built-in')
+  })
+
+  test('local agents are grouped under "Local Agents"', () => {
+    const groups = categorizeAgents([localAgent])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].id).toBe('local')
+    expect(groups[0].label).toBe('Local Agents')
+    expect(groups[0].items).toHaveLength(1)
+    expect(groups[0].items[0].id).toBe('agent-local-claude')
+  })
+
+  test('remote agents are grouped under "Remote Agents"', () => {
+    const groups = categorizeAgents([remoteAgent])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].id).toBe('remote')
+    expect(groups[0].label).toBe('Remote Agents')
+    expect(groups[0].items).toHaveLength(1)
+    expect(groups[0].items[0].id).toBe('agent-remote-1')
+  })
+
+  test('agents of all types are grouped correctly', () => {
+    const groups = categorizeAgents([builtInAgent, localAgent, remoteAgent])
+    expect(groups).toHaveLength(3)
+    expect(groups[0].id).toBe('built-in')
+    expect(groups[1].id).toBe('local')
+    expect(groups[2].id).toBe('remote')
+  })
+
+  test('items have description matching type label', () => {
+    const groups = categorizeAgents([builtInAgent, localAgent, remoteAgent])
+    const builtInItem = groups[0].items[0]
+    const localItem = groups[1].items[0]
+    const remoteItem = groups[2].items[0]
+
+    expect(builtInItem.description).toBe('Built-in')
+    expect(localItem.description).toBe('Local')
+    expect(remoteItem.description).toBe('Remote')
+  })
+
+  test('items have icons', () => {
+    const groups = categorizeAgents([builtInAgent, localAgent])
+    expect(groups[0].items[0].icon).toBeDefined()
+    expect(groups[1].items[0].icon).toBeDefined()
+  })
+
+  test('multiple local agents are in the same group', () => {
+    const codexAgent = makeAgent({
+      id: 'agent-local-codex',
+      name: 'Codex',
+      type: 'local',
+      transport: 'stdio',
+      command: 'codex',
+    })
+    const groups = categorizeAgents([localAgent, codexAgent])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].id).toBe('local')
+    expect(groups[0].items).toHaveLength(2)
+  })
+
+  test('groups preserve order: built-in, local, remote', () => {
+    // Pass in reverse order to verify categorization, not insertion order
+    const groups = categorizeAgents([remoteAgent, localAgent, builtInAgent])
+    expect(groups[0].id).toBe('built-in')
+    expect(groups[1].id).toBe('local')
+    expect(groups[2].id).toBe('remote')
+  })
+})

--- a/src/components/ui/agent-selector/agent-selector.tsx
+++ b/src/components/ui/agent-selector/agent-selector.tsx
@@ -1,0 +1,140 @@
+import { SearchableMenu, type SearchableMenuGroup, type SearchableMenuItem } from '@/components/ui/searchable-menu'
+import { useHaptics } from '@/hooks/use-haptics'
+import { cn } from '@/lib/utils'
+import type { Agent } from '@/types'
+import { Bot, ChevronDown, Terminal, Globe } from 'lucide-react'
+import { useCallback, useMemo, type ReactNode } from 'react'
+
+export type AgentSelectorProps = {
+  agents: Agent[]
+  selectedAgent: Agent | null
+  onAgentChange: (agentId: string) => void
+  side?: 'top' | 'bottom' | 'left' | 'right'
+  align?: 'start' | 'center' | 'end'
+}
+
+type AgentItemData = {
+  agent: Agent
+}
+
+const agentIconMap: Record<string, ReactNode> = {
+  bot: <Bot className="size-4 text-muted-foreground" />,
+  terminal: <Terminal className="size-4 text-muted-foreground" />,
+  globe: <Globe className="size-4 text-muted-foreground" />,
+}
+
+const getAgentIcon = (iconName: string | null): ReactNode => {
+  return agentIconMap[iconName ?? 'bot'] ?? <Bot className="size-4 text-muted-foreground" />
+}
+
+const agentTypeLabels: Record<string, string> = {
+  'built-in': 'Built-in',
+  local: 'Local',
+  remote: 'Remote',
+}
+
+const toMenuItem = (agent: Agent): SearchableMenuItem<AgentItemData> => ({
+  id: agent.id,
+  label: agent.name,
+  description: agentTypeLabels[agent.type] ?? agent.type,
+  icon: getAgentIcon(agent.icon),
+  data: { agent },
+})
+
+/**
+ * Groups agents by type: Built-in, Local (auto-discovered), Remote (user-configured)
+ */
+export const categorizeAgents = (agents: Agent[]): SearchableMenuGroup<AgentItemData>[] => {
+  const builtIn: SearchableMenuItem<AgentItemData>[] = []
+  const local: SearchableMenuItem<AgentItemData>[] = []
+  const remote: SearchableMenuItem<AgentItemData>[] = []
+
+  for (const agent of agents) {
+    const item = toMenuItem(agent)
+
+    switch (agent.type) {
+      case 'built-in':
+        builtIn.push(item)
+        break
+      case 'local':
+        local.push(item)
+        break
+      case 'remote':
+        remote.push(item)
+        break
+    }
+  }
+
+  const groups: SearchableMenuGroup<AgentItemData>[] = []
+
+  if (builtIn.length > 0) {
+    groups.push({ id: 'built-in', items: builtIn })
+  }
+  if (local.length > 0) {
+    groups.push({ id: 'local', label: 'Local Agents', items: local })
+  }
+  if (remote.length > 0) {
+    groups.push({ id: 'remote', label: 'Remote Agents', items: remote })
+  }
+
+  return groups
+}
+
+export const AgentSelector = ({ agents, selectedAgent, onAgentChange, side, align }: AgentSelectorProps) => {
+  const groupedItems = useMemo(() => categorizeAgents(agents), [agents])
+
+  const renderTrigger = (selected: SearchableMenuItem<AgentItemData> | undefined, isOpen: boolean) => (
+    <div
+      className={cn(
+        'flex items-center gap-2 px-3 h-[var(--touch-height-sm)] rounded-full cursor-pointer transition-colors text-[length:var(--font-size-body)]',
+        isOpen ? 'bg-secondary' : 'hover:bg-secondary/50',
+      )}
+    >
+      {selected?.icon ?? <Bot className="size-4 text-muted-foreground" />}
+      <span className="font-medium">{selected?.label ?? 'Select Agent'}</span>
+      <ChevronDown className={cn('size-3.5 text-muted-foreground transition-transform', isOpen && 'rotate-180')} />
+    </div>
+  )
+
+  const renderItem = (item: SearchableMenuItem<AgentItemData>, isSelected: boolean) => (
+    <div
+      className={cn(
+        'w-full flex items-center justify-between px-3 py-2 rounded-lg transition-colors text-left cursor-pointer',
+        'hover:bg-accent/50',
+        isSelected && 'bg-accent',
+      )}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        {item.icon}
+        <span className="font-medium truncate">{item.label}</span>
+      </div>
+    </div>
+  )
+
+  const { triggerSelection } = useHaptics()
+  const handleAgentChange = useCallback(
+    (id: string) => {
+      triggerSelection()
+      onAgentChange(id)
+    },
+    [onAgentChange, triggerSelection],
+  )
+
+  return (
+    <SearchableMenu
+      items={groupedItems}
+      value={selectedAgent?.id}
+      onValueChange={handleAgentChange}
+      searchable={agents.length > 10}
+      searchPlaceholder="Search Agents"
+      emptyMessage="No agents found"
+      blurBackdrop
+      trigger={renderTrigger}
+      renderItem={renderItem}
+      width={280}
+      maxHeight={340}
+      side={side}
+      align={align}
+    />
+  )
+}

--- a/src/components/ui/agent-selector/agent-selector.tsx
+++ b/src/components/ui/agent-selector/agent-selector.tsx
@@ -99,15 +99,13 @@ export const AgentSelector = ({ agents, selectedAgent, onAgentChange, side, alig
   const renderItem = (item: SearchableMenuItem<AgentItemData>, isSelected: boolean) => (
     <div
       className={cn(
-        'w-full flex items-center justify-between px-3 py-2 rounded-lg transition-colors text-left cursor-pointer',
+        'w-full flex items-center gap-2 px-3 py-2 rounded-lg transition-colors text-left cursor-pointer min-w-0',
         'hover:bg-accent/50',
         isSelected && 'bg-accent',
       )}
     >
-      <div className="flex items-center gap-2 min-w-0">
-        {item.icon}
-        <span className="font-medium truncate">{item.label}</span>
-      </div>
+      {item.icon}
+      <span className="font-medium truncate">{item.label}</span>
     </div>
   )
 

--- a/src/components/ui/agent-selector/index.tsx
+++ b/src/components/ui/agent-selector/index.tsx
@@ -1,0 +1,1 @@
+export { AgentSelector, type AgentSelectorProps } from './agent-selector'

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -2,14 +2,14 @@ import { Button } from '@/components/ui/button'
 import { useSidebar } from '@/components/ui/sidebar'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { Menu, MessageCirclePlus } from 'lucide-react'
-import { ModelSelector } from './model-selector'
+import { AgentSelector } from './agent-selector'
 import { useChatStore } from '@/chats/chat-store'
 import { useShallow } from 'zustand/react/shallow'
 import { useNavigate, useLocation } from 'react-router'
 import { PowerSyncStatus } from '@/components/powersync-status'
 
 /**
- * Reusable page header component with sidebar trigger and model selector
+ * Reusable page header component with sidebar trigger and agent selector
  */
 export const Header = () => {
   const { toggleSidebar } = useSidebar()
@@ -17,46 +17,39 @@ export const Header = () => {
   const navigate = useNavigate()
   const location = useLocation()
 
-  const { models, selectedModel, setSelectedModel, chatThread, chatThreadId } = useChatStore(
+  const { agents, selectedAgent, setSelectedAgent, chatThreadId } = useChatStore(
     useShallow((state) => {
       const session = state.sessions.get(state.currentSessionId ?? '')
 
       return {
-        models: state.models,
-        selectedModel: session?.selectedModel,
-        setSelectedModel: state.setSelectedModel,
-        chatThread: session?.chatThread,
+        agents: state.agents,
+        selectedAgent: session?.selectedAgent,
+        setSelectedAgent: state.setSelectedAgent,
         chatThreadId: session?.id,
       }
     }),
   )
-
-  const handleAddModels = () => {
-    navigate('/settings/models')
-  }
 
   const handleNewChat = () => {
     navigate('/chats/new')
   }
 
   const isChatRoute = location.pathname.startsWith('/chats')
-  const showModelSelector = isChatRoute && models.length > 0
+  const showAgentSelector = isChatRoute && agents.length > 0
 
-  const modelSelector = showModelSelector && (
-    <ModelSelector
-      models={models}
-      selectedModel={selectedModel ?? null}
-      chatThread={chatThread ?? null}
-      onModelChange={(modelId) => {
-        if (chatThreadId && modelId) {
-          setSelectedModel(chatThreadId, modelId).catch(console.error)
+  const agentSelector = showAgentSelector && (
+    <AgentSelector
+      agents={agents}
+      selectedAgent={selectedAgent ?? null}
+      onAgentChange={(agentId) => {
+        if (chatThreadId && agentId) {
+          setSelectedAgent(chatThreadId, agentId).catch(console.error)
         }
       }}
-      onAddModels={handleAddModels}
     />
   )
 
-  // Mobile: 3-column layout with centered model selector
+  // Mobile: 3-column layout with centered agent selector
   if (isMobile) {
     const showNewChatButton = isChatRoute && location.pathname !== '/chats/new'
 
@@ -74,7 +67,7 @@ export const Header = () => {
           </Button>
         </div>
 
-        <div className="flex shrink-0 items-center justify-center">{modelSelector}</div>
+        <div className="flex shrink-0 items-center justify-center">{agentSelector}</div>
 
         <div className="flex flex-1 items-center gap-1 justify-end">
           {showNewChatButton && (
@@ -96,7 +89,7 @@ export const Header = () => {
   // Desktop: Left-aligned with PowerSync status on the right
   return (
     <header className="flex h-[var(--touch-height-xl)] w-full items-center justify-between px-2 flex-shrink-0">
-      <div className="flex items-center">{modelSelector}</div>
+      <div className="flex items-center">{agentSelector}</div>
       <PowerSyncStatus />
     </header>
   )

--- a/src/dal/agents.test.ts
+++ b/src/dal/agents.test.ts
@@ -3,8 +3,6 @@ import { agentsTable } from '@/db/tables'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
-import { defaultAgentBuiltIn } from '@/defaults/agents'
-import type { Agent } from '@/types'
 import {
   createAgent,
   deleteAgent,

--- a/src/dal/agents.test.ts
+++ b/src/dal/agents.test.ts
@@ -1,0 +1,490 @@
+import { getDb } from '@/db/database'
+import { agentsTable } from '@/db/tables'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { v7 as uuidv7 } from 'uuid'
+import { defaultAgentBuiltIn } from '@/defaults/agents'
+import type { Agent } from '@/types'
+import {
+  createAgent,
+  deleteAgent,
+  getAgent,
+  getAllAgents,
+  getEnabledAgents,
+  getSelectedAgent,
+  getSystemAgent,
+  updateAgent,
+} from './agents'
+import { updateSettings } from './settings'
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
+
+beforeAll(async () => {
+  await setupTestDatabase()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+describe('Agents DAL', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  describe('getAgent', () => {
+    it('should return null when agent does not exist', async () => {
+      const agent = await getAgent(getDb(), 'nonexistent-agent-id')
+      expect(agent).toBe(null)
+    })
+
+    it('should return null when agent ID is empty string', async () => {
+      const agent = await getAgent(getDb(), '')
+      expect(agent).toBe(null)
+    })
+
+    it('should return agent when it exists', async () => {
+      const db = getDb()
+      const agentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: agentId,
+        name: 'Test Agent',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 1,
+      })
+
+      const agent = await getAgent(getDb(), agentId)
+      expect(agent).not.toBe(null)
+      expect(agent?.id).toBe(agentId)
+      expect(agent?.name).toBe('Test Agent')
+    })
+
+    it('should not return soft-deleted agents', async () => {
+      const db = getDb()
+      const agentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: agentId,
+        name: 'Deleted Agent',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 1,
+        deletedAt: '2024-01-01T00:00:00.000Z',
+      })
+
+      const agent = await getAgent(getDb(), agentId)
+      expect(agent).toBe(null)
+    })
+  })
+
+  describe('getAllAgents', () => {
+    it('should return empty array when no agents exist', async () => {
+      const agents = await getAllAgents(getDb())
+      expect(agents).toEqual([])
+    })
+
+    it('should return all non-deleted agents', async () => {
+      const db = getDb()
+      const agentId1 = uuidv7()
+      const agentId2 = uuidv7()
+
+      await db.insert(agentsTable).values([
+        { id: agentId1, name: 'Agent 1', type: 'local', transport: 'stdio', enabled: 1 },
+        { id: agentId2, name: 'Agent 2', type: 'remote', transport: 'websocket', enabled: 1 },
+      ])
+
+      const agents = await getAllAgents(getDb())
+      expect(agents).toHaveLength(2)
+    })
+
+    it('should sort system agents first', async () => {
+      const db = getDb()
+
+      await db.insert(agentsTable).values([
+        { id: uuidv7(), name: 'Custom Agent', type: 'local', transport: 'stdio', isSystem: 0, enabled: 1 },
+        { id: uuidv7(), name: 'System Agent', type: 'built-in', transport: 'in-process', isSystem: 1, enabled: 1 },
+      ])
+
+      const agents = await getAllAgents(getDb())
+      expect(agents[0]?.isSystem).toBe(1)
+      expect(agents[1]?.isSystem).toBe(0)
+    })
+
+    it('should exclude soft-deleted agents', async () => {
+      const db = getDb()
+
+      await db.insert(agentsTable).values([
+        { id: uuidv7(), name: 'Active Agent', type: 'local', transport: 'stdio', enabled: 1 },
+        {
+          id: uuidv7(),
+          name: 'Deleted Agent',
+          type: 'local',
+          transport: 'stdio',
+          enabled: 1,
+          deletedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ])
+
+      const agents = await getAllAgents(getDb())
+      expect(agents).toHaveLength(1)
+      expect(agents[0]?.name).toBe('Active Agent')
+    })
+  })
+
+  describe('getEnabledAgents', () => {
+    it('should return only enabled agents', async () => {
+      const db = getDb()
+
+      await db.insert(agentsTable).values([
+        { id: uuidv7(), name: 'Enabled Agent', type: 'local', transport: 'stdio', enabled: 1 },
+        { id: uuidv7(), name: 'Disabled Agent', type: 'local', transport: 'stdio', enabled: 0 },
+      ])
+
+      const agents = await getEnabledAgents(getDb())
+      expect(agents).toHaveLength(1)
+      expect(agents[0]?.name).toBe('Enabled Agent')
+    })
+
+    it('should return empty array when no enabled agents exist', async () => {
+      const db = getDb()
+
+      await db.insert(agentsTable).values({
+        id: uuidv7(),
+        name: 'Disabled Agent',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 0,
+      })
+
+      const agents = await getEnabledAgents(getDb())
+      expect(agents).toEqual([])
+    })
+  })
+
+  describe('getSystemAgent', () => {
+    it('should return null when no system agent exists', async () => {
+      const db = getDb()
+
+      await db.insert(agentsTable).values({
+        id: uuidv7(),
+        name: 'Custom Agent',
+        type: 'local',
+        transport: 'stdio',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      const systemAgent = await getSystemAgent(getDb())
+      expect(systemAgent).toBe(null)
+    })
+
+    it('should return the system agent when it exists', async () => {
+      const db = getDb()
+      const systemAgentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: systemAgentId,
+        name: 'Built-in',
+        type: 'built-in',
+        transport: 'in-process',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      const systemAgent = await getSystemAgent(getDb())
+      expect(systemAgent).not.toBe(null)
+      expect(systemAgent?.id).toBe(systemAgentId)
+      expect(systemAgent?.isSystem).toBe(1)
+    })
+  })
+
+  describe('getSelectedAgent', () => {
+    it('should return system agent when no selected_agent setting exists', async () => {
+      const db = getDb()
+      const systemAgentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: systemAgentId,
+        name: 'Built-in',
+        type: 'built-in',
+        transport: 'in-process',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      const agent = await getSelectedAgent(getDb())
+      expect(agent.id).toBe(systemAgentId)
+    })
+
+    it('should return selected agent when selected_agent setting exists', async () => {
+      const db = getDb()
+
+      // Create system agent
+      await db.insert(agentsTable).values({
+        id: uuidv7(),
+        name: 'Built-in',
+        type: 'built-in',
+        transport: 'in-process',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      // Create selected agent
+      const selectedId = uuidv7()
+      await db.insert(agentsTable).values({
+        id: selectedId,
+        name: 'Claude Code',
+        type: 'local',
+        transport: 'stdio',
+        isSystem: 0,
+        enabled: 1,
+      })
+
+      await updateSettings(getDb(), { selected_agent: selectedId })
+
+      const agent = await getSelectedAgent(getDb())
+      expect(agent.id).toBe(selectedId)
+      expect(agent.name).toBe('Claude Code')
+    })
+
+    it('should fall back to system agent when selected agent is disabled', async () => {
+      const db = getDb()
+      const systemAgentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: systemAgentId,
+        name: 'Built-in',
+        type: 'built-in',
+        transport: 'in-process',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      const disabledId = uuidv7()
+      await db.insert(agentsTable).values({
+        id: disabledId,
+        name: 'Disabled Agent',
+        type: 'local',
+        transport: 'stdio',
+        isSystem: 0,
+        enabled: 0,
+      })
+
+      await updateSettings(getDb(), { selected_agent: disabledId })
+
+      const agent = await getSelectedAgent(getDb())
+      expect(agent.id).toBe(systemAgentId)
+    })
+
+    it('should fall back to system agent when selected agent is deleted', async () => {
+      const db = getDb()
+      const systemAgentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: systemAgentId,
+        name: 'Built-in',
+        type: 'built-in',
+        transport: 'in-process',
+        isSystem: 1,
+        enabled: 1,
+      })
+
+      const deletedId = uuidv7()
+      await db.insert(agentsTable).values({
+        id: deletedId,
+        name: 'Deleted Agent',
+        type: 'local',
+        transport: 'stdio',
+        isSystem: 0,
+        enabled: 1,
+        deletedAt: '2024-01-01T00:00:00.000Z',
+      })
+
+      await updateSettings(getDb(), { selected_agent: deletedId })
+
+      const agent = await getSelectedAgent(getDb())
+      expect(agent.id).toBe(systemAgentId)
+    })
+
+    it('should throw when no system agent exists and no selection', async () => {
+      await expect(getSelectedAgent(getDb())).rejects.toThrow('No system agent found')
+    })
+  })
+
+  describe('createAgent', () => {
+    it('should create a new agent', async () => {
+      const agentId = uuidv7()
+
+      await createAgent(getDb(), {
+        id: agentId,
+        name: 'Claude Code',
+        type: 'local',
+        transport: 'stdio',
+        command: 'claude',
+        args: JSON.stringify(['--acp']),
+        enabled: 1,
+      })
+
+      const agent = await getAgent(getDb(), agentId)
+      expect(agent).not.toBe(null)
+      expect(agent?.name).toBe('Claude Code')
+      expect(agent?.type).toBe('local')
+      expect(agent?.transport).toBe('stdio')
+      expect(agent?.command).toBe('claude')
+    })
+
+    it('should create a remote agent with url', async () => {
+      const agentId = uuidv7()
+
+      await createAgent(getDb(), {
+        id: agentId,
+        name: 'Haystack',
+        type: 'remote',
+        transport: 'websocket',
+        url: 'wss://haystack.example.com',
+        enabled: 1,
+      })
+
+      const agent = await getAgent(getDb(), agentId)
+      expect(agent?.url).toBe('wss://haystack.example.com')
+    })
+  })
+
+  describe('updateAgent', () => {
+    it('should update agent name', async () => {
+      const db = getDb()
+      const agentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: agentId,
+        name: 'Original Name',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 1,
+      })
+
+      await updateAgent(getDb(), agentId, { name: 'Updated Name' })
+
+      const agent = await getAgent(getDb(), agentId)
+      expect(agent?.name).toBe('Updated Name')
+    })
+
+    it('should update agent enabled status', async () => {
+      const db = getDb()
+      const agentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: agentId,
+        name: 'Test Agent',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 1,
+      })
+
+      await updateAgent(getDb(), agentId, { enabled: 0 })
+
+      const enabledAgents = await getEnabledAgents(getDb())
+      expect(enabledAgents.map((a) => a.id)).not.toContain(agentId)
+    })
+
+    it('should not update defaultHash field', async () => {
+      const db = getDb()
+      const agentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: agentId,
+        name: 'Test Agent',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 1,
+        defaultHash: 'original-hash',
+      })
+
+      await updateAgent(getDb(), agentId, { name: 'Updated', defaultHash: 'new-hash' } as Parameters<
+        typeof updateAgent
+      >[2])
+
+      const rawAgent = await db.select().from(agentsTable).where(eq(agentsTable.id, agentId)).get()
+      expect(rawAgent?.defaultHash).toBe('original-hash')
+      expect(rawAgent?.name).toBe('Updated')
+    })
+
+    it('should not throw when updating non-existent agent', async () => {
+      await expect(updateAgent(getDb(), 'non-existent-id', { name: 'test' })).resolves.toBeUndefined()
+    })
+  })
+
+  describe('deleteAgent', () => {
+    it('should soft delete an agent by id', async () => {
+      const db = getDb()
+      const agentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: agentId,
+        name: 'Agent to delete',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 1,
+      })
+
+      const agentBefore = await getAgent(getDb(), agentId)
+      expect(agentBefore).not.toBe(null)
+
+      await deleteAgent(getDb(), agentId)
+
+      const agentAfter = await getAgent(getDb(), agentId)
+      expect(agentAfter).toBe(null)
+
+      // Should still exist in database with deletedAt set
+      const rawAgent = await db.select().from(agentsTable).where(eq(agentsTable.id, agentId)).get()
+      expect(rawAgent).not.toBeUndefined()
+      expect(rawAgent?.deletedAt).not.toBeNull()
+    })
+
+    it('should not throw when deleting non-existent agent', async () => {
+      await expect(deleteAgent(getDb(), 'non-existent-id')).resolves.toBeUndefined()
+    })
+
+    it('should preserve original deletedAt for already-deleted agent', async () => {
+      const db = getDb()
+      const agentId = uuidv7()
+      const originalDeletedAt = '2024-01-15T12:00:00.000Z'
+
+      await db.insert(agentsTable).values({
+        id: agentId,
+        name: 'Already deleted',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 1,
+        deletedAt: originalDeletedAt,
+      })
+
+      await deleteAgent(getDb(), agentId)
+
+      const rawAgent = await db.select().from(agentsTable).where(eq(agentsTable.id, agentId)).get()
+      expect(rawAgent?.deletedAt).toBe(originalDeletedAt)
+    })
+
+    it('should not return soft-deleted agent via getAllAgents', async () => {
+      const db = getDb()
+      const agentId = uuidv7()
+
+      await db.insert(agentsTable).values({
+        id: agentId,
+        name: 'Agent to delete',
+        type: 'local',
+        transport: 'stdio',
+        enabled: 1,
+      })
+
+      const agentsBefore = await getAllAgents(getDb())
+      expect(agentsBefore).toHaveLength(1)
+
+      await deleteAgent(getDb(), agentId)
+
+      const agentsAfter = await getAllAgents(getDb())
+      expect(agentsAfter).toHaveLength(0)
+    })
+  })
+})

--- a/src/dal/agents.ts
+++ b/src/dal/agents.ts
@@ -5,10 +5,6 @@ import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { Agent } from '@/types'
 import { getSettings } from './settings'
 
-/**
- * Gets all agents from the database (excluding soft-deleted)
- * Sorted with system agents first, then alphabetically by name
- */
 export const getAllAgents = async (db: AnyDrizzleDatabase): Promise<Agent[]> => {
   const results = await db
     .select()
@@ -19,9 +15,6 @@ export const getAllAgents = async (db: AnyDrizzleDatabase): Promise<Agent[]> => 
   return results as Agent[]
 }
 
-/**
- * Gets all enabled agents from the database (excluding soft-deleted)
- */
 export const getEnabledAgents = async (db: AnyDrizzleDatabase): Promise<Agent[]> => {
   const results = await db
     .select()
@@ -32,9 +25,6 @@ export const getEnabledAgents = async (db: AnyDrizzleDatabase): Promise<Agent[]>
   return results as Agent[]
 }
 
-/**
- * Gets a specific agent by ID (excluding soft-deleted)
- */
 export const getAgent = async (db: AnyDrizzleDatabase, id: string): Promise<Agent | null> => {
   const agent = await db
     .select()
@@ -45,9 +35,6 @@ export const getAgent = async (db: AnyDrizzleDatabase, id: string): Promise<Agen
   return agent ? (agent as Agent) : null
 }
 
-/**
- * Gets the system agent (built-in)
- */
 export const getSystemAgent = async (db: AnyDrizzleDatabase): Promise<Agent | null> => {
   const agent = await db
     .select()
@@ -60,7 +47,7 @@ export const getSystemAgent = async (db: AnyDrizzleDatabase): Promise<Agent | nu
 }
 
 /**
- * Gets the currently selected agent from settings, or falls back to the system agent
+ * Falls back to the system agent if the selected agent is missing or disabled.
  */
 export const getSelectedAgent = async (db: AnyDrizzleDatabase): Promise<Agent> => {
   const settings = await getSettings(db, { selected_agent: String })
@@ -82,9 +69,6 @@ export const getSelectedAgent = async (db: AnyDrizzleDatabase): Promise<Agent> =
   return systemAgent
 }
 
-/**
- * Creates a new agent
- */
 export const createAgent = async (
   db: AnyDrizzleDatabase,
   data: Partial<Agent> & Pick<Agent, 'id' | 'name' | 'type' | 'transport'>,
@@ -92,17 +76,12 @@ export const createAgent = async (
   await db.insert(agentsTable).values(data)
 }
 
-/**
- * Updates an agent (preserves defaultHash for modification tracking)
- */
+/** Preserves defaultHash to avoid overwriting modification tracking */
 export const updateAgent = async (db: AnyDrizzleDatabase, id: string, updates: Partial<Agent>): Promise<void> => {
   const { defaultHash, ...updateFields } = updates as Partial<Agent> & { defaultHash?: string }
   await db.update(agentsTable).set(updateFields).where(eq(agentsTable.id, id))
 }
 
-/**
- * Soft deletes an agent by ID (sets deletedAt datetime)
- */
 export const deleteAgent = async (db: AnyDrizzleDatabase, id: string): Promise<void> => {
   await db
     .update(agentsTable)

--- a/src/dal/agents.ts
+++ b/src/dal/agents.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, isNull } from 'drizzle-orm'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
-import { agentsTable, settingsTable } from '../db/tables'
+import { agentsTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { Agent } from '@/types'
 import { getSettings } from './settings'

--- a/src/dal/agents.ts
+++ b/src/dal/agents.ts
@@ -1,0 +1,111 @@
+import { and, desc, eq, isNull } from 'drizzle-orm'
+import type { AnyDrizzleDatabase } from '../db/database-interface'
+import { agentsTable, settingsTable } from '../db/tables'
+import { clearNullableColumns, nowIso } from '../lib/utils'
+import type { Agent } from '@/types'
+import { getSettings } from './settings'
+
+/**
+ * Gets all agents from the database (excluding soft-deleted)
+ * Sorted with system agents first, then alphabetically by name
+ */
+export const getAllAgents = async (db: AnyDrizzleDatabase): Promise<Agent[]> => {
+  const results = await db
+    .select()
+    .from(agentsTable)
+    .where(isNull(agentsTable.deletedAt))
+    .orderBy(desc(agentsTable.isSystem), agentsTable.name)
+
+  return results as Agent[]
+}
+
+/**
+ * Gets all enabled agents from the database (excluding soft-deleted)
+ */
+export const getEnabledAgents = async (db: AnyDrizzleDatabase): Promise<Agent[]> => {
+  const results = await db
+    .select()
+    .from(agentsTable)
+    .where(and(eq(agentsTable.enabled, 1), isNull(agentsTable.deletedAt)))
+    .orderBy(desc(agentsTable.isSystem), agentsTable.name)
+
+  return results as Agent[]
+}
+
+/**
+ * Gets a specific agent by ID (excluding soft-deleted)
+ */
+export const getAgent = async (db: AnyDrizzleDatabase, id: string): Promise<Agent | null> => {
+  const agent = await db
+    .select()
+    .from(agentsTable)
+    .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+    .get()
+
+  return agent ? (agent as Agent) : null
+}
+
+/**
+ * Gets the system agent (built-in)
+ */
+export const getSystemAgent = async (db: AnyDrizzleDatabase): Promise<Agent | null> => {
+  const agent = await db
+    .select()
+    .from(agentsTable)
+    .where(and(eq(agentsTable.isSystem, 1), isNull(agentsTable.deletedAt)))
+    .orderBy(agentsTable.name)
+    .get()
+
+  return agent ? (agent as Agent) : null
+}
+
+/**
+ * Gets the currently selected agent from settings, or falls back to the system agent
+ */
+export const getSelectedAgent = async (db: AnyDrizzleDatabase): Promise<Agent> => {
+  const settings = await getSettings(db, { selected_agent: String })
+  const selectedAgentId = settings.selectedAgent
+
+  if (selectedAgentId) {
+    const agent = await getAgent(db, selectedAgentId)
+    if (agent && agent.enabled) {
+      return agent
+    }
+  }
+
+  const systemAgent = await getSystemAgent(db)
+
+  if (!systemAgent) {
+    throw new Error('No system agent found')
+  }
+
+  return systemAgent
+}
+
+/**
+ * Creates a new agent
+ */
+export const createAgent = async (
+  db: AnyDrizzleDatabase,
+  data: Partial<Agent> & Pick<Agent, 'id' | 'name' | 'type' | 'transport'>,
+): Promise<void> => {
+  await db.insert(agentsTable).values(data)
+}
+
+/**
+ * Updates an agent (preserves defaultHash for modification tracking)
+ */
+export const updateAgent = async (db: AnyDrizzleDatabase, id: string, updates: Partial<Agent>): Promise<void> => {
+  const { defaultHash, ...updateFields } = updates as Partial<Agent> & { defaultHash?: string }
+  await db.update(agentsTable).set(updateFields).where(eq(agentsTable.id, id))
+}
+
+/**
+ * Soft deletes an agent by ID (sets deletedAt datetime)
+ */
+export const deleteAgent = async (db: AnyDrizzleDatabase, id: string): Promise<void> => {
+  await db
+    .update(agentsTable)
+    .set({ ...clearNullableColumns(agentsTable), deletedAt: nowIso() })
+    .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+}

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -1,3 +1,15 @@
+// Agents
+export {
+  createAgent,
+  deleteAgent,
+  getAgent,
+  getAllAgents,
+  getEnabledAgents,
+  getSelectedAgent,
+  getSystemAgent,
+  updateAgent,
+} from './agents'
+
 // Models
 export {
   createModel,

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -23,6 +23,7 @@ export const chatThreadsTable = sqliteTable(
     wasTriggeredByAutomation: integer('was_triggered_by_automation').default(0),
     contextSize: integer('context_size'),
     modeId: text('mode_id'),
+    agentId: text('agent_id'),
     deletedAt: text('deleted_at'),
     userId: text('user_id'),
   },
@@ -214,6 +215,31 @@ export const modesTable = sqliteTable(
   },
   (table) => [
     index('idx_modes_active')
+      .on(table.id)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+)
+
+export const agentsTable = sqliteTable(
+  'agents',
+  {
+    id: text('id').primaryKey(),
+    name: text('name'),
+    type: text('type', { enum: ['built-in', 'local', 'remote'] }),
+    transport: text('transport', { enum: ['in-process', 'stdio', 'websocket'] }),
+    command: text('command'),
+    args: text('args'),
+    url: text('url'),
+    authMethod: text('auth_method'),
+    icon: text('icon'),
+    isSystem: integer('is_system').default(0),
+    enabled: integer('enabled').default(1),
+    deletedAt: text('deleted_at'),
+    userId: text('user_id'),
+    defaultHash: text('default_hash'),
+  },
+  (table) => [
+    index('idx_agents_active')
       .on(table.id)
       .where(sql`${table.deletedAt} IS NULL`),
   ],

--- a/src/defaults/agents.test.ts
+++ b/src/defaults/agents.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test'
+import { defaultAgentBuiltIn, defaultAgents, hashAgent } from './agents'
+
+describe('defaults/agents', () => {
+  describe('defaultAgentBuiltIn', () => {
+    it('should have the expected id', () => {
+      expect(defaultAgentBuiltIn.id).toBe('agent-built-in')
+    })
+
+    it('should be a built-in type with in-process transport', () => {
+      expect(defaultAgentBuiltIn.type).toBe('built-in')
+      expect(defaultAgentBuiltIn.transport).toBe('in-process')
+    })
+
+    it('should be a system agent and enabled', () => {
+      expect(defaultAgentBuiltIn.isSystem).toBe(1)
+      expect(defaultAgentBuiltIn.enabled).toBe(1)
+    })
+
+    it('should have no command, args, url, or authMethod', () => {
+      expect(defaultAgentBuiltIn.command).toBeNull()
+      expect(defaultAgentBuiltIn.args).toBeNull()
+      expect(defaultAgentBuiltIn.url).toBeNull()
+      expect(defaultAgentBuiltIn.authMethod).toBeNull()
+    })
+
+    it('should have a bot icon', () => {
+      expect(defaultAgentBuiltIn.icon).toBe('bot')
+    })
+  })
+
+  describe('defaultAgents', () => {
+    it('should contain the built-in agent', () => {
+      expect(defaultAgents).toContain(defaultAgentBuiltIn)
+    })
+
+    it('should have exactly one default agent', () => {
+      expect(defaultAgents).toHaveLength(1)
+    })
+  })
+
+  describe('hashAgent', () => {
+    it('should return a consistent hash for the same agent', () => {
+      const hash1 = hashAgent(defaultAgentBuiltIn)
+      const hash2 = hashAgent(defaultAgentBuiltIn)
+      expect(hash1).toBe(hash2)
+    })
+
+    it('should return different hashes for different agents', () => {
+      const otherAgent = { ...defaultAgentBuiltIn, name: 'Other Agent' }
+      expect(hashAgent(defaultAgentBuiltIn)).not.toBe(hashAgent(otherAgent))
+    })
+
+    it('should detect changes to name', () => {
+      const original = hashAgent(defaultAgentBuiltIn)
+      const modified = hashAgent({ ...defaultAgentBuiltIn, name: 'Modified' })
+      expect(original).not.toBe(modified)
+    })
+
+    it('should detect changes to enabled', () => {
+      const original = hashAgent(defaultAgentBuiltIn)
+      const modified = hashAgent({ ...defaultAgentBuiltIn, enabled: 0 })
+      expect(original).not.toBe(modified)
+    })
+
+    it('should detect changes to deletedAt', () => {
+      const original = hashAgent(defaultAgentBuiltIn)
+      const modified = hashAgent({ ...defaultAgentBuiltIn, deletedAt: '2024-01-01' })
+      expect(original).not.toBe(modified)
+    })
+
+    it('should return a string', () => {
+      expect(typeof hashAgent(defaultAgentBuiltIn)).toBe('string')
+    })
+  })
+})

--- a/src/defaults/agents.ts
+++ b/src/defaults/agents.ts
@@ -42,7 +42,4 @@ export const defaultAgentBuiltIn: Agent = {
   defaultHash: null,
 }
 
-/**
- * Array of all default agents for iteration
- */
 export const defaultAgents: ReadonlyArray<Agent> = [defaultAgentBuiltIn] as const

--- a/src/defaults/agents.ts
+++ b/src/defaults/agents.ts
@@ -1,0 +1,48 @@
+import { hashValues } from '@/lib/utils'
+import type { Agent } from '@/types'
+
+/**
+ * Compute hash of user-editable fields for an agent
+ * Includes deletedAt to treat soft-delete as a user configuration choice
+ */
+export const hashAgent = (agent: Agent): string => {
+  return hashValues([
+    agent.name,
+    agent.type,
+    agent.transport,
+    agent.command,
+    agent.args,
+    agent.url,
+    agent.authMethod,
+    agent.icon,
+    agent.isSystem,
+    agent.enabled,
+    agent.deletedAt,
+  ])
+}
+
+/**
+ * Default built-in agent shipped with the application.
+ * Uses in-process transport — runs in the same JS context.
+ */
+export const defaultAgentBuiltIn: Agent = {
+  id: 'agent-built-in',
+  name: 'Built-in',
+  type: 'built-in',
+  transport: 'in-process',
+  command: null,
+  args: null,
+  url: null,
+  authMethod: null,
+  icon: 'bot',
+  isSystem: 1,
+  enabled: 1,
+  deletedAt: null,
+  userId: null,
+  defaultHash: null,
+}
+
+/**
+ * Array of all default agents for iteration
+ */
+export const defaultAgents: ReadonlyArray<Agent> = [defaultAgentBuiltIn] as const

--- a/src/defaults/index.ts
+++ b/src/defaults/index.ts
@@ -1,3 +1,4 @@
+export { defaultAgentBuiltIn, defaultAgents, hashAgent } from './agents'
 export {
   defaultAutomationDailyBrief,
   defaultAutomationImportantEmails,

--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -130,7 +130,8 @@ export type EventType =
   | 'chat_new_clicked'
   | 'chat_delete'
   | 'chat_clear_all'
-  // Model & Settings
+  // Agent, Model & Settings
+  | 'agent_select'
   | 'model_select'
   | 'mode_select'
   | 'settings_theme_set'

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -3,7 +3,16 @@ import { createSetting } from '@/dal'
 import { eq } from 'drizzle-orm'
 import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
 import { v7 as uuidv7 } from 'uuid'
-import { modelProfilesTable, modelsTable, modesTable, promptsTable, settingsTable, tasksTable } from '../db/tables'
+import {
+  agentsTable,
+  modelProfilesTable,
+  modelsTable,
+  modesTable,
+  promptsTable,
+  settingsTable,
+  tasksTable,
+} from '../db/tables'
+import { defaultAgents, hashAgent } from '../defaults/agents'
 import { defaultAutomations, hashPrompt } from '../defaults/automations'
 import { defaultModelProfiles, hashModelProfile } from '../defaults/model-profiles'
 import { defaultModes, hashMode } from '../defaults/modes'
@@ -91,6 +100,9 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase) => {
 
     // Automations (Prompts)
     await reconcileDefaultsForTable(tx, promptsTable, defaultAutomations, hashPrompt)
+
+    // Agents
+    await reconcileDefaultsForTable(tx, agentsTable, defaultAgents, hashAgent)
 
     // Settings
     await reconcileDefaultsForTable(tx, settingsTable, defaultSettings, hashSetting, 'key')

--- a/src/test-utils/chat-store-mocks.ts
+++ b/src/test-utils/chat-store-mocks.ts
@@ -1,7 +1,29 @@
 import { useChatStore } from '@/chats/chat-store'
-import type { AutomationRun, ChatThread, Mode, Model, ThunderboltUIMessage } from '@/types'
+import type { Agent, AutomationRun, ChatThread, Mode, Model, ThunderboltUIMessage } from '@/types'
 import { type Chat } from '@ai-sdk/react'
 import { mock } from 'bun:test'
+
+/**
+ * Creates a mock Agent for testing
+ */
+export const createMockAgent = (overrides?: Partial<Agent>): Agent =>
+  ({
+    id: 'agent-built-in',
+    name: 'Built-in',
+    type: 'built-in',
+    transport: 'in-process',
+    enabled: 1,
+    isSystem: 1,
+    command: null,
+    args: null,
+    url: null,
+    authMethod: null,
+    icon: 'bot',
+    deletedAt: null,
+    userId: null,
+    defaultHash: null,
+    ...overrides,
+  }) as Agent
 
 /**
  * Creates a mock Mode for testing
@@ -177,20 +199,47 @@ const defaultTestModel: Model = {
 } as Model
 
 /**
+ * Default agent used when selectedAgent is null but a session needs to be created
+ */
+const defaultTestAgent: Agent = {
+  id: 'agent-built-in',
+  name: 'Built-in',
+  type: 'built-in',
+  transport: 'in-process',
+  enabled: 1,
+  isSystem: 1,
+  command: null,
+  args: null,
+  url: null,
+  authMethod: null,
+  icon: 'bot',
+  deletedAt: null,
+  userId: null,
+  defaultHash: null,
+} as Agent
+
+/**
  * Hydrates the store with a session for testing
  */
 export const hydrateStore = (state: {
+  agents?: Agent[]
   chatInstance: Chat<ThunderboltUIMessage> | null
   chatThread: ChatThread | null
   id: string
   mcpClients?: unknown[]
   modes?: Mode[]
   models?: Model[]
+  selectedAgent?: Agent | null
   selectedMode?: Mode | null
   selectedModel: Model | null
   triggerData: AutomationRun | null
 }) => {
   const store = useChatStore.getState()
+
+  // Set agents
+  if (state.agents) {
+    store.setAgents(state.agents)
+  }
 
   // Set modes first (needed for setSelectedMode)
   if (state.modes) {
@@ -216,6 +265,7 @@ export const hydrateStore = (state: {
       id: state.id,
       retryCount: 0,
       retriesExhausted: false,
+      selectedAgent: state.selectedAgent ?? defaultTestAgent,
       selectedMode: state.selectedMode ?? defaultTestMode,
       selectedModel: state.selectedModel ?? defaultTestModel,
       triggerData: state.triggerData,
@@ -236,6 +286,7 @@ export const hydrateStore = (state: {
  */
 export const resetStore = () => {
   useChatStore.setState({
+    agents: [],
     currentSessionId: null,
     mcpClients: [],
     modes: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import type { z } from 'zod'
 import type { HttpClient } from './contexts'
 import type { AnyDrizzleDatabase } from './db/database-interface'
 import type {
+  agentsTable,
   chatMessagesTable,
   chatThreadsTable,
   mcpServersTable,
@@ -55,6 +56,7 @@ export type McpServerRow = InferSelectModel<typeof mcpServersTable>
 export type PromptRow = InferSelectModel<typeof promptsTable>
 export type TriggerRow = InferSelectModel<typeof triggersTable>
 export type ModelProfileRow = InferSelectModel<typeof modelProfilesTable>
+export type AgentRow = InferSelectModel<typeof agentsTable>
 
 // Application types - Row types with previously-required fields made non-null
 export type ChatMessage = WithRequired<ChatMessageRow, 'content' | 'role' | 'chatThreadId'>
@@ -76,6 +78,7 @@ export type McpServer = WithRequired<McpServerRow, 'name' | 'type' | 'enabled'>
 export type Prompt = WithRequired<PromptRow, 'prompt' | 'modelId'>
 export type Trigger = WithRequired<TriggerRow, 'triggerType' | 'isEnabled' | 'promptId'>
 export type ModelProfile = WithRequired<ModelProfileRow, 'modelId'>
+export type Agent = WithRequired<AgentRow, 'name' | 'type' | 'transport' | 'enabled'>
 
 /**
  * Query usable with PowerSync's toCompilableQuery and direct await.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new persisted `agents` entity and wires agent selection through chat hydration/store and settings, which could affect chat initialization and user preferences. Risk is moderate due to new DB table/default reconciliation and new UI/state paths, though changes are mostly additive with good test coverage.
> 
> **Overview**
> Adds first-class **agent management** alongside models/modes: introduces an `agents` table, DAL (`getEnabledAgents`, `getSelectedAgent`, CRUD/soft-delete), and default reconciliation for a built-in system agent.
> 
> Updates chat hydration and `useChatStore` to load enabled agents, track a per-session `selectedAgent`, persist selection to settings (`selected_agent`), and emit a new PostHog event `agent_select`. The header UI switches from a model selector to a new searchable `AgentSelector`, and the chat prompt hides the mode selector unless the selected agent is `built-in`.
> 
> Adds local CLI agent discovery (`claude`, `codex`, `goose`) plus extensive unit tests, and bumps `@happy-dom/global-registrator` in dev deps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 397d3e2aa14ad93b18d09f9fc4695639488edc8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->