### PR TITLE
THU-285: [PART 3] E2E encryption — backend API endpoints & device logic update

### DIFF
--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -17,9 +17,11 @@ import { createAccountRoutes } from './account'
  * CI runs each file 5× (test:backend:5x), so the second run would hit
  * unique-constraint violations without unique IDs.
  *
- * Fix: a monotonic runId prefixed onto every ID via p() ensures no collisions.
+ * Fix: p() prefixes every ID with a globalThis counter that survives module re-evaluation
+ * (bun's --rerun-each reloads the module, resetting module-scope variables).
  */
-let runId = 0
+const counterKey = Symbol.for('account-test-runId')
+;(globalThis as Record<symbol, number>)[counterKey] ??= 0
 
 describe('Account API', () => {
   let app: ReturnType<typeof createAccountRoutes>
@@ -29,7 +31,7 @@ describe('Account API', () => {
   let p: (id: string) => string
 
   beforeEach(async () => {
-    const rid = ++runId
+    const rid = ++(globalThis as Record<symbol, number>)[counterKey]
     p = (id: string) => `${rid}-${id}`
     const testEnv = await createTestDb()
     db = testEnv.db

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -1,5 +1,6 @@
 import { createAuth } from '@/auth/auth'
-import { user } from '@/db/auth-schema'
+import { session as sessionTable, user } from '@/db/auth-schema'
+import { envelopesTable } from '@/db/encryption-schema'
 import { chatThreadsTable, devicesTable, settingsTable, tasksTable } from '@/db/schema'
 import { createTestDb } from '@/test-utils/db'
 import { eq } from 'drizzle-orm'
@@ -162,6 +163,208 @@ describe('Account API', () => {
 
       const threadsLeft = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.userId, userId))
       expect(threadsLeft).toHaveLength(0)
+    })
+  })
+
+  describe('POST /v1/account/devices/:id/revoke', () => {
+    const createUserAndSession = async (userId: string, token: string) => {
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(user).values({
+        id: userId,
+        name: 'Test User',
+        email: `${userId}@example.com`,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: `session-${userId}`,
+        expiresAt,
+        token,
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      return now
+    }
+
+    it('returns 401 without auth', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices/some-device/revoke', {
+          method: 'POST',
+        }),
+      )
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 401 with invalid token', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices/some-device/revoke', {
+          method: 'POST',
+          headers: { Authorization: 'Bearer bogus-token' },
+        }),
+      )
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 204 and revokes device + deletes envelope', async () => {
+      const userId = 'revoke-user'
+      const token = 'revoke-token'
+      const deviceId = 'device-to-revoke'
+      const now = await createUserAndSession(userId, token)
+
+      await db.insert(devicesTable).values({
+        id: deviceId,
+        userId,
+        name: 'My Device',
+        lastSeen: now,
+        createdAt: now,
+        status: 'TRUSTED',
+      })
+
+      await db.insert(envelopesTable).values({
+        deviceId,
+        userId,
+        wrappedCk: 'wrapped-key-data',
+        updatedAt: now,
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      )
+
+      expect(response.status).toBe(204)
+
+      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+      expect(device.status).toBe('REVOKED')
+      expect(device.revokedAt).not.toBeNull()
+
+      const envelopes = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, deviceId))
+      expect(envelopes).toHaveLength(0)
+    })
+
+    it('does not revoke device belonging to different user', async () => {
+      const userAId = 'user-a-revoke'
+      const userBId = 'user-b-revoke'
+      const tokenA = 'token-user-a'
+      const deviceId = 'device-user-b'
+
+      await createUserAndSession(userAId, tokenA)
+      const now = await createUserAndSession(userBId, 'token-user-b')
+
+      await db.insert(devicesTable).values({
+        id: deviceId,
+        userId: userBId,
+        name: 'User B Device',
+        lastSeen: now,
+        createdAt: now,
+        status: 'TRUSTED',
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${tokenA}` },
+        }),
+      )
+
+      expect(response.status).toBe(204)
+
+      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+      expect(device.status).toBe('TRUSTED')
+      expect(device.revokedAt).toBeNull()
+    })
+
+    it('returns 204 for non-existent device (no-op)', async () => {
+      const userId = 'revoke-nonexistent-user'
+      const token = 'revoke-nonexistent-token'
+      await createUserAndSession(userId, token)
+
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices/does-not-exist/revoke', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      )
+
+      expect(response.status).toBe(204)
+    })
+
+    it('returns 204 when revoking already-revoked device (idempotent)', async () => {
+      const userId = 'revoke-idempotent-user'
+      const token = 'revoke-idempotent-token'
+      const deviceId = 'device-already-revoked'
+      const now = await createUserAndSession(userId, token)
+
+      await db.insert(devicesTable).values({
+        id: deviceId,
+        userId,
+        name: 'Already Revoked',
+        lastSeen: now,
+        createdAt: now,
+        status: 'TRUSTED',
+      })
+
+      // First revoke
+      await app.handle(
+        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      )
+
+      // Second revoke
+      const response = await app.handle(
+        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      )
+
+      expect(response.status).toBe(204)
+
+      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+      expect(device.status).toBe('REVOKED')
+      expect(device.revokedAt).not.toBeNull()
+    })
+
+    it('handles device with no envelope gracefully', async () => {
+      const userId = 'revoke-no-envelope-user'
+      const token = 'revoke-no-envelope-token'
+      const deviceId = 'device-no-envelope'
+      const now = await createUserAndSession(userId, token)
+
+      await db.insert(devicesTable).values({
+        id: deviceId,
+        userId,
+        name: 'Pending Device',
+        lastSeen: now,
+        createdAt: now,
+        status: 'APPROVAL_PENDING',
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      )
+
+      expect(response.status).toBe(204)
+
+      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+      expect(device.status).toBe('REVOKED')
+      expect(device.revokedAt).not.toBeNull()
+
+      const envelopes = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, deviceId))
+      expect(envelopes).toHaveLength(0)
     })
   })
 })

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -8,12 +8,29 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { Elysia } from 'elysia'
 import { createAccountRoutes } from './account'
 
+/**
+ * Unique-ID strategy for PGlite + nested transactions:
+ *
+ * The revoke endpoint calls database.transaction() internally. In PGlite's
+ * single-connection model this commits the outer test transaction (started by
+ * createTestDb's BEGIN), so ROLLBACK in afterEach becomes a no-op and rows persist.
+ * CI runs each file 5× (test:backend:5x), so the second run would hit
+ * unique-constraint violations without unique IDs.
+ *
+ * Fix: a monotonic runId prefixed onto every ID via p() ensures no collisions.
+ */
+let runId = 0
+
 describe('Account API', () => {
   let app: ReturnType<typeof createAccountRoutes>
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
   let cleanup: () => Promise<void>
+  /** Prefix IDs with the current runId — see top-of-file comment for why. */
+  let p: (id: string) => string
 
   beforeEach(async () => {
+    const rid = ++runId
+    p = (id: string) => `${rid}-${id}`
     const testEnv = await createTestDb()
     db = testEnv.db
     cleanup = testEnv.cleanup
@@ -212,9 +229,9 @@ describe('Account API', () => {
     })
 
     it('returns 204 and revokes device + deletes envelope', async () => {
-      const userId = 'revoke-user'
-      const token = 'revoke-token'
-      const deviceId = 'device-to-revoke'
+      const userId = p('revoke-user')
+      const token = p('revoke-token')
+      const deviceId = p('device-to-revoke')
       const now = await createUserAndSession(userId, token)
 
       await db.insert(devicesTable).values({
@@ -251,13 +268,13 @@ describe('Account API', () => {
     })
 
     it('does not revoke device belonging to different user', async () => {
-      const userAId = 'user-a-revoke'
-      const userBId = 'user-b-revoke'
-      const tokenA = 'token-user-a'
-      const deviceId = 'device-user-b'
+      const userAId = p('user-a-revoke')
+      const userBId = p('user-b-revoke')
+      const tokenA = p('token-user-a')
+      const deviceId = p('device-user-b')
 
       await createUserAndSession(userAId, tokenA)
-      const now = await createUserAndSession(userBId, 'token-user-b')
+      const now = await createUserAndSession(userBId, p('token-user-b'))
 
       await db.insert(devicesTable).values({
         id: deviceId,
@@ -283,12 +300,12 @@ describe('Account API', () => {
     })
 
     it('returns 204 for non-existent device (no-op)', async () => {
-      const userId = 'revoke-nonexistent-user'
-      const token = 'revoke-nonexistent-token'
+      const userId = p('revoke-nonexistent-user')
+      const token = p('revoke-nonexistent-token')
       await createUserAndSession(userId, token)
 
       const response = await app.handle(
-        new Request('http://localhost/v1/account/devices/does-not-exist/revoke', {
+        new Request(`http://localhost/v1/account/devices/${p('does-not-exist')}/revoke`, {
           method: 'POST',
           headers: { Authorization: `Bearer ${token}` },
         }),
@@ -298,9 +315,9 @@ describe('Account API', () => {
     })
 
     it('returns 204 when revoking already-revoked device (idempotent)', async () => {
-      const userId = 'revoke-idempotent-user'
-      const token = 'revoke-idempotent-token'
-      const deviceId = 'device-already-revoked'
+      const userId = p('revoke-idempotent-user')
+      const token = p('revoke-idempotent-token')
+      const deviceId = p('device-already-revoked')
       const now = await createUserAndSession(userId, token)
 
       await db.insert(devicesTable).values({
@@ -336,9 +353,9 @@ describe('Account API', () => {
     })
 
     it('handles device with no envelope gracefully', async () => {
-      const userId = 'revoke-no-envelope-user'
-      const token = 'revoke-no-envelope-token'
-      const deviceId = 'device-no-envelope'
+      const userId = p('revoke-no-envelope-user')
+      const token = p('revoke-no-envelope-token')
+      const deviceId = p('device-no-envelope')
       const now = await createUserAndSession(userId, token)
 
       await db.insert(devicesTable).values({

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -27,7 +27,7 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
     })
     .post('/devices/:id/revoke', async ({ params, set, user: sessionUser }) => {
       const userId = sessionUser!.id
-      await deleteEnvelope(database, params.id)
+      await deleteEnvelope(database, params.id, userId)
       await revokeDevice(database, params.id, userId)
       set.status = 204
     })

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -1,10 +1,10 @@
 import type { Auth } from '@/auth/elysia-plugin'
-import { deleteUser, revokeDevice } from '@/dal'
+import { deleteUser, revokeDevice, deleteEnvelope } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import { Elysia } from 'elysia'
 
 /**
- * Account API routes for self-service account deletion.
+ * Account API routes for self-service account deletion and device management.
  * All routes require authentication.
  */
 export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
@@ -27,6 +27,7 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
     })
     .post('/devices/:id/revoke', async ({ params, set, user: sessionUser }) => {
       const userId = sessionUser!.id
+      await deleteEnvelope(database, params.id)
       await revokeDevice(database, params.id, userId)
       set.status = 204
     })

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -27,8 +27,11 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
     })
     .post('/devices/:id/revoke', async ({ params, set, user: sessionUser }) => {
       const userId = sessionUser!.id
-      await deleteEnvelope(database, params.id, userId)
-      await revokeDevice(database, params.id, userId)
+      await database.transaction(async (tx) => {
+        const txDb = tx as unknown as typeof database
+        await deleteEnvelope(txDb, params.id, userId)
+        await revokeDevice(txDb, params.id, userId)
+      })
       set.status = 204
     })
     .delete('/', async ({ set, user: sessionUser }) => {

--- a/backend/src/api/encryption.test.ts
+++ b/backend/src/api/encryption.test.ts
@@ -1,0 +1,835 @@
+import { createAuth } from '@/auth/auth'
+import { session as sessionTable, user as userTable } from '@/db/auth-schema'
+import { encryptionMetadataTable, envelopesTable } from '@/db/encryption-schema'
+import { devicesTable } from '@/db/schema'
+import { createTestDb } from '@/test-utils/db'
+import { eq } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Elysia } from 'elysia'
+import { createEncryptionRoutes } from './encryption'
+
+const BASE = 'http://localhost'
+
+describe('Encryption API', () => {
+  let app: ReturnType<typeof createEncryptionRoutes>
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  const now = new Date()
+  const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+  const createUserAndSession = async (userId: string, token: string, email = `${userId}@test.com`) => {
+    await db.insert(userTable).values({
+      id: userId,
+      name: 'Test User',
+      email,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await db.insert(sessionTable).values({
+      id: `session-${userId}`,
+      expiresAt,
+      token,
+      createdAt: now,
+      updatedAt: now,
+      userId,
+    })
+  }
+
+  const insertDevice = async (
+    id: string,
+    userId: string,
+    status: 'APPROVAL_PENDING' | 'TRUSTED' | 'REVOKED' = 'APPROVAL_PENDING',
+    publicKey = 'pk-test',
+  ) => {
+    await db.insert(devicesTable).values({
+      id,
+      userId,
+      name: 'Test Device',
+      status,
+      publicKey,
+      lastSeen: now,
+      createdAt: now,
+      ...(status === 'REVOKED' ? { revokedAt: now } : {}),
+    })
+  }
+
+  const insertEnvelope = async (deviceId: string, userId: string, wrappedCk = 'wrapped-ck') => {
+    await db.insert(envelopesTable).values({
+      deviceId,
+      userId,
+      wrappedCk,
+      createdAt: now,
+      updatedAt: now,
+    })
+  }
+
+  const insertCanary = async (userId: string, canaryIv = 'iv-test', canaryCtext = 'ctext-test') => {
+    await db.insert(encryptionMetadataTable).values({
+      userId,
+      canaryIv,
+      canaryCtext,
+      createdAt: now,
+    })
+  }
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+    const auth = createAuth(db)
+    app = new Elysia().use(createEncryptionRoutes(auth, db)) as unknown as ReturnType<typeof createEncryptionRoutes>
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  // ─── POST /devices ──────────────────────────────────────────────────
+
+  describe('POST /devices', () => {
+    it('returns 401 without auth', async () => {
+      const response = await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ deviceId: 'd1', publicKey: 'pk' }),
+        }),
+      )
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 401 with invalid token', async () => {
+      const response = await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer invalid-token',
+          },
+          body: JSON.stringify({ deviceId: 'd1', publicKey: 'pk' }),
+        }),
+      )
+      expect(response.status).toBe(401)
+    })
+
+    it('registers new device as APPROVAL_PENDING with firstDevice=true', async () => {
+      await createUserAndSession('u1', 'tok-u1')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-u1',
+          },
+          body: JSON.stringify({ deviceId: 'd1', publicKey: 'pk1', name: 'My Device' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.status).toBe('APPROVAL_PENDING')
+      expect(body.firstDevice).toBe(true)
+
+      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd1'))
+      expect(device).toBeDefined()
+      expect(device.userId).toBe('u1')
+      expect(device.name).toBe('My Device')
+      expect(device.status).toBe('APPROVAL_PENDING')
+    })
+
+    it('registers new device as APPROVAL_PENDING with firstDevice=false when envelopes exist', async () => {
+      await createUserAndSession('u2', 'tok-u2')
+      await insertDevice('d-existing', 'u2', 'TRUSTED')
+      await insertEnvelope('d-existing', 'u2')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-u2',
+          },
+          body: JSON.stringify({ deviceId: 'd-new', publicKey: 'pk2' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.status).toBe('APPROVAL_PENDING')
+      expect(body.firstDevice).toBe(false)
+    })
+
+    it('returns TRUSTED with envelope for already-trusted device', async () => {
+      await createUserAndSession('u3', 'tok-u3')
+      await insertDevice('d-trusted', 'u3', 'TRUSTED')
+      await insertEnvelope('d-trusted', 'u3', 'my-wrapped-ck')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-u3',
+          },
+          body: JSON.stringify({ deviceId: 'd-trusted', publicKey: 'pk3' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.status).toBe('TRUSTED')
+      expect(body.envelope).toBe('my-wrapped-ck')
+    })
+
+    it('returns APPROVAL_PENDING for already-pending device', async () => {
+      await createUserAndSession('u4', 'tok-u4')
+      await insertDevice('d-pending', 'u4', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-u4',
+          },
+          body: JSON.stringify({ deviceId: 'd-pending', publicKey: 'pk4' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.status).toBe('APPROVAL_PENDING')
+      expect(body.firstDevice).toBe(true)
+    })
+
+    it('returns 409 when deviceId belongs to different user', async () => {
+      await createUserAndSession('u5a', 'tok-u5a', 'u5a@test.com')
+      await createUserAndSession('u5b', 'tok-u5b', 'u5b@test.com')
+      await insertDevice('d-conflict', 'u5a')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-u5b',
+          },
+          body: JSON.stringify({ deviceId: 'd-conflict', publicKey: 'pk5' }),
+        }),
+      )
+
+      expect(response.status).toBe(409)
+      const body = await response.json()
+      expect(body.error).toBe('Device ID already taken')
+    })
+
+    it('returns 403 when re-registering a revoked device', async () => {
+      await createUserAndSession('u6', 'tok-u6')
+      await insertDevice('d-revoked', 'u6', 'REVOKED')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-u6',
+          },
+          body: JSON.stringify({ deviceId: 'd-revoked', publicKey: 'pk6' }),
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Device has been revoked')
+    })
+
+    it('uses "Unknown device" for empty or >100 char name', async () => {
+      await createUserAndSession('u7', 'tok-u7')
+
+      // Empty name
+      await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-u7',
+          },
+          body: JSON.stringify({ deviceId: 'd-empty-name', publicKey: 'pk7a', name: '' }),
+        }),
+      )
+
+      const [deviceEmpty] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd-empty-name'))
+      expect(deviceEmpty.name).toBe('Unknown device')
+
+      // Name > 100 chars
+      await app.handle(
+        new Request(`${BASE}/devices`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-u7',
+          },
+          body: JSON.stringify({ deviceId: 'd-long-name', publicKey: 'pk7b', name: 'x'.repeat(101) }),
+        }),
+      )
+
+      const [deviceLong] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd-long-name'))
+      expect(deviceLong.name).toBe('Unknown device')
+    })
+  })
+
+  // ─── POST /devices/:deviceId/envelope ───────────────────────────────
+
+  describe('POST /devices/:deviceId/envelope', () => {
+    it('returns 401 without auth', async () => {
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d1/envelope`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 400 when X-Device-ID header missing', async () => {
+      await createUserAndSession('u-env1', 'tok-env1')
+      await insertDevice('d-env1', 'u-env1')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-env1/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-env1',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.error).toBe('X-Device-ID header is required')
+    })
+
+    it('allows first-device bootstrap: pending device submits own envelope when no envelopes exist', async () => {
+      await createUserAndSession('u-boot', 'tok-boot')
+      await insertDevice('d-boot', 'u-boot', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-boot/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-boot',
+            'X-Device-ID': 'd-boot',
+          },
+          body: JSON.stringify({ wrappedCK: 'wrapped-ck-boot' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.status).toBe('TRUSTED')
+
+      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd-boot'))
+      expect(device.status).toBe('TRUSTED')
+
+      const [envelope] = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, 'd-boot'))
+      expect(envelope.wrappedCk).toBe('wrapped-ck-boot')
+    })
+
+    it('rejects pending device from approving itself when envelopes already exist', async () => {
+      await createUserAndSession('u-self', 'tok-self')
+      await insertDevice('d-trusted-existing', 'u-self', 'TRUSTED')
+      await insertEnvelope('d-trusted-existing', 'u-self')
+      await insertDevice('d-self', 'u-self', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-self/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-self',
+            'X-Device-ID': 'd-self',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Only trusted devices can store envelopes')
+    })
+
+    it('rejects pending device from approving another pending device', async () => {
+      await createUserAndSession('u-pp', 'tok-pp')
+      // Need envelopes to exist so it's not first-device bootstrap
+      await insertDevice('d-pp-trusted', 'u-pp', 'TRUSTED')
+      await insertEnvelope('d-pp-trusted', 'u-pp')
+      await insertDevice('d-pp-caller', 'u-pp', 'APPROVAL_PENDING')
+      await insertDevice('d-pp-target', 'u-pp', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-pp-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-pp',
+            'X-Device-ID': 'd-pp-caller',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Only trusted devices can store envelopes')
+    })
+
+    it('returns 404 when target device belongs to different user', async () => {
+      await createUserAndSession('u-diff1', 'tok-diff1', 'diff1@test.com')
+      await createUserAndSession('u-diff2', 'tok-diff2', 'diff2@test.com')
+      await insertDevice('d-diff-caller', 'u-diff1', 'TRUSTED')
+      await insertEnvelope('d-diff-caller', 'u-diff1')
+      await insertDevice('d-diff-target', 'u-diff2', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-diff-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-diff1',
+            'X-Device-ID': 'd-diff-caller',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(404)
+      const body = await response.json()
+      expect(body.error).toBe('Device not found')
+    })
+
+    it('returns 403 when caller device belongs to different user', async () => {
+      await createUserAndSession('u-cdiff1', 'tok-cdiff1', 'cdiff1@test.com')
+      await createUserAndSession('u-cdiff2', 'tok-cdiff2', 'cdiff2@test.com')
+      await insertDevice('d-cdiff-target', 'u-cdiff1', 'APPROVAL_PENDING')
+      await insertDevice('d-cdiff-caller', 'u-cdiff2', 'TRUSTED')
+      await insertEnvelope('d-cdiff-caller', 'u-cdiff2')
+      // Need envelopes for u-cdiff1 to avoid first-device bootstrap
+      await insertDevice('d-cdiff-existing', 'u-cdiff1', 'TRUSTED')
+      await insertEnvelope('d-cdiff-existing', 'u-cdiff1')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-cdiff-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-cdiff1',
+            'X-Device-ID': 'd-cdiff-caller',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Caller device not found')
+    })
+
+    it('returns 403 when target device is revoked', async () => {
+      await createUserAndSession('u-trev', 'tok-trev')
+      await insertDevice('d-trev-caller', 'u-trev', 'TRUSTED')
+      await insertEnvelope('d-trev-caller', 'u-trev')
+      await insertDevice('d-trev-target', 'u-trev', 'REVOKED')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-trev-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-trev',
+            'X-Device-ID': 'd-trev-caller',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Device has been revoked')
+    })
+
+    it('returns 403 when caller device is revoked', async () => {
+      await createUserAndSession('u-crev', 'tok-crev')
+      await insertDevice('d-crev-caller', 'u-crev', 'REVOKED')
+      await insertDevice('d-crev-target', 'u-crev', 'APPROVAL_PENDING')
+      // Need envelopes so it's not bootstrap
+      await insertDevice('d-crev-existing', 'u-crev', 'TRUSTED')
+      await insertEnvelope('d-crev-existing', 'u-crev')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-crev-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-crev',
+            'X-Device-ID': 'd-crev-caller',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Only trusted devices can store envelopes')
+    })
+
+    it('returns 409 when overwriting trusted device envelope from another device', async () => {
+      await createUserAndSession('u-ow', 'tok-ow')
+      await insertDevice('d-ow-caller', 'u-ow', 'TRUSTED')
+      await insertEnvelope('d-ow-caller', 'u-ow')
+      await insertDevice('d-ow-target', 'u-ow', 'TRUSTED')
+      await insertEnvelope('d-ow-target', 'u-ow')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-ow-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-ow',
+            'X-Device-ID': 'd-ow-caller',
+          },
+          body: JSON.stringify({ wrappedCK: 'new-wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(409)
+      const body = await response.json()
+      expect(body.error).toBe('Cannot overwrite envelope of an already-trusted device')
+    })
+
+    it('allows trusted device to re-key its own envelope', async () => {
+      await createUserAndSession('u-rekey', 'tok-rekey')
+      await insertDevice('d-rekey', 'u-rekey', 'TRUSTED')
+      await insertEnvelope('d-rekey', 'u-rekey', 'old-wck')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-rekey/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-rekey',
+            'X-Device-ID': 'd-rekey',
+          },
+          body: JSON.stringify({ wrappedCK: 'new-wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.status).toBe('TRUSTED')
+
+      const [envelope] = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, 'd-rekey'))
+      expect(envelope.wrappedCk).toBe('new-wck')
+    })
+
+    it('returns 404 when target deviceId does not exist', async () => {
+      await createUserAndSession('u-nodev', 'tok-nodev')
+      await insertDevice('d-nodev-caller', 'u-nodev', 'TRUSTED')
+      await insertEnvelope('d-nodev-caller', 'u-nodev')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-nonexistent/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-nodev',
+            'X-Device-ID': 'd-nodev-caller',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(404)
+      const body = await response.json()
+      expect(body.error).toBe('Device not found')
+    })
+
+    it('returns 403 when caller deviceId does not exist (non-first-device scenario)', async () => {
+      await createUserAndSession('u-nocaller', 'tok-nocaller')
+      await insertDevice('d-nocaller-target', 'u-nocaller', 'APPROVAL_PENDING')
+      // Need envelopes to exist
+      await insertDevice('d-nocaller-existing', 'u-nocaller', 'TRUSTED')
+      await insertEnvelope('d-nocaller-existing', 'u-nocaller')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-nocaller-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-nocaller',
+            'X-Device-ID': 'd-ghost',
+          },
+          body: JSON.stringify({ wrappedCK: 'wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Caller device not found')
+    })
+
+    it('allows trusted device to approve a pending device', async () => {
+      await createUserAndSession('u-approve', 'tok-approve')
+      await insertDevice('d-approve-caller', 'u-approve', 'TRUSTED')
+      await insertEnvelope('d-approve-caller', 'u-approve')
+      await insertDevice('d-approve-target', 'u-approve', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-approve-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-approve',
+            'X-Device-ID': 'd-approve-caller',
+          },
+          body: JSON.stringify({ wrappedCK: 'target-wck' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.status).toBe('TRUSTED')
+
+      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd-approve-target'))
+      expect(device.status).toBe('TRUSTED')
+
+      const [envelope] = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, 'd-approve-target'))
+      expect(envelope.wrappedCk).toBe('target-wck')
+    })
+
+    it('stores canary on first-device bootstrap', async () => {
+      await createUserAndSession('u-canary', 'tok-canary')
+      await insertDevice('d-canary', 'u-canary', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-canary/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-canary',
+            'X-Device-ID': 'd-canary',
+          },
+          body: JSON.stringify({
+            wrappedCK: 'wck',
+            canaryIv: 'my-iv',
+            canaryCtext: 'my-ctext',
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+
+      const [metadata] = await db
+        .select()
+        .from(encryptionMetadataTable)
+        .where(eq(encryptionMetadataTable.userId, 'u-canary'))
+      expect(metadata).toBeDefined()
+      expect(metadata.canaryIv).toBe('my-iv')
+      expect(metadata.canaryCtext).toBe('my-ctext')
+    })
+
+    it('does not overwrite existing canary on subsequent envelope submissions', async () => {
+      await createUserAndSession('u-noow', 'tok-noow')
+      await insertDevice('d-noow-caller', 'u-noow', 'TRUSTED')
+      await insertEnvelope('d-noow-caller', 'u-noow')
+      await insertCanary('u-noow', 'original-iv', 'original-ctext')
+      await insertDevice('d-noow-target', 'u-noow', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/d-noow-target/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer tok-noow',
+            'X-Device-ID': 'd-noow-caller',
+          },
+          body: JSON.stringify({
+            wrappedCK: 'wck',
+            canaryIv: 'new-iv',
+            canaryCtext: 'new-ctext',
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+
+      const [metadata] = await db
+        .select()
+        .from(encryptionMetadataTable)
+        .where(eq(encryptionMetadataTable.userId, 'u-noow'))
+      expect(metadata.canaryIv).toBe('original-iv')
+      expect(metadata.canaryCtext).toBe('original-ctext')
+    })
+  })
+
+  // ─── GET /devices/me/envelope ───────────────────────────────────────
+
+  describe('GET /devices/me/envelope', () => {
+    it('returns 401 without auth', async () => {
+      const response = await app.handle(new Request(`${BASE}/devices/me/envelope`))
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 400 when X-Device-ID missing', async () => {
+      await createUserAndSession('u-me1', 'tok-me1')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/me/envelope`, {
+          headers: { Authorization: 'Bearer tok-me1' },
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.error).toBe('X-Device-ID header is required')
+    })
+
+    it('returns envelope for trusted device', async () => {
+      await createUserAndSession('u-me2', 'tok-me2')
+      await insertDevice('d-me2', 'u-me2', 'TRUSTED')
+      await insertEnvelope('d-me2', 'u-me2', 'my-wrapped-ck')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/me/envelope`, {
+          headers: {
+            Authorization: 'Bearer tok-me2',
+            'X-Device-ID': 'd-me2',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.status).toBe('TRUSTED')
+      expect(body.wrappedCK).toBe('my-wrapped-ck')
+    })
+
+    it('returns 404 when device belongs to different user', async () => {
+      await createUserAndSession('u-me3a', 'tok-me3a', 'me3a@test.com')
+      await createUserAndSession('u-me3b', 'tok-me3b', 'me3b@test.com')
+      await insertDevice('d-me3', 'u-me3b', 'TRUSTED')
+      await insertEnvelope('d-me3', 'u-me3b')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/me/envelope`, {
+          headers: {
+            Authorization: 'Bearer tok-me3a',
+            'X-Device-ID': 'd-me3',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(404)
+      const body = await response.json()
+      expect(body.error).toBe('Device not found')
+    })
+
+    it('returns 403 when device is revoked', async () => {
+      await createUserAndSession('u-me4', 'tok-me4')
+      await insertDevice('d-me4', 'u-me4', 'REVOKED')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/me/envelope`, {
+          headers: {
+            Authorization: 'Bearer tok-me4',
+            'X-Device-ID': 'd-me4',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Device has been revoked')
+    })
+
+    it('returns 404 when device has no envelope (pending device)', async () => {
+      await createUserAndSession('u-me5', 'tok-me5')
+      await insertDevice('d-me5', 'u-me5', 'APPROVAL_PENDING')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/me/envelope`, {
+          headers: {
+            Authorization: 'Bearer tok-me5',
+            'X-Device-ID': 'd-me5',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(404)
+      const body = await response.json()
+      expect(body.error).toBe('Envelope not found')
+    })
+
+    it('returns 404 when deviceId does not exist', async () => {
+      await createUserAndSession('u-me6', 'tok-me6')
+
+      const response = await app.handle(
+        new Request(`${BASE}/devices/me/envelope`, {
+          headers: {
+            Authorization: 'Bearer tok-me6',
+            'X-Device-ID': 'd-ghost',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(404)
+      const body = await response.json()
+      expect(body.error).toBe('Device not found')
+    })
+  })
+
+  // ─── GET /encryption/canary ─────────────────────────────────────────
+
+  describe('GET /encryption/canary', () => {
+    it('returns 401 without auth', async () => {
+      const response = await app.handle(new Request(`${BASE}/encryption/canary`))
+      expect(response.status).toBe(401)
+    })
+
+    it('returns canary when set up', async () => {
+      await createUserAndSession('u-can1', 'tok-can1')
+      await insertCanary('u-can1', 'stored-iv', 'stored-ctext')
+
+      const response = await app.handle(
+        new Request(`${BASE}/encryption/canary`, {
+          headers: { Authorization: 'Bearer tok-can1' },
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.canaryIv).toBe('stored-iv')
+      expect(body.canaryCtext).toBe('stored-ctext')
+    })
+
+    it('returns 404 when encryption not set up', async () => {
+      await createUserAndSession('u-can2', 'tok-can2')
+
+      const response = await app.handle(
+        new Request(`${BASE}/encryption/canary`, {
+          headers: { Authorization: 'Bearer tok-can2' },
+        }),
+      )
+
+      expect(response.status).toBe(404)
+      const body = await response.json()
+      expect(body.error).toBe('Encryption not set up')
+    })
+  })
+})

--- a/backend/src/api/encryption.test.ts
+++ b/backend/src/api/encryption.test.ts
@@ -23,10 +23,11 @@ const BASE = 'http://localhost'
  * the second run hits unique-constraint violations on user/device/session rows left
  * behind by the first run.
  *
- * Fix: a monotonic runId is incremented in beforeEach and used by p() to prefix every
- * ID, so each run's data is unique even if prior data was never rolled back.
+ * Fix: p() prefixes every ID with a globalThis counter that survives module re-evaluation
+ * (bun's --rerun-each reloads the module, resetting module-scope variables).
  */
-let runId = 0
+const counterKey = Symbol.for('encryption-test-runId')
+;(globalThis as Record<symbol, number>)[counterKey] ??= 0
 
 describe('Encryption API', () => {
   let app: ReturnType<typeof createEncryptionRoutes>
@@ -96,7 +97,7 @@ describe('Encryption API', () => {
   }
 
   beforeEach(async () => {
-    const rid = ++runId
+    const rid = ++(globalThis as Record<symbol, number>)[counterKey]
     p = (id: string) => `${rid}-${id}`
     const testEnv = await createTestDb()
     db = testEnv.db

--- a/backend/src/api/encryption.test.ts
+++ b/backend/src/api/encryption.test.ts
@@ -10,10 +10,31 @@ import { createEncryptionRoutes } from './encryption'
 
 const BASE = 'http://localhost'
 
+/**
+ * Unique-ID strategy for PGlite + nested transactions:
+ *
+ * Tests use createTestDb() which wraps each test in BEGIN / ROLLBACK for isolation.
+ * However, some endpoints (e.g. POST /devices/:id/envelope, POST /devices/:id/revoke)
+ * call database.transaction() internally. In PGlite's single-connection model, the
+ * inner BEGIN is treated as a no-op and the inner COMMIT commits the *outer* test
+ * transaction, so ROLLBACK in afterEach becomes a no-op and inserted rows persist.
+ *
+ * CI runs every test file 5× in the same process (test:backend:5x). Without unique IDs
+ * the second run hits unique-constraint violations on user/device/session rows left
+ * behind by the first run.
+ *
+ * Fix: a monotonic runId is incremented in beforeEach and used by p() to prefix every
+ * ID, so each run's data is unique even if prior data was never rolled back.
+ */
+let runId = 0
+
 describe('Encryption API', () => {
   let app: ReturnType<typeof createEncryptionRoutes>
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
   let cleanup: () => Promise<void>
+
+  /** Prefix IDs with the current runId — see top-of-file comment for why. */
+  let p: (id: string) => string
 
   const now = new Date()
   const expiresAt = new Date(now.getTime() + 3600 * 1000)
@@ -75,6 +96,8 @@ describe('Encryption API', () => {
   }
 
   beforeEach(async () => {
+    const rid = ++runId
+    p = (id: string) => `${rid}-${id}`
     const testEnv = await createTestDb()
     db = testEnv.db
     cleanup = testEnv.cleanup
@@ -94,7 +117,7 @@ describe('Encryption API', () => {
         new Request(`${BASE}/devices`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ deviceId: 'd1', publicKey: 'pk' }),
+          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk' }),
         }),
       )
       expect(response.status).toBe(401)
@@ -108,23 +131,23 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: 'Bearer invalid-token',
           },
-          body: JSON.stringify({ deviceId: 'd1', publicKey: 'pk' }),
+          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk' }),
         }),
       )
       expect(response.status).toBe(401)
     })
 
     it('registers new device as APPROVAL_PENDING with firstDevice=true', async () => {
-      await createUserAndSession('u1', 'tok-u1')
+      await createUserAndSession(p('u1'), p('tok-u1'))
 
       const response = await app.handle(
         new Request(`${BASE}/devices`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-u1',
+            Authorization: `Bearer ${p('tok-u1')}`,
           },
-          body: JSON.stringify({ deviceId: 'd1', publicKey: 'pk1', name: 'My Device' }),
+          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk1', name: 'My Device' }),
         }),
       )
 
@@ -133,26 +156,29 @@ describe('Encryption API', () => {
       expect(body.status).toBe('APPROVAL_PENDING')
       expect(body.firstDevice).toBe(true)
 
-      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd1'))
+      const [device] = await db
+        .select()
+        .from(devicesTable)
+        .where(eq(devicesTable.id, p('d1')))
       expect(device).toBeDefined()
-      expect(device.userId).toBe('u1')
+      expect(device.userId).toBe(p('u1'))
       expect(device.name).toBe('My Device')
       expect(device.status).toBe('APPROVAL_PENDING')
     })
 
     it('registers new device as APPROVAL_PENDING with firstDevice=false when envelopes exist', async () => {
-      await createUserAndSession('u2', 'tok-u2')
-      await insertDevice('d-existing', 'u2', 'TRUSTED')
-      await insertEnvelope('d-existing', 'u2')
+      await createUserAndSession(p('u2'), p('tok-u2'))
+      await insertDevice(p('d-existing'), p('u2'), 'TRUSTED')
+      await insertEnvelope(p('d-existing'), p('u2'))
 
       const response = await app.handle(
         new Request(`${BASE}/devices`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-u2',
+            Authorization: `Bearer ${p('tok-u2')}`,
           },
-          body: JSON.stringify({ deviceId: 'd-new', publicKey: 'pk2' }),
+          body: JSON.stringify({ deviceId: p('d-new'), publicKey: 'pk2' }),
         }),
       )
 
@@ -163,18 +189,18 @@ describe('Encryption API', () => {
     })
 
     it('returns TRUSTED with envelope for already-trusted device', async () => {
-      await createUserAndSession('u3', 'tok-u3')
-      await insertDevice('d-trusted', 'u3', 'TRUSTED')
-      await insertEnvelope('d-trusted', 'u3', 'my-wrapped-ck')
+      await createUserAndSession(p('u3'), p('tok-u3'))
+      await insertDevice(p('d-trusted'), p('u3'), 'TRUSTED')
+      await insertEnvelope(p('d-trusted'), p('u3'), 'my-wrapped-ck')
 
       const response = await app.handle(
         new Request(`${BASE}/devices`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-u3',
+            Authorization: `Bearer ${p('tok-u3')}`,
           },
-          body: JSON.stringify({ deviceId: 'd-trusted', publicKey: 'pk3' }),
+          body: JSON.stringify({ deviceId: p('d-trusted'), publicKey: 'pk3' }),
         }),
       )
 
@@ -185,17 +211,17 @@ describe('Encryption API', () => {
     })
 
     it('returns APPROVAL_PENDING for already-pending device', async () => {
-      await createUserAndSession('u4', 'tok-u4')
-      await insertDevice('d-pending', 'u4', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u4'), p('tok-u4'))
+      await insertDevice(p('d-pending'), p('u4'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
         new Request(`${BASE}/devices`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-u4',
+            Authorization: `Bearer ${p('tok-u4')}`,
           },
-          body: JSON.stringify({ deviceId: 'd-pending', publicKey: 'pk4' }),
+          body: JSON.stringify({ deviceId: p('d-pending'), publicKey: 'pk4' }),
         }),
       )
 
@@ -206,18 +232,18 @@ describe('Encryption API', () => {
     })
 
     it('returns 409 when deviceId belongs to different user', async () => {
-      await createUserAndSession('u5a', 'tok-u5a', 'u5a@test.com')
-      await createUserAndSession('u5b', 'tok-u5b', 'u5b@test.com')
-      await insertDevice('d-conflict', 'u5a')
+      await createUserAndSession(p('u5a'), p('tok-u5a'), `${p('u5a')}@test.com`)
+      await createUserAndSession(p('u5b'), p('tok-u5b'), `${p('u5b')}@test.com`)
+      await insertDevice(p('d-conflict'), p('u5a'))
 
       const response = await app.handle(
         new Request(`${BASE}/devices`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-u5b',
+            Authorization: `Bearer ${p('tok-u5b')}`,
           },
-          body: JSON.stringify({ deviceId: 'd-conflict', publicKey: 'pk5' }),
+          body: JSON.stringify({ deviceId: p('d-conflict'), publicKey: 'pk5' }),
         }),
       )
 
@@ -227,17 +253,17 @@ describe('Encryption API', () => {
     })
 
     it('returns 403 when re-registering a revoked device', async () => {
-      await createUserAndSession('u6', 'tok-u6')
-      await insertDevice('d-revoked', 'u6', 'REVOKED')
+      await createUserAndSession(p('u6'), p('tok-u6'))
+      await insertDevice(p('d-revoked'), p('u6'), 'REVOKED')
 
       const response = await app.handle(
         new Request(`${BASE}/devices`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-u6',
+            Authorization: `Bearer ${p('tok-u6')}`,
           },
-          body: JSON.stringify({ deviceId: 'd-revoked', publicKey: 'pk6' }),
+          body: JSON.stringify({ deviceId: p('d-revoked'), publicKey: 'pk6' }),
         }),
       )
 
@@ -247,7 +273,7 @@ describe('Encryption API', () => {
     })
 
     it('uses "Unknown device" for empty or >100 char name', async () => {
-      await createUserAndSession('u7', 'tok-u7')
+      await createUserAndSession(p('u7'), p('tok-u7'))
 
       // Empty name
       await app.handle(
@@ -255,13 +281,16 @@ describe('Encryption API', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-u7',
+            Authorization: `Bearer ${p('tok-u7')}`,
           },
-          body: JSON.stringify({ deviceId: 'd-empty-name', publicKey: 'pk7a', name: '' }),
+          body: JSON.stringify({ deviceId: p('d-empty-name'), publicKey: 'pk7a', name: '' }),
         }),
       )
 
-      const [deviceEmpty] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd-empty-name'))
+      const [deviceEmpty] = await db
+        .select()
+        .from(devicesTable)
+        .where(eq(devicesTable.id, p('d-empty-name')))
       expect(deviceEmpty.name).toBe('Unknown device')
 
       // Name > 100 chars
@@ -270,13 +299,16 @@ describe('Encryption API', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-u7',
+            Authorization: `Bearer ${p('tok-u7')}`,
           },
-          body: JSON.stringify({ deviceId: 'd-long-name', publicKey: 'pk7b', name: 'x'.repeat(101) }),
+          body: JSON.stringify({ deviceId: p('d-long-name'), publicKey: 'pk7b', name: 'x'.repeat(101) }),
         }),
       )
 
-      const [deviceLong] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd-long-name'))
+      const [deviceLong] = await db
+        .select()
+        .from(devicesTable)
+        .where(eq(devicesTable.id, p('d-long-name')))
       expect(deviceLong.name).toBe('Unknown device')
     })
   })
@@ -286,7 +318,7 @@ describe('Encryption API', () => {
   describe('POST /devices/:deviceId/envelope', () => {
     it('returns 401 without auth', async () => {
       const response = await app.handle(
-        new Request(`${BASE}/devices/d1/envelope`, {
+        new Request(`${BASE}/devices/${p('d1')}/envelope`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ wrappedCK: 'wck' }),
@@ -296,15 +328,15 @@ describe('Encryption API', () => {
     })
 
     it('returns 400 when X-Device-ID header missing', async () => {
-      await createUserAndSession('u-env1', 'tok-env1')
-      await insertDevice('d-env1', 'u-env1')
+      await createUserAndSession(p('u-env1'), p('tok-env1'))
+      await insertDevice(p('d-env1'), p('u-env1'))
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-env1/envelope`, {
+        new Request(`${BASE}/devices/${p('d-env1')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-env1',
+            Authorization: `Bearer ${p('tok-env1')}`,
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -316,16 +348,16 @@ describe('Encryption API', () => {
     })
 
     it('allows first-device bootstrap: pending device submits own envelope when no envelopes exist', async () => {
-      await createUserAndSession('u-boot', 'tok-boot')
-      await insertDevice('d-boot', 'u-boot', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-boot'), p('tok-boot'))
+      await insertDevice(p('d-boot'), p('u-boot'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-boot/envelope`, {
+        new Request(`${BASE}/devices/${p('d-boot')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-boot',
-            'X-Device-ID': 'd-boot',
+            Authorization: `Bearer ${p('tok-boot')}`,
+            'X-Device-ID': p('d-boot'),
           },
           body: JSON.stringify({ wrappedCK: 'wrapped-ck-boot' }),
         }),
@@ -335,26 +367,32 @@ describe('Encryption API', () => {
       const body = await response.json()
       expect(body.status).toBe('TRUSTED')
 
-      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd-boot'))
+      const [device] = await db
+        .select()
+        .from(devicesTable)
+        .where(eq(devicesTable.id, p('d-boot')))
       expect(device.status).toBe('TRUSTED')
 
-      const [envelope] = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, 'd-boot'))
+      const [envelope] = await db
+        .select()
+        .from(envelopesTable)
+        .where(eq(envelopesTable.deviceId, p('d-boot')))
       expect(envelope.wrappedCk).toBe('wrapped-ck-boot')
     })
 
     it('rejects pending device from approving itself when envelopes already exist', async () => {
-      await createUserAndSession('u-self', 'tok-self')
-      await insertDevice('d-trusted-existing', 'u-self', 'TRUSTED')
-      await insertEnvelope('d-trusted-existing', 'u-self')
-      await insertDevice('d-self', 'u-self', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-self'), p('tok-self'))
+      await insertDevice(p('d-trusted-existing'), p('u-self'), 'TRUSTED')
+      await insertEnvelope(p('d-trusted-existing'), p('u-self'))
+      await insertDevice(p('d-self'), p('u-self'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-self/envelope`, {
+        new Request(`${BASE}/devices/${p('d-self')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-self',
-            'X-Device-ID': 'd-self',
+            Authorization: `Bearer ${p('tok-self')}`,
+            'X-Device-ID': p('d-self'),
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -366,20 +404,20 @@ describe('Encryption API', () => {
     })
 
     it('rejects pending device from approving another pending device', async () => {
-      await createUserAndSession('u-pp', 'tok-pp')
+      await createUserAndSession(p('u-pp'), p('tok-pp'))
       // Need envelopes to exist so it's not first-device bootstrap
-      await insertDevice('d-pp-trusted', 'u-pp', 'TRUSTED')
-      await insertEnvelope('d-pp-trusted', 'u-pp')
-      await insertDevice('d-pp-caller', 'u-pp', 'APPROVAL_PENDING')
-      await insertDevice('d-pp-target', 'u-pp', 'APPROVAL_PENDING')
+      await insertDevice(p('d-pp-trusted'), p('u-pp'), 'TRUSTED')
+      await insertEnvelope(p('d-pp-trusted'), p('u-pp'))
+      await insertDevice(p('d-pp-caller'), p('u-pp'), 'APPROVAL_PENDING')
+      await insertDevice(p('d-pp-target'), p('u-pp'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-pp-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-pp-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-pp',
-            'X-Device-ID': 'd-pp-caller',
+            Authorization: `Bearer ${p('tok-pp')}`,
+            'X-Device-ID': p('d-pp-caller'),
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -391,19 +429,19 @@ describe('Encryption API', () => {
     })
 
     it('returns 404 when target device belongs to different user', async () => {
-      await createUserAndSession('u-diff1', 'tok-diff1', 'diff1@test.com')
-      await createUserAndSession('u-diff2', 'tok-diff2', 'diff2@test.com')
-      await insertDevice('d-diff-caller', 'u-diff1', 'TRUSTED')
-      await insertEnvelope('d-diff-caller', 'u-diff1')
-      await insertDevice('d-diff-target', 'u-diff2', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-diff1'), p('tok-diff1'), `${p('diff1')}@test.com`)
+      await createUserAndSession(p('u-diff2'), p('tok-diff2'), `${p('diff2')}@test.com`)
+      await insertDevice(p('d-diff-caller'), p('u-diff1'), 'TRUSTED')
+      await insertEnvelope(p('d-diff-caller'), p('u-diff1'))
+      await insertDevice(p('d-diff-target'), p('u-diff2'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-diff-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-diff-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-diff1',
-            'X-Device-ID': 'd-diff-caller',
+            Authorization: `Bearer ${p('tok-diff1')}`,
+            'X-Device-ID': p('d-diff-caller'),
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -415,22 +453,22 @@ describe('Encryption API', () => {
     })
 
     it('returns 403 when caller device belongs to different user', async () => {
-      await createUserAndSession('u-cdiff1', 'tok-cdiff1', 'cdiff1@test.com')
-      await createUserAndSession('u-cdiff2', 'tok-cdiff2', 'cdiff2@test.com')
-      await insertDevice('d-cdiff-target', 'u-cdiff1', 'APPROVAL_PENDING')
-      await insertDevice('d-cdiff-caller', 'u-cdiff2', 'TRUSTED')
-      await insertEnvelope('d-cdiff-caller', 'u-cdiff2')
+      await createUserAndSession(p('u-cdiff1'), p('tok-cdiff1'), `${p('cdiff1')}@test.com`)
+      await createUserAndSession(p('u-cdiff2'), p('tok-cdiff2'), `${p('cdiff2')}@test.com`)
+      await insertDevice(p('d-cdiff-target'), p('u-cdiff1'), 'APPROVAL_PENDING')
+      await insertDevice(p('d-cdiff-caller'), p('u-cdiff2'), 'TRUSTED')
+      await insertEnvelope(p('d-cdiff-caller'), p('u-cdiff2'))
       // Need envelopes for u-cdiff1 to avoid first-device bootstrap
-      await insertDevice('d-cdiff-existing', 'u-cdiff1', 'TRUSTED')
-      await insertEnvelope('d-cdiff-existing', 'u-cdiff1')
+      await insertDevice(p('d-cdiff-existing'), p('u-cdiff1'), 'TRUSTED')
+      await insertEnvelope(p('d-cdiff-existing'), p('u-cdiff1'))
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-cdiff-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-cdiff-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-cdiff1',
-            'X-Device-ID': 'd-cdiff-caller',
+            Authorization: `Bearer ${p('tok-cdiff1')}`,
+            'X-Device-ID': p('d-cdiff-caller'),
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -442,18 +480,18 @@ describe('Encryption API', () => {
     })
 
     it('returns 403 when target device is revoked', async () => {
-      await createUserAndSession('u-trev', 'tok-trev')
-      await insertDevice('d-trev-caller', 'u-trev', 'TRUSTED')
-      await insertEnvelope('d-trev-caller', 'u-trev')
-      await insertDevice('d-trev-target', 'u-trev', 'REVOKED')
+      await createUserAndSession(p('u-trev'), p('tok-trev'))
+      await insertDevice(p('d-trev-caller'), p('u-trev'), 'TRUSTED')
+      await insertEnvelope(p('d-trev-caller'), p('u-trev'))
+      await insertDevice(p('d-trev-target'), p('u-trev'), 'REVOKED')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-trev-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-trev-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-trev',
-            'X-Device-ID': 'd-trev-caller',
+            Authorization: `Bearer ${p('tok-trev')}`,
+            'X-Device-ID': p('d-trev-caller'),
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -465,20 +503,20 @@ describe('Encryption API', () => {
     })
 
     it('returns 403 when caller device is revoked', async () => {
-      await createUserAndSession('u-crev', 'tok-crev')
-      await insertDevice('d-crev-caller', 'u-crev', 'REVOKED')
-      await insertDevice('d-crev-target', 'u-crev', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-crev'), p('tok-crev'))
+      await insertDevice(p('d-crev-caller'), p('u-crev'), 'REVOKED')
+      await insertDevice(p('d-crev-target'), p('u-crev'), 'APPROVAL_PENDING')
       // Need envelopes so it's not bootstrap
-      await insertDevice('d-crev-existing', 'u-crev', 'TRUSTED')
-      await insertEnvelope('d-crev-existing', 'u-crev')
+      await insertDevice(p('d-crev-existing'), p('u-crev'), 'TRUSTED')
+      await insertEnvelope(p('d-crev-existing'), p('u-crev'))
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-crev-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-crev-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-crev',
-            'X-Device-ID': 'd-crev-caller',
+            Authorization: `Bearer ${p('tok-crev')}`,
+            'X-Device-ID': p('d-crev-caller'),
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -490,19 +528,19 @@ describe('Encryption API', () => {
     })
 
     it('returns 409 when overwriting trusted device envelope from another device', async () => {
-      await createUserAndSession('u-ow', 'tok-ow')
-      await insertDevice('d-ow-caller', 'u-ow', 'TRUSTED')
-      await insertEnvelope('d-ow-caller', 'u-ow')
-      await insertDevice('d-ow-target', 'u-ow', 'TRUSTED')
-      await insertEnvelope('d-ow-target', 'u-ow')
+      await createUserAndSession(p('u-ow'), p('tok-ow'))
+      await insertDevice(p('d-ow-caller'), p('u-ow'), 'TRUSTED')
+      await insertEnvelope(p('d-ow-caller'), p('u-ow'))
+      await insertDevice(p('d-ow-target'), p('u-ow'), 'TRUSTED')
+      await insertEnvelope(p('d-ow-target'), p('u-ow'))
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-ow-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-ow-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-ow',
-            'X-Device-ID': 'd-ow-caller',
+            Authorization: `Bearer ${p('tok-ow')}`,
+            'X-Device-ID': p('d-ow-caller'),
           },
           body: JSON.stringify({ wrappedCK: 'new-wck' }),
         }),
@@ -514,17 +552,17 @@ describe('Encryption API', () => {
     })
 
     it('allows trusted device to re-key its own envelope', async () => {
-      await createUserAndSession('u-rekey', 'tok-rekey')
-      await insertDevice('d-rekey', 'u-rekey', 'TRUSTED')
-      await insertEnvelope('d-rekey', 'u-rekey', 'old-wck')
+      await createUserAndSession(p('u-rekey'), p('tok-rekey'))
+      await insertDevice(p('d-rekey'), p('u-rekey'), 'TRUSTED')
+      await insertEnvelope(p('d-rekey'), p('u-rekey'), 'old-wck')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-rekey/envelope`, {
+        new Request(`${BASE}/devices/${p('d-rekey')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-rekey',
-            'X-Device-ID': 'd-rekey',
+            Authorization: `Bearer ${p('tok-rekey')}`,
+            'X-Device-ID': p('d-rekey'),
           },
           body: JSON.stringify({ wrappedCK: 'new-wck' }),
         }),
@@ -534,22 +572,25 @@ describe('Encryption API', () => {
       const body = await response.json()
       expect(body.status).toBe('TRUSTED')
 
-      const [envelope] = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, 'd-rekey'))
+      const [envelope] = await db
+        .select()
+        .from(envelopesTable)
+        .where(eq(envelopesTable.deviceId, p('d-rekey')))
       expect(envelope.wrappedCk).toBe('new-wck')
     })
 
     it('returns 404 when target deviceId does not exist', async () => {
-      await createUserAndSession('u-nodev', 'tok-nodev')
-      await insertDevice('d-nodev-caller', 'u-nodev', 'TRUSTED')
-      await insertEnvelope('d-nodev-caller', 'u-nodev')
+      await createUserAndSession(p('u-nodev'), p('tok-nodev'))
+      await insertDevice(p('d-nodev-caller'), p('u-nodev'), 'TRUSTED')
+      await insertEnvelope(p('d-nodev-caller'), p('u-nodev'))
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-nonexistent/envelope`, {
+        new Request(`${BASE}/devices/${p('d-nonexistent')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-nodev',
-            'X-Device-ID': 'd-nodev-caller',
+            Authorization: `Bearer ${p('tok-nodev')}`,
+            'X-Device-ID': p('d-nodev-caller'),
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -561,19 +602,19 @@ describe('Encryption API', () => {
     })
 
     it('returns 403 when caller deviceId does not exist (non-first-device scenario)', async () => {
-      await createUserAndSession('u-nocaller', 'tok-nocaller')
-      await insertDevice('d-nocaller-target', 'u-nocaller', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-nocaller'), p('tok-nocaller'))
+      await insertDevice(p('d-nocaller-target'), p('u-nocaller'), 'APPROVAL_PENDING')
       // Need envelopes to exist
-      await insertDevice('d-nocaller-existing', 'u-nocaller', 'TRUSTED')
-      await insertEnvelope('d-nocaller-existing', 'u-nocaller')
+      await insertDevice(p('d-nocaller-existing'), p('u-nocaller'), 'TRUSTED')
+      await insertEnvelope(p('d-nocaller-existing'), p('u-nocaller'))
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-nocaller-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-nocaller-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-nocaller',
-            'X-Device-ID': 'd-ghost',
+            Authorization: `Bearer ${p('tok-nocaller')}`,
+            'X-Device-ID': p('d-ghost'),
           },
           body: JSON.stringify({ wrappedCK: 'wck' }),
         }),
@@ -585,18 +626,18 @@ describe('Encryption API', () => {
     })
 
     it('allows trusted device to approve a pending device', async () => {
-      await createUserAndSession('u-approve', 'tok-approve')
-      await insertDevice('d-approve-caller', 'u-approve', 'TRUSTED')
-      await insertEnvelope('d-approve-caller', 'u-approve')
-      await insertDevice('d-approve-target', 'u-approve', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-approve'), p('tok-approve'))
+      await insertDevice(p('d-approve-caller'), p('u-approve'), 'TRUSTED')
+      await insertEnvelope(p('d-approve-caller'), p('u-approve'))
+      await insertDevice(p('d-approve-target'), p('u-approve'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-approve-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-approve-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-approve',
-            'X-Device-ID': 'd-approve-caller',
+            Authorization: `Bearer ${p('tok-approve')}`,
+            'X-Device-ID': p('d-approve-caller'),
           },
           body: JSON.stringify({ wrappedCK: 'target-wck' }),
         }),
@@ -606,24 +647,30 @@ describe('Encryption API', () => {
       const body = await response.json()
       expect(body.status).toBe('TRUSTED')
 
-      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd-approve-target'))
+      const [device] = await db
+        .select()
+        .from(devicesTable)
+        .where(eq(devicesTable.id, p('d-approve-target')))
       expect(device.status).toBe('TRUSTED')
 
-      const [envelope] = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, 'd-approve-target'))
+      const [envelope] = await db
+        .select()
+        .from(envelopesTable)
+        .where(eq(envelopesTable.deviceId, p('d-approve-target')))
       expect(envelope.wrappedCk).toBe('target-wck')
     })
 
     it('stores canary on first-device bootstrap', async () => {
-      await createUserAndSession('u-canary', 'tok-canary')
-      await insertDevice('d-canary', 'u-canary', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-canary'), p('tok-canary'))
+      await insertDevice(p('d-canary'), p('u-canary'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-canary/envelope`, {
+        new Request(`${BASE}/devices/${p('d-canary')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-canary',
-            'X-Device-ID': 'd-canary',
+            Authorization: `Bearer ${p('tok-canary')}`,
+            'X-Device-ID': p('d-canary'),
           },
           body: JSON.stringify({
             wrappedCK: 'wck',
@@ -638,26 +685,26 @@ describe('Encryption API', () => {
       const [metadata] = await db
         .select()
         .from(encryptionMetadataTable)
-        .where(eq(encryptionMetadataTable.userId, 'u-canary'))
+        .where(eq(encryptionMetadataTable.userId, p('u-canary')))
       expect(metadata).toBeDefined()
       expect(metadata.canaryIv).toBe('my-iv')
       expect(metadata.canaryCtext).toBe('my-ctext')
     })
 
     it('does not overwrite existing canary on subsequent envelope submissions', async () => {
-      await createUserAndSession('u-noow', 'tok-noow')
-      await insertDevice('d-noow-caller', 'u-noow', 'TRUSTED')
-      await insertEnvelope('d-noow-caller', 'u-noow')
-      await insertCanary('u-noow', 'original-iv', 'original-ctext')
-      await insertDevice('d-noow-target', 'u-noow', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-noow'), p('tok-noow'))
+      await insertDevice(p('d-noow-caller'), p('u-noow'), 'TRUSTED')
+      await insertEnvelope(p('d-noow-caller'), p('u-noow'))
+      await insertCanary(p('u-noow'), 'original-iv', 'original-ctext')
+      await insertDevice(p('d-noow-target'), p('u-noow'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
-        new Request(`${BASE}/devices/d-noow-target/envelope`, {
+        new Request(`${BASE}/devices/${p('d-noow-target')}/envelope`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer tok-noow',
-            'X-Device-ID': 'd-noow-caller',
+            Authorization: `Bearer ${p('tok-noow')}`,
+            'X-Device-ID': p('d-noow-caller'),
           },
           body: JSON.stringify({
             wrappedCK: 'wck',
@@ -672,7 +719,7 @@ describe('Encryption API', () => {
       const [metadata] = await db
         .select()
         .from(encryptionMetadataTable)
-        .where(eq(encryptionMetadataTable.userId, 'u-noow'))
+        .where(eq(encryptionMetadataTable.userId, p('u-noow')))
       expect(metadata.canaryIv).toBe('original-iv')
       expect(metadata.canaryCtext).toBe('original-ctext')
     })
@@ -687,11 +734,11 @@ describe('Encryption API', () => {
     })
 
     it('returns 400 when X-Device-ID missing', async () => {
-      await createUserAndSession('u-me1', 'tok-me1')
+      await createUserAndSession(p('u-me1'), p('tok-me1'))
 
       const response = await app.handle(
         new Request(`${BASE}/devices/me/envelope`, {
-          headers: { Authorization: 'Bearer tok-me1' },
+          headers: { Authorization: `Bearer ${p('tok-me1')}` },
         }),
       )
 
@@ -701,15 +748,15 @@ describe('Encryption API', () => {
     })
 
     it('returns envelope for trusted device', async () => {
-      await createUserAndSession('u-me2', 'tok-me2')
-      await insertDevice('d-me2', 'u-me2', 'TRUSTED')
-      await insertEnvelope('d-me2', 'u-me2', 'my-wrapped-ck')
+      await createUserAndSession(p('u-me2'), p('tok-me2'))
+      await insertDevice(p('d-me2'), p('u-me2'), 'TRUSTED')
+      await insertEnvelope(p('d-me2'), p('u-me2'), 'my-wrapped-ck')
 
       const response = await app.handle(
         new Request(`${BASE}/devices/me/envelope`, {
           headers: {
-            Authorization: 'Bearer tok-me2',
-            'X-Device-ID': 'd-me2',
+            Authorization: `Bearer ${p('tok-me2')}`,
+            'X-Device-ID': p('d-me2'),
           },
         }),
       )
@@ -721,16 +768,16 @@ describe('Encryption API', () => {
     })
 
     it('returns 404 when device belongs to different user', async () => {
-      await createUserAndSession('u-me3a', 'tok-me3a', 'me3a@test.com')
-      await createUserAndSession('u-me3b', 'tok-me3b', 'me3b@test.com')
-      await insertDevice('d-me3', 'u-me3b', 'TRUSTED')
-      await insertEnvelope('d-me3', 'u-me3b')
+      await createUserAndSession(p('u-me3a'), p('tok-me3a'), `${p('me3a')}@test.com`)
+      await createUserAndSession(p('u-me3b'), p('tok-me3b'), `${p('me3b')}@test.com`)
+      await insertDevice(p('d-me3'), p('u-me3b'), 'TRUSTED')
+      await insertEnvelope(p('d-me3'), p('u-me3b'))
 
       const response = await app.handle(
         new Request(`${BASE}/devices/me/envelope`, {
           headers: {
-            Authorization: 'Bearer tok-me3a',
-            'X-Device-ID': 'd-me3',
+            Authorization: `Bearer ${p('tok-me3a')}`,
+            'X-Device-ID': p('d-me3'),
           },
         }),
       )
@@ -741,14 +788,14 @@ describe('Encryption API', () => {
     })
 
     it('returns 403 when device is revoked', async () => {
-      await createUserAndSession('u-me4', 'tok-me4')
-      await insertDevice('d-me4', 'u-me4', 'REVOKED')
+      await createUserAndSession(p('u-me4'), p('tok-me4'))
+      await insertDevice(p('d-me4'), p('u-me4'), 'REVOKED')
 
       const response = await app.handle(
         new Request(`${BASE}/devices/me/envelope`, {
           headers: {
-            Authorization: 'Bearer tok-me4',
-            'X-Device-ID': 'd-me4',
+            Authorization: `Bearer ${p('tok-me4')}`,
+            'X-Device-ID': p('d-me4'),
           },
         }),
       )
@@ -759,14 +806,14 @@ describe('Encryption API', () => {
     })
 
     it('returns 404 when device has no envelope (pending device)', async () => {
-      await createUserAndSession('u-me5', 'tok-me5')
-      await insertDevice('d-me5', 'u-me5', 'APPROVAL_PENDING')
+      await createUserAndSession(p('u-me5'), p('tok-me5'))
+      await insertDevice(p('d-me5'), p('u-me5'), 'APPROVAL_PENDING')
 
       const response = await app.handle(
         new Request(`${BASE}/devices/me/envelope`, {
           headers: {
-            Authorization: 'Bearer tok-me5',
-            'X-Device-ID': 'd-me5',
+            Authorization: `Bearer ${p('tok-me5')}`,
+            'X-Device-ID': p('d-me5'),
           },
         }),
       )
@@ -777,13 +824,13 @@ describe('Encryption API', () => {
     })
 
     it('returns 404 when deviceId does not exist', async () => {
-      await createUserAndSession('u-me6', 'tok-me6')
+      await createUserAndSession(p('u-me6'), p('tok-me6'))
 
       const response = await app.handle(
         new Request(`${BASE}/devices/me/envelope`, {
           headers: {
-            Authorization: 'Bearer tok-me6',
-            'X-Device-ID': 'd-ghost',
+            Authorization: `Bearer ${p('tok-me6')}`,
+            'X-Device-ID': p('d-ghost'),
           },
         }),
       )
@@ -803,12 +850,12 @@ describe('Encryption API', () => {
     })
 
     it('returns canary when set up', async () => {
-      await createUserAndSession('u-can1', 'tok-can1')
-      await insertCanary('u-can1', 'stored-iv', 'stored-ctext')
+      await createUserAndSession(p('u-can1'), p('tok-can1'))
+      await insertCanary(p('u-can1'), 'stored-iv', 'stored-ctext')
 
       const response = await app.handle(
         new Request(`${BASE}/encryption/canary`, {
-          headers: { Authorization: 'Bearer tok-can1' },
+          headers: { Authorization: `Bearer ${p('tok-can1')}` },
         }),
       )
 
@@ -819,11 +866,11 @@ describe('Encryption API', () => {
     })
 
     it('returns 404 when encryption not set up', async () => {
-      await createUserAndSession('u-can2', 'tok-can2')
+      await createUserAndSession(p('u-can2'), p('tok-can2'))
 
       const response = await app.handle(
         new Request(`${BASE}/encryption/canary`, {
-          headers: { Authorization: 'Bearer tok-can2' },
+          headers: { Authorization: `Bearer ${p('tok-can2')}` },
         }),
       )
 

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -65,6 +65,12 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
               firstDevice: !envelopesExist,
             }
           }
+
+          // Revoked — device cannot re-register
+          if (existingDevice.status === 'REVOKED') {
+            set.status = 403
+            return { error: 'Device has been revoked' }
+          }
         }
 
         // New device — register with APPROVAL_PENDING

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -67,7 +67,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
           }
 
           // Revoked — device cannot re-register
-          if (existingDevice.status === 'REVOKED') {
+          if (existingDevice.status === 'REVOKED' || existingDevice.revokedAt != null) {
             set.status = 403
             return { error: 'Device has been revoked' }
           }
@@ -110,7 +110,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
           return { error: 'Device not found' }
         }
 
-        if (device.status === 'REVOKED') {
+        if (device.status === 'REVOKED' || device.revokedAt != null) {
           set.status = 403
           return { error: 'Device has been revoked' }
         }
@@ -135,6 +135,12 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
 
             const envelopesExist = await hasEnvelopesForUser(txDb, userId)
             const isFirstDeviceBootstrap = !envelopesExist && callerDeviceId === deviceId
+
+            // Re-check target device inside transaction to close race window
+            const targetDevice = await getDeviceById(txDb, deviceId)
+            if (!targetDevice || targetDevice.status === 'REVOKED' || targetDevice.revokedAt != null) {
+              throw new Error('FORBIDDEN:Device has been revoked')
+            }
 
             if (!isFirstDeviceBootstrap) {
               const callerDevice = await getDeviceById(txDb, callerDeviceId)
@@ -199,7 +205,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
         return { error: 'Device not found' }
       }
 
-      if (device.status === 'REVOKED') {
+      if (device.status === 'REVOKED' || device.revokedAt != null) {
         set.status = 403
         return { error: 'Device has been revoked' }
       }

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -115,46 +115,63 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
           return { error: 'Device has been revoked' }
         }
 
-        // Verify caller is a TRUSTED device (or this is a first-device bootstrap)
+        // Reject if target device is already TRUSTED (prevents envelope overwrite attacks)
+        // Only the device itself can re-key its own envelope
         const callerDeviceId = request.headers.get('x-device-id')?.trim()
         if (!callerDeviceId) {
           set.status = 400
           return { error: 'X-Device-ID header is required' }
         }
 
-        const envelopesExist = await hasEnvelopesForUser(database, userId)
-        const isFirstDeviceBootstrap = !envelopesExist && callerDeviceId === deviceId
-
-        if (!isFirstDeviceBootstrap) {
-          const callerDevice = await getDeviceById(database, callerDeviceId)
-          if (!callerDevice || callerDevice.userId !== userId) {
-            set.status = 403
-            return { error: 'Caller device not found' }
-          }
-          if (callerDevice.status !== 'TRUSTED') {
-            set.status = 403
-            return { error: 'Only trusted devices can store envelopes' }
-          }
+        if (device.status === 'TRUSTED' && callerDeviceId !== deviceId) {
+          set.status = 409
+          return { error: 'Cannot overwrite envelope of an already-trusted device' }
         }
 
-        // Store envelope
-        await upsertEnvelope(database, {
-          deviceId,
-          userId,
-          wrappedCk: wrappedCK,
-        })
+        // Use a transaction for atomicity (prevents race conditions on first-device bootstrap)
+        try {
+          await database.transaction(async (tx) => {
+            const txDb = tx as unknown as typeof database
 
-        // Store canary if provided (first device setup — idempotent)
-        if (canaryIv && canaryCtext) {
-          await insertEncryptionMetadataIfNotExists(database, {
-            userId,
-            canaryIv,
-            canaryCtext,
+            const envelopesExist = await hasEnvelopesForUser(txDb, userId)
+            const isFirstDeviceBootstrap = !envelopesExist && callerDeviceId === deviceId
+
+            if (!isFirstDeviceBootstrap) {
+              const callerDevice = await getDeviceById(txDb, callerDeviceId)
+              if (!callerDevice || callerDevice.userId !== userId) {
+                throw new Error('FORBIDDEN:Caller device not found')
+              }
+              if (callerDevice.status !== 'TRUSTED') {
+                throw new Error('FORBIDDEN:Only trusted devices can store envelopes')
+              }
+            }
+
+            // Store envelope
+            await upsertEnvelope(txDb, {
+              deviceId,
+              userId,
+              wrappedCk: wrappedCK,
+            })
+
+            // Store canary if provided (first device setup — idempotent)
+            if (canaryIv && canaryCtext) {
+              await insertEncryptionMetadataIfNotExists(txDb, {
+                userId,
+                canaryIv,
+                canaryCtext,
+              })
+            }
+
+            // Mark device as trusted
+            await updateDeviceStatus(txDb, deviceId, userId, 'TRUSTED')
           })
+        } catch (err) {
+          if (err instanceof Error && err.message.startsWith('FORBIDDEN:')) {
+            set.status = 403
+            return { error: err.message.slice('FORBIDDEN:'.length) }
+          }
+          throw err
         }
-
-        // Mark device as trusted
-        await updateDeviceStatus(database, deviceId, userId, 'TRUSTED')
 
         return { status: 'TRUSTED' as const }
       },

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -110,6 +110,11 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
           return { error: 'Device not found' }
         }
 
+        if (device.status === 'REVOKED') {
+          set.status = 403
+          return { error: 'Device has been revoked' }
+        }
+
         // Store envelope
         await upsertEnvelope(database, {
           deviceId,
@@ -153,6 +158,11 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
       if (!device || device.userId !== userId) {
         set.status = 404
         return { error: 'Device not found' }
+      }
+
+      if (device.status === 'REVOKED') {
+        set.status = 403
+        return { error: 'Device has been revoked' }
       }
 
       const envelope = await getEnvelopeByDeviceId(database, deviceId, userId)

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -98,7 +98,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
     )
     .post(
       '/devices/:deviceId/envelope',
-      async ({ params, body, set, user: sessionUser }) => {
+      async ({ params, body, request, set, user: sessionUser }) => {
         const userId = sessionUser!.id
         const { deviceId } = params
         const { wrappedCK, canaryIv, canaryCtext } = body
@@ -113,6 +113,28 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
         if (device.status === 'REVOKED') {
           set.status = 403
           return { error: 'Device has been revoked' }
+        }
+
+        // Verify caller is a TRUSTED device (or this is a first-device bootstrap)
+        const callerDeviceId = request.headers.get('x-device-id')?.trim()
+        if (!callerDeviceId) {
+          set.status = 400
+          return { error: 'X-Device-ID header is required' }
+        }
+
+        const envelopesExist = await hasEnvelopesForUser(database, userId)
+        const isFirstDeviceBootstrap = !envelopesExist && callerDeviceId === deviceId
+
+        if (!isFirstDeviceBootstrap) {
+          const callerDevice = await getDeviceById(database, callerDeviceId)
+          if (!callerDevice || callerDevice.userId !== userId) {
+            set.status = 403
+            return { error: 'Caller device not found' }
+          }
+          if (callerDevice.status !== 'TRUSTED') {
+            set.status = 403
+            return { error: 'Only trusted devices can store envelopes' }
+          }
         }
 
         // Store envelope

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -1,0 +1,176 @@
+import type { Auth } from '@/auth/elysia-plugin'
+import {
+  getDeviceById,
+  registerDevice,
+  updateDeviceStatus,
+  getEnvelopeByDeviceId,
+  hasEnvelopesForUser,
+  upsertEnvelope,
+  getEncryptionMetadata,
+  insertEncryptionMetadataIfNotExists,
+} from '@/dal'
+import type { db as DbType } from '@/db/client'
+import { Elysia, t } from 'elysia'
+
+/**
+ * Encryption API routes for device registration, envelope management, and canary.
+ * All routes require authentication via session.
+ */
+export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
+  new Elysia()
+    .derive(async ({ request, set }) => {
+      const session = await auth.api.getSession({ headers: request.headers })
+      if (!session) {
+        set.status = 401
+        return { user: null }
+      }
+      return { user: session.user }
+    })
+    .onBeforeHandle(({ user: sessionUser, set }) => {
+      if (!sessionUser) {
+        set.status = 401
+        return { error: 'Unauthorized' }
+      }
+    })
+    .post(
+      '/devices',
+      async ({ body, set, user: sessionUser }) => {
+        const userId = sessionUser!.id
+        const { deviceId, publicKey, name } = body
+
+        // Check if device already exists
+        const existingDevice = await getDeviceById(database, deviceId)
+
+        if (existingDevice) {
+          // Device belongs to a different user
+          if (existingDevice.userId !== userId) {
+            set.status = 409
+            return { error: 'Device ID already taken' }
+          }
+
+          // Already trusted — return envelope
+          if (existingDevice.status === 'TRUSTED') {
+            const envelope = await getEnvelopeByDeviceId(database, deviceId, userId)
+            return {
+              status: 'TRUSTED' as const,
+              envelope: envelope?.wrappedCk ?? null,
+            }
+          }
+
+          // Already pending — return status + firstDevice hint
+          if (existingDevice.status === 'APPROVAL_PENDING') {
+            const envelopesExist = await hasEnvelopesForUser(database, userId)
+            return {
+              status: 'APPROVAL_PENDING' as const,
+              firstDevice: !envelopesExist,
+            }
+          }
+        }
+
+        // New device — register with APPROVAL_PENDING
+        const deviceName = name && name.length > 0 && name.length <= 100 ? name : 'Unknown device'
+        await registerDevice(database, {
+          id: deviceId,
+          userId,
+          name: deviceName,
+          publicKey,
+        })
+
+        const envelopesExist = await hasEnvelopesForUser(database, userId)
+        return {
+          status: 'APPROVAL_PENDING' as const,
+          firstDevice: !envelopesExist,
+        }
+      },
+      {
+        body: t.Object({
+          deviceId: t.String(),
+          publicKey: t.String(),
+          name: t.Optional(t.String()),
+        }),
+      },
+    )
+    .post(
+      '/devices/:deviceId/envelope',
+      async ({ params, body, set, user: sessionUser }) => {
+        const userId = sessionUser!.id
+        const { deviceId } = params
+        const { wrappedCK, canaryIv, canaryCtext } = body
+
+        // Verify the target device exists and belongs to this user
+        const device = await getDeviceById(database, deviceId)
+        if (!device || device.userId !== userId) {
+          set.status = 404
+          return { error: 'Device not found' }
+        }
+
+        // Store envelope
+        await upsertEnvelope(database, {
+          deviceId,
+          userId,
+          wrappedCk: wrappedCK,
+        })
+
+        // Store canary if provided (first device setup — idempotent)
+        if (canaryIv && canaryCtext) {
+          await insertEncryptionMetadataIfNotExists(database, {
+            userId,
+            canaryIv,
+            canaryCtext,
+          })
+        }
+
+        // Mark device as trusted
+        await updateDeviceStatus(database, deviceId, userId, 'TRUSTED')
+
+        return { status: 'TRUSTED' as const }
+      },
+      {
+        body: t.Object({
+          wrappedCK: t.String(),
+          canaryIv: t.Optional(t.String()),
+          canaryCtext: t.Optional(t.String()),
+        }),
+      },
+    )
+    .get('/devices/me/envelope', async ({ request, set, user: sessionUser }) => {
+      const userId = sessionUser!.id
+      const deviceId = request.headers.get('x-device-id')?.trim()
+
+      if (!deviceId) {
+        set.status = 400
+        return { error: 'X-Device-ID header is required' }
+      }
+
+      // Verify device belongs to this user
+      const device = await getDeviceById(database, deviceId)
+      if (!device || device.userId !== userId) {
+        set.status = 404
+        return { error: 'Device not found' }
+      }
+
+      const envelope = await getEnvelopeByDeviceId(database, deviceId, userId)
+      if (!envelope) {
+        set.status = 404
+        return { error: 'Envelope not found' }
+      }
+
+      return {
+        status: device.status,
+        wrappedCK: envelope.wrappedCk,
+      }
+    })
+    .get('/encryption/canary', async ({ set, user: sessionUser }) => {
+      const userId = sessionUser!.id
+
+      const metadata = await getEncryptionMetadata(database, userId)
+      if (!metadata) {
+        set.status = 404
+        return { error: 'Encryption not set up' }
+      }
+
+      return {
+        canaryIv: metadata.canaryIv,
+        canaryCtext: metadata.canaryCtext,
+      }
+    })

--- a/backend/src/api/powersync.ts
+++ b/backend/src/api/powersync.ts
@@ -37,7 +37,7 @@ const validateDeviceNotRevoked = async (
     if (deviceRow.userId !== userId) {
       return { ok: false, status: 409, body: { code: 'DEVICE_ID_TAKEN' } }
     }
-    if (deviceRow.revokedAt != null) {
+    if (deviceRow.status === 'REVOKED' || deviceRow.revokedAt != null) {
       return { ok: false, status: 403, body: { code: 'DEVICE_DISCONNECTED' } }
     }
   }

--- a/backend/src/dal/devices.ts
+++ b/backend/src/dal/devices.ts
@@ -2,10 +2,14 @@ import type { db as DbType } from '@/db/client'
 import { devicesTable } from '@/db/schema'
 import { and, eq } from 'drizzle-orm'
 
-/** Get a device by ID. Returns userId and revokedAt, or null if not found. */
+/** Get a device by ID. Returns userId, status, and revokedAt, or null if not found. */
 export const getDeviceById = async (database: typeof DbType, deviceId: string) =>
   database
-    .select({ userId: devicesTable.userId, revokedAt: devicesTable.revokedAt })
+    .select({
+      userId: devicesTable.userId,
+      status: devicesTable.status,
+      revokedAt: devicesTable.revokedAt,
+    })
     .from(devicesTable)
     .where(eq(devicesTable.id, deviceId))
     .limit(1)
@@ -26,9 +30,47 @@ export const upsertDevice = async (
     })
     .returning()
 
-/** Revoke a device for a specific user. */
+/** Revoke a device for a specific user. Sets both status and revokedAt. */
 export const revokeDevice = async (database: typeof DbType, deviceId: string, userId: string) =>
   database
     .update(devicesTable)
-    .set({ revokedAt: new Date() })
+    .set({ status: 'REVOKED', revokedAt: new Date() })
     .where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId)))
+
+/** Update a device's status. */
+export const updateDeviceStatus = async (
+  database: typeof DbType,
+  deviceId: string,
+  userId: string,
+  status: 'APPROVAL_PENDING' | 'TRUSTED' | 'REVOKED',
+) =>
+  database
+    .update(devicesTable)
+    .set({ status })
+    .where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId)))
+
+/**
+ * Register a device with APPROVAL_PENDING status and a public key.
+ * Used during the encryption setup flow when the FE sends POST /devices.
+ */
+export const registerDevice = async (
+  database: typeof DbType,
+  device: { id: string; userId: string; name: string; publicKey: string },
+) =>
+  database
+    .insert(devicesTable)
+    .values({
+      id: device.id,
+      userId: device.userId,
+      name: device.name,
+      publicKey: device.publicKey,
+      status: 'APPROVAL_PENDING',
+      createdAt: new Date(),
+      lastSeen: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: devicesTable.id,
+      set: { publicKey: device.publicKey, lastSeen: new Date() },
+      setWhere: eq(devicesTable.userId, device.userId),
+    })
+    .returning()

--- a/backend/src/dal/devices.ts
+++ b/backend/src/dal/devices.ts
@@ -15,14 +15,14 @@ export const getDeviceById = async (database: typeof DbType, deviceId: string) =
     .limit(1)
     .then((rows) => rows[0] ?? null)
 
-/** Upsert a device: insert new or update lastSeen/name for existing. Only updates if userId matches. */
+/** Upsert a device: insert new with APPROVAL_PENDING or update lastSeen/name for existing. Only updates if userId matches. */
 export const upsertDevice = async (
   database: typeof DbType,
   device: { id: string; userId: string; name: string; lastSeen: Date; createdAt: Date },
 ) =>
   database
     .insert(devicesTable)
-    .values(device)
+    .values({ ...device, status: 'APPROVAL_PENDING' })
     .onConflictDoUpdate({
       target: devicesTable.id,
       set: { lastSeen: device.lastSeen, name: device.name },

--- a/backend/src/dal/encryption.ts
+++ b/backend/src/dal/encryption.ts
@@ -1,0 +1,61 @@
+import type { db as DbType } from '@/db/client'
+import { encryptionMetadataTable, envelopesTable } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+
+/** Get an envelope by device ID and user ID. */
+export const getEnvelopeByDeviceId = async (database: typeof DbType, deviceId: string, userId: string) =>
+  database
+    .select({ wrappedCk: envelopesTable.wrappedCk })
+    .from(envelopesTable)
+    .where(and(eq(envelopesTable.deviceId, deviceId), eq(envelopesTable.userId, userId)))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+/** Check if any envelopes exist for a user. */
+export const hasEnvelopesForUser = async (database: typeof DbType, userId: string) =>
+  database
+    .select({ deviceId: envelopesTable.deviceId })
+    .from(envelopesTable)
+    .where(eq(envelopesTable.userId, userId))
+    .limit(1)
+    .then((rows) => rows.length > 0)
+
+/** Upsert an envelope for a device. */
+export const upsertEnvelope = async (
+  database: typeof DbType,
+  envelope: { deviceId: string; userId: string; wrappedCk: string },
+) =>
+  database
+    .insert(envelopesTable)
+    .values({
+      deviceId: envelope.deviceId,
+      userId: envelope.userId,
+      wrappedCk: envelope.wrappedCk,
+    })
+    .onConflictDoUpdate({
+      target: envelopesTable.deviceId,
+      set: { wrappedCk: envelope.wrappedCk, updatedAt: new Date() },
+    })
+
+/** Delete an envelope for a device. */
+export const deleteEnvelope = async (database: typeof DbType, deviceId: string) =>
+  database.delete(envelopesTable).where(eq(envelopesTable.deviceId, deviceId))
+
+/** Get encryption metadata (canary) for a user. */
+export const getEncryptionMetadata = async (database: typeof DbType, userId: string) =>
+  database
+    .select({ canaryIv: encryptionMetadataTable.canaryIv, canaryCtext: encryptionMetadataTable.canaryCtext })
+    .from(encryptionMetadataTable)
+    .where(eq(encryptionMetadataTable.userId, userId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+/** Insert encryption metadata (canary) for a user. Idempotent — does nothing if row already exists. */
+export const insertEncryptionMetadataIfNotExists = async (
+  database: typeof DbType,
+  metadata: { userId: string; canaryIv: string; canaryCtext: string },
+) =>
+  database
+    .insert(encryptionMetadataTable)
+    .values(metadata)
+    .onConflictDoNothing({ target: encryptionMetadataTable.userId })

--- a/backend/src/dal/encryption.ts
+++ b/backend/src/dal/encryption.ts
@@ -20,7 +20,7 @@ export const hasEnvelopesForUser = async (database: typeof DbType, userId: strin
     .limit(1)
     .then((rows) => rows.length > 0)
 
-/** Upsert an envelope for a device. */
+/** Upsert an envelope for a device. Only updates if userId matches (defense-in-depth). */
 export const upsertEnvelope = async (
   database: typeof DbType,
   envelope: { deviceId: string; userId: string; wrappedCk: string },
@@ -35,11 +35,12 @@ export const upsertEnvelope = async (
     .onConflictDoUpdate({
       target: envelopesTable.deviceId,
       set: { wrappedCk: envelope.wrappedCk, updatedAt: new Date() },
+      setWhere: eq(envelopesTable.userId, envelope.userId),
     })
 
-/** Delete an envelope for a device. */
-export const deleteEnvelope = async (database: typeof DbType, deviceId: string) =>
-  database.delete(envelopesTable).where(eq(envelopesTable.deviceId, deviceId))
+/** Delete an envelope for a device. Scoped by userId to prevent cross-user deletion. */
+export const deleteEnvelope = async (database: typeof DbType, deviceId: string, userId: string) =>
+  database.delete(envelopesTable).where(and(eq(envelopesTable.deviceId, deviceId), eq(envelopesTable.userId, userId)))
 
 /** Get encryption metadata (canary) for a user. */
 export const getEncryptionMetadata = async (database: typeof DbType, userId: string) =>

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -12,3 +12,13 @@ export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from '.
 
 // PowerSync
 export { applyOperation } from './powersync'
+
+// Encryption
+export {
+  getEnvelopeByDeviceId,
+  hasEnvelopesForUser,
+  upsertEnvelope,
+  deleteEnvelope,
+  getEncryptionMetadata,
+  insertEncryptionMetadataIfNotExists,
+} from './encryption'

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -1,5 +1,5 @@
 // Devices
-export { getDeviceById, upsertDevice, revokeDevice } from './devices'
+export { getDeviceById, upsertDevice, revokeDevice, updateDeviceStatus, registerDevice } from './devices'
 
 // Users
 export { getUserById, getUserByEmail, deleteUser, markUserNotNew } from './users'

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import { createPostHogRoutes } from '@/posthog/routes'
 import { createProToolsRoutes } from '@/pro/routes'
 import { createWaitlistRoutes } from '@/waitlist/routes'
 import { createAccountRoutes } from '@/api/account'
+import { createEncryptionRoutes } from '@/api/encryption'
 import { createPowerSyncRoutes } from '@/api/powersync'
 import type { AppDeps } from '@/types'
 import { cors } from '@elysiajs/cors'
@@ -84,6 +85,7 @@ export const createApp = async (deps?: AppDeps) => {
       .use(createPostHogRoutes(fetchFn))
       .use(createWaitlistRoutes({ database, auth, emailService: deps?.waitlistEmailService }))
       .use(createPowerSyncRoutes(auth, settings, database))
+      .use(createEncryptionRoutes(auth, database))
       .use(createAccountRoutes(auth, database))
   )
 }


### PR DESCRIPTION
## Summary

Implements all encryption API endpoints and updates existing device logic to use the `status` field.

### New endpoints

**`POST /devices`** — Register or identify a device
- Input: `{ deviceId, publicKey, name? }`
- If device exists + TRUSTED → returns `{ status: "TRUSTED", envelope }`
- If device exists + APPROVAL_PENDING → returns `{ status: "APPROVAL_PENDING", firstDevice }`
- If new device → creates with APPROVAL_PENDING, returns `{ status: "APPROVAL_PENDING", firstDevice }`
- `firstDevice: true` when no envelopes exist for the user (FE generates CK locally)

**`POST /devices/:deviceId/envelope`** — Store envelope + mark trusted
- Input: `{ wrappedCK, canaryIv?, canaryCtext? }`
- Stores envelope, optionally stores canary (idempotent), marks device TRUSTED
- Callable by the device itself (first device) or by a trusted device (approval)

**`GET /devices/me/envelope`** — Fetch own envelope
- Requires `X-Device-ID` header
- Returns calling device's envelope only (enforced server-side)

**`GET /encryption/canary`** — Fetch canary for recovery key verification
- Returns `{ canaryIv, canaryCtext }` for the current user

### Updated existing logic

**`POST /account/devices/:id/revoke`** — now also:
- Deletes the device's envelope from `envelopes` table
- Sets `status = 'REVOKED'` (in addition to existing `revokedAt`)

**PowerSync token validation** — now checks `status === 'REVOKED'` in addition to `revokedAt`

### DAL changes

- `getDeviceById` now returns `status` field
- `revokeDevice` now sets both `status: 'REVOKED'` and `revokedAt`
- New: `registerDevice` — creates device with APPROVAL_PENDING + public key
- New: `updateDeviceStatus` — updates device status
- New encryption DAL: `getEnvelopeByDeviceId`, `hasEnvelopesForUser`, `upsertEnvelope`, `deleteEnvelope`, `getEncryptionMetadata`, `insertEncryptionMetadataIfNotExists`

### Files changed
- `backend/src/api/encryption.ts` — new route file (4 endpoints)
- `backend/src/api/account.ts` — revoke deletes envelope
- `backend/src/api/powersync.ts` — status check
- `backend/src/dal/encryption.ts` — new DAL
- `backend/src/dal/devices.ts` — updated + new functions
- `backend/src/dal/index.ts` — re-exports
- `backend/src/index.ts` — registers encryption routes

## Test plan

- [ ] `POST /devices` with new deviceId + no envelopes → `{ status: "APPROVAL_PENDING", firstDevice: true }`
- [ ] `POST /devices` with new deviceId + envelopes exist → `{ status: "APPROVAL_PENDING", firstDevice: false }`
- [ ] `POST /devices` with existing TRUSTED device → `{ status: "TRUSTED", envelope: "..." }`
- [ ] `POST /devices` with existing PENDING device → `{ status: "APPROVAL_PENDING", firstDevice }`
- [ ] `POST /devices/:id/envelope` with wrappedCK + canary → stores both, returns `{ status: "TRUSTED" }`
- [ ] `POST /devices/:id/envelope` without canary (approval path) → stores envelope only
- [ ] `GET /devices/me/envelope` with valid X-Device-ID → returns envelope
- [ ] `GET /devices/me/envelope` without header → 400
- [ ] `GET /encryption/canary` → returns canary for authenticated user
- [ ] `GET /encryption/canary` with no encryption setup → 404
- [ ] `POST /account/devices/:id/revoke` → deletes envelope + sets status REVOKED
- [ ] PowerSync token request from REVOKED device → 403
- [ ] All endpoints return 401 without session
- [ ] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new authenticated endpoints and transactional writes around device trust/envelope storage, so bugs could impact device authorization, key material persistence, or revocation enforcement. Changes are scoped to device/encryption flows but touch PowerSync token validation and account revoke behavior.
> 
> **Overview**
> Adds a new `Encryption API` surface (`POST /devices`, `POST /devices/:deviceId/envelope`, `GET /devices/me/envelope`, `GET /encryption/canary`) to support E2E setup: device registration, envelope storage/approval with transactional checks, and canary retrieval.
> 
> Updates device handling to rely on an explicit `status` field: `getDeviceById` now returns status, `upsertDevice` inserts as `APPROVAL_PENDING`, `revokeDevice` sets `status='REVOKED'` (and `revokedAt`), and PowerSync token issuance now blocks devices with `status='REVOKED'`.
> 
> Tightens revocation semantics by making `POST /account/devices/:id/revoke` delete the device’s envelope and revoke in a single DB transaction, and adds/extends backend tests (including a PGlite rerun-safe ID strategy) to cover encryption flows and revoke edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ba9c0f6f3b54f16422b82f964a5ef11862ff9ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->