### PR TITLE
THU-285: [PART 6.2] Middleware-based encryption with PowerSync sync pipeline

### DIFF
--- a/src/db/powersync/connector.ts
+++ b/src/db/powersync/connector.ts
@@ -1,7 +1,7 @@
 import { getDeviceId, getAuthToken } from '@/lib/auth-token'
 import { getDeviceDisplayName } from '@/lib/platform'
 import type { AbstractPowerSyncDatabase, PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web'
-import { encodeToBase64 } from '@/lib/base64'
+import { encodeForUpload } from '@/db/encryption'
 
 /** Dispatched when backend returns 410 (account deleted), 403 + DEVICE_DISCONNECTED, or 409 + DEVICE_ID_TAKEN. App should reset and reload. */
 export const powersyncCredentialsInvalid = 'powersync_credentials_invalid'
@@ -125,37 +125,17 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
     }
 
     try {
-      // Convert CRUD operations to our API format
-      const operations = transaction.crud.map((op) => {
-        /**
-         * **************************************************************
-         * Encode base64 for tasks.item when the value is valid base64.
-         * Temporary solution for testing purposes.
-         *
-         * TODO: Remove this once we have a proper encryption middleware.
-         */
-        let data = op.opData
-        if (
-          op.table === 'tasks' &&
-          data != null &&
-          typeof data.item === 'string' &&
-          (op.op === 'PUT' || op.op === 'PATCH')
-        ) {
-          data = { ...data, item: encodeToBase64(data.item) }
-        }
-        /**
-         * Temporary solution for testing purposes.
-         * TODO: Remove this once we have a proper encryption middleware.
-         * **************************************************************
-         */
-
-        return {
-          op: op.op.toUpperCase() as 'PUT' | 'PATCH' | 'DELETE',
-          type: op.table,
-          id: op.id,
-          data,
-        }
-      })
+      // Convert CRUD operations to our API format (encrypt encrypted columns)
+      const operations = await Promise.all(
+        transaction.crud.map((op) =>
+          encodeForUpload({
+            op: op.op.toUpperCase() as 'PUT' | 'PATCH' | 'DELETE',
+            type: op.table,
+            id: op.id,
+            data: op.opData,
+          }),
+        ),
+      )
 
       console.info(`Uploading ${operations.length} operations to backend`)
 

--- a/src/db/powersync/database.test.ts
+++ b/src/db/powersync/database.test.ts
@@ -54,10 +54,15 @@ describe('getPowerSyncOptions', () => {
       expect(options.database).toEqual({ dbFilename: 'thunderbolt.db' })
     })
 
-    it('does not include flags or sync', () => {
-      const options = getPowerSyncOptions('thunderbolt.db', 'default')
+    it('does not include flags', () => {
+      const options = getPowerSyncOptions('thunderbolt.db')
       expect(options).not.toHaveProperty('flags')
-      expect(options).not.toHaveProperty('sync')
+    })
+
+    it('includes custom SharedWorker for sync', () => {
+      const options = getPowerSyncOptions('thunderbolt.db')
+      expect(options).toHaveProperty('sync')
+      expect(options.sync).toHaveProperty('worker')
     })
   })
 

--- a/src/db/powersync/middleware/EncryptionMiddleware.ts
+++ b/src/db/powersync/middleware/EncryptionMiddleware.ts
@@ -1,33 +1,51 @@
+import type { SyncDataBatch } from '@powersync/common'
 import type { DataTransformMiddleware } from '../TransformableBucketStorage'
-import { isValidBase64, decodeIfValidBase64 } from '@/lib/base64'
+import { encryptedColumnsMap } from '@/db/encryption/config'
+import { codec } from '@/db/encryption/codec'
 
-const tasksTable = 'tasks'
-const itemColumn = 'item'
+type SyncEntry = SyncDataBatch['buckets'][number]['data'][number]
+
+/** Decrypt encrypted columns in a single sync entry. Mutates entry.data in place. */
+const decryptEntry = async (entry: SyncEntry) => {
+  if (!entry.object_type || !entry.data) {
+    return
+  }
+  const columns = encryptedColumnsMap[entry.object_type]
+  if (!columns) {
+    return
+  }
+
+  try {
+    const obj = JSON.parse(entry.data) as Record<string, unknown>
+    let changed = false
+
+    for (const col of columns) {
+      const val = obj[col]
+      if (typeof val === 'string') {
+        obj[col] = await codec.decode(val)
+        changed = true
+      }
+    }
+
+    if (changed) {
+      entry.data = JSON.stringify(obj)
+    }
+  } catch {
+    // Leave entry.data unchanged on parse error
+  }
+}
 
 /**
- * Decodes base64 for tasks.item when the value is valid base64.
- * Will evolve to full decryption layer for all tables/columns.
- *
- * Temporary solution for testing purposes.
+ * Decrypts encrypted columns in sync data before it reaches SQLite.
+ * Config-driven: uses encryptedColumnsMap to determine which columns to decrypt.
+ * Handles __enc: (AES-GCM), b64: (legacy base64), and unprefixed base64 formats.
+ * Passes through when no CK is available (pre-setup or CK cleared).
  */
 export const encryptionMiddleware: DataTransformMiddleware = {
-  transform(batch) {
+  async transform(batch) {
     for (const bucket of batch.buckets) {
       for (const entry of bucket.data) {
-        if (entry.object_type !== tasksTable || !entry.data) {
-          continue
-        }
-
-        try {
-          const obj = JSON.parse(entry.data) as Record<string, unknown>
-          const item = obj[itemColumn]
-          if (typeof item === 'string' && isValidBase64(item)) {
-            obj[itemColumn] = decodeIfValidBase64(item)
-            entry.data = JSON.stringify(obj)
-          }
-        } catch {
-          // Leave entry.data unchanged on parse error
-        }
+        await decryptEntry(entry)
       }
     }
     return batch


### PR DESCRIPTION
## Summary

Middleware-based encryption that decrypts data **before** it reaches SQLite — no shadow tables, no DAL changes, no COALESCE joins. Uses PowerSync's sync data interception via a custom `TransformableBucketStorage` and SharedWorker to transform encrypted fields in-flight.

**This PR includes the full AES-256-GCM codec** using the Content Key (CK) from IndexedDB. The codec runs inside the SharedWorker (IndexedDB + `crypto.subtle` are available in SharedWorker contexts), eliminating the need for `postMessage` key passing.

### Architecture

```
Server (encrypted data)
  ↓ PROCESS_TEXT_LINE
SharedWorker: ThunderboltSharedSyncImplementation
  ├─ TransformableBucketStorage.control()
  │  ├─ Parse JSON payload → SyncDataBatch
  │  ├─ Run middleware pipeline
  │  └─ Serialize transformed batch → super.control()
  │
  └─ encryptionMiddleware.transform()
     ├─ Look up table in encryptedColumnsMap
     ├─ For each encrypted column: codec.decode()
     │  ├─ __enc:<iv>:<ctext> → AES-256-GCM decrypt
     │  ├─ b64:<base64> → legacy base64 decode
     │  └─ plaintext → passthrough
     └─ Return transformed batch

  ↓ SQLite (data stored DECRYPTED)
  ↓
DAL / Drizzle (reads directly — no joins needed)
  ↓
React components
```

### Upload flow

```
User edits data → DAL writes plaintext to SQLite
  ↓ PowerSync CRUD queue
connector.uploadData()
  ├─ encodeForUpload() per operation
  │  ├─ Look up table in encryptedColumnsMap
  │  └─ For each encrypted column: codec.encode()
  │     └─ AES-256-GCM encrypt → __enc:<iv>:<ctext>
  └─ Upload encrypted operations to backend
```

### Key advantage over trigger-based approach (PR 6.1)

| Aspect | 6.2 Middleware | 6.1 Triggers |
|--------|---------------|-------------|
| Storage | Single table (decrypted) | Two tables per encrypted table |
| DAL impact | Zero — reads directly | All DAL queries need COALESCE joins |
| Decryption location | Before SQLite write | After SQLite write (into shadow tables) |
| Complexity | Lower | Higher |

### Config-driven design

`encryptedColumnsMap` is the single source of truth. Adding a table + columns automatically enables encryption in both the download middleware and upload encoder. Zero boilerplate.

### Encrypted tables

| Table | Encrypted columns |
|-------|-------------------|
| `settings` | value |
| `chat_threads` | title |
| `chat_messages` | content, parts, cache, metadata |
| `tasks` | item |
| `models` | name, model, url, api_key, vendor, description |
| `mcp_servers` | name, url, command, args |
| `prompts` | title, prompt |
| `triggers` | trigger_time |
| `model_profiles` | 13 fields (tools_override, link_previews_override, etc.) |
| `modes` | name, label, icon, system_prompt |
| `devices` | name |

### AES-256-GCM codec

- **Encrypt**: `plaintext → __enc:<iv_base64>:<ciphertext_base64>` using CK from IndexedDB
- **Decrypt**: Parses `__enc:` prefix, extracts IV + ciphertext, decrypts with CK
- **Legacy support**: Decodes `b64:` prefixed strings and unprefixed base64
- **Passthrough**: Returns plaintext when no CK available (pre-setup)
- **CK cache**: Lazy-loaded from IndexedDB on first use, invalidated on sign-out/wipe
- **SharedWorker-safe**: IndexedDB + `crypto.subtle` available in worker context — no `postMessage` key passing needed

### Key files

```
src/db/encryption/
  ├── config.ts             # Table → encrypted DB columns (snake_case)
  ├── codec.ts              # AES-256-GCM codec with CK cache
  ├── upload-encoder.ts     # Async CRUD encryption before upload
  └── index.ts              # Barrel export (incl. invalidateCKCache)

src/db/powersync/
  ├── middleware/
  │   └── EncryptionMiddleware.ts   # Config-driven async AES-GCM decryption
  ├── TransformableBucketStorage.ts # Intercepts sync data, runs middleware
  ├── ThunderboltPowerSyncDatabase.ts # Injects TransformableBucketStorage
  ├── worker/
  │   ├── ThunderboltSharedSyncImplementation.ts      # Custom SharedWorker impl
  │   └── ThunderboltSharedSyncImplementation.worker.ts # Worker entry point
  ├── connector.ts          # Upload encoding via encodeForUpload
  └── database.ts           # Wires SharedWorker + middleware

src/services/encryption.ts  # CK cache invalidation on sign-out/wipe
docs/powersync-sync-middleware.md  # Architecture documentation
```

## Test plan

- [x] `bun run type-check` passes (0 errors)
- [x] `bun test` passes (1866 pass, 0 fail — 25 new tests)
- [x] `bun run lint` passes for all changed files
- [ ] Verify local edits → `__enc:` encrypted values uploaded to backend
- [ ] Verify sync round-trip: encrypted on server → middleware decrypts → plaintext in SQLite
- [ ] Verify DAL reads show decrypted data directly (no COALESCE, no shadow tables)
- [ ] Verify multi-tab sync works (SharedWorker path: Chrome/Edge/Firefox)
- [ ] Verify Safari/Tauri main-thread path works
- [ ] Verify sign-out clears CK cache; data remains encrypted on server
- [ ] Verify recovery key flow restores decryption on a new device
- [ ] Verify pre-setup passthrough: before encryption setup, data flows unencrypted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes the PowerSync sync/storage pipeline (including a custom SharedWorker using `@powersync/web` internals) and adds automatic encrypt/decrypt of synced fields, which could impact data correctness and sync stability across browsers.
> 
> **Overview**
> Adds a PowerSync sync-data transformation layer that decrypts configured columns *before* writing to local SQLite, via `TransformableBucketStorage.control(PROCESS_TEXT_LINE)` and a new `encryptionMiddleware`.
> 
> Replaces the app’s PowerSync DB instance with `ThunderboltPowerSyncDatabase` and wires the middleware in both execution paths: main-thread adapter (Safari/Tauri) and a new custom SharedWorker (Chrome/Edge/Firefox) that injects `TransformableBucketStorage` despite PowerSync’s default multi-tab worker hardcoding `SqliteBucketStorage`.
> 
> Updates upload handling to encrypt configured columns in outgoing CRUD operations (`encodeForUpload`), adds Vite/TS path aliases for `@powersync/web` internal imports, adjusts tests for the new `sync.worker` option, and documents the middleware/worker architecture.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41d23c58ce5406d0e2cc7d1580848f928d61717b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->