### PR TITLE
fix: remove copy reference to magic link in email template

### DIFF
--- a/backend/src/emails/magic-link.tsx
+++ b/backend/src/emails/magic-link.tsx
@@ -9,13 +9,13 @@ type MagicLinkEmailProps = {
 export const MagicLinkEmail = ({ code, magicLinkUrl }: MagicLinkEmailProps) => (
   <EmailLayout preview={`Thunderbolt Verification Code: ${code}`}>
     <Section className="bg-white border border-solid border-tb-border rounded-2xl text-center px-8 py-8">
-      <Text className="text-sm text-tb-text m-0 mb-6">Use the code below to sign in, or click the magic link.</Text>
+      <Text className="text-sm text-tb-text m-0 mb-6">Use the code below to sign in, or click the button.</Text>
       <Text className="text-2xl font-semibold text-tb-text m-0 mb-6">{code}</Text>
       <Button
         href={magicLinkUrl}
         className="bg-tb-button text-white text-sm font-medium rounded-xl px-6 py-2.5 box-border"
       >
-        Magic link
+        Sign In
       </Button>
     </Section>
   </EmailLayout>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk copy-only change to the magic link email template; no logic, routing, or data handling is modified.
> 
> **Overview**
> Updates the `MagicLinkEmail` template text to remove explicit “magic link” wording, changing the instruction to “click the button” and renaming the button label from `Magic link` to `Sign In`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e849d34f9c8e88ed2ad19f8b38019592732f4f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->