### PR TITLE
THU-365: Search chats overflow and collapsing search bar

### DIFF
--- a/src/layout/sidebar/chat-list.tsx
+++ b/src/layout/sidebar/chat-list.tsx
@@ -35,7 +35,7 @@ export const ChatList = ({
   return (
     <>
       <SidebarGroup className="flex-1 flex flex-col min-h-0">
-        {!isCollapsed && (chatThreads.length > 0 || debouncedSearchQuery) && (
+        {!isCollapsed && (chatThreads.length > 0 || debouncedSearchQuery || showSearch) && (
           <div className="flex items-center justify-between flex-shrink-0">
             <SidebarGroupLabel>Recent Chats</SidebarGroupLabel>
             <ChatActions
@@ -49,9 +49,7 @@ export const ChatList = ({
         )}
         <div
           className={`transition-all duration-300 ease-in-out flex-shrink-0 ${
-            showSearch && !isCollapsed && (chatThreads.length > 0 || debouncedSearchQuery)
-              ? 'max-h-12 opacity-100 mt-2'
-              : 'max-h-0 opacity-0 overflow-hidden'
+            showSearch && !isCollapsed ? 'max-h-12 opacity-100 mt-2' : 'max-h-0 opacity-0 overflow-hidden'
           }`}
         >
           <SearchInput

--- a/src/layout/sidebar/index.tsx
+++ b/src/layout/sidebar/index.tsx
@@ -175,6 +175,7 @@ export default function Sidebar() {
       setShowSearch(true)
     } else {
       setShowSearch(false)
+      setSearchQuery('')
     }
   }
 


### PR DESCRIPTION
- show search bar and header when search is toggled on, regardless of chat count
- clear search query when toggling search off

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state tweak limited to sidebar search visibility and query reset; main risk is minor UX regression around when the header/search appears or search text is cleared.
> 
> **Overview**
> Fixes sidebar chat search visibility so the **"Recent Chats" header and search input show whenever search is toggled on**, even if there are no chats or no active query.
> 
> Also resets the search state by clearing `searchQuery` when the user toggles search off, preventing stale filters from persisting between opens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd15c313593d28971402bd96376deba8455fc8df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->