### PR TITLE
THU-348: Get MCPs working (including authenticated options) [4/6]

### DIFF
--- a/src/hooks/use-mcp-server-form.test.ts
+++ b/src/hooks/use-mcp-server-form.test.ts
@@ -1,0 +1,135 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+import { useMcpServerFormState } from './use-mcp-server-form'
+
+describe('useMcpServerFormState', () => {
+  describe('SET_TRANSPORT_TYPE', () => {
+    it('resets url, command, args and connection state on transport change', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'http://example.com' })
+        result.current.dispatch({ type: 'SET_CONNECTION_STATUS', payload: 'success' })
+        result.current.dispatch({ type: 'SET_CONNECTION_ERROR', payload: 'some error' })
+      })
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'sse' })
+      })
+      expect(result.current.state.url).toBe('')
+      expect(result.current.state.command).toBe('')
+      expect(result.current.state.args).toEqual([])
+      expect(result.current.state.connectionStatus).toBe('idle')
+      expect(result.current.state.connectionError).toBeNull()
+    })
+  })
+
+  describe('SET_AUTH_TYPE', () => {
+    it('clears bearer token when auth type changes', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_AUTH_TYPE', payload: 'bearer' })
+        result.current.dispatch({ type: 'SET_BEARER_TOKEN', payload: 'secret-token' })
+      })
+      act(() => {
+        result.current.dispatch({ type: 'SET_AUTH_TYPE', payload: 'none' })
+      })
+      expect(result.current.state.bearerToken).toBe('')
+    })
+  })
+
+  describe('RESET', () => {
+    it('resets all state to initial values', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx' })
+        result.current.dispatch({ type: 'SET_AUTH_TYPE', payload: 'bearer' })
+        result.current.dispatch({ type: 'SET_BEARER_TOKEN', payload: 'secret' })
+        result.current.dispatch({ type: 'SET_CONNECTION_STATUS', payload: 'success' })
+      })
+      act(() => {
+        result.current.dispatch({ type: 'RESET' })
+      })
+      expect(result.current.state.transportType).toBe('http')
+      expect(result.current.state.command).toBe('')
+      expect(result.current.state.authType).toBe('none')
+      expect(result.current.state.bearerToken).toBe('')
+      expect(result.current.state.connectionStatus).toBe('idle')
+    })
+  })
+
+  describe('isValid', () => {
+    it('returns false when http transport has empty url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns true when http transport has valid url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'http://localhost:8000/mcp/' })
+      })
+      expect(result.current.isValid()).toBe(true)
+    })
+
+    it('returns false when http transport has invalid url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'not-a-url' })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns false when http transport has javascript: url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_URL', payload: 'javascript:alert(1)' })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns true when sse transport has valid url', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'sse' })
+        result.current.dispatch({ type: 'SET_URL', payload: 'https://example.com/sse' })
+      })
+      expect(result.current.isValid()).toBe(true)
+    })
+
+    it('returns false when stdio transport has empty command', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns true when stdio transport has valid command', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx' })
+      })
+      expect(result.current.isValid()).toBe(true)
+    })
+
+    it('returns false when stdio transport has invalid command', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx; rm -rf /' })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+
+    it('returns false when stdio args contain null byte', () => {
+      const { result } = renderHook(() => useMcpServerFormState())
+      act(() => {
+        result.current.dispatch({ type: 'SET_TRANSPORT_TYPE', payload: 'stdio' })
+        result.current.dispatch({ type: 'SET_COMMAND', payload: 'npx' })
+        result.current.dispatch({ type: 'SET_ARGS', payload: ['arg\0'] })
+      })
+      expect(result.current.isValid()).toBe(false)
+    })
+  })
+})

--- a/src/hooks/use-mcp-server-form.ts
+++ b/src/hooks/use-mcp-server-form.ts
@@ -30,9 +30,15 @@ const formReducer = (state: McpServerFormState, action: McpServerFormAction): Mc
     case 'SET_URL':
       return { ...state, url: action.payload, connectionStatus: 'idle', connectionError: null, serverCapabilities: [] }
     case 'SET_COMMAND':
-      return { ...state, command: action.payload }
+      return {
+        ...state,
+        command: action.payload,
+        connectionStatus: 'idle',
+        connectionError: null,
+        serverCapabilities: [],
+      }
     case 'SET_ARGS':
-      return { ...state, args: action.payload }
+      return { ...state, args: action.payload, connectionStatus: 'idle', connectionError: null, serverCapabilities: [] }
     case 'SET_AUTH_TYPE':
       return {
         ...state,
@@ -72,7 +78,7 @@ export const useMcpServerFormState = () => {
     } catch {
       return false
     }
-  }, [state])
+  }, [state.transportType, state.command, state.args, state.url])
 
   return { state, dispatch, isValid }
 }

--- a/src/hooks/use-mcp-server-form.ts
+++ b/src/hooks/use-mcp-server-form.ts
@@ -1,0 +1,70 @@
+import { useCallback, useReducer } from 'react'
+import type { McpServerFormAction, McpServerFormState } from '@/types/mcp'
+import { validateMcpUrl, validateStdioArgs, validateStdioCommand } from '@/lib/mcp-utils'
+
+const initialFormState: McpServerFormState = {
+  transportType: 'http',
+  url: '',
+  command: '',
+  args: [],
+  authType: 'none',
+  bearerToken: '',
+  connectionStatus: 'idle',
+  connectionError: null,
+  serverCapabilities: [],
+}
+
+const formReducer = (state: McpServerFormState, action: McpServerFormAction): McpServerFormState => {
+  switch (action.type) {
+    case 'SET_TRANSPORT_TYPE':
+      return {
+        ...state,
+        transportType: action.payload,
+        url: '',
+        command: '',
+        args: [],
+        connectionStatus: 'idle',
+        connectionError: null,
+      }
+    case 'SET_URL':
+      return { ...state, url: action.payload }
+    case 'SET_COMMAND':
+      return { ...state, command: action.payload }
+    case 'SET_ARGS':
+      return { ...state, args: action.payload }
+    case 'SET_AUTH_TYPE':
+      return { ...state, authType: action.payload, bearerToken: '' }
+    case 'SET_BEARER_TOKEN':
+      return { ...state, bearerToken: action.payload }
+    case 'SET_CONNECTION_STATUS':
+      return { ...state, connectionStatus: action.payload }
+    case 'SET_CONNECTION_ERROR':
+      return { ...state, connectionError: action.payload }
+    case 'SET_CAPABILITIES':
+      return { ...state, serverCapabilities: action.payload }
+    case 'RESET':
+      return initialFormState
+    default:
+      return state
+  }
+}
+
+export const useMcpServerFormState = () => {
+  const [state, dispatch] = useReducer(formReducer, initialFormState)
+
+  const isValid = useCallback(() => {
+    try {
+      if (state.transportType === 'stdio') {
+        validateStdioCommand(state.command)
+        validateStdioArgs(state.args)
+        return true
+      }
+      validateMcpUrl(state.url)
+      return true
+    } catch {
+      return false
+    }
+  }, [state])
+
+  return { state, dispatch, isValid }
+}

--- a/src/hooks/use-mcp-server-form.ts
+++ b/src/hooks/use-mcp-server-form.ts
@@ -28,13 +28,20 @@ const formReducer = (state: McpServerFormState, action: McpServerFormAction): Mc
         serverCapabilities: [],
       }
     case 'SET_URL':
-      return { ...state, url: action.payload }
+      return { ...state, url: action.payload, connectionStatus: 'idle', connectionError: null, serverCapabilities: [] }
     case 'SET_COMMAND':
       return { ...state, command: action.payload }
     case 'SET_ARGS':
       return { ...state, args: action.payload }
     case 'SET_AUTH_TYPE':
-      return { ...state, authType: action.payload, bearerToken: '' }
+      return {
+        ...state,
+        authType: action.payload,
+        bearerToken: '',
+        connectionStatus: 'idle',
+        connectionError: null,
+        serverCapabilities: [],
+      }
     case 'SET_BEARER_TOKEN':
       return { ...state, bearerToken: action.payload }
     case 'SET_CONNECTION_STATUS':

--- a/src/hooks/use-mcp-server-form.ts
+++ b/src/hooks/use-mcp-server-form.ts
@@ -25,6 +25,7 @@ const formReducer = (state: McpServerFormState, action: McpServerFormAction): Mc
         args: [],
         connectionStatus: 'idle',
         connectionError: null,
+        serverCapabilities: [],
       }
     case 'SET_URL':
       return { ...state, url: action.payload }

--- a/src/lib/mcp-auth/credential-store.ts
+++ b/src/lib/mcp-auth/credential-store.ts
@@ -4,10 +4,10 @@ import { mcpServersTable } from '@/db/tables'
 import type { CredentialStore, McpCredential } from '@/types/mcp'
 
 /** Application-specific salt prefix mixed with the device hostname */
-const APP_SALT_PREFIX = 'thunderbolt-mcp-v1:'
+const appSaltPrefix = 'thunderbolt-mcp-v1:'
 
 /** PBKDF2 iteration count — must be >= 100,000 per security requirements */
-const PBKDF2_ITERATIONS = 100_000
+const pbkdf2Iterations = 100_000
 
 /** Encrypts a credential using AES-GCM with a derived key */
 type EncryptedBlob = {
@@ -23,7 +23,7 @@ const deriveKey = async (hostname: string): Promise<CryptoKey> => {
   const encoder = new TextEncoder()
   const keyMaterial = await crypto.subtle.importKey(
     'raw',
-    encoder.encode(APP_SALT_PREFIX + hostname),
+    encoder.encode(appSaltPrefix + hostname),
     'PBKDF2',
     false,
     ['deriveKey'],
@@ -33,7 +33,7 @@ const deriveKey = async (hostname: string): Promise<CryptoKey> => {
     {
       name: 'PBKDF2',
       salt: encoder.encode('thunderbolt-mcp-credential-salt'),
-      iterations: PBKDF2_ITERATIONS,
+      iterations: pbkdf2Iterations,
       hash: 'SHA-256',
     },
     keyMaterial,
@@ -104,7 +104,7 @@ const getEncryptionKey = (): Promise<CryptoKey> => {
  * Creates an encrypted credential store that persists credentials
  * in the `mcp_servers.encrypted_credential` column using AES-GCM encryption.
  *
- * Key derivation: PBKDF2(APP_SALT_PREFIX + hostname) -> 256-bit AES-GCM key.
+ * Key derivation: PBKDF2(appSaltPrefix + hostname) -> 256-bit AES-GCM key.
  * Storage format: `{ iv: base64, ciphertext: base64 }` serialized as JSON.
  *
  * Credentials are never stored in plaintext — only the encrypted blob reaches SQLite.
@@ -123,7 +123,7 @@ const createCredentialStore = (db: AnyDrizzleDatabase): CredentialStore => {
       .where(eq(mcpServersTable.id, serverId))
 
     const row = rows[0]
-    if (!row?.encryptedCredential) return null
+    if (!row?.encryptedCredential) { return null }
 
     const key = await getEncryptionKey()
     const plaintext = await decrypt(key, row.encryptedCredential)

--- a/src/lib/mcp-auth/oauth-client-provider.ts
+++ b/src/lib/mcp-auth/oauth-client-provider.ts
@@ -13,7 +13,7 @@ import type { CredentialStore } from '@/types/mcp'
  * Static client ID for Thunderbolt published as a Client ID Metadata Document (CIMD).
  * Authorization servers that support CIMD will fetch this to verify the client.
  */
-const THUNDERBOLT_CLIENT_ID = 'https://thunderbolt.io/.well-known/oauth-client/thunderbolt'
+const thunderboltClientId = 'https://thunderbolt.io/.well-known/oauth-client/thunderbolt'
 
 /**
  * OAuth 2.1 client provider for MCP servers.
@@ -51,9 +51,9 @@ class McpOAuthClientProvider implements OAuthClientProvider {
   }
 
   clientInformation(): OAuthClientInformation | undefined {
-    if (this.clientInfo) return this.clientInfo
+    if (this.clientInfo) { return this.clientInfo }
     // Return static client ID for CIMD-based registration
-    return { client_id: THUNDERBOLT_CLIENT_ID }
+    return { client_id: thunderboltClientId }
   }
 
   async saveClientInformation(clientInformation: OAuthClientInformationFull): Promise<void> {
@@ -62,7 +62,7 @@ class McpOAuthClientProvider implements OAuthClientProvider {
 
   async tokens(): Promise<OAuthTokens | undefined> {
     const cred = await this.credentialStore.load(this.serverId)
-    if (!cred || cred.type !== 'oauth') return undefined
+    if (!cred || cred.type !== 'oauth') { return undefined }
 
     return {
       access_token: cred.accessToken,
@@ -92,7 +92,7 @@ class McpOAuthClientProvider implements OAuthClientProvider {
   }
 
   async codeVerifier(): Promise<string> {
-    if (!this.codeVerifierValue) throw new Error('codeVerifier called before saveCodeVerifier')
+    if (!this.codeVerifierValue) { throw new Error('codeVerifier called before saveCodeVerifier') }
     return this.codeVerifierValue
   }
 

--- a/src/lib/mcp-transports/tauri-stdio-transport.ts
+++ b/src/lib/mcp-transports/tauri-stdio-transport.ts
@@ -4,7 +4,7 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
 
 /** Regex for validating stdio command names — no shell meta-characters */
-const COMMAND_PATTERN = /^[a-zA-Z0-9._/-]+$/
+const commandPattern = /^[a-zA-Z0-9._/-]+$/
 
 /** Options for TauriStdioTransport */
 type TauriStdioTransportOptions = {
@@ -62,12 +62,12 @@ export class TauriStdioTransport implements Transport {
   }
 
   async send(message: JSONRPCMessage): Promise<void> {
-    if (!this.child) throw new Error('Transport not started')
+    if (!this.child) { throw new Error('Transport not started') }
     await this.child.write(JSON.stringify(message) + '\n')
   }
 
   async close(): Promise<void> {
-    if (!this.child) return
+    if (!this.child) { return }
     const child = this.child
     this.child = null
     await child.kill()
@@ -83,7 +83,7 @@ export class TauriStdioTransport implements Transport {
     // All complete lines are all but the last element (which may be incomplete)
     for (let i = 0; i < lines.length - 1; i++) {
       const line = lines[i].trim()
-      if (!line) continue
+      if (!line) { continue }
       this.parseAndEmitMessage(line)
     }
 
@@ -105,7 +105,7 @@ export class TauriStdioTransport implements Transport {
  * Rejects shell meta-characters to prevent injection.
  */
 export const validateCommand = (command: string): void => {
-  if (!COMMAND_PATTERN.test(command)) {
+  if (!commandPattern.test(command)) {
     throw new Error(
       `Invalid MCP stdio command "${command}": only alphanumeric characters, dots, underscores, hyphens, and forward slashes are allowed`,
     )
@@ -117,7 +117,7 @@ export const validateCommand = (command: string): void => {
  * truncate argument strings in certain environments.
  */
 export const validateArgs = (args?: string[]): void => {
-  if (!args) return
+  if (!args) { return }
   for (const arg of args) {
     if (arg.includes('\0')) {
       throw new Error('MCP stdio arguments must not contain null bytes')

--- a/src/lib/mcp-transports/transport-factory.ts
+++ b/src/lib/mcp-transports/transport-factory.ts
@@ -63,10 +63,10 @@ const buildRequestInit = async (
   authType: McpServerConfig['auth']['authType'],
   credentialStore: CredentialStore,
 ): Promise<RequestInit | undefined> => {
-  if (authType !== 'bearer') return undefined
+  if (authType !== 'bearer') { return undefined }
 
   const credential = await credentialStore.load(serverId)
-  if (!credential || credential.type !== 'bearer') return undefined
+  if (!credential || credential.type !== 'bearer') { return undefined }
 
   return {
     headers: { Authorization: `Bearer ${credential.token}` },
@@ -83,10 +83,10 @@ const buildStdioEnv = async (
   authType: McpServerConfig['auth']['authType'],
   credentialStore: CredentialStore,
 ): Promise<Record<string, string> | undefined> => {
-  if (authType !== 'bearer') return undefined
+  if (authType !== 'bearer') { return undefined }
 
   const credential = await credentialStore.load(serverId)
-  if (!credential || credential.type !== 'bearer') return undefined
+  if (!credential || credential.type !== 'bearer') { return undefined }
 
   return { MCP_BEARER_TOKEN: credential.token }
 }

--- a/src/lib/mcp-utils.test.ts
+++ b/src/lib/mcp-utils.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test'
+import { validateMcpUrl, validateStdioArgs, validateStdioCommand } from './mcp-utils'
+
+describe('validateMcpUrl', () => {
+  it('accepts http URLs', () => {
+    const result = validateMcpUrl('http://localhost:8000/mcp/')
+    expect(result.hostname).toBe('localhost')
+  })
+
+  it('accepts https URLs', () => {
+    const result = validateMcpUrl('https://api.example.com/mcp')
+    expect(result.hostname).toBe('api.example.com')
+  })
+
+  it('returns a URL object', () => {
+    const result = validateMcpUrl('http://localhost:8000/mcp/')
+    expect(result).toBeInstanceOf(URL)
+  })
+
+  it('throws on invalid URL string', () => {
+    expect(() => validateMcpUrl('not a url')).toThrow()
+  })
+
+  it('throws on ftp protocol', () => {
+    expect(() => validateMcpUrl('ftp://example.com/mcp')).toThrow('URL must use http: or https: protocol')
+  })
+
+  it('throws on javascript: protocol', () => {
+    expect(() => validateMcpUrl('javascript:alert(1)')).toThrow('URL must use http: or https: protocol')
+  })
+
+  it('throws on data: protocol', () => {
+    expect(() => validateMcpUrl('data:text/html,<h1>hello</h1>')).toThrow('URL must use http: or https: protocol')
+  })
+
+  it('throws on empty string', () => {
+    expect(() => validateMcpUrl('')).toThrow()
+  })
+})
+
+describe('validateStdioCommand', () => {
+  it('accepts simple binary names', () => {
+    expect(() => validateStdioCommand('npx')).not.toThrow()
+    expect(() => validateStdioCommand('uvx')).not.toThrow()
+    expect(() => validateStdioCommand('node')).not.toThrow()
+    expect(() => validateStdioCommand('python3')).not.toThrow()
+    expect(() => validateStdioCommand('bun')).not.toThrow()
+  })
+
+  it('accepts paths with slashes', () => {
+    expect(() => validateStdioCommand('/usr/local/bin/mcp-server')).not.toThrow()
+    expect(() => validateStdioCommand('./bin/server')).not.toThrow()
+  })
+
+  it('accepts names with dots and hyphens', () => {
+    expect(() => validateStdioCommand('mcp-server.sh')).not.toThrow()
+  })
+
+  it('throws on empty command', () => {
+    expect(() => validateStdioCommand('')).toThrow('Command is required')
+  })
+
+  it('throws on whitespace-only command', () => {
+    expect(() => validateStdioCommand('   ')).toThrow('Command is required')
+  })
+
+  it('throws on command with semicolon', () => {
+    expect(() => validateStdioCommand('npx; rm -rf /')).toThrow('Command contains invalid characters')
+  })
+
+  it('throws on command with pipe', () => {
+    expect(() => validateStdioCommand('npx | cat')).toThrow('Command contains invalid characters')
+  })
+
+  it('throws on command with dollar sign', () => {
+    expect(() => validateStdioCommand('$PATH')).toThrow('Command contains invalid characters')
+  })
+
+  it('throws on command with backtick', () => {
+    expect(() => validateStdioCommand('`whoami`')).toThrow('Command contains invalid characters')
+  })
+
+  it('throws on command with spaces', () => {
+    expect(() => validateStdioCommand('node server')).toThrow('Command contains invalid characters')
+  })
+})
+
+describe('validateStdioArgs', () => {
+  it('accepts normal args', () => {
+    expect(() => validateStdioArgs(['--port', '8080', '--verbose'])).not.toThrow()
+  })
+
+  it('accepts args with special characters (non-null)', () => {
+    expect(() => validateStdioArgs(['--key=value', '-x', 'some/path'])).not.toThrow()
+  })
+
+  it('accepts empty array', () => {
+    expect(() => validateStdioArgs([])).not.toThrow()
+  })
+
+  it('throws when any arg contains null byte', () => {
+    expect(() => validateStdioArgs(['--port', 'val\0ue'])).toThrow('Arguments must not contain null bytes')
+  })
+
+  it('throws on null byte at start of arg', () => {
+    expect(() => validateStdioArgs(['\0malicious'])).toThrow('Arguments must not contain null bytes')
+  })
+
+  it('throws on null byte at end of arg', () => {
+    expect(() => validateStdioArgs(['arg\0'])).toThrow('Arguments must not contain null bytes')
+  })
+})

--- a/src/lib/mcp-utils.test.ts
+++ b/src/lib/mcp-utils.test.ts
@@ -2,86 +2,41 @@ import { describe, expect, it } from 'bun:test'
 import { validateMcpUrl, validateStdioArgs, validateStdioCommand } from './mcp-utils'
 
 describe('validateMcpUrl', () => {
-  it('accepts http URLs', () => {
-    const result = validateMcpUrl('http://localhost:8000/mcp/')
-    expect(result.hostname).toBe('localhost')
-  })
-
-  it('accepts https URLs', () => {
-    const result = validateMcpUrl('https://api.example.com/mcp')
-    expect(result.hostname).toBe('api.example.com')
-  })
-
-  it('returns a URL object', () => {
-    const result = validateMcpUrl('http://localhost:8000/mcp/')
-    expect(result).toBeInstanceOf(URL)
+  it('accepts valid http/https URLs', () => {
+    expect(validateMcpUrl('http://localhost:8000/mcp/')).toBeInstanceOf(URL)
+    expect(validateMcpUrl('https://api.example.com/mcp').hostname).toBe('api.example.com')
   })
 
   it('throws on invalid URL string', () => {
     expect(() => validateMcpUrl('not a url')).toThrow()
   })
 
-  it('throws on ftp protocol', () => {
+  it('throws on non-http protocols', () => {
     expect(() => validateMcpUrl('ftp://example.com/mcp')).toThrow('URL must use http: or https: protocol')
   })
 
   it('throws on javascript: protocol', () => {
     expect(() => validateMcpUrl('javascript:alert(1)')).toThrow('URL must use http: or https: protocol')
   })
-
-  it('throws on data: protocol', () => {
-    expect(() => validateMcpUrl('data:text/html,<h1>hello</h1>')).toThrow('URL must use http: or https: protocol')
-  })
-
-  it('throws on empty string', () => {
-    expect(() => validateMcpUrl('')).toThrow()
-  })
 })
 
 describe('validateStdioCommand', () => {
-  it('accepts simple binary names', () => {
+  it('accepts valid command names', () => {
     expect(() => validateStdioCommand('npx')).not.toThrow()
-    expect(() => validateStdioCommand('uvx')).not.toThrow()
-    expect(() => validateStdioCommand('node')).not.toThrow()
-    expect(() => validateStdioCommand('python3')).not.toThrow()
-    expect(() => validateStdioCommand('bun')).not.toThrow()
-  })
-
-  it('accepts paths with slashes', () => {
     expect(() => validateStdioCommand('/usr/local/bin/mcp-server')).not.toThrow()
-    expect(() => validateStdioCommand('./bin/server')).not.toThrow()
-  })
-
-  it('accepts names with dots and hyphens', () => {
     expect(() => validateStdioCommand('mcp-server.sh')).not.toThrow()
   })
 
   it('throws on empty command', () => {
     expect(() => validateStdioCommand('')).toThrow('Command is required')
-  })
-
-  it('throws on whitespace-only command', () => {
     expect(() => validateStdioCommand('   ')).toThrow('Command is required')
   })
 
-  it('throws on command with semicolon', () => {
+  it('rejects shell meta-characters', () => {
     expect(() => validateStdioCommand('npx; rm -rf /')).toThrow('Command contains invalid characters')
-  })
-
-  it('throws on command with pipe', () => {
     expect(() => validateStdioCommand('npx | cat')).toThrow('Command contains invalid characters')
-  })
-
-  it('throws on command with dollar sign', () => {
-    expect(() => validateStdioCommand('$PATH')).toThrow('Command contains invalid characters')
-  })
-
-  it('throws on command with backtick', () => {
-    expect(() => validateStdioCommand('`whoami`')).toThrow('Command contains invalid characters')
-  })
-
-  it('throws on command with spaces', () => {
-    expect(() => validateStdioCommand('node server')).toThrow('Command contains invalid characters')
+    expect(() => validateStdioCommand('$(whoami)')).toThrow('Command contains invalid characters')
+    expect(() => validateStdioCommand('`id`')).toThrow('Command contains invalid characters')
   })
 })
 
@@ -90,23 +45,7 @@ describe('validateStdioArgs', () => {
     expect(() => validateStdioArgs(['--port', '8080', '--verbose'])).not.toThrow()
   })
 
-  it('accepts args with special characters (non-null)', () => {
-    expect(() => validateStdioArgs(['--key=value', '-x', 'some/path'])).not.toThrow()
-  })
-
-  it('accepts empty array', () => {
-    expect(() => validateStdioArgs([])).not.toThrow()
-  })
-
   it('throws when any arg contains null byte', () => {
     expect(() => validateStdioArgs(['--port', 'val\0ue'])).toThrow('Arguments must not contain null bytes')
-  })
-
-  it('throws on null byte at start of arg', () => {
-    expect(() => validateStdioArgs(['\0malicious'])).toThrow('Arguments must not contain null bytes')
-  })
-
-  it('throws on null byte at end of arg', () => {
-    expect(() => validateStdioArgs(['arg\0'])).toThrow('Arguments must not contain null bytes')
   })
 })

--- a/src/lib/mcp-utils.ts
+++ b/src/lib/mcp-utils.ts
@@ -4,7 +4,7 @@ import type { McpTransportType } from '@/types/mcp'
 type PlatformCategory = 'desktop' | 'mobile' | 'web'
 
 /** Transport types supported on each platform */
-const PLATFORM_TRANSPORTS: Record<PlatformCategory, McpTransportType[]> = {
+const platformTransports: Record<PlatformCategory, McpTransportType[]> = {
   desktop: ['http', 'sse', 'stdio'],
   mobile: ['http', 'sse'],
   web: ['http', 'sse'],
@@ -12,13 +12,13 @@ const PLATFORM_TRANSPORTS: Record<PlatformCategory, McpTransportType[]> = {
 
 /** Returns the platform category for transport filtering */
 const getPlatformCategory = (): PlatformCategory => {
-  if (isDesktop()) return 'desktop'
-  if (isMobile()) return 'mobile'
+  if (isDesktop()) { return 'desktop' }
+  if (isMobile()) { return 'mobile' }
   return 'web'
 }
 
 /** Returns the transport types available on the current platform */
-export const getSupportedTransports = (): McpTransportType[] => PLATFORM_TRANSPORTS[getPlatformCategory()]
+export const getSupportedTransports = (): McpTransportType[] => platformTransports[getPlatformCategory()]
 
 /** Checks if a transport type is supported on the current platform */
 export const isSupportedTransport = (type: McpTransportType): boolean => getSupportedTransports().includes(type)
@@ -43,7 +43,7 @@ export const validateMcpUrl = (url: string): URL => {
  * Rejects shell meta-characters.
  */
 export const validateStdioCommand = (command: string): void => {
-  if (!command.trim()) throw new Error('Command is required')
+  if (!command.trim()) { throw new Error('Command is required') }
   if (!/^[a-zA-Z0-9._/-]+$/.test(command)) {
     throw new Error('Command contains invalid characters')
   }

--- a/src/lib/mcp-utils.ts
+++ b/src/lib/mcp-utils.ts
@@ -1,0 +1,62 @@
+import { isDesktop, isMobile, isTauri } from '@/lib/platform'
+import type { McpTransportType } from '@/types/mcp'
+
+type PlatformCategory = 'desktop' | 'mobile' | 'web'
+
+/** Transport types supported on each platform */
+const PLATFORM_TRANSPORTS: Record<PlatformCategory, McpTransportType[]> = {
+  desktop: ['http', 'sse', 'stdio'],
+  mobile: ['http', 'sse'],
+  web: ['http', 'sse'],
+}
+
+/** Returns the platform category for transport filtering */
+const getPlatformCategory = (): PlatformCategory => {
+  if (isDesktop()) return 'desktop'
+  if (isMobile()) return 'mobile'
+  return 'web'
+}
+
+/** Returns the transport types available on the current platform */
+export const getSupportedTransports = (): McpTransportType[] => PLATFORM_TRANSPORTS[getPlatformCategory()]
+
+/** Checks if a transport type is supported on the current platform */
+export const isSupportedTransport = (type: McpTransportType): boolean => getSupportedTransports().includes(type)
+
+/** Returns true when the current platform may encounter CORS issues with remote MCP servers */
+export const isCorsRestricted = (): boolean => !isTauri()
+
+/**
+ * Validates an MCP server URL for HTTP/SSE transport.
+ * Throws with a descriptive message on invalid input.
+ */
+export const validateMcpUrl = (url: string): URL => {
+  const parsed = new URL(url)
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('URL must use http: or https: protocol')
+  }
+  return parsed
+}
+
+/**
+ * Validates a stdio command against the allowlist pattern.
+ * Rejects shell meta-characters.
+ */
+export const validateStdioCommand = (command: string): void => {
+  if (!command.trim()) throw new Error('Command is required')
+  if (!/^[a-zA-Z0-9._/-]+$/.test(command)) {
+    throw new Error('Command contains invalid characters')
+  }
+}
+
+/**
+ * Validates stdio args array for injection safety.
+ * Rejects args containing null bytes.
+ */
+export const validateStdioArgs = (args: string[]): void => {
+  for (const arg of args) {
+    if (arg.includes('\0')) {
+      throw new Error('Arguments must not contain null bytes')
+    }
+  }
+}

--- a/src/lib/mcp-utils.ts
+++ b/src/lib/mcp-utils.ts
@@ -4,7 +4,7 @@ import type { McpTransportType } from '@/types/mcp'
 type PlatformCategory = 'desktop' | 'mobile' | 'web'
 
 /** Transport types supported on each platform */
-const platformTransports: Record<PlatformCategory, McpTransportType[]> = {
+const PLATFORM_TRANSPORTS: Record<PlatformCategory, McpTransportType[]> = {
   desktop: ['http', 'sse', 'stdio'],
   mobile: ['http', 'sse'],
   web: ['http', 'sse'],
@@ -12,13 +12,13 @@ const platformTransports: Record<PlatformCategory, McpTransportType[]> = {
 
 /** Returns the platform category for transport filtering */
 const getPlatformCategory = (): PlatformCategory => {
-  if (isDesktop()) { return 'desktop' }
-  if (isMobile()) { return 'mobile' }
+  if (isDesktop()) return 'desktop'
+  if (isMobile()) return 'mobile'
   return 'web'
 }
 
 /** Returns the transport types available on the current platform */
-export const getSupportedTransports = (): McpTransportType[] => platformTransports[getPlatformCategory()]
+export const getSupportedTransports = (): McpTransportType[] => PLATFORM_TRANSPORTS[getPlatformCategory()]
 
 /** Checks if a transport type is supported on the current platform */
 export const isSupportedTransport = (type: McpTransportType): boolean => getSupportedTransports().includes(type)
@@ -43,7 +43,7 @@ export const validateMcpUrl = (url: string): URL => {
  * Rejects shell meta-characters.
  */
 export const validateStdioCommand = (command: string): void => {
-  if (!command.trim()) { throw new Error('Command is required') }
+  if (!command.trim()) throw new Error('Command is required')
   if (!/^[a-zA-Z0-9._/-]+$/.test(command)) {
     throw new Error('Command contains invalid characters')
   }
@@ -58,5 +58,15 @@ export const validateStdioArgs = (args: string[]): void => {
     if (arg.includes('\0')) {
       throw new Error('Arguments must not contain null bytes')
     }
+  }
+}
+
+/** Returns true when an MCP server URL targets localhost/loopback (no CORS proxy needed) */
+export const isLocalMcpServer = (url: string): boolean => {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase()
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '0.0.0.0'
+  } catch {
+    return false
   }
 }


### PR DESCRIPTION
## Summary
URL/command validation, platform-aware transport filtering, and useReducer form state hook.

## Changes
- `mcp-utils.ts` — `validateMcpUrl`, `validateStdioCommand`, `validateStdioArgs`, `getSupportedTransports`, `isCorsRestricted`
- `mcp-utils.test.ts` — 24 tests
- `use-mcp-server-form.ts` — useReducer form hook (replaces 9 useState calls)
- `use-mcp-server-form.test.ts` — 12 tests

## Stack
- ✅ [1/6] Foundation
- ✅ [2/6] Transport layer
- ✅ [3/6] Auth layer
- 👉 **[4/6] Validation utils + form hook** (this PR)
- ⬜ [5/6] Settings UI
- ⬜ [6/6] Provider integration

Review diff against `italomenezes/thu-348-mcp-3-auth`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces new validation and platform-dependent transport filtering that can block previously-accepted inputs, plus minor edits in auth/transport code paths (mostly refactors/guard formatting).
> 
> **Overview**
> Adds `mcp-utils` helpers for **platform-aware transport availability** (`getSupportedTransports`, `isSupportedTransport`, `isCorsRestricted`) plus **input validation** for MCP server configuration (`validateMcpUrl` restricted to http/https, `validateStdioCommand` allowlist pattern, `validateStdioArgs` null-byte rejection, and `isLocalMcpServer`).
> 
> Introduces a new `useMcpServerFormState` hook built on `useReducer`, including an `isValid()` helper that validates either URL (HTTP/SSE) or command/args (stdio), and resets connection/capabilities state when transport/auth inputs change. Adds unit tests covering the new utils and reducer behavior.
> 
> Includes small refactors/guard-style tweaks in MCP auth (`credential-store`, `oauth-client-provider`) and transport modules (`tauri-stdio-transport`, `transport-factory`) without changing their core behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 639a2090ee5f786315398b1a27ceb54c4971730d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->