### PR TITLE
THU-285: [PART 5] Frontend encryption integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",
@@ -36,6 +35,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@scure/bip39": "^2.0.1",
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/react-query": "^5.85.5",
         "@tauri-apps/api": "^2.9.0",
@@ -563,6 +563,10 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.52.5", "", { "os": "win32", "cpu": "x64" }, "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.5", "", { "os": "win32", "cpu": "x64" }, "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg=="],
+
+    "@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
+
+    "@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
 
     "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@scure/bip39": "^2.0.1",
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query": "^5.85.5",
     "@tauri-apps/api": "^2.9.0",

--- a/src/api/encryption.test.ts
+++ b/src/api/encryption.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import ky, { type KyInstance } from 'ky'
+import { registerDevice, storeEnvelope, fetchMyEnvelope, fetchCanary } from './encryption'
+
+const deviceIdKey = 'thunderbolt_device_id'
+const authTokenKey = 'thunderbolt_auth_token'
+
+type CapturedRequest = { url: string; method: string; body: Record<string, unknown> | null; headers: Headers }
+
+const createCapturingHttpClient = (
+  mockResponse: unknown = {},
+): { httpClient: KyInstance; getLastRequest: () => CapturedRequest } => {
+  let lastRequest: CapturedRequest = {
+    url: '',
+    method: 'GET',
+    body: null,
+    headers: new Headers(),
+  }
+
+  const mockFetch = async (input: Request): Promise<Response> => {
+    const url = input.url
+    const method = input.method
+    const headers = input.headers
+    let body: Record<string, unknown> | null = null
+    try {
+      body = (await input.json()) as Record<string, unknown>
+    } catch {
+      // GET requests have no body
+    }
+    lastRequest = { url, method, body, headers }
+
+    return new Response(JSON.stringify(mockResponse), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  return {
+    httpClient: ky.create({ fetch: mockFetch as unknown as typeof fetch, prefixUrl: 'http://test-api.local' }),
+    getLastRequest: () => lastRequest,
+  }
+}
+
+describe('encryption API client', () => {
+  beforeEach(() => {
+    localStorage.setItem(deviceIdKey, 'test-device-id')
+    localStorage.setItem(authTokenKey, 'test-token')
+  })
+
+  afterEach(() => {
+    localStorage.removeItem(deviceIdKey)
+    localStorage.removeItem(authTokenKey)
+  })
+
+  describe('registerDevice', () => {
+    it('sends POST /devices with correct body and auth headers', async () => {
+      const mockResponse = { status: 'APPROVAL_PENDING' as const, firstDevice: true }
+      const { httpClient, getLastRequest } = createCapturingHttpClient(mockResponse)
+
+      const result = await registerDevice(httpClient, {
+        deviceId: 'dev-1',
+        publicKey: 'pk-base64',
+        name: 'Test Device',
+      })
+
+      const req = getLastRequest()
+      expect(req.url).toContain('/devices')
+      expect(req.method).toBe('POST')
+      expect(req.body).toEqual({ deviceId: 'dev-1', publicKey: 'pk-base64', name: 'Test Device' })
+      expect(req.headers.get('authorization')).toBe('Bearer test-token')
+      expect(req.headers.get('x-device-id')).toBe('test-device-id')
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('returns TRUSTED response with envelope', async () => {
+      const mockResponse = { status: 'TRUSTED' as const, envelope: 'wrapped-ck-base64' }
+      const { httpClient } = createCapturingHttpClient(mockResponse)
+
+      const result = await registerDevice(httpClient, {
+        deviceId: 'dev-1',
+        publicKey: 'pk-base64',
+      })
+
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('storeEnvelope', () => {
+    it('sends POST /devices/:id/envelope with correct body', async () => {
+      const mockResponse = { status: 'TRUSTED' as const }
+      const { httpClient, getLastRequest } = createCapturingHttpClient(mockResponse)
+
+      const result = await storeEnvelope(httpClient, {
+        deviceId: 'dev-1',
+        wrappedCK: 'wrapped-base64',
+        canaryIv: 'iv-base64',
+        canaryCtext: 'ctext-base64',
+      })
+
+      const req = getLastRequest()
+      expect(req.url).toContain('/devices/dev-1/envelope')
+      expect(req.method).toBe('POST')
+      expect(req.body).toEqual({
+        wrappedCK: 'wrapped-base64',
+        canaryIv: 'iv-base64',
+        canaryCtext: 'ctext-base64',
+      })
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('URL-encodes device ID', async () => {
+      const { httpClient, getLastRequest } = createCapturingHttpClient({ status: 'TRUSTED' })
+
+      await storeEnvelope(httpClient, {
+        deviceId: 'dev/special',
+        wrappedCK: 'wrapped',
+      })
+
+      const req = getLastRequest()
+      expect(req.url).toContain('/devices/dev%2Fspecial/envelope')
+    })
+  })
+
+  describe('fetchMyEnvelope', () => {
+    it('sends GET /devices/me/envelope with auth headers', async () => {
+      const mockResponse = { status: 'TRUSTED', wrappedCK: 'wrapped-base64' }
+      const { httpClient, getLastRequest } = createCapturingHttpClient(mockResponse)
+
+      const result = await fetchMyEnvelope(httpClient)
+
+      const req = getLastRequest()
+      expect(req.url).toContain('/devices/me/envelope')
+      expect(req.method).toBe('GET')
+      expect(req.headers.get('x-device-id')).toBe('test-device-id')
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('fetchCanary', () => {
+    it('sends GET /encryption/canary with auth headers', async () => {
+      const mockResponse = { canaryIv: 'iv-base64', canaryCtext: 'ctext-base64' }
+      const { httpClient, getLastRequest } = createCapturingHttpClient(mockResponse)
+
+      const result = await fetchCanary(httpClient)
+
+      const req = getLastRequest()
+      expect(req.url).toContain('/encryption/canary')
+      expect(req.method).toBe('GET')
+      expect(req.headers.get('authorization')).toBe('Bearer test-token')
+      expect(result).toEqual(mockResponse)
+    })
+  })
+})

--- a/src/api/encryption.ts
+++ b/src/api/encryption.ts
@@ -1,0 +1,83 @@
+import type { KyInstance } from 'ky'
+import { getAuthToken, getDeviceId } from '@/lib/auth-token'
+
+// =============================================================================
+// Response types (matching backend)
+// =============================================================================
+
+export type RegisterDeviceResponse =
+  | { status: 'TRUSTED'; envelope: string | null }
+  | { status: 'APPROVAL_PENDING'; firstDevice: boolean }
+
+type StoreEnvelopeResponse = { status: 'TRUSTED' }
+
+type FetchEnvelopeResponse = { status: string; wrappedCK: string }
+
+type FetchCanaryResponse = { canaryIv: string; canaryCtext: string }
+
+// =============================================================================
+// Auth headers helper
+// =============================================================================
+
+const authHeaders = (): Record<string, string> => {
+  const headers: Record<string, string> = {}
+  const token = getAuthToken()
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+  const deviceId = getDeviceId()
+  if (deviceId) {
+    headers['X-Device-ID'] = deviceId
+  }
+  return headers
+}
+
+// =============================================================================
+// API functions
+// =============================================================================
+
+/** Register (or re-identify) this device with the server. */
+export const registerDevice = async (
+  httpClient: KyInstance,
+  params: { deviceId: string; publicKey: string; name?: string },
+): Promise<RegisterDeviceResponse> =>
+  httpClient
+    .post('devices', {
+      json: params,
+      headers: authHeaders(),
+      credentials: 'omit',
+    })
+    .json<RegisterDeviceResponse>()
+
+/** Store a wrapped content key (envelope) for a device. Optionally includes canary on first setup. */
+export const storeEnvelope = async (
+  httpClient: KyInstance,
+  params: { deviceId: string; wrappedCK: string; canaryIv?: string; canaryCtext?: string },
+): Promise<StoreEnvelopeResponse> => {
+  const { deviceId, ...body } = params
+  return httpClient
+    .post(`devices/${encodeURIComponent(deviceId)}/envelope`, {
+      json: body,
+      headers: authHeaders(),
+      credentials: 'omit',
+    })
+    .json<StoreEnvelopeResponse>()
+}
+
+/** Fetch the wrapped content key for the current device. */
+export const fetchMyEnvelope = async (httpClient: KyInstance): Promise<FetchEnvelopeResponse> =>
+  httpClient
+    .get('devices/me/envelope', {
+      headers: authHeaders(),
+      credentials: 'omit',
+    })
+    .json<FetchEnvelopeResponse>()
+
+/** Fetch the canary for recovery key verification. */
+export const fetchCanary = async (httpClient: KyInstance): Promise<FetchCanaryResponse> =>
+  httpClient
+    .get('encryption/canary', {
+      headers: authHeaders(),
+      credentials: 'omit',
+    })
+    .json<FetchCanaryResponse>()

--- a/src/api/encryption.ts
+++ b/src/api/encryption.ts
@@ -19,7 +19,7 @@ type FetchCanaryResponse = { canaryIv: string; canaryCtext: string }
 // Auth headers helper
 // =============================================================================
 
-const authHeaders = (): Record<string, string> => {
+export const authHeaders = (): Record<string, string> => {
   const headers: Record<string, string> = {}
   const token = getAuthToken()
   if (token) {

--- a/src/components/logout-modal.tsx
+++ b/src/components/logout-modal.tsx
@@ -13,9 +13,9 @@ import {
 import { SelectableCard, type DataOption } from '@/components/ui/selectable-card'
 import { useAuth } from '@/contexts'
 import { setSyncEnabled } from '@/db/powersync'
-import { clearAuthToken } from '@/lib/auth-token'
+import { clearAuthToken, clearDeviceId } from '@/lib/auth-token'
 import { resetAppDir } from '@/lib/fs'
-import { handleSignOut, handleFullWipe } from '@/services/encryption'
+import { handleFullWipe } from '@/services/encryption'
 
 type LogoutModalProps = {
   open: boolean
@@ -37,13 +37,10 @@ export const LogoutModal = ({ open, onOpenChange }: LogoutModalProps) => {
       console.error('Failed to disable sync:', error)
     }
 
-    // Clear encryption keys before signing out
+    // Clear all encryption keys — device ID is also cleared below,
+    // so the old key pair is orphaned regardless of keep/delete choice
     try {
-      if (selectedOption === 'delete') {
-        await handleFullWipe()
-      } else {
-        await handleSignOut()
-      }
+      await handleFullWipe()
     } catch (error) {
       console.error('Failed to clear encryption keys:', error)
     }
@@ -54,8 +51,9 @@ export const LogoutModal = ({ open, onOpenChange }: LogoutModalProps) => {
       console.error('Failed to sign out:', error)
     }
 
-    // Clear local bearer token (mobile auth)
+    // Clear local bearer token and device ID (forces new UUID on next login)
     await clearAuthToken()
+    clearDeviceId()
 
     try {
       if (selectedOption === 'delete') {

--- a/src/components/logout-modal.tsx
+++ b/src/components/logout-modal.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '@/contexts'
 import { setSyncEnabled } from '@/db/powersync'
 import { clearAuthToken } from '@/lib/auth-token'
 import { resetAppDir } from '@/lib/fs'
+import { handleSignOut, handleFullWipe } from '@/services/encryption'
 
 type LogoutModalProps = {
   open: boolean
@@ -34,6 +35,17 @@ export const LogoutModal = ({ open, onOpenChange }: LogoutModalProps) => {
       await setSyncEnabled(false)
     } catch (error) {
       console.error('Failed to disable sync:', error)
+    }
+
+    // Clear encryption keys before signing out
+    try {
+      if (selectedOption === 'delete') {
+        await handleFullWipe()
+      } else {
+        await handleSignOut()
+      }
+    } catch (error) {
+      console.error('Failed to clear encryption keys:', error)
     }
 
     try {

--- a/src/components/revoked-device-modal.tsx
+++ b/src/components/revoked-device-modal.tsx
@@ -14,6 +14,7 @@ import { SelectableCard, type DataOption } from '@/components/ui/selectable-card
 import { setSyncEnabled } from '@/db/powersync'
 import { clearAuthToken, clearDeviceId } from '@/lib/auth-token'
 import { resetAppDir } from '@/lib/fs'
+import { handleFullWipe } from '@/services/encryption'
 
 type RevokedDeviceModalProps = {
   open: boolean
@@ -30,6 +31,13 @@ export const RevokedDeviceModal = ({ open }: RevokedDeviceModalProps) => {
       await setSyncEnabled(false)
     } catch (error) {
       console.error('Failed to disable sync:', error)
+    }
+
+    // Clear all encryption keys on revocation
+    try {
+      await handleFullWipe()
+    } catch (error) {
+      console.error('Failed to clear encryption keys:', error)
     }
 
     try {

--- a/src/components/sync-setup/recovery-key-display-step.tsx
+++ b/src/components/sync-setup/recovery-key-display-step.tsx
@@ -13,8 +13,6 @@ export const RecoveryKeyDisplayStep = ({ recoveryKey, onDone, onConfirmedChange 
   const [copied, setCopied] = useState(false)
   const [confirmed, setConfirmed] = useState(false)
 
-  const words = recoveryKey.split(' ')
-
   const handleCopy = async () => {
     await navigator.clipboard.writeText(recoveryKey)
     setCopied(true)
@@ -38,14 +36,7 @@ export const RecoveryKeyDisplayStep = ({ recoveryKey, onDone, onConfirmedChange 
 
       <div className="pt-5 space-y-4">
         <div className="rounded-xl bg-muted p-4">
-          <div className="grid grid-cols-3 gap-x-4 gap-y-2">
-            {words.map((word, i) => (
-              <div key={i} className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground w-5 text-right tabular-nums">{i + 1}.</span>
-                <span className="text-sm font-medium">{word}</span>
-              </div>
-            ))}
-          </div>
+          <p className="text-sm font-medium leading-relaxed">{recoveryKey}</p>
         </div>
 
         <Button variant="outline" className="w-full" onClick={handleCopy}>

--- a/src/components/sync-setup/recovery-key-display-step.tsx
+++ b/src/components/sync-setup/recovery-key-display-step.tsx
@@ -13,6 +13,8 @@ export const RecoveryKeyDisplayStep = ({ recoveryKey, onDone, onConfirmedChange 
   const [copied, setCopied] = useState(false)
   const [confirmed, setConfirmed] = useState(false)
 
+  const words = recoveryKey.split(' ')
+
   const handleCopy = async () => {
     await navigator.clipboard.writeText(recoveryKey)
     setCopied(true)
@@ -36,7 +38,14 @@ export const RecoveryKeyDisplayStep = ({ recoveryKey, onDone, onConfirmedChange 
 
       <div className="pt-5 space-y-4">
         <div className="rounded-xl bg-muted p-4">
-          <p className="text-sm font-medium leading-relaxed">{recoveryKey}</p>
+          <div className="grid grid-cols-3 gap-x-4 gap-y-2">
+            {words.map((word, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground w-5 text-right tabular-nums">{i + 1}.</span>
+                <span className="text-sm font-medium">{word}</span>
+              </div>
+            ))}
+          </div>
         </div>
 
         <Button variant="outline" className="w-full" onClick={handleCopy}>

--- a/src/components/sync-setup/sync-setup-modal.tsx
+++ b/src/components/sync-setup/sync-setup-modal.tsx
@@ -2,6 +2,8 @@ import { ResponsiveModal, ResponsiveModalContent } from '@/components/ui/respons
 import { Button } from '@/components/ui/button'
 import { useSyncSetup } from '@/hooks/use-sync-setup'
 import { useApprovalPolling } from '@/hooks/use-approval-polling'
+import { checkApprovalAndUnwrap } from '@/services/encryption'
+import { useHttpClient } from '@/contexts'
 import { RecoveryKeyDisplayStep } from './recovery-key-display-step'
 import { ApprovalWaitingStep } from './approval-waiting-step'
 import { RecoveryKeyEntryStep } from './recovery-key-entry-step'
@@ -22,6 +24,7 @@ type SyncSetupModalProps = {
  */
 export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModalProps) => {
   const setup = useSyncSetup()
+  const httpClient = useHttpClient()
   const [_recoveryKeyConfirmed, setRecoveryKeyConfirmed] = useState(false)
   const hasCompletedRef = useRef(false)
 
@@ -72,6 +75,7 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
 
   const { isPolling } = useApprovalPolling({
     enabled: setup.step === 'approval-waiting',
+    checkApproval: () => checkApprovalAndUnwrap(httpClient),
     onApproved: completeAndClose,
   })
 

--- a/src/components/sync-setup/sync-setup-modal.tsx
+++ b/src/components/sync-setup/sync-setup-modal.tsx
@@ -1,6 +1,7 @@
 import { ResponsiveModal, ResponsiveModalContent } from '@/components/ui/responsive-modal'
 import { Button } from '@/components/ui/button'
 import { useSyncSetup } from '@/hooks/use-sync-setup'
+import { useApprovalPolling } from '@/hooks/use-approval-polling'
 import { RecoveryKeyDisplayStep } from './recovery-key-display-step'
 import { ApprovalWaitingStep } from './approval-waiting-step'
 import { RecoveryKeyEntryStep } from './recovery-key-entry-step'
@@ -54,8 +55,7 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
   const handleContinueIntro = async () => {
     const result = await setup.continueIntro()
     if (result === 'already-trusted') {
-      onComplete()
-      handleClose()
+      completeAndClose()
     }
   }
 
@@ -69,6 +69,11 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
       showSuccess()
     }
   }
+
+  const { isPolling } = useApprovalPolling({
+    enabled: setup.step === 'approval-waiting',
+    onApproved: completeAndClose,
+  })
 
   const handleRecoveryKeySubmit = async () => {
     const success = await setup.submitRecoveryKey()
@@ -142,7 +147,7 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
             onContinue={handleApprovalContinue}
             onUseRecoveryKey={setup.goToRecoveryKeyEntry}
             isLoading={setup.isLoading}
-            isPolling={false}
+            isPolling={isPolling}
           />
         )}
 

--- a/src/components/sync-setup/sync-setup-modal.tsx
+++ b/src/components/sync-setup/sync-setup-modal.tsx
@@ -51,23 +51,27 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
     completeAndClose()
   }
 
-  const handleContinueIntro = () => {
-    setup.continueIntro()
+  const handleContinueIntro = async () => {
+    const result = await setup.continueIntro()
+    if (result === 'already-trusted') {
+      onComplete()
+      handleClose()
+    }
   }
 
-  const handleContinueFirstDeviceSetup = () => {
-    setup.continueFirstDeviceSetup()
+  const handleContinueFirstDeviceSetup = async () => {
+    await setup.continueFirstDeviceSetup()
   }
 
-  const handleApprovalContinue = () => {
-    const success = setup.confirmApproval()
+  const handleApprovalContinue = async () => {
+    const success = await setup.confirmApproval()
     if (success) {
       showSuccess()
     }
   }
 
-  const handleRecoveryKeySubmit = () => {
-    const success = setup.submitRecoveryKey()
+  const handleRecoveryKeySubmit = async () => {
+    const success = await setup.submitRecoveryKey()
     if (success) {
       showSuccess()
     }

--- a/src/components/sync-setup/sync-setup-modal.tsx
+++ b/src/components/sync-setup/sync-setup-modal.tsx
@@ -247,30 +247,6 @@ type FirstDeviceSetupStepProps = {
 }
 
 // =============================================================================
-// Setup complete step — success confirmation for additional device flows
-// =============================================================================
-
-const SetupCompleteStep = ({ onDone }: { onDone: () => void }) => (
-  <div className="w-full flex flex-col">
-    <div className="text-center space-y-4">
-      <IconCircle>
-        <CheckCircle className="w-8 h-8 text-green-600 dark:text-green-400" />
-      </IconCircle>
-      <h2 className="text-2xl font-bold">You&apos;re all set!</h2>
-      <p className="text-muted-foreground">
-        This device has been approved and sync is now enabled across your devices.
-      </p>
-    </div>
-
-    <div className="pt-5">
-      <Button className="w-full" onClick={onDone}>
-        Done
-      </Button>
-    </div>
-  </div>
-)
-
-// =============================================================================
 // First device setup step — explanation before key generation
 // =============================================================================
 

--- a/src/components/sync-setup/sync-setup-modal.tsx
+++ b/src/components/sync-setup/sync-setup-modal.tsx
@@ -58,7 +58,7 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
   const handleContinueIntro = async () => {
     const result = await setup.continueIntro()
     if (result === 'already-trusted') {
-      completeAndClose()
+      showSuccess()
     }
   }
 
@@ -76,7 +76,7 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
   const { isPolling } = useApprovalPolling({
     enabled: setup.step === 'approval-waiting',
     checkApproval: () => checkApprovalAndUnwrap(httpClient),
-    onApproved: completeAndClose,
+    onApproved: showSuccess,
   })
 
   const handleRecoveryKeySubmit = async () => {
@@ -245,6 +245,34 @@ type FirstDeviceSetupStepProps = {
   isLoading: boolean
   error: string | null
 }
+
+// =============================================================================
+// Setup complete step — success confirmation for additional device flows
+// =============================================================================
+
+const SetupCompleteStep = ({ onDone }: { onDone: () => void }) => (
+  <div className="w-full flex flex-col">
+    <div className="text-center space-y-4">
+      <IconCircle>
+        <CheckCircle className="w-8 h-8 text-green-600 dark:text-green-400" />
+      </IconCircle>
+      <h2 className="text-2xl font-bold">You&apos;re all set!</h2>
+      <p className="text-muted-foreground">
+        This device has been approved and sync is now enabled across your devices.
+      </p>
+    </div>
+
+    <div className="pt-5">
+      <Button className="w-full" onClick={onDone}>
+        Done
+      </Button>
+    </div>
+  </div>
+)
+
+// =============================================================================
+// First device setup step — explanation before key generation
+// =============================================================================
 
 const FirstDeviceSetupStep = ({ onContinue, isLoading, error }: FirstDeviceSetupStepProps) => (
   <div className="w-full flex flex-col">

--- a/src/crypto/recovery-key.test.ts
+++ b/src/crypto/recovery-key.test.ts
@@ -1,42 +1,66 @@
 import { describe, expect, it } from 'bun:test'
+
 import { encodeRecoveryKey, decodeRecoveryKey } from './recovery-key'
 import { generateCK, encrypt, decrypt } from './primitives'
 
 describe('encodeRecoveryKey', () => {
-  it('produces a 64-character hex string', async () => {
+  it('produces a 24-word mnemonic', async () => {
     const ck = await generateCK(true)
-    const recoveryKey = await encodeRecoveryKey(ck)
-    expect(recoveryKey).toHaveLength(64)
-    expect(/^[0-9a-f]{64}$/.test(recoveryKey)).toBe(true)
+    const mnemonic = await encodeRecoveryKey(ck)
+    const words = mnemonic.split(' ')
+    expect(words).toHaveLength(24)
+  })
+
+  it('produces only lowercase words', async () => {
+    const ck = await generateCK(true)
+    const mnemonic = await encodeRecoveryKey(ck)
+    expect(mnemonic).toBe(mnemonic.toLowerCase())
   })
 })
 
 describe('decodeRecoveryKey', () => {
   it('round-trips: encode then decode produces a working key', async () => {
     const originalCK = await generateCK(true)
-    const recoveryKey = await encodeRecoveryKey(originalCK)
-    const restoredCK = await decodeRecoveryKey(recoveryKey)
+    const mnemonic = await encodeRecoveryKey(originalCK)
+    const restoredCK = await decodeRecoveryKey(mnemonic)
 
-    // Verify the restored key can decrypt data encrypted with the original
     const encrypted = await encrypt('test data', originalCK)
     const decrypted = await decrypt(encrypted, restoredCK)
     expect(decrypted).toBe('test data')
   })
 
-  it('accepts spaces in the input', async () => {
+  it('accepts extra whitespace in the input', async () => {
     const ck = await generateCK(true)
-    const recoveryKey = await encodeRecoveryKey(ck)
-    const withSpaces = recoveryKey.match(/.{8}/g)!.join(' ')
-    const restored = await decodeRecoveryKey(withSpaces)
+    const mnemonic = await encodeRecoveryKey(ck)
+    const withExtraSpaces = `  ${mnemonic.replace(/ /g, '   ')}  `
+    const restored = await decodeRecoveryKey(withExtraSpaces)
     expect(restored.algorithm.name).toBe('AES-GCM')
   })
 
-  it('rejects a key that is too short', async () => {
-    await expect(decodeRecoveryKey('abc123')).rejects.toThrow('64 hex characters')
+  it('accepts mixed case input', async () => {
+    const ck = await generateCK(true)
+    const mnemonic = await encodeRecoveryKey(ck)
+    const restored = await decodeRecoveryKey(mnemonic.toUpperCase())
+    expect(restored.algorithm.name).toBe('AES-GCM')
   })
 
-  it('rejects non-hex characters', async () => {
-    const badKey = 'g'.repeat(64)
-    await expect(decodeRecoveryKey(badKey)).rejects.toThrow('hex characters')
+  it('rejects an invalid mnemonic (bad checksum)', async () => {
+    const ck = await generateCK(true)
+    const mnemonic = await encodeRecoveryKey(ck)
+    const words = mnemonic.split(' ')
+    ;[words[0], words[1]] = [words[1], words[0]]
+    await expect(decodeRecoveryKey(words.join(' '))).rejects.toThrow('Invalid recovery phrase')
+  })
+
+  it('rejects a word not in the wordlist', async () => {
+    const fakeWords = Array(24).fill('zzzznotaword').join(' ')
+    await expect(decodeRecoveryKey(fakeWords)).rejects.toThrow('Invalid recovery phrase')
+  })
+
+  it('rejects wrong word count', async () => {
+    const ck = await generateCK(true)
+    const mnemonic = await encodeRecoveryKey(ck)
+    const tooFew = mnemonic.split(' ').slice(0, 12).join(' ')
+    await expect(decodeRecoveryKey(tooFew)).rejects.toThrow()
   })
 })

--- a/src/crypto/recovery-key.ts
+++ b/src/crypto/recovery-key.ts
@@ -34,10 +34,11 @@ export const decodeRecoveryKey = async (mnemonic: string): Promise<CryptoKey> =>
     throw new ValidationError('Recovery phrase must be exactly 24 words (256-bit key).')
   }
 
-  return crypto.subtle.importKey('raw', bytes.buffer as ArrayBuffer, { name: 'AES-GCM', length: 256 }, true, [
-    'encrypt',
-    'decrypt',
-    'wrapKey',
-    'unwrapKey',
-  ])
+  return crypto.subtle.importKey(
+    'raw',
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+  )
 }

--- a/src/crypto/recovery-key.ts
+++ b/src/crypto/recovery-key.ts
@@ -1,34 +1,40 @@
+import { entropyToMnemonic, mnemonicToEntropy } from '@scure/bip39'
+import { wordlist } from '@scure/bip39/wordlists/english.js'
+
 import { ValidationError } from './errors'
 
 /**
- * Encode an extractable CK as a 64-character hex string (recovery key).
+ * Encode an extractable CK as a 24-word BIP-39 mnemonic (recovery phrase).
  * CK must be extractable — this is only valid during first device setup.
  */
 export const encodeRecoveryKey = async (ck: CryptoKey): Promise<string> => {
   const raw = await crypto.subtle.exportKey('raw', ck)
-  return Array.from(new Uint8Array(raw))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('')
+  return entropyToMnemonic(new Uint8Array(raw), wordlist)
 }
 
 /**
- * Decode a 64-character hex recovery key into an extractable AES-256-GCM CryptoKey.
+ * Decode a 24-word BIP-39 mnemonic into an extractable AES-256-GCM CryptoKey.
+ * Validates checksum per BIP-39 spec.
  * Extractable because the recovery flow needs to wrap it for the device's envelope.
  * Caller must reimport as non-extractable before storing in IndexedDB.
  */
-export const decodeRecoveryKey = async (hex: string): Promise<CryptoKey> => {
-  const cleaned = hex.replace(/\s/g, '')
+export const decodeRecoveryKey = async (mnemonic: string): Promise<CryptoKey> => {
+  const normalized = mnemonic.trim().toLowerCase().replace(/\s+/g, ' ')
 
-  if (cleaned.length !== 64) {
-    throw new ValidationError('Recovery key must be 64 hex characters (32 bytes).')
+  let bytes: Uint8Array
+  try {
+    bytes = mnemonicToEntropy(normalized, wordlist)
+  } catch {
+    throw new ValidationError(
+      'Invalid recovery phrase. Please check that all 24 words are correct and in the right order.',
+    )
   }
-  if (!/^[0-9a-f]+$/i.test(cleaned)) {
-    throw new ValidationError('Recovery key must contain only hex characters (0-9, a-f).')
+
+  if (bytes.length !== 32) {
+    throw new ValidationError('Recovery phrase must be exactly 24 words (256-bit key).')
   }
 
-  const bytes = new Uint8Array(cleaned.match(/.{2}/g)!.map((byte) => parseInt(byte, 16)))
-
-  return crypto.subtle.importKey('raw', bytes, { name: 'AES-GCM', length: 256 }, true, [
+  return crypto.subtle.importKey('raw', bytes.buffer as ArrayBuffer, { name: 'AES-GCM', length: 256 }, true, [
     'encrypt',
     'decrypt',
     'wrapKey',

--- a/src/dal/devices.ts
+++ b/src/dal/devices.ts
@@ -3,10 +3,14 @@ import type { AnyDrizzleDatabase } from '@/db/database-interface'
 import { devicesTable } from '@/db/tables'
 import type { DrizzleQueryWithPromise } from '@/types'
 
+export type DeviceStatus = 'APPROVAL_PENDING' | 'TRUSTED' | 'REVOKED'
+
 export type Device = {
   id: string
   userId: string
   name: string
+  status: DeviceStatus | null
+  publicKey: string | null
   lastSeen: string | null
   createdAt: string | null
   revokedAt: string | null
@@ -25,5 +29,17 @@ export const getDevice = (db: AnyDrizzleDatabase, deviceId: string) => {
  */
 export const getAllDevices = (db: AnyDrizzleDatabase) => {
   const query = db.select().from(devicesTable).orderBy(desc(devicesTable.lastSeen))
+  return query as typeof query & DrizzleQueryWithPromise<Device>
+}
+
+/**
+ * Gets devices with APPROVAL_PENDING status (synced via PowerSync).
+ */
+export const getPendingDevices = (db: AnyDrizzleDatabase) => {
+  const query = db
+    .select()
+    .from(devicesTable)
+    .where(eq(devicesTable.status, 'APPROVAL_PENDING'))
+    .orderBy(desc(devicesTable.createdAt))
   return query as typeof query & DrizzleQueryWithPromise<Device>
 }

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -96,4 +96,4 @@ export {
 } from './model-profiles'
 
 // Devices
-export { getAllDevices, getDevice, type Device } from './devices'
+export { getAllDevices, getDevice, getPendingDevices, type Device, type DeviceStatus } from './devices'

--- a/src/db/encryption/codec.test.ts
+++ b/src/db/encryption/codec.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test'
+
+const mockCK = 'mock-ck' as unknown as CryptoKey
+let mockGetCKReturn: CryptoKey | null = null
+
+/** Safe base64 that handles unicode via URI encoding */
+const safeEncode = (str: string) => btoa(unescape(encodeURIComponent(str)))
+const safeDecode = (b64: string) => decodeURIComponent(escape(atob(b64)))
+
+const mockEncrypt = mock(async (plaintext: string, _ck: CryptoKey) => ({
+  iv: safeEncode(`iv-for-${plaintext.slice(0, 8)}`),
+  ciphertext: safeEncode(`ct-for-${plaintext}`),
+}))
+
+const mockDecrypt = mock(async (data: { iv: string; ciphertext: string }, _ck: CryptoKey) => {
+  const ct = safeDecode(data.ciphertext)
+  if (!ct.startsWith('ct-for-')) {
+    throw new Error('Decryption failed')
+  }
+  return ct.slice('ct-for-'.length)
+})
+
+mock.module('@/crypto', () => ({
+  encrypt: mockEncrypt,
+  decrypt: mockDecrypt,
+  getCK: async () => mockGetCKReturn,
+  generateKeyPair: async () => ({}),
+  generateCK: async () => ({}),
+  reimportAsNonExtractable: async () => ({}),
+  exportPublicKey: async () => '',
+  importPublicKey: async () => ({}),
+  wrapCK: async () => '',
+  rewrapCK: async () => '',
+  unwrapCK: async () => ({}),
+  createCanary: async () => ({ canaryIv: '', canaryCtext: '' }),
+  verifyCanary: async () => true,
+  encodeRecoveryKey: async () => '',
+  decodeRecoveryKey: async () => ({}),
+  storeKeyPair: async () => {},
+  getKeyPair: async () => null,
+  storeCK: async () => {},
+  clearCK: async () => {},
+  clearAllKeys: async () => {},
+  EncryptionError: class extends Error {},
+  DecryptionError: class extends Error {},
+  StorageError: class extends Error {},
+  ValidationError: class extends Error {},
+}))
+
+const { codec, invalidateCKCache } = await import('./codec')
+
+describe('AES-GCM codec', () => {
+  beforeEach(() => {
+    mockEncrypt.mockClear()
+    mockDecrypt.mockClear()
+    invalidateCKCache()
+    mockGetCKReturn = mockCK
+  })
+
+  afterEach(() => {
+    invalidateCKCache()
+  })
+
+  describe('encode', () => {
+    it('produces __enc: prefixed output', async () => {
+      const encoded = await codec.encode('hello world')
+      expect(encoded.startsWith('__enc:')).toBe(true)
+      expect(mockEncrypt).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes through when no CK is available', async () => {
+      mockGetCKReturn = null
+      const result = await codec.encode('hello')
+      expect(result).toBe('hello')
+      expect(mockEncrypt).not.toHaveBeenCalled()
+    })
+
+    it('encodes empty string', async () => {
+      const encoded = await codec.encode('')
+      expect(encoded.startsWith('__enc:')).toBe(true)
+    })
+  })
+
+  describe('decode', () => {
+    it('round-trips through encode → decode', async () => {
+      const original = 'hello world'
+      const encoded = await codec.encode(original)
+      const decoded = await codec.decode(encoded)
+      expect(decoded).toBe(original)
+    })
+
+    it('round-trips unicode content', async () => {
+      const original = 'Hello 🌍 café résumé'
+      const encoded = await codec.encode(original)
+      const decoded = await codec.decode(encoded)
+      expect(decoded).toBe(original)
+    })
+
+    it('returns as-is for __enc: prefix when no CK', async () => {
+      const encoded = await codec.encode('test')
+      invalidateCKCache()
+      mockGetCKReturn = null
+      const decoded = await codec.decode(encoded)
+      expect(decoded).toBe(encoded)
+    })
+
+    it('handles legacy b64: prefix', async () => {
+      const legacy = 'b64:' + btoa(unescape(encodeURIComponent('hello')))
+      const decoded = await codec.decode(legacy)
+      expect(decoded).toBe('hello')
+    })
+
+    it('passes through plaintext (no prefix)', async () => {
+      const decoded = await codec.decode('just plain text')
+      expect(decoded).toBe('just plain text')
+    })
+
+    it('returns as-is for malformed __enc: string', async () => {
+      const malformed = '__enc:no-separator-here'
+      const decoded = await codec.decode(malformed)
+      expect(decoded).toBe(malformed)
+    })
+
+    it('returns as-is when decryption fails', async () => {
+      mockDecrypt.mockImplementationOnce(async () => {
+        throw new Error('bad decrypt')
+      })
+      const encoded = '__enc:aXY=:Y3Q='
+      const decoded = await codec.decode(encoded)
+      expect(decoded).toBe(encoded)
+    })
+  })
+
+  describe('CK cache', () => {
+    it('caches CK across calls', async () => {
+      await codec.encode('a')
+      await codec.encode('b')
+      expect(mockEncrypt).toHaveBeenCalledTimes(2)
+    })
+
+    it('invalidation forces re-check', async () => {
+      await codec.encode('a')
+      invalidateCKCache()
+      mockGetCKReturn = null
+      const result = await codec.encode('b')
+      expect(result).toBe('b')
+    })
+  })
+})

--- a/src/db/encryption/codec.ts
+++ b/src/db/encryption/codec.ts
@@ -1,5 +1,4 @@
 import { encrypt, decrypt, getCK } from '@/crypto'
-import { decodeIfValidBase64 } from '@/lib/base64'
 
 const encPrefix = '__enc:'
 const legacyB64Prefix = 'b64:'
@@ -76,7 +75,7 @@ export const codec: EncryptionCodec = {
       }
     }
 
-    // Legacy unprefixed base64 (from earlier testing)
-    return decodeIfValidBase64(encoded)
+    // No recognized prefix — return as-is (plaintext)
+    return encoded
   },
 }

--- a/src/db/encryption/codec.ts
+++ b/src/db/encryption/codec.ts
@@ -1,0 +1,82 @@
+import { encrypt, decrypt, getCK } from '@/crypto'
+import { decodeIfValidBase64 } from '@/lib/base64'
+
+const encPrefix = '__enc:'
+const legacyB64Prefix = 'b64:'
+
+export type EncryptionCodec = {
+  encode: (plaintext: string) => Promise<string>
+  decode: (encoded: string) => Promise<string>
+}
+
+// =============================================================================
+// CK cache — lazy-loaded from IndexedDB, invalidated on sign-out/wipe.
+// Works in both main thread and SharedWorker (both have indexedDB access).
+// =============================================================================
+
+let cachedCK: CryptoKey | null = null
+
+const getCachedCK = async (): Promise<CryptoKey | null> => {
+  if (cachedCK) {
+    return cachedCK
+  }
+  cachedCK = await getCK()
+  return cachedCK
+}
+
+/** Clear the CK cache. Call on sign-out or full wipe so the codec reloads. */
+export const invalidateCKCache = () => {
+  cachedCK = null
+}
+
+// =============================================================================
+// AES-GCM codec
+// =============================================================================
+
+/** AES-256-GCM codec using CK from IndexedDB. Passes through when CK is unavailable. */
+export const codec: EncryptionCodec = {
+  async encode(plaintext: string): Promise<string> {
+    const ck = await getCachedCK()
+    if (!ck) {
+      return plaintext
+    }
+    const { iv, ciphertext } = await encrypt(plaintext, ck)
+    return `${encPrefix}${iv}:${ciphertext}`
+  },
+
+  async decode(encoded: string): Promise<string> {
+    // AES-GCM encrypted format: __enc:<iv>:<ciphertext>
+    if (encoded.startsWith(encPrefix)) {
+      const payload = encoded.slice(encPrefix.length)
+      const separatorIdx = payload.indexOf(':')
+      if (separatorIdx === -1) {
+        return encoded
+      }
+      const iv = payload.slice(0, separatorIdx)
+      const ciphertext = payload.slice(separatorIdx + 1)
+
+      const ck = await getCachedCK()
+      if (!ck) {
+        return encoded
+      }
+
+      try {
+        return await decrypt({ iv, ciphertext }, ck)
+      } catch {
+        return encoded
+      }
+    }
+
+    // Legacy base64 format: b64:<base64> (backward compat with 6.1 PoC data)
+    if (encoded.startsWith(legacyB64Prefix)) {
+      try {
+        return decodeURIComponent(escape(atob(encoded.slice(legacyB64Prefix.length))))
+      } catch {
+        return encoded
+      }
+    }
+
+    // Legacy unprefixed base64 (from earlier testing)
+    return decodeIfValidBase64(encoded)
+  },
+}

--- a/src/db/encryption/config.ts
+++ b/src/db/encryption/config.ts
@@ -1,0 +1,35 @@
+/**
+ * Single source of truth for encrypted tables and their columns.
+ * Uses DB column names (snake_case) — matches both PowerSync sync data and CRUD upload operations.
+ *
+ * Adding a table here automatically enables:
+ * - Download decryption via EncryptionMiddleware (sync pipeline)
+ * - Upload encryption via encodeForUpload (connector)
+ */
+export const encryptedColumnsMap: Readonly<Record<string, readonly string[]>> = {
+  settings: ['value'],
+  chat_threads: ['title'],
+  chat_messages: ['content', 'parts', 'cache', 'metadata'],
+  tasks: ['item'],
+  models: ['name', 'model', 'url', 'api_key', 'vendor', 'description'],
+  mcp_servers: ['name', 'url', 'command', 'args'],
+  prompts: ['title', 'prompt'],
+  triggers: ['trigger_time'],
+  model_profiles: [
+    'tools_override',
+    'link_previews_override',
+    'chat_mode_addendum',
+    'search_mode_addendum',
+    'research_mode_addendum',
+    'citation_reinforcement_prompt',
+    'nudge_final_step',
+    'nudge_preventive',
+    'nudge_retry',
+    'nudge_search_final_step',
+    'nudge_search_preventive',
+    'nudge_search_retry',
+    'provider_options',
+  ],
+  modes: ['name', 'label', 'icon', 'system_prompt'],
+  devices: ['name'],
+}

--- a/src/db/encryption/index.ts
+++ b/src/db/encryption/index.ts
@@ -1,0 +1,3 @@
+export { encryptedColumnsMap } from './config'
+export { codec, invalidateCKCache, type EncryptionCodec } from './codec'
+export { encodeForUpload } from './upload-encoder'

--- a/src/db/encryption/upload-encoder.test.ts
+++ b/src/db/encryption/upload-encoder.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, beforeEach, mock } from 'bun:test'
+
+mock.module('@/crypto', () => ({
+  encrypt: async (plaintext: string) => ({
+    iv: btoa('iv'),
+    ciphertext: btoa(`ct-${plaintext}`),
+  }),
+  decrypt: async () => '',
+  getCK: async () => 'mock-ck' as unknown as CryptoKey,
+  generateKeyPair: async () => ({}),
+  generateCK: async () => ({}),
+  reimportAsNonExtractable: async () => ({}),
+  exportPublicKey: async () => '',
+  importPublicKey: async () => ({}),
+  wrapCK: async () => '',
+  unwrapCK: async () => ({}),
+  createCanary: async () => ({ canaryIv: '', canaryCtext: '' }),
+  verifyCanary: async () => true,
+  encodeRecoveryKey: async () => '',
+  decodeRecoveryKey: async () => ({}),
+  storeKeyPair: async () => {},
+  getKeyPair: async () => null,
+  storeCK: async () => {},
+  clearCK: async () => {},
+  clearAllKeys: async () => {},
+  EncryptionError: class extends Error {},
+  DecryptionError: class extends Error {},
+  StorageError: class extends Error {},
+  ValidationError: class extends Error {},
+}))
+
+const { invalidateCKCache } = await import('./codec')
+const { encodeForUpload } = await import('./upload-encoder')
+
+describe('encodeForUpload', () => {
+  beforeEach(() => {
+    invalidateCKCache()
+  })
+
+  it('encrypts encrypted columns for known tables', async () => {
+    const op = {
+      op: 'PUT' as const,
+      type: 'tasks',
+      id: '123',
+      data: { item: 'Buy groceries', order: 1, is_complete: 0 },
+    }
+
+    const result = await encodeForUpload(op)
+
+    expect(typeof result.data?.item).toBe('string')
+    expect((result.data?.item as string).startsWith('__enc:')).toBe(true)
+    expect(result.data?.order).toBe(1)
+    expect(result.data?.is_complete).toBe(0)
+  })
+
+  it('passes through DELETE operations', async () => {
+    const op = { op: 'DELETE' as const, type: 'tasks', id: '123' }
+    const result = await encodeForUpload(op)
+    expect(result).toEqual(op)
+  })
+
+  it('passes through unknown tables', async () => {
+    const op = {
+      op: 'PUT' as const,
+      type: 'unknown_table',
+      id: '123',
+      data: { foo: 'bar' },
+    }
+
+    const result = await encodeForUpload(op)
+    expect(result.data?.foo).toBe('bar')
+  })
+
+  it('does not encrypt non-string values', async () => {
+    const op = {
+      op: 'PUT' as const,
+      type: 'tasks',
+      id: '123',
+      data: { item: null, order: 5 },
+    }
+
+    const result = await encodeForUpload(op)
+    expect(result.data?.item).toBeNull()
+    expect(result.data?.order).toBe(5)
+  })
+
+  it('encrypts multiple columns', async () => {
+    const op = {
+      op: 'PUT' as const,
+      type: 'chat_messages',
+      id: '456',
+      data: {
+        content: 'Hello',
+        parts: '[{"type":"text"}]',
+        chat_thread_id: 'thread-1',
+      },
+    }
+
+    const result = await encodeForUpload(op)
+
+    expect((result.data?.content as string).startsWith('__enc:')).toBe(true)
+    expect((result.data?.parts as string).startsWith('__enc:')).toBe(true)
+    expect(result.data?.chat_thread_id).toBe('thread-1')
+  })
+})

--- a/src/db/encryption/upload-encoder.ts
+++ b/src/db/encryption/upload-encoder.ts
@@ -1,0 +1,34 @@
+import { encryptedColumnsMap } from './config'
+import { codec } from './codec'
+
+type CrudOperation = {
+  op: 'PUT' | 'PATCH' | 'DELETE'
+  type: string
+  id: string
+  data?: Record<string, unknown>
+}
+
+/**
+ * Encrypts encrypted columns in a CRUD operation before upload.
+ * Returns the operation unchanged if the table has no encrypted columns or op is DELETE.
+ */
+export const encodeForUpload = async (operation: CrudOperation): Promise<CrudOperation> => {
+  if (operation.op === 'DELETE' || !operation.data) {
+    return operation
+  }
+
+  const columns = encryptedColumnsMap[operation.type]
+  if (!columns) {
+    return operation
+  }
+
+  const encodedData = { ...operation.data }
+  for (const col of columns) {
+    const value = encodedData[col]
+    if (typeof value === 'string') {
+      encodedData[col] = await codec.encode(value)
+    }
+  }
+
+  return { ...operation, data: encodedData }
+}

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -224,6 +224,8 @@ export const devicesTable = sqliteTable('devices', {
   id: text('id').primaryKey(),
   userId: text('user_id'),
   name: text('name'),
+  status: text('status'),
+  publicKey: text('public_key'),
   lastSeen: text('last_seen'),
   createdAt: text('created_at'),
   revokedAt: text('revoked_at'),

--- a/src/hooks/use-approval-polling.test.ts
+++ b/src/hooks/use-approval-polling.test.ts
@@ -1,0 +1,118 @@
+import '@/testing-library'
+import { getClock } from '@/testing-library'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const mockCheckApprovalAndUnwrap = mock(() => Promise.resolve(false))
+const mockUseHttpClient = mock(() => 'mock-http-client')
+
+mock.module('@/services/encryption', () => ({
+  checkApprovalAndUnwrap: mockCheckApprovalAndUnwrap,
+}))
+
+mock.module('@/contexts', () => ({
+  useHttpClient: mockUseHttpClient,
+}))
+
+import { useApprovalPolling } from './use-approval-polling'
+
+describe('useApprovalPolling', () => {
+  beforeEach(() => {
+    mockCheckApprovalAndUnwrap.mockClear()
+    mockCheckApprovalAndUnwrap.mockImplementation(() => Promise.resolve(false))
+  })
+
+  afterEach(() => {
+    cleanup()
+    mockCheckApprovalAndUnwrap.mockRestore?.()
+  })
+
+  it('does not poll when disabled', async () => {
+    const onApproved = mock(() => {})
+    renderHook(() => useApprovalPolling({ enabled: false, onApproved, intervalMs: 50 }))
+
+    await act(async () => {
+      await getClock().tickAsync(200)
+    })
+    expect(mockCheckApprovalAndUnwrap).not.toHaveBeenCalled()
+  })
+
+  it('returns isPolling=false when disabled', () => {
+    const onApproved = mock(() => {})
+    const { result } = renderHook(() => useApprovalPolling({ enabled: false, onApproved }))
+
+    expect(result.current.isPolling).toBe(false)
+  })
+
+  it('returns isPolling=true when enabled', () => {
+    const onApproved = mock(() => {})
+    const { result } = renderHook(() => useApprovalPolling({ enabled: true, onApproved, intervalMs: 5000 }))
+
+    expect(result.current.isPolling).toBe(true)
+  })
+
+  it('polls and calls onApproved when approved', async () => {
+    mockCheckApprovalAndUnwrap.mockImplementation(() => Promise.resolve(true))
+    const onApproved = mock(() => {})
+
+    renderHook(() => useApprovalPolling({ enabled: true, onApproved, intervalMs: 50 }))
+
+    await act(async () => {
+      await getClock().tickAsync(60)
+    })
+    expect(mockCheckApprovalAndUnwrap).toHaveBeenCalled()
+    expect(onApproved).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues polling silently on errors then succeeds', async () => {
+    let callCount = 0
+    mockCheckApprovalAndUnwrap.mockImplementation(() => {
+      callCount++
+      if (callCount <= 2) {
+        return Promise.reject(new Error('Network error'))
+      }
+      return Promise.resolve(true)
+    })
+    const onApproved = mock(() => {})
+
+    renderHook(() => useApprovalPolling({ enabled: true, onApproved, intervalMs: 50 }))
+
+    await act(async () => {
+      await getClock().tickAsync(200)
+    })
+    expect(onApproved).toHaveBeenCalledTimes(1)
+    expect(callCount).toBeGreaterThanOrEqual(3)
+  })
+
+  it('stops polling on unmount', async () => {
+    const onApproved = mock(() => {})
+    const { unmount } = renderHook(() => useApprovalPolling({ enabled: true, onApproved, intervalMs: 50 }))
+
+    unmount()
+    const callsBefore = mockCheckApprovalAndUnwrap.mock.calls.length
+
+    await act(async () => {
+      await getClock().tickAsync(200)
+    })
+    expect(mockCheckApprovalAndUnwrap.mock.calls.length).toBe(callsBefore)
+  })
+
+  it('stops polling when enabled changes to false', async () => {
+    const onApproved = mock(() => {})
+    const { rerender } = renderHook(({ enabled }) => useApprovalPolling({ enabled, onApproved, intervalMs: 50 }), {
+      initialProps: { enabled: true },
+    })
+
+    await act(async () => {
+      await getClock().tickAsync(60)
+    })
+
+    rerender({ enabled: false })
+
+    const callsBefore = mockCheckApprovalAndUnwrap.mock.calls.length
+    await act(async () => {
+      await getClock().tickAsync(200)
+    })
+    expect(mockCheckApprovalAndUnwrap.mock.calls.length).toBe(callsBefore)
+  })
+})

--- a/src/hooks/use-approval-polling.test.ts
+++ b/src/hooks/use-approval-polling.test.ts
@@ -1,72 +1,59 @@
 import '@/testing-library'
 import { getClock } from '@/testing-library'
 import { act, cleanup, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-
-const mockCheckApprovalAndUnwrap = mock(() => Promise.resolve(false))
-const mockUseHttpClient = mock(() => 'mock-http-client')
-
-mock.module('@/services/encryption', () => ({
-  checkApprovalAndUnwrap: mockCheckApprovalAndUnwrap,
-}))
-
-mock.module('@/contexts', () => ({
-  useHttpClient: mockUseHttpClient,
-}))
-
+import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { useApprovalPolling } from './use-approval-polling'
 
 describe('useApprovalPolling', () => {
-  beforeEach(() => {
-    mockCheckApprovalAndUnwrap.mockClear()
-    mockCheckApprovalAndUnwrap.mockImplementation(() => Promise.resolve(false))
-  })
-
   afterEach(() => {
     cleanup()
-    mockCheckApprovalAndUnwrap.mockRestore?.()
   })
 
   it('does not poll when disabled', async () => {
+    const checkApproval = mock(() => Promise.resolve(false))
     const onApproved = mock(() => {})
-    renderHook(() => useApprovalPolling({ enabled: false, onApproved, intervalMs: 50 }))
+    renderHook(() => useApprovalPolling({ enabled: false, checkApproval, onApproved, intervalMs: 50 }))
 
     await act(async () => {
       await getClock().tickAsync(200)
     })
-    expect(mockCheckApprovalAndUnwrap).not.toHaveBeenCalled()
+    expect(checkApproval).not.toHaveBeenCalled()
   })
 
   it('returns isPolling=false when disabled', () => {
+    const checkApproval = mock(() => Promise.resolve(false))
     const onApproved = mock(() => {})
-    const { result } = renderHook(() => useApprovalPolling({ enabled: false, onApproved }))
+    const { result } = renderHook(() => useApprovalPolling({ enabled: false, checkApproval, onApproved }))
 
     expect(result.current.isPolling).toBe(false)
   })
 
   it('returns isPolling=true when enabled', () => {
+    const checkApproval = mock(() => Promise.resolve(false))
     const onApproved = mock(() => {})
-    const { result } = renderHook(() => useApprovalPolling({ enabled: true, onApproved, intervalMs: 5000 }))
+    const { result } = renderHook(() =>
+      useApprovalPolling({ enabled: true, checkApproval, onApproved, intervalMs: 5000 }),
+    )
 
     expect(result.current.isPolling).toBe(true)
   })
 
   it('polls and calls onApproved when approved', async () => {
-    mockCheckApprovalAndUnwrap.mockImplementation(() => Promise.resolve(true))
+    const checkApproval = mock(() => Promise.resolve(true))
     const onApproved = mock(() => {})
 
-    renderHook(() => useApprovalPolling({ enabled: true, onApproved, intervalMs: 50 }))
+    renderHook(() => useApprovalPolling({ enabled: true, checkApproval, onApproved, intervalMs: 50 }))
 
     await act(async () => {
       await getClock().tickAsync(60)
     })
-    expect(mockCheckApprovalAndUnwrap).toHaveBeenCalled()
+    expect(checkApproval).toHaveBeenCalled()
     expect(onApproved).toHaveBeenCalledTimes(1)
   })
 
   it('continues polling silently on errors then succeeds', async () => {
     let callCount = 0
-    mockCheckApprovalAndUnwrap.mockImplementation(() => {
+    const checkApproval = mock(() => {
       callCount++
       if (callCount <= 2) {
         return Promise.reject(new Error('Network error'))
@@ -75,7 +62,7 @@ describe('useApprovalPolling', () => {
     })
     const onApproved = mock(() => {})
 
-    renderHook(() => useApprovalPolling({ enabled: true, onApproved, intervalMs: 50 }))
+    renderHook(() => useApprovalPolling({ enabled: true, checkApproval, onApproved, intervalMs: 50 }))
 
     await act(async () => {
       await getClock().tickAsync(200)
@@ -85,23 +72,28 @@ describe('useApprovalPolling', () => {
   })
 
   it('stops polling on unmount', async () => {
+    const checkApproval = mock(() => Promise.resolve(false))
     const onApproved = mock(() => {})
-    const { unmount } = renderHook(() => useApprovalPolling({ enabled: true, onApproved, intervalMs: 50 }))
+    const { unmount } = renderHook(() =>
+      useApprovalPolling({ enabled: true, checkApproval, onApproved, intervalMs: 50 }),
+    )
 
     unmount()
-    const callsBefore = mockCheckApprovalAndUnwrap.mock.calls.length
+    const callsBefore = checkApproval.mock.calls.length
 
     await act(async () => {
       await getClock().tickAsync(200)
     })
-    expect(mockCheckApprovalAndUnwrap.mock.calls.length).toBe(callsBefore)
+    expect(checkApproval.mock.calls.length).toBe(callsBefore)
   })
 
   it('stops polling when enabled changes to false', async () => {
+    const checkApproval = mock(() => Promise.resolve(false))
     const onApproved = mock(() => {})
-    const { rerender } = renderHook(({ enabled }) => useApprovalPolling({ enabled, onApproved, intervalMs: 50 }), {
-      initialProps: { enabled: true },
-    })
+    const { rerender } = renderHook(
+      ({ enabled }) => useApprovalPolling({ enabled, checkApproval, onApproved, intervalMs: 50 }),
+      { initialProps: { enabled: true } },
+    )
 
     await act(async () => {
       await getClock().tickAsync(60)
@@ -109,10 +101,40 @@ describe('useApprovalPolling', () => {
 
     rerender({ enabled: false })
 
-    const callsBefore = mockCheckApprovalAndUnwrap.mock.calls.length
+    const callsBefore = checkApproval.mock.calls.length
     await act(async () => {
       await getClock().tickAsync(200)
     })
-    expect(mockCheckApprovalAndUnwrap.mock.calls.length).toBe(callsBefore)
+    expect(checkApproval.mock.calls.length).toBe(callsBefore)
+  })
+
+  it('does not call onApproved after cleanup even if check resolves', async () => {
+    let resolveCheck: (value: boolean) => void
+    const checkApproval = mock(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveCheck = resolve
+        }),
+    )
+    const onApproved = mock(() => {})
+
+    const { unmount } = renderHook(() =>
+      useApprovalPolling({ enabled: true, checkApproval, onApproved, intervalMs: 50 }),
+    )
+
+    // Trigger the first check
+    await act(async () => {
+      await getClock().tickAsync(60)
+    })
+
+    // Unmount while check is in-flight
+    unmount()
+
+    // Resolve the in-flight check with approved=true
+    await act(async () => {
+      resolveCheck!(true)
+    })
+
+    expect(onApproved).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/use-approval-polling.ts
+++ b/src/hooks/use-approval-polling.ts
@@ -1,24 +1,29 @@
 import { useEffect, useRef, useState } from 'react'
-import { useHttpClient } from '@/contexts'
-import { checkApprovalAndUnwrap } from '@/services/encryption'
 
 type UseApprovalPollingOptions = {
   enabled: boolean
+  checkApproval: () => Promise<boolean>
   onApproved: () => void
   intervalMs?: number
 }
 
 /**
- * Polls the server to detect when this device has been approved by a trusted device.
- * Calls `checkApprovalAndUnwrap` at a regular interval; on success, fires `onApproved`.
+ * Polls to detect when this device has been approved by a trusted device.
+ * Calls `checkApproval` at a regular interval; on success, fires `onApproved`.
  * Errors are silently ignored — the manual Continue button serves as fallback.
  */
-export const useApprovalPolling = ({ enabled, onApproved, intervalMs = 3000 }: UseApprovalPollingOptions) => {
-  const httpClient = useHttpClient()
+export const useApprovalPolling = ({
+  enabled,
+  checkApproval,
+  onApproved,
+  intervalMs = 3000,
+}: UseApprovalPollingOptions) => {
   const [isPolling, setIsPolling] = useState(false)
   const isCheckingRef = useRef(false)
   const onApprovedRef = useRef(onApproved)
   onApprovedRef.current = onApproved
+  const checkApprovalRef = useRef(checkApproval)
+  checkApprovalRef.current = checkApproval
 
   useEffect(() => {
     if (!enabled) {
@@ -36,7 +41,7 @@ export const useApprovalPolling = ({ enabled, onApproved, intervalMs = 3000 }: U
       isCheckingRef.current = true
 
       try {
-        const approved = await checkApprovalAndUnwrap(httpClient)
+        const approved = await checkApprovalRef.current()
         if (approved && !cancelled) {
           clearInterval(intervalId)
           setIsPolling(false)
@@ -56,7 +61,7 @@ export const useApprovalPolling = ({ enabled, onApproved, intervalMs = 3000 }: U
       clearInterval(intervalId)
       setIsPolling(false)
     }
-  }, [enabled, httpClient, intervalMs])
+  }, [enabled, intervalMs])
 
   return { isPolling }
 }

--- a/src/hooks/use-approval-polling.ts
+++ b/src/hooks/use-approval-polling.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react'
+import { useHttpClient } from '@/contexts'
+import { checkApprovalAndUnwrap } from '@/services/encryption'
+
+type UseApprovalPollingOptions = {
+  enabled: boolean
+  onApproved: () => void
+  intervalMs?: number
+}
+
+/**
+ * Polls the server to detect when this device has been approved by a trusted device.
+ * Calls `checkApprovalAndUnwrap` at a regular interval; on success, fires `onApproved`.
+ * Errors are silently ignored — the manual Continue button serves as fallback.
+ */
+export const useApprovalPolling = ({ enabled, onApproved, intervalMs = 3000 }: UseApprovalPollingOptions) => {
+  const httpClient = useHttpClient()
+  const [isPolling, setIsPolling] = useState(false)
+  const isCheckingRef = useRef(false)
+  const onApprovedRef = useRef(onApproved)
+  onApprovedRef.current = onApproved
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsPolling(false)
+      return
+    }
+
+    let cancelled = false
+    setIsPolling(true)
+
+    const check = async () => {
+      if (isCheckingRef.current) {
+        return
+      }
+      isCheckingRef.current = true
+
+      try {
+        const approved = await checkApprovalAndUnwrap(httpClient)
+        if (approved && !cancelled) {
+          clearInterval(intervalId)
+          setIsPolling(false)
+          onApprovedRef.current()
+        }
+      } catch {
+        // Silently continue — manual button is fallback
+      } finally {
+        isCheckingRef.current = false
+      }
+    }
+
+    const intervalId = setInterval(check, intervalMs)
+
+    return () => {
+      cancelled = true
+      clearInterval(intervalId)
+      setIsPolling(false)
+    }
+  }, [enabled, httpClient, intervalMs])
+
+  return { isPolling }
+}

--- a/src/hooks/use-sync-setup.ts
+++ b/src/hooks/use-sync-setup.ts
@@ -173,7 +173,10 @@ export const useSyncSetup = () => {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Recovery failed'
       if (message === 'Invalid recovery key') {
-        dispatch({ type: 'SET_RECOVERY_KEY_ERROR', payload: 'Invalid recovery key. Please check and try again.' })
+        dispatch({
+          type: 'SET_RECOVERY_KEY_ERROR',
+          payload: 'Invalid recovery phrase. Please check that all words are correct and in the right order.',
+        })
       } else {
         dispatch({ type: 'SET_RECOVERY_KEY_ERROR', payload: message })
       }

--- a/src/hooks/use-sync-setup.ts
+++ b/src/hooks/use-sync-setup.ts
@@ -1,8 +1,11 @@
 import { useReducer } from 'react'
-
-// Mock recovery phrase for UI testing (replaced with real BIP-39 mnemonic in PR 5)
-const mockRecoveryPhrase =
-  'abandon ability able about above absent absorb abstract absurd abuse access accident alcohol alien alpha already amateur amazing among amount amused analyst anchor annual'
+import { useHttpClient } from '@/contexts'
+import {
+  registerThisDevice,
+  completeFirstDeviceSetup,
+  checkApprovalAndUnwrap,
+  recoverWithKey,
+} from '@/services/encryption'
 
 type SyncSetupStep =
   | 'intro'
@@ -89,31 +92,68 @@ const reducer = (state: SyncSetupState, action: SyncSetupAction): SyncSetupState
 
 /**
  * State machine for the sync setup wizard.
- * All crypto/API calls are stubs — replaced with real implementations in PR 5.
+ * Orchestrates device registration, key generation, and encryption setup flows.
  */
 export const useSyncSetup = () => {
+  const httpClient = useHttpClient()
   const [state, dispatch] = useReducer(reducer, initialState)
 
-  // Stub: In PR 5, this will call registerThisDevice() and auto-detect first vs additional
-  const continueIntro = () => {
+  const continueIntro = async () => {
     dispatch({ type: 'CONTINUE_INTRO' })
-    // Mock auto-detection: always treats as first device
-    dispatch({ type: 'DETECTED_FIRST_DEVICE' })
+
+    try {
+      const result = await registerThisDevice(httpClient)
+
+      if (result.status === 'TRUSTED') {
+        // Device already trusted — try to unwrap CK from existing envelope
+        const unwrapped = await checkApprovalAndUnwrap(httpClient)
+        if (unwrapped) {
+          // CK recovered — signal completion via a special state
+          // The caller (modal) should detect this and call onComplete
+          dispatch({ type: 'STOP_LOADING' })
+          return 'already-trusted' as const
+        }
+        // Envelope missing — treat as first device scenario
+        dispatch({ type: 'DETECTED_FIRST_DEVICE' })
+        return 'first-device' as const
+      }
+
+      if ('firstDevice' in result && result.firstDevice) {
+        dispatch({ type: 'DETECTED_FIRST_DEVICE' })
+        return 'first-device' as const
+      }
+
+      dispatch({ type: 'DETECTED_ADDITIONAL_DEVICE' })
+      return 'additional-device' as const
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to register device'
+      dispatch({ type: 'SET_ERROR', payload: message })
+      return 'error' as const
+    }
   }
 
   const goBack = () => dispatch({ type: 'GO_BACK' })
 
-  // Stub: In PR 5, this will call completeFirstDeviceSetup() to generate real keys
-  const continueFirstDeviceSetup = () => {
-    dispatch({ type: 'SET_RECOVERY_KEY', payload: mockRecoveryPhrase })
+  const continueFirstDeviceSetup = async () => {
+    dispatch({ type: 'START_LOADING' })
+
+    try {
+      const recoveryKey = await completeFirstDeviceSetup(httpClient)
+      dispatch({ type: 'SET_RECOVERY_KEY', payload: recoveryKey })
+      return true
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to set up encryption'
+      dispatch({ type: 'SET_ERROR', payload: message })
+      return false
+    }
   }
 
-  const chooseAdditionalDevice = () => dispatch({ type: 'DETECTED_ADDITIONAL_DEVICE' })
   const goToRecoveryKeyEntry = () => dispatch({ type: 'GO_TO_RECOVERY_KEY_ENTRY' })
+  const chooseAdditionalDevice = () => dispatch({ type: 'DETECTED_ADDITIONAL_DEVICE' })
 
   const setRecoveryKeyInput = (value: string) => dispatch({ type: 'SET_RECOVERY_KEY_INPUT', payload: value })
 
-  const submitRecoveryKey = () => {
+  const submitRecoveryKey = async () => {
     const normalized = state.recoveryKeyInput.trim().toLowerCase().replace(/\s+/g, ' ')
     const wordCount = normalized.split(' ').length
 
@@ -125,12 +165,42 @@ export const useSyncSetup = () => {
       return false
     }
 
-    // Stub: In PR 5, this will verify via canary decryption
-    return true
+    dispatch({ type: 'START_LOADING' })
+
+    try {
+      await recoverWithKey(httpClient, normalized)
+      return true
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Recovery failed'
+      if (message === 'Invalid recovery key') {
+        dispatch({ type: 'SET_RECOVERY_KEY_ERROR', payload: 'Invalid recovery key. Please check and try again.' })
+      } else {
+        dispatch({ type: 'SET_RECOVERY_KEY_ERROR', payload: message })
+      }
+      return false
+    }
   }
 
-  // Stub: In PR 5, this will call checkApprovalAndUnwrap()
-  const confirmApproval = () => true
+  const confirmApproval = async () => {
+    dispatch({ type: 'START_LOADING' })
+
+    try {
+      const approved = await checkApprovalAndUnwrap(httpClient)
+      if (!approved) {
+        dispatch({
+          type: 'SET_APPROVAL_ERROR',
+          payload: 'This device has not been approved yet. Please approve it from a trusted device first.',
+        })
+        return false
+      }
+      dispatch({ type: 'STOP_LOADING' })
+      return true
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to check approval'
+      dispatch({ type: 'SET_APPROVAL_ERROR', payload: message })
+      return false
+    }
+  }
 
   const completeSetup = () => dispatch({ type: 'SETUP_COMPLETE' })
   const reset = () => dispatch({ type: 'RESET' })

--- a/src/lib/base64.test.ts
+++ b/src/lib/base64.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test'
+import { isValidBase64, decodeIfValidBase64, encodeToBase64 } from './base64'
+
+describe('base64 utilities', () => {
+  describe('isValidBase64', () => {
+    it('returns true for valid base64', () => {
+      expect(isValidBase64(btoa('hello'))).toBe(true)
+    })
+
+    it('returns false for non-base64 strings', () => {
+      expect(isValidBase64('not base64!!!')).toBe(false)
+    })
+
+    it('returns false for empty strings', () => {
+      expect(isValidBase64('')).toBe(false)
+    })
+  })
+
+  describe('encodeToBase64', () => {
+    it('encodes to base64', () => {
+      expect(encodeToBase64('hello')).toBe(btoa('hello'))
+    })
+  })
+
+  describe('decodeIfValidBase64', () => {
+    it('decodes valid base64', () => {
+      const encoded = btoa('hello world')
+      expect(decodeIfValidBase64(encoded)).toBe('hello world')
+    })
+
+    it('returns original for non-base64', () => {
+      expect(decodeIfValidBase64('not base64!!!')).toBe('not base64!!!')
+    })
+
+    it('returns empty string as-is', () => {
+      expect(decodeIfValidBase64('')).toBe('')
+    })
+  })
+
+  describe('round-trip', () => {
+    it('encode → decode returns original', () => {
+      const cases = ['hello', 'hello world', '{"key": "value"}', 'a']
+      for (const original of cases) {
+        const encoded = encodeToBase64(original)
+        const decoded = decodeIfValidBase64(encoded)
+        expect(decoded).toBe(original)
+      }
+    })
+  })
+})

--- a/src/lib/base64.ts
+++ b/src/lib/base64.ts
@@ -1,0 +1,34 @@
+/**
+ * Returns true if the string is valid base64 (non-empty, decodable).
+ * Uses try/catch around atob(); refactor later for format checks or encryption markers.
+ */
+export const isValidBase64 = (value: string): boolean => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false
+  }
+  try {
+    atob(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * If valid base64, returns decoded string; otherwise returns original.
+ */
+export const decodeIfValidBase64 = (value: string): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return value
+  }
+  try {
+    return atob(value)
+  } catch {
+    return value
+  }
+}
+
+/**
+ * Encodes a string to base64.
+ */
+export const encodeToBase64 = (value: string): string => btoa(value)

--- a/src/services/encryption.test.ts
+++ b/src/services/encryption.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test'
+import type { KyInstance } from 'ky'
+
+// Mock crypto module before importing the service
+const mockKeyPair = {
+  privateKey: 'mock-private-key' as unknown as CryptoKey,
+  publicKey: 'mock-public-key' as unknown as CryptoKey,
+}
+const mockCK = 'mock-ck' as unknown as CryptoKey
+const mockExtractableCK = 'mock-extractable-ck' as unknown as CryptoKey
+
+const cryptoMocks = {
+  generateKeyPair: mock(async () => mockKeyPair),
+  generateCK: mock(async () => mockExtractableCK),
+  reimportAsNonExtractable: mock(async () => mockCK),
+  exportPublicKey: mock(async () => 'mock-public-key-base64'),
+  importPublicKey: mock(async () => 'mock-imported-public-key' as unknown as CryptoKey),
+  wrapCK: mock(async () => 'mock-wrapped-ck'),
+  unwrapCK: mock(async () => mockCK),
+  createCanary: mock(async () => ({ canaryIv: 'mock-iv', canaryCtext: 'mock-ctext' })),
+  verifyCanary: mock(async () => true),
+  encodeRecoveryKey: mock(async () => 'a'.repeat(64)),
+  decodeRecoveryKey: mock(async () => mockCK),
+  storeKeyPair: mock(async () => {}),
+  getKeyPair: mock(async () => null as { privateKey: CryptoKey; publicKey: CryptoKey } | null),
+  storeCK: mock(async () => {}),
+  getCK: mock(async () => null as CryptoKey | null),
+  clearCK: mock(async () => {}),
+  clearAllKeys: mock(async () => {}),
+}
+
+mock.module('@/crypto', () => cryptoMocks)
+
+const apiMocks = {
+  registerDevice: mock(async () => ({ status: 'APPROVAL_PENDING' as const, firstDevice: true })),
+  storeEnvelope: mock(async () => ({ status: 'TRUSTED' as const })),
+  fetchMyEnvelope: mock(async () => ({ status: 'TRUSTED', wrappedCK: 'mock-wrapped-ck' })),
+  fetchCanary: mock(async () => ({ canaryIv: 'mock-iv', canaryCtext: 'mock-ctext' })),
+}
+
+mock.module('@/api/encryption', () => apiMocks)
+
+// Import after mocking
+const {
+  registerThisDevice,
+  completeFirstDeviceSetup,
+  approveDevice,
+  checkApprovalAndUnwrap,
+  recoverWithKey,
+  handleSignOut,
+  handleFullWipe,
+} = await import('./encryption')
+
+const deviceIdKey = 'thunderbolt_device_id'
+const authTokenKey = 'thunderbolt_auth_token'
+
+const mockHttpClient = {} as KyInstance
+
+const resetAllMocks = () => {
+  Object.values(cryptoMocks).forEach((m) => m.mockClear())
+  Object.values(apiMocks).forEach((m) => m.mockClear())
+
+  // Reset default return values
+  cryptoMocks.generateKeyPair.mockImplementation(async () => mockKeyPair)
+  cryptoMocks.generateCK.mockImplementation(async () => mockExtractableCK)
+  cryptoMocks.reimportAsNonExtractable.mockImplementation(async () => mockCK)
+  cryptoMocks.exportPublicKey.mockImplementation(async () => 'mock-public-key-base64')
+  cryptoMocks.importPublicKey.mockImplementation(async () => 'mock-imported-public-key' as unknown as CryptoKey)
+  cryptoMocks.wrapCK.mockImplementation(async () => 'mock-wrapped-ck')
+  cryptoMocks.unwrapCK.mockImplementation(async () => mockCK)
+  cryptoMocks.createCanary.mockImplementation(async () => ({ canaryIv: 'mock-iv', canaryCtext: 'mock-ctext' }))
+  cryptoMocks.verifyCanary.mockImplementation(async () => true)
+  cryptoMocks.encodeRecoveryKey.mockImplementation(async () => 'a'.repeat(64))
+  cryptoMocks.decodeRecoveryKey.mockImplementation(async () => mockCK)
+  cryptoMocks.storeKeyPair.mockImplementation(async () => {})
+  cryptoMocks.getKeyPair.mockImplementation(async () => null)
+  cryptoMocks.storeCK.mockImplementation(async () => {})
+  cryptoMocks.getCK.mockImplementation(async () => null)
+  cryptoMocks.clearCK.mockImplementation(async () => {})
+  cryptoMocks.clearAllKeys.mockImplementation(async () => {})
+
+  apiMocks.registerDevice.mockImplementation(async () => ({ status: 'APPROVAL_PENDING' as const, firstDevice: true }))
+  apiMocks.storeEnvelope.mockImplementation(async () => ({ status: 'TRUSTED' as const }))
+  apiMocks.fetchMyEnvelope.mockImplementation(async () => ({ status: 'TRUSTED', wrappedCK: 'mock-wrapped-ck' }))
+  apiMocks.fetchCanary.mockImplementation(async () => ({ canaryIv: 'mock-iv', canaryCtext: 'mock-ctext' }))
+}
+
+describe('encryption service', () => {
+  beforeEach(() => {
+    localStorage.setItem(deviceIdKey, 'test-device-id')
+    localStorage.setItem(authTokenKey, 'test-token')
+    resetAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.removeItem(deviceIdKey)
+    localStorage.removeItem(authTokenKey)
+  })
+
+  describe('registerThisDevice', () => {
+    it('generates new key pair when none exists', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => null)
+
+      const result = await registerThisDevice(mockHttpClient)
+
+      expect(cryptoMocks.generateKeyPair).toHaveBeenCalledTimes(1)
+      expect(cryptoMocks.storeKeyPair).toHaveBeenCalledWith(mockKeyPair.privateKey, mockKeyPair.publicKey)
+      expect(cryptoMocks.exportPublicKey).toHaveBeenCalledWith(mockKeyPair.publicKey)
+      expect(apiMocks.registerDevice).toHaveBeenCalledTimes(1)
+      expect(result).toEqual({ status: 'APPROVAL_PENDING', firstDevice: true })
+    })
+
+    it('reuses existing key pair', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => mockKeyPair)
+
+      await registerThisDevice(mockHttpClient)
+
+      expect(cryptoMocks.generateKeyPair).not.toHaveBeenCalled()
+      expect(cryptoMocks.storeKeyPair).not.toHaveBeenCalled()
+      expect(cryptoMocks.exportPublicKey).toHaveBeenCalledWith(mockKeyPair.publicKey)
+    })
+
+    it('passes device ID and public key to API', async () => {
+      await registerThisDevice(mockHttpClient)
+
+      expect(apiMocks.registerDevice).toHaveBeenCalledWith(mockHttpClient, {
+        deviceId: 'test-device-id',
+        publicKey: 'mock-public-key-base64',
+        name: expect.any(String),
+      })
+    })
+  })
+
+  describe('completeFirstDeviceSetup', () => {
+    it('generates CK, canary, envelope, stores keys, returns recovery key', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => mockKeyPair)
+
+      const recoveryKey = await completeFirstDeviceSetup(mockHttpClient)
+
+      // Should generate extractable CK
+      expect(cryptoMocks.generateCK).toHaveBeenCalledWith(true)
+      // Should encode recovery key
+      expect(cryptoMocks.encodeRecoveryKey).toHaveBeenCalledWith(mockExtractableCK)
+      // Should create canary
+      expect(cryptoMocks.createCanary).toHaveBeenCalledWith(mockExtractableCK)
+      // Should reimport as non-extractable
+      expect(cryptoMocks.reimportAsNonExtractable).toHaveBeenCalledWith(mockExtractableCK)
+      // Should wrap CK with own public key
+      expect(cryptoMocks.wrapCK).toHaveBeenCalledWith(mockCK, mockKeyPair.publicKey)
+      // Should store envelope with canary
+      expect(apiMocks.storeEnvelope).toHaveBeenCalledWith(mockHttpClient, {
+        deviceId: 'test-device-id',
+        wrappedCK: 'mock-wrapped-ck',
+        canaryIv: 'mock-iv',
+        canaryCtext: 'mock-ctext',
+      })
+      // Should store CK locally
+      expect(cryptoMocks.storeCK).toHaveBeenCalledWith(mockCK)
+      // Should return recovery key
+      expect(recoveryKey).toBe('a'.repeat(64))
+    })
+
+    it('throws if key pair is missing', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => null)
+
+      await expect(completeFirstDeviceSetup(mockHttpClient)).rejects.toThrow('Key pair not found')
+    })
+  })
+
+  describe('approveDevice', () => {
+    it('wraps CK with pending device public key and stores envelope', async () => {
+      cryptoMocks.getCK.mockImplementation(async () => mockCK)
+
+      await approveDevice(mockHttpClient, 'pending-dev', 'pending-pub-key-base64')
+
+      expect(cryptoMocks.importPublicKey).toHaveBeenCalledWith('pending-pub-key-base64')
+      expect(cryptoMocks.wrapCK).toHaveBeenCalledWith(mockCK, 'mock-imported-public-key')
+      expect(apiMocks.storeEnvelope).toHaveBeenCalledWith(mockHttpClient, {
+        deviceId: 'pending-dev',
+        wrappedCK: 'mock-wrapped-ck',
+      })
+    })
+
+    it('throws if CK is missing', async () => {
+      cryptoMocks.getCK.mockImplementation(async () => null)
+
+      await expect(approveDevice(mockHttpClient, 'dev', 'key')).rejects.toThrow('Content key not found')
+    })
+  })
+
+  describe('checkApprovalAndUnwrap', () => {
+    it('fetches envelope, unwraps CK, stores it, returns true', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => mockKeyPair)
+
+      const result = await checkApprovalAndUnwrap(mockHttpClient)
+
+      expect(apiMocks.fetchMyEnvelope).toHaveBeenCalledWith(mockHttpClient)
+      expect(cryptoMocks.unwrapCK).toHaveBeenCalledWith('mock-wrapped-ck', mockKeyPair.privateKey)
+      expect(cryptoMocks.storeCK).toHaveBeenCalledWith(mockCK)
+      expect(result).toBe(true)
+    })
+
+    it('returns false when envelope fetch fails', async () => {
+      apiMocks.fetchMyEnvelope.mockImplementation(async () => {
+        throw new Error('Not found')
+      })
+
+      const result = await checkApprovalAndUnwrap(mockHttpClient)
+      expect(result).toBe(false)
+    })
+
+    it('returns false when key pair is missing', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => null)
+
+      const result = await checkApprovalAndUnwrap(mockHttpClient)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('recoverWithKey', () => {
+    it('verifies canary, registers device, stores envelope and CK', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => null)
+
+      await recoverWithKey(mockHttpClient, 'a'.repeat(64))
+
+      // Should fetch canary
+      expect(apiMocks.fetchCanary).toHaveBeenCalledWith(mockHttpClient)
+      // Should decode recovery key
+      expect(cryptoMocks.decodeRecoveryKey).toHaveBeenCalledWith('a'.repeat(64))
+      // Should verify canary
+      expect(cryptoMocks.verifyCanary).toHaveBeenCalledWith(mockCK, 'mock-iv', 'mock-ctext')
+      // Should generate new key pair (none existed)
+      expect(cryptoMocks.generateKeyPair).toHaveBeenCalledTimes(1)
+      expect(cryptoMocks.storeKeyPair).toHaveBeenCalled()
+      // Should register device
+      expect(apiMocks.registerDevice).toHaveBeenCalledTimes(1)
+      // Should store envelope
+      expect(apiMocks.storeEnvelope).toHaveBeenCalledTimes(1)
+      // Should store CK
+      expect(cryptoMocks.storeCK).toHaveBeenCalledWith(mockCK)
+    })
+
+    it('reuses existing key pair during recovery', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => mockKeyPair)
+
+      await recoverWithKey(mockHttpClient, 'a'.repeat(64))
+
+      expect(cryptoMocks.generateKeyPair).not.toHaveBeenCalled()
+    })
+
+    it('throws on invalid recovery key (canary verification fails)', async () => {
+      cryptoMocks.verifyCanary.mockImplementation(async () => false)
+
+      await expect(recoverWithKey(mockHttpClient, 'b'.repeat(64))).rejects.toThrow('Invalid recovery key')
+    })
+  })
+
+  describe('handleSignOut', () => {
+    it('clears CK only', async () => {
+      await handleSignOut()
+
+      expect(cryptoMocks.clearCK).toHaveBeenCalledTimes(1)
+      expect(cryptoMocks.clearAllKeys).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleFullWipe', () => {
+    it('clears all keys', async () => {
+      await handleFullWipe()
+
+      expect(cryptoMocks.clearAllKeys).toHaveBeenCalledTimes(1)
+      expect(cryptoMocks.clearCK).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/services/encryption.test.ts
+++ b/src/services/encryption.test.ts
@@ -16,11 +16,14 @@ const cryptoMocks = {
   exportPublicKey: mock(async () => 'mock-public-key-base64'),
   importPublicKey: mock(async () => 'mock-imported-public-key' as unknown as CryptoKey),
   wrapCK: mock(async () => 'mock-wrapped-ck'),
+  rewrapCK: mock(async () => 'mock-rewrapped-ck'),
   unwrapCK: mock(async () => mockCK),
   createCanary: mock(async () => ({ canaryIv: 'mock-iv', canaryCtext: 'mock-ctext' })),
   verifyCanary: mock(async () => true),
   encodeRecoveryKey: mock(async () => 'a'.repeat(64)),
   decodeRecoveryKey: mock(async () => mockCK),
+  encrypt: mock(async () => ({ iv: '', ciphertext: '' })),
+  decrypt: mock(async () => ''),
   storeKeyPair: mock(async () => {}),
   getKeyPair: mock(async () => null as { privateKey: CryptoKey; publicKey: CryptoKey } | null),
   storeCK: mock(async () => {}),
@@ -67,11 +70,14 @@ const resetAllMocks = () => {
   cryptoMocks.exportPublicKey.mockImplementation(async () => 'mock-public-key-base64')
   cryptoMocks.importPublicKey.mockImplementation(async () => 'mock-imported-public-key' as unknown as CryptoKey)
   cryptoMocks.wrapCK.mockImplementation(async () => 'mock-wrapped-ck')
+  cryptoMocks.rewrapCK.mockImplementation(async () => 'mock-rewrapped-ck')
   cryptoMocks.unwrapCK.mockImplementation(async () => mockCK)
   cryptoMocks.createCanary.mockImplementation(async () => ({ canaryIv: 'mock-iv', canaryCtext: 'mock-ctext' }))
   cryptoMocks.verifyCanary.mockImplementation(async () => true)
   cryptoMocks.encodeRecoveryKey.mockImplementation(async () => 'a'.repeat(64))
   cryptoMocks.decodeRecoveryKey.mockImplementation(async () => mockCK)
+  cryptoMocks.encrypt.mockImplementation(async () => ({ iv: '', ciphertext: '' }))
+  cryptoMocks.decrypt.mockImplementation(async () => '')
   cryptoMocks.storeKeyPair.mockImplementation(async () => {})
   cryptoMocks.getKeyPair.mockImplementation(async () => null)
   cryptoMocks.storeCK.mockImplementation(async () => {})
@@ -168,23 +174,28 @@ describe('encryption service', () => {
   })
 
   describe('approveDevice', () => {
-    it('wraps CK with pending device public key and stores envelope', async () => {
-      cryptoMocks.getCK.mockImplementation(async () => mockCK)
+    it('fetches own envelope, rewraps CK for pending device, stores envelope', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => mockKeyPair)
 
       await approveDevice(mockHttpClient, 'pending-dev', 'pending-pub-key-base64')
 
+      expect(apiMocks.fetchMyEnvelope).toHaveBeenCalledWith(mockHttpClient)
       expect(cryptoMocks.importPublicKey).toHaveBeenCalledWith('pending-pub-key-base64')
-      expect(cryptoMocks.wrapCK).toHaveBeenCalledWith(mockCK, 'mock-imported-public-key')
+      expect(cryptoMocks.rewrapCK).toHaveBeenCalledWith(
+        'mock-wrapped-ck',
+        mockKeyPair.privateKey,
+        'mock-imported-public-key',
+      )
       expect(apiMocks.storeEnvelope).toHaveBeenCalledWith(mockHttpClient, {
         deviceId: 'pending-dev',
-        wrappedCK: 'mock-wrapped-ck',
+        wrappedCK: 'mock-rewrapped-ck',
       })
     })
 
-    it('throws if CK is missing', async () => {
-      cryptoMocks.getCK.mockImplementation(async () => null)
+    it('throws if key pair is missing', async () => {
+      cryptoMocks.getKeyPair.mockImplementation(async () => null)
 
-      await expect(approveDevice(mockHttpClient, 'dev', 'key')).rejects.toThrow('Content key not found')
+      await expect(approveDevice(mockHttpClient, 'dev', 'key')).rejects.toThrow('Key pair not found')
     })
   })
 
@@ -236,7 +247,9 @@ describe('encryption service', () => {
       expect(apiMocks.registerDevice).toHaveBeenCalledTimes(1)
       // Should store envelope
       expect(apiMocks.storeEnvelope).toHaveBeenCalledTimes(1)
-      // Should store CK
+      // Should reimport CK as non-extractable before storing
+      expect(cryptoMocks.reimportAsNonExtractable).toHaveBeenCalledWith(mockCK)
+      // Should store non-extractable CK
       expect(cryptoMocks.storeCK).toHaveBeenCalledWith(mockCK)
     })
 

--- a/src/services/encryption.test.ts
+++ b/src/services/encryption.test.ts
@@ -143,10 +143,10 @@ describe('encryption service', () => {
       expect(cryptoMocks.encodeRecoveryKey).toHaveBeenCalledWith(mockExtractableCK)
       // Should create canary
       expect(cryptoMocks.createCanary).toHaveBeenCalledWith(mockExtractableCK)
+      // Should wrap CK with own public key
+      expect(cryptoMocks.wrapCK).toHaveBeenCalledWith(mockExtractableCK, mockKeyPair.publicKey)
       // Should reimport as non-extractable
       expect(cryptoMocks.reimportAsNonExtractable).toHaveBeenCalledWith(mockExtractableCK)
-      // Should wrap CK with own public key
-      expect(cryptoMocks.wrapCK).toHaveBeenCalledWith(mockCK, mockKeyPair.publicKey)
       // Should store envelope with canary
       expect(apiMocks.storeEnvelope).toHaveBeenCalledWith(mockHttpClient, {
         deviceId: 'test-device-id',

--- a/src/services/encryption.test.ts
+++ b/src/services/encryption.test.ts
@@ -211,20 +211,28 @@ describe('encryption service', () => {
       expect(result).toBe(true)
     })
 
-    it('returns false when envelope fetch fails', async () => {
+    it('returns false when envelope fetch returns 404 (not yet approved)', async () => {
+      const notFoundError = Object.assign(new Error('Not found'), { response: { status: 404 } })
       apiMocks.fetchMyEnvelope.mockImplementation(async () => {
-        throw new Error('Not found')
+        throw notFoundError
       })
 
       const result = await checkApprovalAndUnwrap(mockHttpClient)
       expect(result).toBe(false)
     })
 
-    it('returns false when key pair is missing', async () => {
+    it('throws when envelope fetch fails with non-404 error', async () => {
+      apiMocks.fetchMyEnvelope.mockImplementation(async () => {
+        throw new Error('Network error')
+      })
+
+      await expect(checkApprovalAndUnwrap(mockHttpClient)).rejects.toThrow('Network error')
+    })
+
+    it('throws when key pair is missing', async () => {
       cryptoMocks.getKeyPair.mockImplementation(async () => null)
 
-      const result = await checkApprovalAndUnwrap(mockHttpClient)
-      expect(result).toBe(false)
+      await expect(checkApprovalAndUnwrap(mockHttpClient)).rejects.toThrow('Key pair not found')
     })
   })
 

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -73,11 +73,12 @@ export const completeFirstDeviceSetup = async (httpClient: KyInstance): Promise<
   const recoveryKey = await encodeRecoveryKey(extractableCK)
   const { canaryIv, canaryCtext } = await createCanary(extractableCK)
 
+  // Wrap CK with own public key and store on server
+  const wrappedCK = await wrapCK(extractableCK, keyPair.publicKey)
+
   // Re-import as non-extractable for storage
   const ck = await reimportAsNonExtractable(extractableCK)
 
-  // Wrap CK with own public key and store on server
-  const wrappedCK = await wrapCK(ck, keyPair.publicKey)
   const deviceId = getDeviceId()
 
   await storeEnvelope(httpClient, {

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -156,10 +156,10 @@ export const checkApprovalAndUnwrap = async (httpClient: KyInstance): Promise<bo
  * Recover encryption access using a recovery key.
  * Verifies the key against the canary, then creates a new envelope for this device.
  */
-export const recoverWithKey = async (httpClient: KyInstance, recoveryKeyHex: string): Promise<void> => {
-  // Fetch canary and verify recovery key
+export const recoverWithKey = async (httpClient: KyInstance, recoveryPhrase: string): Promise<void> => {
+  // Fetch canary and verify recovery phrase
   const { canaryIv, canaryCtext } = await fetchCanary(httpClient)
-  const ck = await decodeRecoveryKey(recoveryKeyHex)
+  const ck = await decodeRecoveryKey(recoveryPhrase)
   const valid = await verifyCanary(ck, canaryIv, canaryCtext)
   if (!valid) {
     throw new Error('Invalid recovery key')

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -6,6 +6,7 @@ import {
   exportPublicKey,
   importPublicKey,
   wrapCK,
+  rewrapCK,
   unwrapCK,
   createCanary,
   verifyCanary,
@@ -14,7 +15,6 @@ import {
   storeKeyPair,
   getKeyPair,
   storeCK,
-  getCK,
   clearCK,
   clearAllKeys,
 } from '@/crypto'
@@ -27,6 +27,7 @@ import {
   fetchCanary,
   type RegisterDeviceResponse,
 } from '@/api/encryption'
+import { invalidateCKCache } from '@/db/encryption'
 
 // =============================================================================
 // Detecting step — register device and store key pair
@@ -99,20 +100,23 @@ export const completeFirstDeviceSetup = async (httpClient: KyInstance): Promise<
 // =============================================================================
 
 /**
- * Approve a pending device by wrapping the CK with its public key and storing the envelope.
+ * Approve a pending device by rewrapping the CK with its public key and storing the envelope.
+ * Fetches this device's own envelope from the server and rewraps — the locally stored
+ * non-extractable CK is never touched, preserving its security properties.
  */
 export const approveDevice = async (
   httpClient: KyInstance,
   pendingDeviceId: string,
   pendingPublicKeyBase64: string,
 ): Promise<void> => {
-  const ck = await getCK()
-  if (!ck) {
-    throw new Error('Content key not found in IndexedDB')
+  const keyPair = await getKeyPair()
+  if (!keyPair) {
+    throw new Error('Key pair not found in IndexedDB')
   }
 
+  const { wrappedCK: myWrappedCK } = await fetchMyEnvelope(httpClient)
   const pendingPublicKey = await importPublicKey(pendingPublicKeyBase64)
-  const wrappedCK = await wrapCK(ck, pendingPublicKey)
+  const wrappedCK = await rewrapCK(myWrappedCK, keyPair.privateKey, pendingPublicKey)
 
   await storeEnvelope(httpClient, {
     deviceId: pendingDeviceId,
@@ -186,7 +190,9 @@ export const recoverWithKey = async (httpClient: KyInstance, recoveryKeyHex: str
     canaryCtext,
   })
 
-  await storeCK(ck)
+  // Re-import as non-extractable for local storage
+  const nonExtractableCK = await reimportAsNonExtractable(ck)
+  await storeCK(nonExtractableCK)
 }
 
 // =============================================================================
@@ -195,6 +201,7 @@ export const recoverWithKey = async (httpClient: KyInstance, recoveryKeyHex: str
 
 export const handleSignOut = async (): Promise<void> => {
   await clearCK()
+  invalidateCKCache()
 }
 
 // =============================================================================
@@ -203,4 +210,5 @@ export const handleSignOut = async (): Promise<void> => {
 
 export const handleFullWipe = async (): Promise<void> => {
   await clearAllKeys()
+  invalidateCKCache()
 }

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -143,8 +143,16 @@ export const checkApprovalAndUnwrap = async (httpClient: KyInstance): Promise<bo
     const ck = await unwrapCK(wrappedCK, keyPair.privateKey)
     await storeCK(ck)
     return true
-  } catch {
-    return false
+  } catch (err) {
+    // 404 = not yet approved, return false so caller can retry
+    if (err instanceof Error && 'response' in err) {
+      const status = (err as Error & { response: { status: number } }).response.status
+      if (status === 404) {
+        return false
+      }
+    }
+    // Re-throw transient/unexpected errors so they surface properly
+    throw err
   }
 }
 

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -1,0 +1,205 @@
+import type { KyInstance } from 'ky'
+import {
+  generateKeyPair,
+  generateCK,
+  reimportAsNonExtractable,
+  exportPublicKey,
+  importPublicKey,
+  wrapCK,
+  unwrapCK,
+  createCanary,
+  verifyCanary,
+  encodeRecoveryKey,
+  decodeRecoveryKey,
+  storeKeyPair,
+  getKeyPair,
+  storeCK,
+  getCK,
+  clearCK,
+  clearAllKeys,
+} from '@/crypto'
+import { getDeviceId } from '@/lib/auth-token'
+import { getDeviceDisplayName } from '@/lib/platform'
+import {
+  registerDevice,
+  storeEnvelope,
+  fetchMyEnvelope,
+  fetchCanary,
+  type RegisterDeviceResponse,
+} from '@/api/encryption'
+
+// =============================================================================
+// Detecting step — register device and store key pair
+// =============================================================================
+
+/**
+ * Register this device with the server and store the key pair.
+ * Idempotent: reuses existing key pair from IndexedDB if present.
+ * Returns the registration response so the caller can determine first vs additional device.
+ */
+export const registerThisDevice = async (httpClient: KyInstance): Promise<RegisterDeviceResponse> => {
+  let keyPair = await getKeyPair()
+  if (!keyPair) {
+    keyPair = await generateKeyPair()
+    await storeKeyPair(keyPair.privateKey, keyPair.publicKey)
+  }
+
+  const publicKeyBase64 = await exportPublicKey(keyPair.publicKey)
+  const deviceId = getDeviceId()
+
+  return registerDevice(httpClient, {
+    deviceId,
+    publicKey: publicKeyBase64,
+    name: getDeviceDisplayName(),
+  })
+}
+
+// =============================================================================
+// Flow C — First device setup
+// =============================================================================
+
+/**
+ * Complete first device setup: generate CK, canary, envelope, return recovery key.
+ * Must be called after `registerThisDevice` (key pair already in IndexedDB).
+ */
+export const completeFirstDeviceSetup = async (httpClient: KyInstance): Promise<string> => {
+  const keyPair = await getKeyPair()
+  if (!keyPair) {
+    throw new Error('Key pair not found — call registerThisDevice first')
+  }
+
+  // Generate extractable CK for recovery key encoding
+  const extractableCK = await generateCK(true)
+  const recoveryKey = await encodeRecoveryKey(extractableCK)
+  const { canaryIv, canaryCtext } = await createCanary(extractableCK)
+
+  // Re-import as non-extractable for storage
+  const ck = await reimportAsNonExtractable(extractableCK)
+
+  // Wrap CK with own public key and store on server
+  const wrappedCK = await wrapCK(ck, keyPair.publicKey)
+  const deviceId = getDeviceId()
+
+  await storeEnvelope(httpClient, {
+    deviceId,
+    wrappedCK,
+    canaryIv,
+    canaryCtext,
+  })
+
+  // Store CK locally
+  await storeCK(ck)
+
+  return recoveryKey
+}
+
+// =============================================================================
+// Flow D (trusted device) — Approve another device
+// =============================================================================
+
+/**
+ * Approve a pending device by wrapping the CK with its public key and storing the envelope.
+ */
+export const approveDevice = async (
+  httpClient: KyInstance,
+  pendingDeviceId: string,
+  pendingPublicKeyBase64: string,
+): Promise<void> => {
+  const ck = await getCK()
+  if (!ck) {
+    throw new Error('Content key not found in IndexedDB')
+  }
+
+  const pendingPublicKey = await importPublicKey(pendingPublicKeyBase64)
+  const wrappedCK = await wrapCK(ck, pendingPublicKey)
+
+  await storeEnvelope(httpClient, {
+    deviceId: pendingDeviceId,
+    wrappedCK,
+  })
+}
+
+// =============================================================================
+// Flow D (new device) — Check approval and unwrap CK
+// =============================================================================
+
+/**
+ * Check if this device has been approved (envelope exists) and unwrap the CK.
+ * Returns true if CK was successfully unwrapped and stored, false if not yet approved.
+ */
+export const checkApprovalAndUnwrap = async (httpClient: KyInstance): Promise<boolean> => {
+  try {
+    const { wrappedCK } = await fetchMyEnvelope(httpClient)
+    const keyPair = await getKeyPair()
+    if (!keyPair) {
+      throw new Error('Key pair not found in IndexedDB')
+    }
+
+    const ck = await unwrapCK(wrappedCK, keyPair.privateKey)
+    await storeCK(ck)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// =============================================================================
+// Flow E — Recover with recovery key
+// =============================================================================
+
+/**
+ * Recover encryption access using a recovery key.
+ * Verifies the key against the canary, then creates a new envelope for this device.
+ */
+export const recoverWithKey = async (httpClient: KyInstance, recoveryKeyHex: string): Promise<void> => {
+  // Fetch canary and verify recovery key
+  const { canaryIv, canaryCtext } = await fetchCanary(httpClient)
+  const ck = await decodeRecoveryKey(recoveryKeyHex)
+  const valid = await verifyCanary(ck, canaryIv, canaryCtext)
+  if (!valid) {
+    throw new Error('Invalid recovery key')
+  }
+
+  // Ensure we have a key pair
+  let keyPair = await getKeyPair()
+  if (!keyPair) {
+    keyPair = await generateKeyPair()
+    await storeKeyPair(keyPair.privateKey, keyPair.publicKey)
+  }
+
+  // Register device and store envelope
+  const publicKeyBase64 = await exportPublicKey(keyPair.publicKey)
+  const deviceId = getDeviceId()
+
+  await registerDevice(httpClient, {
+    deviceId,
+    publicKey: publicKeyBase64,
+    name: getDeviceDisplayName(),
+  })
+
+  const wrappedCK = await wrapCK(ck, keyPair.publicKey)
+  await storeEnvelope(httpClient, {
+    deviceId,
+    wrappedCK,
+    canaryIv,
+    canaryCtext,
+  })
+
+  await storeCK(ck)
+}
+
+// =============================================================================
+// Flow G — Sign out (clear CK, keep key pair)
+// =============================================================================
+
+export const handleSignOut = async (): Promise<void> => {
+  await clearCK()
+}
+
+// =============================================================================
+// Flow H — Full wipe (clear all keys)
+// =============================================================================
+
+export const handleFullWipe = async (): Promise<void> => {
+  await clearAllKeys()
+}

--- a/src/settings/devices.test.tsx
+++ b/src/settings/devices.test.tsx
@@ -3,12 +3,15 @@ import { getDb } from '@/db/database'
 import { devicesTable } from '@/db/tables'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { renderWithReactivity, waitForElement } from '@/test-utils/powersync-reactivity-test'
+import { createMockHttpClient } from '@/test-utils/http-client'
+import { HttpClientProvider } from '@/contexts/http-client-context'
 import { getClock } from '@/testing-library'
 import '@testing-library/jest-dom'
 import { act, cleanup, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
+import type { ReactNode } from 'react'
 
 const deviceId1 = uuidv7()
 const deviceId2 = uuidv7()
@@ -17,6 +20,10 @@ const deviceIdKey = 'thunderbolt_device_id'
 const authTokenKey = 'thunderbolt_auth_token'
 
 import DevicesSettingsPage from './devices'
+
+const HttpClientWrapper = ({ children }: { children: ReactNode }) => (
+  <HttpClientProvider httpClient={createMockHttpClient()}>{children}</HttpClientProvider>
+)
 
 describe('DevicesSettingsPage reactivity', () => {
   beforeAll(async () => {
@@ -49,6 +56,7 @@ describe('DevicesSettingsPage reactivity', () => {
 
     const { triggerChange } = renderWithReactivity(<DevicesSettingsPage />, {
       tables: ['devices'],
+      wrapper: HttpClientWrapper,
     })
 
     await waitForElement(() => screen.queryByText('Other Device'))

--- a/src/settings/devices.tsx
+++ b/src/settings/devices.tsx
@@ -1,7 +1,6 @@
 import { useDatabase, useHttpClient } from '@/contexts'
 import { getAllDevices, getPendingDevices } from '@/dal'
-import { getDeviceId, getAuthToken } from '@/lib/auth-token'
-import { useSettings } from '@/hooks/use-settings'
+import { getDeviceId } from '@/lib/auth-token'
 import { PageHeader } from '@/components/ui/page-header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -17,7 +16,6 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import dayjs from 'dayjs'
-import ky from 'ky'
 import { SectionCard } from '@/components/ui/section-card'
 import { CheckCircle2, Loader2, Smartphone, Trash2 } from 'lucide-react'
 import { useState } from 'react'
@@ -35,14 +33,6 @@ const formatLastSeen = (ts: string | null): string => {
   return dayjs.duration(diffMs, 'millisecond').humanize(true)
 }
 
-const revokeDevice = async (deviceId: string, baseUrl: string, token: string): Promise<void> => {
-  await ky.post(`account/devices/${encodeURIComponent(deviceId)}/revoke`, {
-    prefixUrl: baseUrl,
-    headers: { Authorization: `Bearer ${token}` },
-    credentials: 'omit',
-  })
-}
-
 export default function DevicesSettingsPage() {
   const db = useDatabase()
   const httpClient = useHttpClient()
@@ -55,20 +45,14 @@ export default function DevicesSettingsPage() {
     queryKey: ['pending-devices'],
     query: toCompilableQuery(getPendingDevices(db)),
   })
-  const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
   const [revokeTarget, setRevokeTarget] = useState<string | null>(null)
   const [approveTarget, setApproveTarget] = useState<string | null>(null)
 
   const visibleDevices = devices.filter((d) => d.revokedAt == null || dayjs().diff(dayjs(d.revokedAt), 'hour') < 24)
 
   const revokeMutation = useMutation({
-    mutationFn: (deviceId: string) => {
-      const token = getAuthToken()
-      if (!token) {
-        throw new Error('Not signed in')
-      }
-      return revokeDevice(deviceId, cloudUrl.value, token)
-    },
+    mutationFn: (deviceId: string) =>
+      httpClient.post(`account/devices/${encodeURIComponent(deviceId)}/revoke`).then(() => {}),
     onSuccess: () => {
       setRevokeTarget(null)
     },

--- a/src/settings/devices.tsx
+++ b/src/settings/devices.tsx
@@ -21,6 +21,7 @@ import { CheckCircle2, Loader2, Smartphone, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
+import { authHeaders } from '@/api/encryption'
 import { approveDevice } from '@/services/encryption'
 
 const formatLastSeen = (ts: string | null): string => {
@@ -52,7 +53,12 @@ export default function DevicesSettingsPage() {
 
   const revokeMutation = useMutation({
     mutationFn: (deviceId: string) =>
-      httpClient.post(`account/devices/${encodeURIComponent(deviceId)}/revoke`).then(() => {}),
+      httpClient
+        .post(`account/devices/${encodeURIComponent(deviceId)}/revoke`, {
+          headers: authHeaders(),
+          credentials: 'omit',
+        })
+        .then(() => {}),
     onSuccess: () => {
       setRevokeTarget(null)
     },

--- a/src/settings/devices.tsx
+++ b/src/settings/devices.tsx
@@ -1,5 +1,5 @@
-import { useDatabase } from '@/contexts'
-import { getAllDevices } from '@/dal'
+import { useDatabase, useHttpClient } from '@/contexts'
+import { getAllDevices, getPendingDevices } from '@/dal'
 import { getDeviceId, getAuthToken } from '@/lib/auth-token'
 import { useSettings } from '@/hooks/use-settings'
 import { PageHeader } from '@/components/ui/page-header'
@@ -19,10 +19,11 @@ import {
 import dayjs from 'dayjs'
 import ky from 'ky'
 import { SectionCard } from '@/components/ui/section-card'
-import { CheckCircle2, Smartphone, Trash2 } from 'lucide-react'
+import { CheckCircle2, Loader2, Smartphone, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
+import { approveDevice } from '@/services/encryption'
 
 const formatLastSeen = (ts: string | null): string => {
   if (ts == null) {
@@ -44,13 +45,19 @@ const revokeDevice = async (deviceId: string, baseUrl: string, token: string): P
 
 export default function DevicesSettingsPage() {
   const db = useDatabase()
+  const httpClient = useHttpClient()
   const currentDeviceId = getDeviceId()
   const { data: devices = [], isLoading } = useQuery({
     queryKey: ['devices'],
     query: toCompilableQuery(getAllDevices(db)),
   })
+  const { data: pendingDevices = [] } = useQuery({
+    queryKey: ['pending-devices'],
+    query: toCompilableQuery(getPendingDevices(db)),
+  })
   const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
   const [revokeTarget, setRevokeTarget] = useState<string | null>(null)
+  const [approveTarget, setApproveTarget] = useState<string | null>(null)
 
   const visibleDevices = devices.filter((d) => d.revokedAt == null || dayjs().diff(dayjs(d.revokedAt), 'hour') < 24)
 
@@ -67,6 +74,19 @@ export default function DevicesSettingsPage() {
     },
   })
 
+  const approveMutation = useMutation({
+    mutationFn: async (deviceId: string) => {
+      const device = pendingDevices.find((d) => d.id === deviceId)
+      if (!device?.publicKey) {
+        throw new Error('Device has no public key')
+      }
+      await approveDevice(httpClient, deviceId, device.publicKey)
+    },
+    onSuccess: () => {
+      setApproveTarget(null)
+    },
+  })
+
   const handleRevoke = (deviceId: string) => {
     setRevokeTarget(deviceId)
   }
@@ -77,23 +97,13 @@ export default function DevicesSettingsPage() {
     }
   }
 
-  // Mock pending devices for UI review (replaced with real synced data in PR 5)
-  const mockPendingDevices = [
-    { id: 'pending-1', name: 'Chrome on Windows PC' },
-    { id: 'pending-2', name: 'Safari on iPad' },
-  ]
-
-  const [approveTarget, setApproveTarget] = useState<string | null>(null)
-
   const confirmApprove = () => {
     if (approveTarget) {
-      // Stub: In PR 5, this wraps CK with pending device's public key
-      console.log('Approve device (stub):', approveTarget)
-      setApproveTarget(null)
+      approveMutation.mutate(approveTarget)
     }
   }
 
-  const hasPendingDevices = mockPendingDevices.length > 0
+  const hasPendingDevices = pendingDevices.length > 0
 
   return (
     <div className="flex flex-col gap-6 p-4 pb-12 w-full max-w-[760px] mx-auto">
@@ -103,7 +113,7 @@ export default function DevicesSettingsPage() {
         <>
           <SectionCard title="Pending Approvals">
             <div className="flex flex-col gap-3">
-              {mockPendingDevices.map((device) => (
+              {pendingDevices.map((device) => (
                 <Card key={device.id} className="bg-secondary/50">
                   <CardContent>
                     <div className="flex items-center justify-between gap-4">
@@ -114,8 +124,17 @@ export default function DevicesSettingsPage() {
                           <p className="text-sm text-muted-foreground">Waiting for approval</p>
                         </div>
                       </div>
-                      <Button variant="default" size="sm" onClick={() => setApproveTarget(device.id)}>
-                        <CheckCircle2 className="size-4 mr-1" />
+                      <Button
+                        variant="default"
+                        size="sm"
+                        onClick={() => setApproveTarget(device.id)}
+                        disabled={approveMutation.isPending}
+                      >
+                        {approveMutation.isPending && approveMutation.variables === device.id ? (
+                          <Loader2 className="size-4 mr-1 animate-spin" />
+                        ) : (
+                          <CheckCircle2 className="size-4 mr-1" />
+                        )}
                         Approve
                       </Button>
                     </div>
@@ -191,8 +210,10 @@ export default function DevicesSettingsPage() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmApprove}>Approve</AlertDialogAction>
+            <AlertDialogCancel disabled={approveMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmApprove} disabled={approveMutation.isPending}>
+              {approveMutation.isPending ? 'Approving…' : 'Approve'}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
## Summary

- **API client** (`src/api/encryption.ts`): 4 functions mapping 1:1 to backend encryption endpoints (register device, store envelope, fetch envelope, fetch canary)
- **Service layer** (`src/services/encryption.ts`): 7 orchestration functions composing crypto + API + IndexedDB into complete user flows (first device setup, device approval, recovery key, sign-out/wipe)
- **UI wiring**: Replaced all mocked stubs in the sync setup wizard with real async service calls, auto-detection (replacing test buttons), and loading/error states across all steps
- **Device schema**: Added `status` and `publicKey` columns to frontend `devicesTable` (already synced via PowerSync `SELECT *`)
- **Devices page**: Real pending devices query from PowerSync, real approve mutation via service layer
- **Encryption cleanup**: Added key cleanup to logout modal and revoked device modal — both unconditionally call `clearAllKeys` (full wipe of key pair + CK) regardless of the user's keep/delete choice, since the device ID is also cleared on logout making the old key pair orphaned anyway. The keep/delete choice only controls whether local data (chats, settings, cached files) is preserved via `resetAppDir`.

## Test plan

- [x] `bun run type-check` passes (0 errors)
- [x] `bun test` passes (1841 pass, 0 fail — 21 new tests)
- [x] `bun run lint` passes for all changed files
- [ ] Manual: Sync setup wizard → intro → auto-detects first device → generates real recovery key
- [ ] Manual: Second device → auto-detects additional device → approval-waiting step
- [ ] Manual: Devices page shows real pending devices → approve wraps CK
- [ ] Manual: Recovery key entry → verifies against canary
- [ ] Manual: Logout clears encryption keys appropriately
- [ ] Confirm data still syncs unencrypted (encryption not connected to sync until PR 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces new client-side encryption/key management flows (recovery phrases, envelope wrapping/unwrapping, key wiping) and wires them into onboarding and device-approval UX, where mistakes can lock users out or leak keys.
> 
> **Overview**
> Implements the frontend encryption integration end-to-end: adds an `src/api/encryption.ts` client for device registration, envelope storage/fetching, and canary retrieval, plus a new `src/services/encryption.ts` orchestration layer that generates/stores keypairs and CKs, handles first-device setup, device approval, approval checking, recovery-key flow, and sign-out/full-wipe key cleanup.
> 
> Updates the sync setup wizard to replace mocked steps with real async registration/setup/recovery calls, including automatic handling of already-trusted devices and background approval polling via a new `useApprovalPolling` hook.
> 
> Introduces an encryption codec + upload encoder (`__enc:` prefix) with a centralized `encryptedColumnsMap` to encrypt specific CRUD payload columns before upload (with legacy `b64:` decode compatibility), and expands the local `devices` schema/querying to include `status`/`publicKey` and real pending-device approvals on the Devices settings page.
> 
> Logout/revocation flows now also wipe encryption keys (and clear device ID) in addition to clearing auth, and recovery keys switch from hex to 24-word BIP-39 mnemonics (`@scure/bip39`), backed by new unit tests across API/service/codec/hooks/utilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b270b7a7a0a7c7da011a69418ee022f3c0eb86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->