### PR TITLE
THU-285: [PART 6] E2E encryption — frontend integration

### DIFF
--- a/src/api/encryption.ts
+++ b/src/api/encryption.ts
@@ -1,0 +1,87 @@
+import { getAuthToken, getDeviceId } from '@/lib/auth-token'
+import { getDeviceDisplayName } from '@/lib/platform'
+import ky from 'ky'
+
+type RegisterDeviceResponse =
+  | { status: 'TRUSTED'; envelope: string | null }
+  | { status: 'APPROVAL_PENDING'; firstDevice: boolean }
+
+type StoreEnvelopeResponse = {
+  status: 'TRUSTED'
+}
+
+type FetchEnvelopeResponse = {
+  status: string
+  wrappedCK: string
+}
+
+type FetchCanaryResponse = {
+  canaryIv: string
+  canaryCtext: string
+}
+
+const buildHeaders = (): Record<string, string> => {
+  const headers: Record<string, string> = {}
+  const token = getAuthToken()
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+  const deviceId = getDeviceId()
+  if (deviceId) {
+    headers['X-Device-ID'] = deviceId
+    headers['X-Device-Name'] = getDeviceDisplayName()
+  }
+  return headers
+}
+
+/** POST /devices — Register or identify a device. */
+export const registerDevice = async (
+  baseUrl: string,
+  deviceId: string,
+  publicKey: string,
+  name: string,
+): Promise<RegisterDeviceResponse> =>
+  ky
+    .post('devices', {
+      prefixUrl: baseUrl,
+      headers: buildHeaders(),
+      json: { deviceId, publicKey, name },
+      credentials: 'omit',
+    })
+    .json<RegisterDeviceResponse>()
+
+/** POST /devices/:deviceId/envelope — Store envelope and mark device trusted. */
+export const storeEnvelope = async (
+  baseUrl: string,
+  deviceId: string,
+  wrappedCK: string,
+  canary?: { canaryIv: string; canaryCtext: string },
+): Promise<StoreEnvelopeResponse> =>
+  ky
+    .post(`devices/${encodeURIComponent(deviceId)}/envelope`, {
+      prefixUrl: baseUrl,
+      headers: buildHeaders(),
+      json: { wrappedCK, ...canary },
+      credentials: 'omit',
+    })
+    .json<StoreEnvelopeResponse>()
+
+/** GET /devices/me/envelope — Fetch calling device's own envelope. */
+export const fetchMyEnvelope = async (baseUrl: string): Promise<FetchEnvelopeResponse> =>
+  ky
+    .get('devices/me/envelope', {
+      prefixUrl: baseUrl,
+      headers: buildHeaders(),
+      credentials: 'omit',
+    })
+    .json<FetchEnvelopeResponse>()
+
+/** GET /encryption/canary — Fetch canary for recovery key verification. */
+export const fetchCanary = async (baseUrl: string): Promise<FetchCanaryResponse> =>
+  ky
+    .get('encryption/canary', {
+      prefixUrl: baseUrl,
+      headers: buildHeaders(),
+      credentials: 'omit',
+    })
+    .json<FetchCanaryResponse>()

--- a/src/components/sync-setup/sync-setup-modal.tsx
+++ b/src/components/sync-setup/sync-setup-modal.tsx
@@ -1,5 +1,6 @@
 import { ResponsiveModal, ResponsiveModalContent } from '@/components/ui/responsive-modal'
 import { Button } from '@/components/ui/button'
+import { useSettings } from '@/hooks/use-settings'
 import { useSyncSetup } from '@/hooks/use-sync-setup'
 import { RecoveryKeyDisplayStep } from './recovery-key-display-step'
 import { ApprovalWaitingStep } from './approval-waiting-step'
@@ -17,13 +18,14 @@ type SyncSetupModalProps = {
 /**
  * Multi-step wizard for sync/encryption setup.
  *
- * Flow: intro → detecting → (first-device-setup → recovery-key-display | approval-waiting)
+ * Flow: intro → detecting (test buttons) → (first-device-setup → recovery-key-display | approval-waiting)
  *
- * The "detecting" step uses test buttons for now. In PR 5 it will make a
- * BE request to determine firstDevice automatically.
+ * The "detecting" step shows test buttons. The intro step calls the real BE
+ * to register the device and detect firstDevice, then shows detecting for manual path selection.
  */
 export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModalProps) => {
-  const setup = useSyncSetup()
+  const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
+  const setup = useSyncSetup(cloudUrl.value)
   const [_recoveryKeyConfirmed, setRecoveryKeyConfirmed] = useState(false)
 
   const isRecoveryKeyStep = setup.step === 'recovery-key-display'
@@ -40,16 +42,24 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
     handleClose()
   }
 
-  const handleApprovalContinue = () => {
-    const success = setup.confirmApproval()
+  const handleIntro = async () => {
+    const result = await setup.continueIntro()
+    if (result === 'already-trusted') {
+      onComplete()
+      handleClose()
+    }
+  }
+
+  const handleApprovalContinue = async () => {
+    const success = await setup.confirmApproval()
     if (success) {
       onComplete()
       handleClose()
     }
   }
 
-  const handleRecoveryKeySubmit = () => {
-    const success = setup.submitRecoveryKey()
+  const handleRecoveryKeySubmit = async () => {
+    const success = await setup.submitRecoveryKey()
     if (success) {
       onComplete()
       handleClose()
@@ -89,13 +99,21 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
       )}
 
       <ResponsiveModalContent>
-        {setup.step === 'intro' && <IntroStep onContinue={setup.continueIntro} />}
-
-        {setup.step === 'detecting' && (
-          <DetectingStep onFirstDevice={setup.chooseFirstDevice} onAdditionalDevice={setup.chooseAdditionalDevice} />
+        {setup.step === 'intro' && (
+          <IntroStep onContinue={handleIntro} isLoading={setup.isLoading} error={setup.error} />
         )}
 
-        {setup.step === 'first-device-setup' && <FirstDeviceSetupStep onContinue={setup.continueFirstDeviceSetup} />}
+        {setup.step === 'detecting' && (
+          <DetectingStep
+            onFirstDevice={setup.chooseFirstDevice}
+            onAdditionalDevice={setup.chooseAdditionalDevice}
+            detectedFirstDevice={setup.detectedFirstDevice}
+          />
+        )}
+
+        {setup.step === 'first-device-setup' && (
+          <FirstDeviceSetupStep onContinue={setup.continueFirstDeviceSetup} isLoading={setup.isLoading} />
+        )}
 
         {setup.step === 'recovery-key-display' && (
           <RecoveryKeyDisplayStep
@@ -132,7 +150,13 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
 // Intro step — user-facing welcome screen
 // =============================================================================
 
-const IntroStep = ({ onContinue }: { onContinue: () => void }) => (
+type IntroStepProps = {
+  onContinue: () => void
+  isLoading: boolean
+  error: string | null
+}
+
+const IntroStep = ({ onContinue, isLoading, error }: IntroStepProps) => (
   <div className="w-full flex flex-col">
     <div className="text-center space-y-4">
       <IconCircle>
@@ -143,32 +167,37 @@ const IntroStep = ({ onContinue }: { onContinue: () => void }) => (
         Keep your data in sync across all your devices. Everything is encrypted end-to-end — only your devices can read
         your data.
       </p>
+      {error && <p className="text-sm text-destructive">{error}</p>}
     </div>
 
     <div className="pt-5">
-      <Button className="w-full" onClick={onContinue}>
-        Continue
+      <Button className="w-full" onClick={onContinue} disabled={isLoading}>
+        {isLoading ? 'Setting up…' : 'Continue'}
       </Button>
     </div>
   </div>
 )
 
 // =============================================================================
-// Detecting step — test buttons for now, BE auto-detection in PR 5
+// Detecting step — test buttons for now, auto-detection via BE in future
 // =============================================================================
 
 type DetectingStepProps = {
   onFirstDevice: () => void
   onAdditionalDevice: () => void
+  detectedFirstDevice: boolean | null
 }
 
-const DetectingStep = ({ onFirstDevice, onAdditionalDevice }: DetectingStepProps) => (
+const DetectingStep = ({ onFirstDevice, onAdditionalDevice, detectedFirstDevice }: DetectingStepProps) => (
   <div className="w-full flex flex-col">
     <div className="text-center space-y-4">
-      <h2 className="text-2xl font-bold">Detecting your devices…</h2>
-      <p className="text-xs text-muted-foreground/60">
-        (Testing only — in production this step auto-detects via BE request)
-      </p>
+      <h2 className="text-2xl font-bold">Choose setup path</h2>
+      {detectedFirstDevice !== null && (
+        <p className="text-sm text-muted-foreground">
+          Server detected: <strong>{detectedFirstDevice ? 'First device' : 'Additional device'}</strong>
+        </p>
+      )}
+      <p className="text-xs text-muted-foreground/60">(Testing only — select a path to continue)</p>
     </div>
 
     <div className="flex flex-col gap-3 pt-5">
@@ -195,7 +224,12 @@ const DetectingStep = ({ onFirstDevice, onAdditionalDevice }: DetectingStepProps
 // First device setup step — explanation before recovery key
 // =============================================================================
 
-const FirstDeviceSetupStep = ({ onContinue }: { onContinue: () => void }) => (
+type FirstDeviceSetupStepProps = {
+  onContinue: () => void
+  isLoading: boolean
+}
+
+const FirstDeviceSetupStep = ({ onContinue, isLoading }: FirstDeviceSetupStepProps) => (
   <div className="w-full flex flex-col">
     <div className="text-center space-y-4">
       <IconCircle>
@@ -213,8 +247,8 @@ const FirstDeviceSetupStep = ({ onContinue }: { onContinue: () => void }) => (
     </div>
 
     <div className="pt-5">
-      <Button className="w-full" onClick={onContinue}>
-        Continue
+      <Button className="w-full" onClick={onContinue} disabled={isLoading}>
+        {isLoading ? 'Generating encryption key…' : 'Continue'}
       </Button>
     </div>
   </div>

--- a/src/dal/devices.ts
+++ b/src/dal/devices.ts
@@ -4,10 +4,14 @@ import { devicesTable } from '@/db/tables'
 import { getShadowTable, decryptedJoin, decryptedSelectFor } from '@/db/encryption'
 import type { DrizzleQueryWithPromise } from '@/types'
 
+export type DeviceStatus = 'APPROVAL_PENDING' | 'TRUSTED' | 'REVOKED'
+
 export type Device = {
   id: string
   userId: string
   name: string
+  status: DeviceStatus | null
+  publicKey: string | null
   lastSeen: string | null
   createdAt: string | null
   revokedAt: string | null
@@ -36,6 +40,19 @@ export const getAllDevices = (db: AnyDrizzleDatabase) => {
     .select(devicesSelect)
     .from(devicesTable)
     .leftJoin(devicesShadow, decryptedJoin(devicesTable, devicesShadow))
+    .orderBy(desc(devicesTable.lastSeen))
+  return query as typeof query & DrizzleQueryWithPromise<Device>
+}
+
+/**
+ * Gets all devices with APPROVAL_PENDING status.
+ */
+export const getPendingDevices = (db: AnyDrizzleDatabase) => {
+  const query = db
+    .select(devicesSelect)
+    .from(devicesTable)
+    .leftJoin(devicesShadow, decryptedJoin(devicesTable, devicesShadow))
+    .where(eq(devicesTable.status, 'APPROVAL_PENDING'))
     .orderBy(desc(devicesTable.lastSeen))
   return query as typeof query & DrizzleQueryWithPromise<Device>
 }

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -96,4 +96,4 @@ export {
 } from './model-profiles'
 
 // Devices
-export { getAllDevices, getDevice, type Device } from './devices'
+export { getAllDevices, getDevice, getPendingDevices, type Device, type DeviceStatus } from './devices'

--- a/src/db/encryption/codec.ts
+++ b/src/db/encryption/codec.ts
@@ -1,12 +1,39 @@
-import { encodeIfNotBase64, decodeIfBase64 } from '@/lib/base64'
+import { encrypt, decrypt, getCK } from '@/crypto'
+import { isEncryptionEnabled } from './enabled'
 
 export type EncryptionCodec = {
-  encode: (plaintext: string) => string
-  decode: (ciphertext: string) => string
+  encode: (plaintext: string) => Promise<string>
+  decode: (ciphertext: string) => Promise<string>
 }
 
-/** Base64 codec (PoC). Replace internals with AES-GCM when ready. */
+const encPrefix = '__enc:'
+
+/** AES-GCM codec using CK from IndexedDB. */
 export const codec: EncryptionCodec = {
-  encode: encodeIfNotBase64,
-  decode: decodeIfBase64,
+  encode: async (plaintext) => {
+    if (!isEncryptionEnabled()) {
+      return plaintext
+    }
+    const ck = await getCK()
+    if (!ck) {
+      return plaintext
+    }
+    const { iv, ciphertext } = await encrypt(plaintext, ck)
+    return `${encPrefix}${iv}:${ciphertext}`
+  },
+
+  decode: async (encoded) => {
+    if (!encoded.startsWith(encPrefix)) {
+      return encoded
+    }
+    const ck = await getCK()
+    if (!ck) {
+      return encoded
+    }
+    const payload = encoded.slice(encPrefix.length)
+    const separatorIdx = payload.indexOf(':')
+    const iv = payload.slice(0, separatorIdx)
+    const ciphertext = payload.slice(separatorIdx + 1)
+    return decrypt({ iv, ciphertext }, ck)
+  },
 }

--- a/src/db/encryption/upload-encoder.ts
+++ b/src/db/encryption/upload-encoder.ts
@@ -26,7 +26,7 @@ type CrudOperation = {
  * Encodes encrypted columns in a CRUD operation before upload.
  * Returns the operation unchanged if the table has no encrypted columns or op is DELETE.
  */
-export const encodeForUpload = (operation: CrudOperation): CrudOperation => {
+export const encodeForUpload = async (operation: CrudOperation): Promise<CrudOperation> => {
   if (!isEncryptionEnabled() || operation.op === 'DELETE' || !operation.data) {
     return operation
   }
@@ -40,7 +40,7 @@ export const encodeForUpload = (operation: CrudOperation): CrudOperation => {
   for (const col of columns) {
     const value = encodedData[col]
     if (typeof value === 'string') {
-      encodedData[col] = codec.encode(value)
+      encodedData[col] = await codec.encode(value)
     }
   }
 

--- a/src/db/encryption/watcher.ts
+++ b/src/db/encryption/watcher.ts
@@ -36,11 +36,13 @@ export const setupDecryptionWatchers = async (powerSync: PowerSyncDatabase): Pro
     const destColumnList = srcColumnList
     const placeholders = ['id', ...dbNames].map(() => '?').join(', ')
 
-    const decodeRow = (row: Record<string, string | null>) =>
-      dbNames.map((dbName) => {
-        const val = row[dbName]
-        return val ? codec.decode(val) : val
-      })
+    const decodeRow = async (row: Record<string, string | null>) =>
+      Promise.all(
+        dbNames.map(async (dbName) => {
+          const val = row[dbName]
+          return val ? codec.decode(val) : val
+        }),
+      )
 
     const cleanup = await powerSync.triggers.trackTableDiff({
       source: srcTableName,
@@ -58,7 +60,7 @@ export const setupDecryptionWatchers = async (powerSync: PowerSyncDatabase): Pro
           for (const row of existing) {
             await ctx.execute(`INSERT OR REPLACE INTO ${destTableName} (${destColumnList}) VALUES (${placeholders})`, [
               row.id,
-              ...decodeRow(row),
+              ...(await decodeRow(row)),
             ])
           }
         },
@@ -73,7 +75,7 @@ export const setupDecryptionWatchers = async (powerSync: PowerSyncDatabase): Pro
           } else {
             await context.execute(
               `INSERT OR REPLACE INTO ${destTableName} (${destColumnList}) VALUES (${placeholders})`,
-              [diff.id, ...decodeRow(diff)],
+              [diff.id, ...(await decodeRow(diff))],
             )
           }
         }

--- a/src/db/powersync/connector.ts
+++ b/src/db/powersync/connector.ts
@@ -127,14 +127,16 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
     }
 
     try {
-      // Convert CRUD operations to our API format
-      const operations = transaction.crud.map((op) =>
-        encodeForUpload({
-          op: op.op.toUpperCase() as 'PUT' | 'PATCH' | 'DELETE',
-          type: op.table,
-          id: op.id,
-          data: op.opData,
-        }),
+      // Convert CRUD operations to our API format (encodeForUpload is async for AES-GCM)
+      const operations = await Promise.all(
+        transaction.crud.map((op) =>
+          encodeForUpload({
+            op: op.op.toUpperCase() as 'PUT' | 'PATCH' | 'DELETE',
+            type: op.table,
+            id: op.id,
+            data: op.opData,
+          }),
+        ),
       )
 
       console.info(`Uploading ${operations.length} operations to backend`)

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -219,11 +219,13 @@ export const modesTable = sqliteTable(
   ],
 )
 
-/** Synced via PowerSync. No token. Used for device list and revoke access. */
+/** Synced via PowerSync. Device identity, status, and public key for encryption. */
 export const devicesTable = sqliteTable('devices', {
   id: text('id').primaryKey(),
   userId: text('user_id'),
   name: text('name'),
+  status: text('status'),
+  publicKey: text('public_key'),
   lastSeen: text('last_seen'),
   createdAt: text('created_at'),
   revokedAt: text('revoked_at'),

--- a/src/hooks/use-sync-setup.ts
+++ b/src/hooks/use-sync-setup.ts
@@ -1,7 +1,5 @@
-import { useReducer } from 'react'
-
-// Mock recovery key for UI testing (replaced with real crypto in PR 5)
-const mockRecoveryKey = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+import { useReducer, useState } from 'react'
+import { setupFirstDevice, requestDeviceApproval, recoverWithKey, checkApprovalAndUnwrap } from '@/services/encryption'
 
 type SyncSetupStep =
   | 'intro'
@@ -18,13 +16,18 @@ type SyncSetupState = {
   recoveryKeyError: string | null
   approvalChecked: boolean
   approvalError: string | null
+  isLoading: boolean
+  error: string | null
 }
 
 type SyncSetupAction =
-  | { type: 'CONTINUE_INTRO' }
-  | { type: 'CHOOSE_FIRST_DEVICE' }
-  | { type: 'CONTINUE_FIRST_DEVICE_SETUP' }
-  | { type: 'CHOOSE_ADDITIONAL_DEVICE' }
+  | { type: 'SET_LOADING'; payload: boolean }
+  | { type: 'SET_ERROR'; payload: string | null }
+  | { type: 'DETECTED_FIRST_DEVICE' }
+  | { type: 'DETECTED_ADDITIONAL_DEVICE' }
+  | { type: 'SETUP_COMPLETE'; payload: string }
+  | { type: 'GO_TO_FIRST_DEVICE_SETUP' }
+  | { type: 'GO_TO_APPROVAL_WAITING' }
   | { type: 'GO_TO_RECOVERY_KEY_ENTRY' }
   | { type: 'SET_RECOVERY_KEY_INPUT'; payload: string }
   | { type: 'SET_RECOVERY_KEY_ERROR'; payload: string | null }
@@ -35,33 +38,41 @@ type SyncSetupAction =
 
 const initialState: SyncSetupState = {
   step: 'intro',
-  recoveryKey: mockRecoveryKey,
+  recoveryKey: '',
   recoveryKeyInput: '',
   recoveryKeyError: null,
   approvalChecked: false,
   approvalError: null,
+  isLoading: false,
+  error: null,
 }
 
 const reducer = (state: SyncSetupState, action: SyncSetupAction): SyncSetupState => {
   switch (action.type) {
-    case 'CONTINUE_INTRO':
-      return { ...state, step: 'detecting' }
-    case 'CHOOSE_FIRST_DEVICE':
+    case 'SET_LOADING':
+      return { ...state, isLoading: action.payload, error: null }
+    case 'SET_ERROR':
+      return { ...state, error: action.payload, isLoading: false }
+    case 'DETECTED_FIRST_DEVICE':
+      return { ...state, step: 'first-device-setup', isLoading: false }
+    case 'DETECTED_ADDITIONAL_DEVICE':
+      return { ...state, step: 'approval-waiting', isLoading: false }
+    case 'GO_TO_FIRST_DEVICE_SETUP':
       return { ...state, step: 'first-device-setup' }
-    case 'CONTINUE_FIRST_DEVICE_SETUP':
-      return { ...state, step: 'recovery-key-display' }
-    case 'CHOOSE_ADDITIONAL_DEVICE':
+    case 'GO_TO_APPROVAL_WAITING':
       return { ...state, step: 'approval-waiting' }
+    case 'SETUP_COMPLETE':
+      return { ...state, step: 'recovery-key-display', recoveryKey: action.payload, isLoading: false }
     case 'GO_TO_RECOVERY_KEY_ENTRY':
       return { ...state, step: 'recovery-key-entry', recoveryKeyInput: '', recoveryKeyError: null }
     case 'SET_RECOVERY_KEY_INPUT':
       return { ...state, recoveryKeyInput: action.payload, recoveryKeyError: null }
     case 'SET_RECOVERY_KEY_ERROR':
-      return { ...state, recoveryKeyError: action.payload }
+      return { ...state, recoveryKeyError: action.payload, isLoading: false }
     case 'SET_APPROVAL_CHECKED':
       return { ...state, approvalChecked: action.payload, approvalError: null }
     case 'SET_APPROVAL_ERROR':
-      return { ...state, approvalError: action.payload }
+      return { ...state, approvalError: action.payload, isLoading: false }
     case 'GO_BACK':
       return { ...initialState, step: 'intro' }
     case 'RESET':
@@ -73,54 +84,130 @@ const reducer = (state: SyncSetupState, action: SyncSetupAction): SyncSetupState
 
 /**
  * State machine for the sync setup wizard.
- * All crypto/API calls are stubs — replaced with real implementations in PR 5.
+ * Orchestrates real crypto + API calls via the encryption service layer.
  */
-export const useSyncSetup = () => {
+export const useSyncSetup = (baseUrl: string) => {
   const [state, dispatch] = useReducer(reducer, initialState)
+  // Track if device detection returned firstDevice (for the test-only detecting step)
+  const [detectedFirstDevice, setDetectedFirstDevice] = useState<boolean | null>(null)
 
-  const continueIntro = () => dispatch({ type: 'CONTINUE_INTRO' })
+  const continueIntro = async () => {
+    dispatch({ type: 'SET_LOADING', payload: true })
+    try {
+      const response = await requestDeviceApproval(baseUrl)
+      if (response.status === 'TRUSTED') {
+        // Already trusted — skip setup
+        dispatch({ type: 'SET_LOADING', payload: false })
+        return 'already-trusted' as const
+      }
+      setDetectedFirstDevice(
+        response.status === 'APPROVAL_PENDING' && 'firstDevice' in response && response.firstDevice,
+      )
+      // Go to detecting step (test-only step with two buttons)
+      dispatch({ type: 'SET_LOADING', payload: false })
+      return null
+    } catch (err) {
+      dispatch({ type: 'SET_ERROR', payload: err instanceof Error ? err.message : 'Failed to register device' })
+      return null
+    }
+  }
+
   const goBack = () => dispatch({ type: 'GO_BACK' })
-  const chooseFirstDevice = () => dispatch({ type: 'CHOOSE_FIRST_DEVICE' })
-  const continueFirstDeviceSetup = () => dispatch({ type: 'CONTINUE_FIRST_DEVICE_SETUP' })
-  const chooseAdditionalDevice = () => dispatch({ type: 'CHOOSE_ADDITIONAL_DEVICE' })
+
+  // Test-only: manually choose first device path
+  const chooseFirstDevice = () => dispatch({ type: 'GO_TO_FIRST_DEVICE_SETUP' })
+
+  // Test-only: manually choose additional device path
+  const chooseAdditionalDevice = () => dispatch({ type: 'GO_TO_APPROVAL_WAITING' })
+
+  const continueFirstDeviceSetup = async () => {
+    dispatch({ type: 'SET_LOADING', payload: true })
+    try {
+      const { recoveryKey } = await setupFirstDevice(baseUrl)
+      dispatch({ type: 'SETUP_COMPLETE', payload: recoveryKey })
+    } catch (err) {
+      dispatch({ type: 'SET_ERROR', payload: err instanceof Error ? err.message : 'Failed to set up encryption' })
+    }
+  }
+
   const goToRecoveryKeyEntry = () => dispatch({ type: 'GO_TO_RECOVERY_KEY_ENTRY' })
 
   const setRecoveryKeyInput = (value: string) => dispatch({ type: 'SET_RECOVERY_KEY_INPUT', payload: value })
 
-  const submitRecoveryKey = () => {
+  const submitRecoveryKey = async (): Promise<boolean> => {
     const cleaned = state.recoveryKeyInput.replace(/\s/g, '')
     if (cleaned.length !== 64) {
       dispatch({ type: 'SET_RECOVERY_KEY_ERROR', payload: 'Recovery key must be 64 characters.' })
       return false
     }
     if (!/^[0-9a-f]+$/i.test(cleaned)) {
-      dispatch({ type: 'SET_RECOVERY_KEY_ERROR', payload: 'Recovery key must contain only hex characters (0-9, a-f).' })
+      dispatch({
+        type: 'SET_RECOVERY_KEY_ERROR',
+        payload: 'Recovery key must contain only hex characters (0-9, a-f).',
+      })
       return false
     }
-    // Stub: In PR 5, this will verify via canary decryption
-    return true
+
+    dispatch({ type: 'SET_LOADING', payload: true })
+    try {
+      const isValid = await recoverWithKey(baseUrl, cleaned)
+      if (!isValid) {
+        dispatch({ type: 'SET_RECOVERY_KEY_ERROR', payload: 'Recovery key is incorrect. Please check and try again.' })
+        return false
+      }
+      dispatch({ type: 'SET_LOADING', payload: false })
+      return true
+    } catch (err) {
+      dispatch({
+        type: 'SET_RECOVERY_KEY_ERROR',
+        payload: err instanceof Error ? err.message : 'Failed to verify recovery key',
+      })
+      return false
+    }
   }
 
   const setApprovalChecked = (checked: boolean) => dispatch({ type: 'SET_APPROVAL_CHECKED', payload: checked })
 
-  const confirmApproval = () => {
+  const confirmApproval = async (): Promise<boolean> => {
     if (!state.approvalChecked) {
       return false
     }
-    // Stub: In PR 5, this will call GET /devices/me/envelope to check if approved
-    // For now, always succeed
-    return true
+
+    dispatch({ type: 'SET_LOADING', payload: true })
+    try {
+      const approved = await checkApprovalAndUnwrap(baseUrl)
+      if (!approved) {
+        dispatch({
+          type: 'SET_APPROVAL_ERROR',
+          payload: 'Not approved yet. Check your other device and try again.',
+        })
+        dispatch({ type: 'SET_APPROVAL_CHECKED', payload: false })
+        return false
+      }
+      dispatch({ type: 'SET_LOADING', payload: false })
+      return true
+    } catch (err) {
+      dispatch({
+        type: 'SET_APPROVAL_ERROR',
+        payload: err instanceof Error ? err.message : 'Failed to check approval',
+      })
+      return false
+    }
   }
 
-  const reset = () => dispatch({ type: 'RESET' })
+  const reset = () => {
+    dispatch({ type: 'RESET' })
+    setDetectedFirstDevice(null)
+  }
 
   return {
     ...state,
+    detectedFirstDevice,
     continueIntro,
     goBack,
     chooseFirstDevice,
-    continueFirstDeviceSetup,
     chooseAdditionalDevice,
+    continueFirstDeviceSetup,
     goToRecoveryKeyEntry,
     setRecoveryKeyInput,
     submitRecoveryKey,

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -1,0 +1,190 @@
+import {
+  generateKeyPair,
+  generateCK,
+  reimportAsNonExtractable,
+  exportPublicKey,
+  importPublicKey,
+  wrapCK,
+  unwrapCK,
+  encodeRecoveryKey,
+  decodeRecoveryKey,
+  createCanary,
+  verifyCanary,
+  storeKeyPair,
+  getKeyPair,
+  storeCK,
+  getCK,
+  clearCK,
+  clearAllKeys,
+} from '@/crypto'
+import { registerDevice, storeEnvelope, fetchMyEnvelope, fetchCanary } from '@/api/encryption'
+import { getDeviceId } from '@/lib/auth-token'
+import { getDeviceDisplayName } from '@/lib/platform'
+import { setEncryptionEnabled } from '@/db/encryption'
+
+type SetupFirstDeviceResult = {
+  recoveryKey: string
+}
+
+/**
+ * Flow C — First device ever.
+ * Generates key pair + CK, creates canary, wraps envelope, stores on server.
+ * Returns the recovery key (shown once to the user).
+ */
+export const setupFirstDevice = async (baseUrl: string): Promise<SetupFirstDeviceResult> => {
+  // 1. Generate device key pair
+  const keyPair = await generateKeyPair()
+  await storeKeyPair(keyPair.privateKey, keyPair.publicKey)
+
+  // 2. Generate CK (extractable for recovery key encoding)
+  const extractableCK = await generateCK(true)
+
+  // 3. Encode recovery key
+  const recoveryKey = await encodeRecoveryKey(extractableCK)
+
+  // 4. Create canary
+  const canary = await createCanary(extractableCK)
+
+  // 5. Wrap CK with own public key
+  const wrappedCK = await wrapCK(extractableCK, keyPair.publicKey)
+
+  // 6. Re-import CK as non-extractable and store
+  const nonExtractableCK = await reimportAsNonExtractable(extractableCK)
+  await storeCK(nonExtractableCK)
+
+  // 7. Store envelope + canary on server
+  const deviceId = getDeviceId()
+  await storeEnvelope(baseUrl, deviceId, wrappedCK, canary)
+
+  // 8. Enable encryption
+  setEncryptionEnabled(true)
+
+  return { recoveryKey }
+}
+
+/**
+ * Flow D (new device side) — Request device approval.
+ * Generates key pair, registers device on server.
+ * Returns the server response (APPROVAL_PENDING with firstDevice flag).
+ */
+export const requestDeviceApproval = async (baseUrl: string) => {
+  // Generate key pair
+  const keyPair = await generateKeyPair()
+  await storeKeyPair(keyPair.privateKey, keyPair.publicKey)
+
+  // Export public key and register
+  const publicKeyBase64 = await exportPublicKey(keyPair.publicKey)
+  const deviceId = getDeviceId()
+  const name = getDeviceDisplayName()
+
+  return registerDevice(baseUrl, deviceId, publicKeyBase64, name)
+}
+
+/**
+ * Flow D (trusted device side) — Approve a pending device.
+ * Wraps CK with the pending device's public key and stores envelope on server.
+ */
+export const approveDevice = async (baseUrl: string, pendingDeviceId: string, pendingDevicePublicKey: string) => {
+  const ck = await getCK()
+  if (!ck) {
+    throw new Error('CK not available — cannot approve device')
+  }
+
+  // Import the pending device's public key
+  const publicKey = await importPublicKey(pendingDevicePublicKey)
+
+  // Wrap CK with the pending device's public key
+  const wrappedCK = await wrapCK(ck, publicKey)
+
+  // Store envelope on server for the pending device
+  await storeEnvelope(baseUrl, pendingDeviceId, wrappedCK)
+}
+
+/**
+ * Flow E — Recover with recovery key.
+ * Verifies the key against the canary, then creates own envelope.
+ */
+export const recoverWithKey = async (baseUrl: string, recoveryKeyHex: string): Promise<boolean> => {
+  // 1. Decode recovery key → CK
+  const ck = await decodeRecoveryKey(recoveryKeyHex)
+
+  // 2. Fetch canary from server
+  const { canaryIv, canaryCtext } = await fetchCanary(baseUrl)
+
+  // 3. Verify canary
+  const isValid = await verifyCanary(ck, canaryIv, canaryCtext)
+  if (!isValid) {
+    return false
+  }
+
+  // 4. Store CK locally
+  await storeCK(ck)
+
+  // 5. Get key pair (should already exist from requestDeviceApproval)
+  const keyPair = await getKeyPair()
+  if (!keyPair) {
+    throw new Error('Key pair not found — was requestDeviceApproval called first?')
+  }
+
+  // 6. Wrap CK with own public key and store envelope
+  const wrappedCK = await wrapCK(ck, keyPair.publicKey)
+  const deviceId = getDeviceId()
+  await storeEnvelope(baseUrl, deviceId, wrappedCK)
+
+  // 7. Enable encryption
+  setEncryptionEnabled(true)
+
+  return true
+}
+
+/**
+ * Flow F — Recover CK from envelope (returning device, CK lost from IndexedDB).
+ */
+export const recoverCKFromEnvelope = async (baseUrl: string) => {
+  const keyPair = await getKeyPair()
+  if (!keyPair) {
+    throw new Error('Key pair not found')
+  }
+
+  const { wrappedCK } = await fetchMyEnvelope(baseUrl)
+  const ck = await unwrapCK(wrappedCK, keyPair.privateKey)
+  await storeCK(ck)
+  setEncryptionEnabled(true)
+}
+
+/**
+ * Flow D Continue — Check if device has been approved.
+ * Fetches own envelope. If found, unwraps CK and enables encryption.
+ * Returns true if approved, false if still pending.
+ */
+export const checkApprovalAndUnwrap = async (baseUrl: string): Promise<boolean> => {
+  try {
+    const { wrappedCK } = await fetchMyEnvelope(baseUrl)
+    const keyPair = await getKeyPair()
+    if (!keyPair) {
+      throw new Error('Key pair not found')
+    }
+    const ck = await unwrapCK(wrappedCK, keyPair.privateKey)
+    await storeCK(ck)
+    setEncryptionEnabled(true)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Flow G — Sign out. Clears CK but keeps key pair.
+ */
+export const handleSignOut = async () => {
+  await clearCK()
+  setEncryptionEnabled(false)
+}
+
+/**
+ * Flow H — Full wipe. Clears all key material.
+ */
+export const handleFullWipe = async () => {
+  await clearAllKeys()
+  setEncryptionEnabled(false)
+}

--- a/src/settings/devices.tsx
+++ b/src/settings/devices.tsx
@@ -1,7 +1,8 @@
 import { useDatabase } from '@/contexts'
-import { getAllDevices } from '@/dal'
+import { getAllDevices, getPendingDevices } from '@/dal'
 import { getDeviceId, getAuthToken } from '@/lib/auth-token'
 import { useSettings } from '@/hooks/use-settings'
+import { approveDevice } from '@/services/encryption'
 import { PageHeader } from '@/components/ui/page-header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -49,10 +50,17 @@ export default function DevicesSettingsPage() {
     queryKey: ['devices'],
     query: toCompilableQuery(getAllDevices(db)),
   })
+  const { data: pendingDevices = [] } = useQuery({
+    queryKey: ['devices', 'pending'],
+    query: toCompilableQuery(getPendingDevices(db)),
+  })
   const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
   const [revokeTarget, setRevokeTarget] = useState<string | null>(null)
+  const [approveTarget, setApproveTarget] = useState<string | null>(null)
 
-  const visibleDevices = devices.filter((d) => d.revokedAt == null || dayjs().diff(dayjs(d.revokedAt), 'hour') < 24)
+  const trustedDevices = devices.filter(
+    (d) => d.status !== 'APPROVAL_PENDING' && (d.revokedAt == null || dayjs().diff(dayjs(d.revokedAt), 'hour') < 24),
+  )
 
   const revokeMutation = useMutation({
     mutationFn: (deviceId: string) => {
@@ -67,6 +75,19 @@ export default function DevicesSettingsPage() {
     },
   })
 
+  const approveMutation = useMutation({
+    mutationFn: async (deviceId: string) => {
+      const device = pendingDevices.find((d) => d.id === deviceId)
+      if (!device?.publicKey) {
+        throw new Error('Device public key not available')
+      }
+      await approveDevice(cloudUrl.value, deviceId, device.publicKey)
+    },
+    onSuccess: () => {
+      setApproveTarget(null)
+    },
+  })
+
   const handleRevoke = (deviceId: string) => {
     setRevokeTarget(deviceId)
   }
@@ -77,23 +98,13 @@ export default function DevicesSettingsPage() {
     }
   }
 
-  // Mock pending devices for UI review (replaced with real synced data in PR 5)
-  const mockPendingDevices = [
-    { id: 'pending-1', name: 'Chrome on Windows PC' },
-    { id: 'pending-2', name: 'Safari on iPad' },
-  ]
-
-  const [approveTarget, setApproveTarget] = useState<string | null>(null)
-
   const confirmApprove = () => {
     if (approveTarget) {
-      // Stub: In PR 5, this wraps CK with pending device's public key
-      console.log('Approve device (stub):', approveTarget)
-      setApproveTarget(null)
+      approveMutation.mutate(approveTarget)
     }
   }
 
-  const hasPendingDevices = mockPendingDevices.length > 0
+  const hasPendingDevices = pendingDevices.length > 0
 
   return (
     <div className="flex flex-col gap-6 p-4 pb-12 w-full max-w-[760px] mx-auto">
@@ -103,7 +114,7 @@ export default function DevicesSettingsPage() {
         <>
           <SectionCard title="Pending Approvals">
             <div className="flex flex-col gap-3">
-              {mockPendingDevices.map((device) => (
+              {pendingDevices.map((device) => (
                 <Card key={device.id} className="bg-secondary/50">
                   <CardContent>
                     <div className="flex items-center justify-between gap-4">
@@ -114,7 +125,12 @@ export default function DevicesSettingsPage() {
                           <p className="text-sm text-muted-foreground">Waiting for approval</p>
                         </div>
                       </div>
-                      <Button variant="default" size="sm" onClick={() => setApproveTarget(device.id)}>
+                      <Button
+                        variant="default"
+                        size="sm"
+                        onClick={() => setApproveTarget(device.id)}
+                        disabled={approveMutation.isPending}
+                      >
                         <CheckCircle2 className="size-4 mr-1" />
                         Approve
                       </Button>
@@ -133,13 +149,13 @@ export default function DevicesSettingsPage() {
 
       {isLoading ? (
         <p className="text-muted-foreground py-4">Loading devices…</p>
-      ) : visibleDevices.length === 0 ? (
+      ) : trustedDevices.length === 0 ? (
         <p className="text-muted-foreground py-4">No devices yet. Sign in with sync to see devices here.</p>
       ) : (
         <div className="flex flex-col gap-4">
-          {visibleDevices.map((device) => {
+          {trustedDevices.map((device) => {
             const isCurrent = device.id === currentDeviceId
-            const isRevoked = device.revokedAt != null
+            const isRevoked = device.status === 'REVOKED' || device.revokedAt != null
             return (
               <Card key={device.id}>
                 <CardContent>
@@ -192,7 +208,9 @@ export default function DevicesSettingsPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmApprove}>Approve</AlertDialogAction>
+            <AlertDialogAction onClick={confirmApprove} disabled={approveMutation.isPending}>
+              {approveMutation.isPending ? 'Approving…' : 'Approve'}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
## Summary

Wires the crypto module, API client, and UI together into a working E2E encryption flow. Replaces the base64 PoC codec with real AES-GCM encryption and replaces all mock/stub calls with real service layer operations.

### AES-GCM codec (replaces base64 PoC)
- `src/db/encryption/codec.ts` — async encode/decode using CK from IndexedDB via `src/crypto` primitives
- Encrypted values use `__enc:` prefix with `iv:ciphertext` format
- Upload encoder and decryption watcher updated for async codec
- PowerSync connector awaits encoding via `Promise.all`

### Frontend device schema
- `src/db/tables.ts` — added `status` and `publicKey` columns to `devicesTable`
- `src/dal/devices.ts` — added `DeviceStatus` type, `getPendingDevices()` query
- Devices page filters by `status` instead of only `revokedAt`

### API client (`src/api/encryption.ts`)
- `registerDevice()` → POST /devices
- `storeEnvelope()` → POST /devices/:deviceId/envelope
- `fetchMyEnvelope()` → GET /devices/me/envelope
- `fetchCanary()` → GET /encryption/canary

### Service layer (`src/services/encryption.ts`)
- `setupFirstDevice()` — Flow C: generate keys, CK, canary, envelope, recovery key
- `requestDeviceApproval()` — Flow D (new device): generate keys, register
- `approveDevice()` — Flow D (trusted device): wrap CK with pending device's public key
- `recoverWithKey()` — Flow E: verify canary, create envelope
- `recoverCKFromEnvelope()` — Flow F: fetch envelope, unwrap CK
- `checkApprovalAndUnwrap()` — Flow D continue: check if approved, unwrap CK
- `handleSignOut()` — Flow G: clear CK, keep key pair
- `handleFullWipe()` — Flow H: clear all keys

### UI wiring
- `use-sync-setup.ts` — replaced all stubs with real async service calls, added `isLoading`/`error` state, `detectedFirstDevice` from server response
- `sync-setup-modal.tsx` — passes `baseUrl` via `useSettings`, handles async handlers, shows loading/error states in step components
- `devices.tsx` — replaced mock pending devices with real `getPendingDevices` query, wired approve button to `approveDevice` service, filters trusted devices by `status`

### Files changed
- `src/api/encryption.ts` — new API client
- `src/services/encryption.ts` — new service layer
- `src/db/encryption/codec.ts` — AES-GCM replacing base64
- `src/db/encryption/upload-encoder.ts` — async
- `src/db/encryption/watcher.ts` — async decode
- `src/db/powersync/connector.ts` — async upload encoding
- `src/db/tables.ts` — device schema update
- `src/dal/devices.ts` + `src/dal/index.ts` — new type + query
- `src/hooks/use-sync-setup.ts` — real service calls
- `src/components/sync-setup/sync-setup-modal.tsx` — wired to services
- `src/settings/devices.tsx` — real synced data

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Enable sync (first device): intro → Continue (registers device on BE) → detecting → First device → first device setup → Continue (generates keys, creates envelope) → recovery key shown → Done enables sync
- [ ] Enable sync (additional device): intro → detecting → Additional device → approval waiting → approve from trusted device → Continue (fetches envelope, unwraps CK) → sync enabled
- [ ] Recovery key flow: approval waiting → Use my recovery key → enter key → Submit (verifies canary, creates envelope) → sync enabled
- [ ] Devices page: pending devices show from real synced data, Approve button calls real service
- [ ] Revoke device: deletes envelope, sets status REVOKED
- [ ] Encrypted data: uploads encoded with `__enc:` prefix, shadow tables decode on sync
- [ ] Encryption disabled: uploads and reads work transparently without encryption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes client-side encryption from a PoC to real AES-GCM, alters how data is encoded/decoded during PowerSync upload and shadow-table decryption, and adds new device approval/recovery flows that impact key handling and sync access.
> 
> **Overview**
> Implements the **frontend integration for E2E encryption**, replacing the base64 PoC with an async AES-GCM `codec` that encrypts/decrypts fields using the locally stored CK (`__enc:` `iv:ciphertext` format), and updates PowerSync upload + decryption watchers to `await` encoding/decoding.
> 
> Adds a new encryption API client (`registerDevice`, `storeEnvelope`, `fetchMyEnvelope`, `fetchCanary`) and a service layer (`setupFirstDevice`, `requestDeviceApproval`, `approveDevice`, recovery + approval-check flows) to generate/store keys, create envelopes/canaries, and enable/disable encryption.
> 
> Updates device data/schema and UI to support approvals: `devicesTable` gains `status`/`publicKey`, DAL adds `DeviceStatus` + `getPendingDevices`, sync setup wizard now performs real async setup/recovery with loading/error states, and the Devices settings page lists pending devices from synced data and can approve them by wrapping CK with the pending device’s public key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0997e971c7be794f7f9891064fb88397354adecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->