### PR TITLE
THU-348: Get MCPs working (including authenticated options) [2/6]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ src-tauri/gen/apple/.bundle/
 
 # Powersync
 public/@powersync/**
+.team/

--- a/src/lib/mcp-transports/index.ts
+++ b/src/lib/mcp-transports/index.ts
@@ -1,0 +1,4 @@
+export { createTauriFetch, createTauriHttpTransport } from './tauri-http-transport'
+export { createTauriSseTransport } from './tauri-sse-transport'
+export { TauriStdioTransport, validateCommand, validateArgs } from './tauri-stdio-transport'
+export { createTransport } from './transport-factory'

--- a/src/lib/mcp-transports/index.ts
+++ b/src/lib/mcp-transports/index.ts
@@ -1,4 +1,5 @@
 export { createTauriFetch, createTauriHttpTransport } from './tauri-http-transport'
 export { createTauriSseTransport } from './tauri-sse-transport'
-export { TauriStdioTransport, validateCommand, validateArgs } from './tauri-stdio-transport'
 export { createTransport } from './transport-factory'
+export { createProxiedFetch } from './proxied-fetch'
+export { validateStdioCommand, validateStdioArgs } from '@/lib/mcp-utils'

--- a/src/lib/mcp-transports/proxied-fetch.ts
+++ b/src/lib/mcp-transports/proxied-fetch.ts
@@ -1,0 +1,16 @@
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+
+/**
+ * Creates a fetch function that proxies MCP requests through the backend
+ * to bypass CORS restrictions for web browsers.
+ *
+ * The original MCP server URL is passed as an X-Mcp-Target-Url header,
+ * and the actual request is sent to the backend's /v1/mcp-proxy endpoint.
+ */
+export const createProxiedFetch =
+  (proxyBaseUrl: string): FetchLike =>
+  async (url: string | URL, init?: RequestInit): Promise<Response> => {
+    const headers = new Headers(init?.headers)
+    headers.set('X-Mcp-Target-Url', url.toString())
+    return globalThis.fetch(`${proxyBaseUrl}/mcp-proxy`, { ...init, headers })
+  }

--- a/src/lib/mcp-transports/tauri-http-transport.ts
+++ b/src/lib/mcp-transports/tauri-http-transport.ts
@@ -1,0 +1,24 @@
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+
+/**
+ * Returns Tauri's native HTTP fetch function, which bypasses CORS restrictions
+ * imposed on the webview's built-in fetch.
+ */
+export const createTauriFetch = (): FetchLike => (url: string | URL, init?: RequestInit) =>
+  tauriFetch(url.toString(), init ?? {})
+
+/**
+ * Creates a Streamable HTTP MCP transport that uses Tauri's native HTTP client
+ * for CORS bypass on external MCP server URLs.
+ */
+export const createTauriHttpTransport = (
+  url: URL,
+  options?: StreamableHTTPClientTransportOptions,
+): StreamableHTTPClientTransport =>
+  new StreamableHTTPClientTransport(url, {
+    ...options,
+    fetch: createTauriFetch(),
+  })

--- a/src/lib/mcp-transports/tauri-sse-transport.ts
+++ b/src/lib/mcp-transports/tauri-sse-transport.ts
@@ -1,0 +1,16 @@
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import type { SSEClientTransportOptions } from '@modelcontextprotocol/sdk/client/sse.js'
+import { createTauriFetch } from './tauri-http-transport'
+
+/**
+ * Creates an SSE MCP transport that uses Tauri's native HTTP client for CORS
+ * bypass on external MCP server URLs.
+ *
+ * SSE transport is the legacy predecessor to Streamable HTTP. Some older MCP
+ * servers still use it.
+ */
+export const createTauriSseTransport = (url: URL, options?: SSEClientTransportOptions): SSEClientTransport =>
+  new SSEClientTransport(url, {
+    ...options,
+    fetch: createTauriFetch(),
+  })

--- a/src/lib/mcp-transports/tauri-stdio-transport.ts
+++ b/src/lib/mcp-transports/tauri-stdio-transport.ts
@@ -1,0 +1,126 @@
+import { Command } from '@tauri-apps/plugin-shell'
+import type { Child } from '@tauri-apps/plugin-shell'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
+
+/** Regex for validating stdio command names — no shell meta-characters */
+const COMMAND_PATTERN = /^[a-zA-Z0-9._/-]+$/
+
+/** Options for TauriStdioTransport */
+type TauriStdioTransportOptions = {
+  /** The command to execute (e.g. 'npx', 'uvx', 'node') */
+  command: string
+  /** Arguments to pass to the command */
+  args?: string[]
+  /** Environment variables to inject into the child process */
+  env?: Record<string, string>
+}
+
+/**
+ * Custom MCP transport that spawns a child process via Tauri's shell plugin
+ * and communicates over stdin/stdout using newline-delimited JSON-RPC.
+ *
+ * This is necessary because the MCP SDK's StdioClientTransport uses Node.js
+ * child_process.spawn() which does not work in a Tauri webview context.
+ */
+export class TauriStdioTransport implements Transport {
+  onclose?: () => void
+  onerror?: (error: Error) => void
+  onmessage?: (message: JSONRPCMessage) => void
+
+  private readonly options: TauriStdioTransportOptions
+  private child: Child | null = null
+  private lineBuffer = ''
+
+  constructor(options: TauriStdioTransportOptions) {
+    validateCommand(options.command)
+    validateArgs(options.args)
+    this.options = options
+  }
+
+  async start(): Promise<void> {
+    const { command, args = [], env } = this.options
+
+    const cmd = Command.create(command, args, env ? { env } : undefined)
+
+    cmd.stdout.on('data', (chunk: string) => this.handleStdoutData(chunk))
+
+    cmd.stderr.on('data', (chunk: string) => {
+      this.onerror?.(new Error(`[stdio stderr] ${chunk}`))
+    })
+
+    cmd.on('close', () => {
+      this.child = null
+      this.onclose?.()
+    })
+
+    cmd.on('error', (message: string) => {
+      this.onerror?.(new Error(`[stdio process error] ${message}`))
+    })
+
+    this.child = await cmd.spawn()
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (!this.child) throw new Error('Transport not started')
+    await this.child.write(JSON.stringify(message) + '\n')
+  }
+
+  async close(): Promise<void> {
+    if (!this.child) return
+    const child = this.child
+    this.child = null
+    await child.kill()
+    this.onclose?.()
+  }
+
+  /** Buffers incoming stdout data, emitting complete JSON-RPC messages line by line. */
+  private handleStdoutData(chunk: string): void {
+    this.lineBuffer += chunk
+
+    const lines = this.lineBuffer.split('\n')
+
+    // All complete lines are all but the last element (which may be incomplete)
+    for (let i = 0; i < lines.length - 1; i++) {
+      const line = lines[i].trim()
+      if (!line) continue
+      this.parseAndEmitMessage(line)
+    }
+
+    this.lineBuffer = lines[lines.length - 1]
+  }
+
+  private parseAndEmitMessage(line: string): void {
+    try {
+      const message = JSON.parse(line) as JSONRPCMessage
+      this.onmessage?.(message)
+    } catch {
+      this.onerror?.(new Error(`Failed to parse JSON-RPC message from stdio: ${line}`))
+    }
+  }
+}
+
+/**
+ * Validates that a stdio command contains only safe characters.
+ * Rejects shell meta-characters to prevent injection.
+ */
+export const validateCommand = (command: string): void => {
+  if (!COMMAND_PATTERN.test(command)) {
+    throw new Error(
+      `Invalid MCP stdio command "${command}": only alphanumeric characters, dots, underscores, hyphens, and forward slashes are allowed`,
+    )
+  }
+}
+
+/**
+ * Validates that stdio args contain no null bytes, which could be used to
+ * truncate argument strings in certain environments.
+ */
+export const validateArgs = (args?: string[]): void => {
+  if (!args) return
+  for (const arg of args) {
+    if (arg.includes('\0')) {
+      throw new Error('MCP stdio arguments must not contain null bytes')
+    }
+  }
+}

--- a/src/lib/mcp-transports/tauri-stdio-transport.ts
+++ b/src/lib/mcp-transports/tauri-stdio-transport.ts
@@ -4,7 +4,7 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
 
 /** Regex for validating stdio command names — no shell meta-characters */
-const COMMAND_PATTERN = /^[a-zA-Z0-9._/-]+$/
+const commandPattern = /^[a-zA-Z0-9._/-]+$/
 
 /** Options for TauriStdioTransport */
 type TauriStdioTransportOptions = {
@@ -62,12 +62,12 @@ export class TauriStdioTransport implements Transport {
   }
 
   async send(message: JSONRPCMessage): Promise<void> {
-    if (!this.child) throw new Error('Transport not started')
+    if (!this.child) { throw new Error('Transport not started') }
     await this.child.write(JSON.stringify(message) + '\n')
   }
 
   async close(): Promise<void> {
-    if (!this.child) return
+    if (!this.child) { return }
     const child = this.child
     this.child = null
     await child.kill()
@@ -83,7 +83,7 @@ export class TauriStdioTransport implements Transport {
     // All complete lines are all but the last element (which may be incomplete)
     for (let i = 0; i < lines.length - 1; i++) {
       const line = lines[i].trim()
-      if (!line) continue
+      if (!line) { continue }
       this.parseAndEmitMessage(line)
     }
 
@@ -105,7 +105,7 @@ export class TauriStdioTransport implements Transport {
  * Rejects shell meta-characters to prevent injection.
  */
 export const validateCommand = (command: string): void => {
-  if (!COMMAND_PATTERN.test(command)) {
+  if (!commandPattern.test(command)) {
     throw new Error(
       `Invalid MCP stdio command "${command}": only alphanumeric characters, dots, underscores, hyphens, and forward slashes are allowed`,
     )
@@ -117,7 +117,7 @@ export const validateCommand = (command: string): void => {
  * truncate argument strings in certain environments.
  */
 export const validateArgs = (args?: string[]): void => {
-  if (!args) return
+  if (!args) { return }
   for (const arg of args) {
     if (arg.includes('\0')) {
       throw new Error('MCP stdio arguments must not contain null bytes')

--- a/src/lib/mcp-transports/tauri-stdio-transport.ts
+++ b/src/lib/mcp-transports/tauri-stdio-transport.ts
@@ -71,7 +71,6 @@ export class TauriStdioTransport implements Transport {
     const child = this.child
     this.child = null
     await child.kill()
-    this.onclose?.()
   }
 
   /** Buffers incoming stdout data, emitting complete JSON-RPC messages line by line. */

--- a/src/lib/mcp-transports/tauri-stdio-transport.ts
+++ b/src/lib/mcp-transports/tauri-stdio-transport.ts
@@ -2,9 +2,7 @@ import { Command } from '@tauri-apps/plugin-shell'
 import type { Child } from '@tauri-apps/plugin-shell'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
-
-/** Regex for validating stdio command names — no shell meta-characters */
-const commandPattern = /^[a-zA-Z0-9._/-]+$/
+import { validateStdioCommand, validateStdioArgs } from '@/lib/mcp-utils'
 
 /** Options for TauriStdioTransport */
 type TauriStdioTransportOptions = {
@@ -33,12 +31,15 @@ export class TauriStdioTransport implements Transport {
   private lineBuffer = ''
 
   constructor(options: TauriStdioTransportOptions) {
-    validateCommand(options.command)
-    validateArgs(options.args)
+    validateStdioCommand(options.command)
+    validateStdioArgs(options.args ?? [])
     this.options = options
   }
 
   async start(): Promise<void> {
+    if (this.child) {
+      return
+    }
     const { command, args = [], env } = this.options
 
     const cmd = Command.create(command, args, env ? { env } : undefined)
@@ -62,12 +63,12 @@ export class TauriStdioTransport implements Transport {
   }
 
   async send(message: JSONRPCMessage): Promise<void> {
-    if (!this.child) { throw new Error('Transport not started') }
+    if (!this.child) throw new Error('Transport not started')
     await this.child.write(JSON.stringify(message) + '\n')
   }
 
   async close(): Promise<void> {
-    if (!this.child) { return }
+    if (!this.child) return
     const child = this.child
     this.child = null
     await child.kill()
@@ -82,7 +83,7 @@ export class TauriStdioTransport implements Transport {
     // All complete lines are all but the last element (which may be incomplete)
     for (let i = 0; i < lines.length - 1; i++) {
       const line = lines[i].trim()
-      if (!line) { continue }
+      if (!line) continue
       this.parseAndEmitMessage(line)
     }
 
@@ -95,31 +96,6 @@ export class TauriStdioTransport implements Transport {
       this.onmessage?.(message)
     } catch {
       this.onerror?.(new Error(`Failed to parse JSON-RPC message from stdio: ${line}`))
-    }
-  }
-}
-
-/**
- * Validates that a stdio command contains only safe characters.
- * Rejects shell meta-characters to prevent injection.
- */
-export const validateCommand = (command: string): void => {
-  if (!commandPattern.test(command)) {
-    throw new Error(
-      `Invalid MCP stdio command "${command}": only alphanumeric characters, dots, underscores, hyphens, and forward slashes are allowed`,
-    )
-  }
-}
-
-/**
- * Validates that stdio args contain no null bytes, which could be used to
- * truncate argument strings in certain environments.
- */
-export const validateArgs = (args?: string[]): void => {
-  if (!args) { return }
-  for (const arg of args) {
-    if (arg.includes('\0')) {
-      throw new Error('MCP stdio arguments must not contain null bytes')
     }
   }
 }

--- a/src/lib/mcp-transports/transport-factory.test.ts
+++ b/src/lib/mcp-transports/transport-factory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock } from 'bun:test'
 import { createTransport } from './transport-factory'
-import { validateCommand, validateArgs, TauriStdioTransport } from './tauri-stdio-transport'
+import { TauriStdioTransport } from './tauri-stdio-transport'
+import { validateStdioCommand as validateCommand, validateStdioArgs as validateArgs } from '@/lib/mcp-utils'
 import type { McpServerConfig, CredentialStore, McpCredential } from '@/types/mcp'
 
 // Mock Tauri plugins so tests can run outside a Tauri runtime
@@ -127,7 +128,7 @@ describe('createTransport', () => {
   })
 
   it('throws for unknown transport type', async () => {
-    const config = makeConfig({ transport: { type: 'unknown' as 'http' } })
+    const config = makeConfig({ transport: { type: 'unknown' as 'http', url: 'https://example.com' } })
     await expect(createTransport(config, makeCredentialStore())).rejects.toThrow('Unknown MCP transport type')
   })
 })
@@ -162,8 +163,8 @@ describe('validateArgs', () => {
     expect(() => validateArgs(['--flag', 'value', '-x'])).not.toThrow()
   })
 
-  it('accepts undefined args', () => {
-    expect(() => validateArgs(undefined)).not.toThrow()
+  it('accepts empty args', () => {
+    expect(() => validateArgs([])).not.toThrow()
   })
 
   it('rejects args containing null bytes', () => {

--- a/src/lib/mcp-transports/transport-factory.test.ts
+++ b/src/lib/mcp-transports/transport-factory.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { createTransport } from './transport-factory'
+import { validateCommand, validateArgs, TauriStdioTransport } from './tauri-stdio-transport'
+import type { McpServerConfig, CredentialStore, McpCredential } from '@/types/mcp'
+
+// Mock Tauri plugins so tests can run outside a Tauri runtime
+mock.module('@tauri-apps/plugin-http', () => ({
+  fetch: mock(() => Promise.resolve(new Response())),
+}))
+
+mock.module('@tauri-apps/plugin-shell', () => ({
+  Command: {
+    create: mock(() => ({
+      stdout: { on: mock(() => {}) },
+      stderr: { on: mock(() => {}) },
+      on: mock(() => {}),
+      spawn: mock(() =>
+        Promise.resolve({ pid: 1234, write: mock(() => Promise.resolve()), kill: mock(() => Promise.resolve()) }),
+      ),
+    })),
+  },
+}))
+
+mock.module('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {
+    constructor(
+      public url: URL,
+      public opts: unknown,
+    ) {}
+    start() {
+      return Promise.resolve()
+    }
+    send() {
+      return Promise.resolve()
+    }
+    close() {
+      return Promise.resolve()
+    }
+  },
+}))
+
+mock.module('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: class {
+    constructor(
+      public url: URL,
+      public opts: unknown,
+    ) {}
+    start() {
+      return Promise.resolve()
+    }
+    send() {
+      return Promise.resolve()
+    }
+    close() {
+      return Promise.resolve()
+    }
+  },
+}))
+
+const makeConfig = (overrides: Partial<McpServerConfig> = {}): McpServerConfig => ({
+  id: 'server-1',
+  name: 'Test Server',
+  enabled: true,
+  transport: { type: 'http', url: 'https://example.com/mcp' },
+  auth: { authType: 'none' },
+  ...overrides,
+})
+
+const makeCredentialStore = (credential: McpCredential | null = null): CredentialStore => ({
+  save: mock(() => Promise.resolve()),
+  load: mock(() => Promise.resolve(credential)),
+  delete: mock(() => Promise.resolve()),
+})
+
+describe('createTransport', () => {
+  it('creates HTTP transport for http type', async () => {
+    const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js')
+    const result = await createTransport(
+      makeConfig({ transport: { type: 'http', url: 'https://example.com/mcp' } }),
+      makeCredentialStore(),
+    )
+    expect(result.transport).toBeInstanceOf(StreamableHTTPClientTransport)
+  })
+
+  it('creates SSE transport for sse type', async () => {
+    const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js')
+    const result = await createTransport(
+      makeConfig({ transport: { type: 'sse', url: 'https://example.com/sse' } }),
+      makeCredentialStore(),
+    )
+    expect(result.transport).toBeInstanceOf(SSEClientTransport)
+  })
+
+  it('creates stdio transport for stdio type', async () => {
+    const result = await createTransport(
+      makeConfig({ transport: { type: 'stdio', command: 'npx', args: ['some-server'] } }),
+      makeCredentialStore(),
+    )
+    expect(result.transport).toBeInstanceOf(TauriStdioTransport)
+  })
+
+  it('injects bearer token as Authorization header for HTTP transport', async () => {
+    const credential: McpCredential = { type: 'bearer', token: 'secret-token' }
+    const result = await createTransport(
+      makeConfig({
+        transport: { type: 'http', url: 'https://example.com/mcp' },
+        auth: { authType: 'bearer' },
+      }),
+      makeCredentialStore(credential),
+    )
+    // The transport is created; we verify the store was queried
+    expect(result.transport).toBeDefined()
+  })
+
+  it('injects bearer token as env var for stdio transport', async () => {
+    const credential: McpCredential = { type: 'bearer', token: 'my-api-key' }
+    const store = makeCredentialStore(credential)
+    const result = await createTransport(
+      makeConfig({
+        transport: { type: 'stdio', command: 'uvx', args: ['zendesk-mcp'] },
+        auth: { authType: 'bearer' },
+      }),
+      store,
+    )
+    expect(result.transport).toBeInstanceOf(TauriStdioTransport)
+    expect(store.load).toHaveBeenCalledWith('server-1')
+  })
+
+  it('throws for unknown transport type', async () => {
+    const config = makeConfig({ transport: { type: 'unknown' as 'http' } })
+    await expect(createTransport(config, makeCredentialStore())).rejects.toThrow('Unknown MCP transport type')
+  })
+})
+
+describe('validateCommand', () => {
+  it('accepts valid command names', () => {
+    expect(() => validateCommand('npx')).not.toThrow()
+    expect(() => validateCommand('uvx')).not.toThrow()
+    expect(() => validateCommand('node')).not.toThrow()
+    expect(() => validateCommand('python3')).not.toThrow()
+    expect(() => validateCommand('/usr/bin/node')).not.toThrow()
+    expect(() => validateCommand('bun')).not.toThrow()
+  })
+
+  it('rejects shell meta-characters', () => {
+    expect(() => validateCommand('node; rm -rf')).toThrow()
+    expect(() => validateCommand('node | cat')).toThrow()
+    expect(() => validateCommand('node && evil')).toThrow()
+    expect(() => validateCommand('$(whoami)')).toThrow()
+    expect(() => validateCommand('`id`')).toThrow()
+    expect(() => validateCommand('node > /dev/null')).toThrow()
+    expect(() => validateCommand('node < input')).toThrow()
+  })
+
+  it('rejects commands with spaces', () => {
+    expect(() => validateCommand('node server.js')).toThrow()
+  })
+})
+
+describe('validateArgs', () => {
+  it('accepts normal args', () => {
+    expect(() => validateArgs(['--flag', 'value', '-x'])).not.toThrow()
+  })
+
+  it('accepts undefined args', () => {
+    expect(() => validateArgs(undefined)).not.toThrow()
+  })
+
+  it('rejects args containing null bytes', () => {
+    expect(() => validateArgs(['valid', 'arg\0injection'])).toThrow('null bytes')
+  })
+})

--- a/src/lib/mcp-transports/transport-factory.ts
+++ b/src/lib/mcp-transports/transport-factory.ts
@@ -63,10 +63,10 @@ const buildRequestInit = async (
   authType: McpServerConfig['auth']['authType'],
   credentialStore: CredentialStore,
 ): Promise<RequestInit | undefined> => {
-  if (authType !== 'bearer') return undefined
+  if (authType !== 'bearer') { return undefined }
 
   const credential = await credentialStore.load(serverId)
-  if (!credential || credential.type !== 'bearer') return undefined
+  if (!credential || credential.type !== 'bearer') { return undefined }
 
   return {
     headers: { Authorization: `Bearer ${credential.token}` },
@@ -83,10 +83,10 @@ const buildStdioEnv = async (
   authType: McpServerConfig['auth']['authType'],
   credentialStore: CredentialStore,
 ): Promise<Record<string, string> | undefined> => {
-  if (authType !== 'bearer') return undefined
+  if (authType !== 'bearer') { return undefined }
 
   const credential = await credentialStore.load(serverId)
-  if (!credential || credential.type !== 'bearer') return undefined
+  if (!credential || credential.type !== 'bearer') { return undefined }
 
   return { MCP_BEARER_TOKEN: credential.token }
 }

--- a/src/lib/mcp-transports/transport-factory.ts
+++ b/src/lib/mcp-transports/transport-factory.ts
@@ -1,0 +1,92 @@
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import { isTauri } from '@/lib/platform'
+import type { McpServerConfig, McpTransportResult, CredentialStore } from '@/types/mcp'
+
+/**
+ * Creates the appropriate MCP transport based on server configuration.
+ *
+ * Platform-aware: uses Tauri native HTTP (CORS bypass) when available,
+ * falls back to browser fetch for web. stdio is desktop-only.
+ */
+export const createTransport = async (
+  config: McpServerConfig,
+  credentialStore: CredentialStore,
+): Promise<McpTransportResult> => {
+  const { transport, auth } = config
+
+  if (transport.type === 'http') {
+    const url = new URL(transport.url!)
+    const requestInit = await buildRequestInit(config.id, auth.authType, credentialStore)
+    const opts = requestInit ? { requestInit } : undefined
+
+    if (isTauri()) {
+      const { createTauriHttpTransport } = await import('./tauri-http-transport')
+      return { transport: createTauriHttpTransport(url, opts) }
+    }
+    return { transport: new StreamableHTTPClientTransport(url, opts) }
+  }
+
+  if (transport.type === 'sse') {
+    const url = new URL(transport.url!)
+    const requestInit = await buildRequestInit(config.id, auth.authType, credentialStore)
+    const opts = requestInit ? { requestInit } : undefined
+
+    if (isTauri()) {
+      const { createTauriSseTransport } = await import('./tauri-sse-transport')
+      return { transport: createTauriSseTransport(url, opts) }
+    }
+    return { transport: new SSEClientTransport(url, opts) }
+  }
+
+  if (transport.type === 'stdio') {
+    const { TauriStdioTransport } = await import('./tauri-stdio-transport')
+    const env = await buildStdioEnv(config.id, auth.authType, credentialStore)
+    return {
+      transport: new TauriStdioTransport({
+        command: transport.command!,
+        args: transport.args,
+        env,
+      }),
+    }
+  }
+
+  throw new Error(`Unknown MCP transport type: ${(transport as { type: string }).type}`)
+}
+
+/**
+ * Builds a RequestInit with Authorization header for bearer auth.
+ * Returns undefined for 'none' and 'oauth' (OAuth is handled via authProvider).
+ */
+const buildRequestInit = async (
+  serverId: string,
+  authType: McpServerConfig['auth']['authType'],
+  credentialStore: CredentialStore,
+): Promise<RequestInit | undefined> => {
+  if (authType !== 'bearer') return undefined
+
+  const credential = await credentialStore.load(serverId)
+  if (!credential || credential.type !== 'bearer') return undefined
+
+  return {
+    headers: { Authorization: `Bearer ${credential.token}` },
+  }
+}
+
+/**
+ * Builds an env var map for stdio processes. For bearer auth, the token is
+ * passed as MCP_BEARER_TOKEN per the MCP spec recommendation to use env vars
+ * for stdio credentials rather than CLI args.
+ */
+const buildStdioEnv = async (
+  serverId: string,
+  authType: McpServerConfig['auth']['authType'],
+  credentialStore: CredentialStore,
+): Promise<Record<string, string> | undefined> => {
+  if (authType !== 'bearer') return undefined
+
+  const credential = await credentialStore.load(serverId)
+  if (!credential || credential.type !== 'bearer') return undefined
+
+  return { MCP_BEARER_TOKEN: credential.token }
+}

--- a/src/lib/mcp-transports/transport-factory.ts
+++ b/src/lib/mcp-transports/transport-factory.ts
@@ -1,6 +1,7 @@
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { isTauri } from '@/lib/platform'
+import { isLocalMcpServer } from '@/lib/mcp-utils'
 import type { McpServerConfig, McpTransportResult, CredentialStore } from '@/types/mcp'
 
 /**
@@ -12,11 +13,12 @@ import type { McpServerConfig, McpTransportResult, CredentialStore } from '@/typ
 export const createTransport = async (
   config: McpServerConfig,
   credentialStore: CredentialStore,
+  options?: { cloudUrl?: string },
 ): Promise<McpTransportResult> => {
   const { transport, auth } = config
 
   if (transport.type === 'http') {
-    const url = new URL(transport.url!)
+    const url = new URL(transport.url)
     const requestInit = await buildRequestInit(config.id, auth.authType, credentialStore)
     const opts = requestInit ? { requestInit } : undefined
 
@@ -24,11 +26,19 @@ export const createTransport = async (
       const { createTauriHttpTransport } = await import('./tauri-http-transport')
       return { transport: createTauriHttpTransport(url, opts) }
     }
+
+    if (options?.cloudUrl && !isLocalMcpServer(transport.url)) {
+      const { createProxiedFetch } = await import('./proxied-fetch')
+      return {
+        transport: new StreamableHTTPClientTransport(url, { ...opts, fetch: createProxiedFetch(options.cloudUrl) }),
+      }
+    }
+
     return { transport: new StreamableHTTPClientTransport(url, opts) }
   }
 
   if (transport.type === 'sse') {
-    const url = new URL(transport.url!)
+    const url = new URL(transport.url)
     const requestInit = await buildRequestInit(config.id, auth.authType, credentialStore)
     const opts = requestInit ? { requestInit } : undefined
 
@@ -36,6 +46,12 @@ export const createTransport = async (
       const { createTauriSseTransport } = await import('./tauri-sse-transport')
       return { transport: createTauriSseTransport(url, opts) }
     }
+
+    if (options?.cloudUrl && !isLocalMcpServer(transport.url)) {
+      const { createProxiedFetch } = await import('./proxied-fetch')
+      return { transport: new SSEClientTransport(url, { ...opts, fetch: createProxiedFetch(options.cloudUrl) }) }
+    }
+
     return { transport: new SSEClientTransport(url, opts) }
   }
 
@@ -44,7 +60,7 @@ export const createTransport = async (
     const env = await buildStdioEnv(config.id, auth.authType, credentialStore)
     return {
       transport: new TauriStdioTransport({
-        command: transport.command!,
+        command: transport.command,
         args: transport.args,
         env,
       }),
@@ -63,10 +79,10 @@ const buildRequestInit = async (
   authType: McpServerConfig['auth']['authType'],
   credentialStore: CredentialStore,
 ): Promise<RequestInit | undefined> => {
-  if (authType !== 'bearer') { return undefined }
+  if (authType !== 'bearer') return undefined
 
   const credential = await credentialStore.load(serverId)
-  if (!credential || credential.type !== 'bearer') { return undefined }
+  if (!credential || credential.type !== 'bearer') return undefined
 
   return {
     headers: { Authorization: `Bearer ${credential.token}` },
@@ -83,10 +99,10 @@ const buildStdioEnv = async (
   authType: McpServerConfig['auth']['authType'],
   credentialStore: CredentialStore,
 ): Promise<Record<string, string> | undefined> => {
-  if (authType !== 'bearer') { return undefined }
+  if (authType !== 'bearer') return undefined
 
   const credential = await credentialStore.load(serverId)
-  if (!credential || credential.type !== 'bearer') { return undefined }
+  if (!credential || credential.type !== 'bearer') return undefined
 
   return { MCP_BEARER_TOKEN: credential.token }
 }


### PR DESCRIPTION
## Summary
All three MCP transport types with a platform-aware factory.

## Changes
- `tauri-http-transport.ts` — clean fetch injection via SDK option
- `tauri-sse-transport.ts` — SSE with Tauri CORS bypass
- `tauri-stdio-transport.ts` — stdio via `@tauri-apps/plugin-shell` with JSON-RPC line framing
- `transport-factory.ts` — platform-aware (dynamic imports for Tauri, browser fallback)
- `transport-factory.test.ts` — 12 tests

## Stack
- ✅ [1/6] Foundation
- 👉 **[2/6] Transport layer** (this PR)
- ⬜ [3/6] Auth layer
- ⬜ [4/6] Validation utils + form hook
- ⬜ [5/6] Settings UI
- ⬜ [6/6] Provider integration

Review diff against `italomenezes/thu-348-mcp-1-foundation`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new transport layer including desktop process spawning via Tauri shell and automatic bearer-token injection, which can affect security and connectivity paths. Risk is moderated by input validation and unit tests but still touches execution/auth handling.
> 
> **Overview**
> Adds a new MCP transport layer with a platform-aware `createTransport` factory that selects Streamable HTTP, SSE, or a new Tauri-based stdio transport, and dynamically switches to Tauri native HTTP to bypass CORS on desktop.
> 
> For web, introduces `createProxiedFetch` to route non-local MCP HTTP/SSE requests through a backend proxy endpoint (via `X-Mcp-Target-Url`). The factory also injects bearer credentials: HTTP/SSE via `Authorization` header and stdio via `MCP_BEARER_TOKEN` env var.
> 
> Includes a new Tauri stdio transport implementation using `@tauri-apps/plugin-shell` with newline-delimited JSON-RPC framing, an exports index for the transports, unit tests for the factory/validation behavior, and ignores `.team/` in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 868d2fd3ded132a863f48d8f35cca9c792ff7063. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->