### PR TITLE
THU-366: Keyboard theme should follow app preference theme

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3937,6 +3937,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,6 +4077,7 @@ checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.10.0",
  "objc2 0.6.3",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -4088,8 +4099,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.10.0",
+ "block2 0.6.2",
  "objc2 0.6.3",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.3",
  "objc2-foundation 0.3.2",
 ]
 
@@ -6593,6 +6623,8 @@ name = "thunderbolt"
 version = "0.1.78"
 dependencies = [
  "anyhow",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,6 +88,10 @@ tauri-plugin-store = "2.4.2"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
 
+[target.'cfg(target_os = "ios")'.dependencies]
+objc2-ui-kit = { version = "0.3.2", features = ["UIApplication", "UIWindow", "UIInterface", "UIScene", "UIWindowScene"] }
+objc2-foundation = "0.3.2"
+
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -109,6 +109,43 @@ pub async fn get_bridge_connection_status() -> Result<serde_json::Value, String>
     }))
 }
 
+// === Interface Style (iOS keyboard/system UI theme) ==========================================
+
+/// Set the native user interface style on iOS to control keyboard and system UI appearance.
+/// Android keyboards follow the system dark mode setting and cannot be overridden per-app.
+/// Desktop: no-op.
+/// style: "system" | "light" | "dark"
+#[command]
+pub fn set_interface_style(style: String) {
+    #[cfg(target_os = "ios")]
+    {
+        use objc2_foundation::MainThreadMarker;
+        use objc2_ui_kit::{UIApplication, UIUserInterfaceStyle, UIWindowScene};
+
+        let ui_style = match style.as_str() {
+            "light" => UIUserInterfaceStyle::Light,
+            "dark" => UIUserInterfaceStyle::Dark,
+            _ => UIUserInterfaceStyle::Unspecified,
+        };
+
+        if let Some(mtm) = MainThreadMarker::new() {
+            let app = UIApplication::sharedApplication(mtm);
+            for scene in app.connectedScenes() {
+                if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
+                    for window in window_scene.windows() {
+                        window.setOverrideUserInterfaceStyle(ui_style);
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = style;
+    }
+}
+
 // === Capabilities ============================================================================
 
 /// List of runtime capabilities that the renderer can query once and cache.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -116,7 +116,7 @@ pub async fn get_bridge_connection_status() -> Result<serde_json::Value, String>
 /// Desktop: no-op.
 /// style: "system" | "light" | "dark"
 #[command]
-pub fn set_interface_style(style: String) {
+pub fn set_interface_style(style: String) -> Result<(), String> {
     #[cfg(target_os = "ios")]
     {
         use objc2_foundation::MainThreadMarker;
@@ -128,13 +128,14 @@ pub fn set_interface_style(style: String) {
             _ => UIUserInterfaceStyle::Unspecified,
         };
 
-        if let Some(mtm) = MainThreadMarker::new() {
-            let app = UIApplication::sharedApplication(mtm);
-            for scene in app.connectedScenes() {
-                if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
-                    for window in window_scene.windows() {
-                        window.setOverrideUserInterfaceStyle(ui_style);
-                    }
+        let mtm = MainThreadMarker::new()
+            .ok_or_else(|| "set_interface_style must run on the main thread".to_string())?;
+
+        let app = UIApplication::sharedApplication(mtm);
+        for scene in app.connectedScenes() {
+            if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
+                for window in window_scene.windows() {
+                    window.setOverrideUserInterfaceStyle(ui_style);
                 }
             }
         }
@@ -144,6 +145,8 @@ pub fn set_interface_style(style: String) {
     {
         let _ = style;
     }
+
+    Ok(())
 }
 
 // === Capabilities ============================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,6 +68,7 @@ pub fn create_app() -> tauri::Builder<tauri::Wry> {
         .invoke_handler(tauri::generate_handler![
             commands::toggle_dock_icon,
             commands::capabilities,
+            commands::set_interface_style,
             commands::start_oauth_server,
             #[cfg(feature = "bridge")]
             commands::init_bridge,

--- a/src/lib/theme-provider.tsx
+++ b/src/lib/theme-provider.tsx
@@ -5,7 +5,9 @@ import { isTauri } from './platform'
 
 /** Sync native UI (keyboard, system controls) with the resolved theme on iOS. */
 const syncNativeInterfaceStyle = (resolvedTheme: 'dark' | 'light') => {
-  if (!isTauri()) return
+  if (!isTauri()) {
+    return
+  }
   invoke('set_interface_style', { style: resolvedTheme }).catch(console.error)
 }
 

--- a/src/lib/theme-provider.tsx
+++ b/src/lib/theme-provider.tsx
@@ -1,6 +1,13 @@
+import { invoke } from '@tauri-apps/api/core'
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { M3 } from 'tauri-plugin-m3'
 import { isTauri } from './platform'
+
+/** Sync native UI (keyboard, system controls) with the resolved theme on iOS. */
+const syncNativeInterfaceStyle = (resolvedTheme: 'dark' | 'light') => {
+  if (!isTauri()) return
+  invoke('set_interface_style', { style: resolvedTheme }).catch(console.error)
+}
 
 /**
  * Mirror theme to Tauri's plugin-store so native code can read it at startup.
@@ -74,6 +81,7 @@ export const ThemeProvider = ({
       if (isTauri()) {
         M3.setBarColor(systemTheme === 'dark' ? 'light' : 'dark')
       }
+      syncNativeInterfaceStyle(systemTheme)
 
       return
     }
@@ -87,6 +95,7 @@ export const ThemeProvider = ({
     if (isTauri()) {
       M3.setBarColor(theme === 'dark' ? 'light' : 'dark')
     }
+    syncNativeInterfaceStyle(theme)
   }, [theme])
 
   useEffect(() => {
@@ -108,6 +117,7 @@ export const ThemeProvider = ({
         if (isTauri()) {
           M3.setBarColor(systemTheme === 'dark' ? 'light' : 'dark')
         }
+        syncNativeInterfaceStyle(systemTheme)
       }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds iOS-specific native UI style overrides and new Rust↔JS command wiring, which could impact iOS builds or cause main-thread/runtime issues if mis-invoked. Non-iOS platforms are no-ops, limiting blast radius.
> 
> **Overview**
> Ensures iOS native UI (including keyboard appearance) follows the app’s resolved theme by adding a new Tauri command `set_interface_style` that sets `UIUserInterfaceStyle` on all connected `UIWindowScene` windows.
> 
> The React `ThemeProvider` now invokes this command whenever the theme resolves or changes (including `system` mode media-query updates). iOS builds add `objc2-ui-kit`/`objc2-foundation` dependencies and update `Cargo.lock` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ea3bd9bdfa8238023639d50317d5a43173c24b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->