### PR TITLE
THU-367: Add e2e support w/ parallelization

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,11 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -77,11 +72,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/2, 2/2]
+        shard: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
+        shard: [1/2, 2/2]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,109 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: ['**']
+
+concurrency:
+  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/2, 2/2]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install backend dependencies
+        run: cd backend && bun install
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run e2e tests (shard ${{ matrix.shard }})
+        run: bunx playwright test --shard=${{ matrix.shard }}
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ strategy.job-index }}
+          path: blob-report/
+          retention-days: 7
+
+      - name: Upload test screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-screenshots-${{ strategy.job-index }}
+          path: test-results/
+          retention-days: 7
+
+  e2e-report:
+    if: always() && needs.e2e.result != 'skipped'
+    needs: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: blob-report-*
+          path: all-blob-reports
+          merge-multiple: true
+
+      - name: Merge reports
+        run: bunx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,10 @@ src-tauri/gen/apple/.bundle/
 
 .worktrees/
 
+# Playwright / e2e
+test-results/
+playwright-report/
+blob-report/
+
 # Powersync
 public/@powersync/**

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,6 +1,8 @@
 import { PGlite } from '@electric-sql/pglite'
 import { drizzle as drizzlePglite } from 'drizzle-orm/pglite'
+import { migrate } from 'drizzle-orm/pglite/migrator'
 import { drizzle as drizzlePostgres } from 'drizzle-orm/postgres-js'
+import { resolve } from 'path'
 import postgres from 'postgres'
 import * as schema from './schema'
 
@@ -9,7 +11,21 @@ if (process.env.DATABASE_DRIVER === 'postgres' && !process.env.DATABASE_URL) {
   throw new Error('DATABASE_URL is required when DATABASE_DRIVER=postgres')
 }
 
-export const db =
-  process.env.DATABASE_DRIVER === 'postgres'
-    ? drizzlePostgres({ client: postgres(process.env.DATABASE_URL!), schema })
-    : drizzlePglite({ client: new PGlite(process.env.DATABASE_URL), schema }) // undefined = in-memory
+const isPglite = process.env.DATABASE_DRIVER !== 'postgres'
+
+const pgliteDb = isPglite
+  ? drizzlePglite({ client: new PGlite(process.env.DATABASE_URL), schema }) // undefined = in-memory
+  : null
+
+export const db = pgliteDb ?? drizzlePostgres({ client: postgres(process.env.DATABASE_URL!), schema })
+
+/**
+ * Run Drizzle migrations on PGLite databases.
+ * PGLite (especially in-memory) starts with an empty schema, so migrations
+ * must be applied before the server can handle requests.
+ */
+export const runMigrations = async () => {
+  if (!pgliteDb) return
+  const migrationsFolder = resolve(import.meta.dir, '../../drizzle')
+  await migrate(pgliteDb, { migrationsFolder })
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import { createGoogleAuthRoutes } from '@/auth/google'
 import { createMicrosoftAuthRoutes } from '@/auth/microsoft'
 import { createLoggerMiddleware, createStandaloneLogger } from '@/config/logger'
 import { getCorsOriginsList, getSettings } from '@/config/settings'
+import { runMigrations } from '@/db/client'
 import { createInferenceRoutes } from '@/inference/routes'
 import { createErrorHandlingMiddleware } from '@/middleware/error-handling'
 import { createHttpLoggingMiddleware } from '@/middleware/http-logging'
@@ -109,7 +110,6 @@ const startServer = async () => {
 
   try {
     // Run PGLite migrations before creating the app (no-op for Postgres)
-    const { runMigrations } = await import('@/db/client')
     await runMigrations()
 
     const app = await createApp()

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -108,6 +108,10 @@ const startServer = async () => {
   )
 
   try {
+    // Run PGLite migrations before creating the app (no-op for Postgres)
+    const { runMigrations } = await import('@/db/client')
+    await runMigrations()
+
     const app = await createApp()
 
     const hostname = process.env.HOST

--- a/bun.lock
+++ b/bun.lock
@@ -119,7 +119,7 @@
         "lint-staged": "^16.1.5",
         "msw": "^2.10.5",
         "oauth2-mock-server": "^8.2.2",
-        "playwright": "^1.55.0",
+        "playwright": "^1.58.2",
         "prettier": "^3.6.2",
         "size-limit": "^12.0.1",
         "storybook": "^9.1.3",
@@ -1630,9 +1630,9 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
 
-    "playwright": ["playwright@1.56.1", "", { "dependencies": { "playwright-core": "1.56.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw=="],
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
-    "playwright-core": ["playwright-core@1.56.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ=="],
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2078,8 +2078,6 @@
 
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@playwright/test/playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
-
     "@powersync/react/@powersync/common": ["@powersync/common@1.48.0", "", { "dependencies": { "async-mutex": "^0.5.0", "event-iterator": "^2.0.0" } }, "sha512-CMnQQdQdheJMOobcQJWPW2CLv17+Yyqtg+zk+kS45EyZSV5wnC5tiRcsrGb6f3ShvHSfKaHZJFIySgp9Lbkkbg=="],
 
     "@powersync/tanstack-react-query/@powersync/common": ["@powersync/common@1.48.0", "", { "dependencies": { "async-mutex": "^0.5.0", "event-iterator": "^2.0.0" } }, "sha512-CMnQQdQdheJMOobcQJWPW2CLv17+Yyqtg+zk+kS45EyZSV5wnC5tiRcsrGb6f3ShvHSfKaHZJFIySgp9Lbkkbg=="],
@@ -2277,8 +2275,6 @@
     "@modelcontextprotocol/sdk/express/body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
     "@modelcontextprotocol/sdk/express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "@playwright/test/playwright/playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,7 @@
         "@eslint/js": "^9.33.0",
         "@happy-dom/global-registrator": "^20.0.8",
         "@libsql/client": "^0.15.12",
+        "@playwright/test": "^1.58.2",
         "@sinonjs/fake-timers": "^15.0.0",
         "@size-limit/file": "^12.0.1",
         "@storybook/addon-a11y": "^9.1.3",
@@ -117,6 +118,7 @@
         "jsdom": "^26.1.0",
         "lint-staged": "^16.1.5",
         "msw": "^2.10.5",
+        "oauth2-mock-server": "^8.2.2",
         "playwright": "^1.55.0",
         "prettier": "^3.6.2",
         "size-limit": "^12.0.1",
@@ -413,6 +415,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -838,13 +842,15 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.8.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ=="],
 
+    "basic-auth": ["basic-auth@2.0.1", "", { "dependencies": { "safe-buffer": "5.1.2" } }, "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg=="],
+
     "better-auth": ["better-auth@1.4.2", "", { "dependencies": { "@better-auth/core": "1.4.2", "@better-auth/telemetry": "1.4.2", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "@standard-schema/spec": "^1.0.0", "better-call": "1.1.0", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.1.12" } }, "sha512-0NlJL+wNdHWGcGs9+kLTbYLoN0Vhft+pwhadn2QRWY7gqNdkLgH+UqX4x+yvCRyACRFStOJULQyZXWmQ3u7wTQ=="],
 
     "better-call": ["better-call@1.1.0", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1" } }, "sha512-7CecYG+yN8J1uBJni/Mpjryp8bW/YySYsrGEWgFe048ORASjq17keGjbKI2kHEOSc6u8pi11UxzkJ7jIovQw6w=="],
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
-    "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -934,7 +940,7 @@
 
     "core-js": ["core-js@3.46.0", "", {}, "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA=="],
 
-    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1084,7 +1090,7 @@
 
     "expect-type": ["expect-type@1.2.2", "", {}, "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA=="],
 
-    "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
@@ -1320,7 +1326,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@6.1.2", "", {}, "sha512-MpcPtHLE5EmztuFIqB0vzHAWJPpmN1E6L4oo+kze56LIs3MyXIj9ZHMDxqOvkP38gBR7K1v3jqd4WU2+nrfONQ=="],
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
@@ -1558,6 +1564,8 @@
 
     "nwsapi": ["nwsapi@2.2.22", "", {}, "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ=="],
 
+    "oauth2-mock-server": ["oauth2-mock-server@8.2.2", "", { "dependencies": { "basic-auth": "^2.0.1", "cors": "^2.8.6", "express": "^5.2.1", "is-plain-obj": "^4.1.0", "jose": "^6.1.3" }, "bin": { "oauth2-mock-server": "dist/oauth2-mock-server.js" } }, "sha512-ZjMFtomGM4q1DflxEJpq2WVtSLbOjqlJYkkuGWdq9nL3oAbDExamFyhDN/bUqcooCHWeI0n99K/NU+gXEZLNiA=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -1732,7 +1740,7 @@
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
@@ -2064,7 +2072,13 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
+    "@modelcontextprotocol/sdk/cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+
+    "@modelcontextprotocol/sdk/express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
+
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@playwright/test/playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "@powersync/react/@powersync/common": ["@powersync/common@1.48.0", "", { "dependencies": { "async-mutex": "^0.5.0", "event-iterator": "^2.0.0" } }, "sha512-CMnQQdQdheJMOobcQJWPW2CLv17+Yyqtg+zk+kS45EyZSV5wnC5tiRcsrGb6f3ShvHSfKaHZJFIySgp9Lbkkbg=="],
 
@@ -2114,11 +2128,19 @@
 
     "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "better-auth/jose": ["jose@6.1.2", "", {}, "sha512-MpcPtHLE5EmztuFIqB0vzHAWJPpmN1E6L4oo+kze56LIs3MyXIj9ZHMDxqOvkP38gBR7K1v3jqd4WU2+nrfONQ=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
+
+    "body-parser/qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
     "cli-truncate/string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "content-disposition/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "data-urls/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
@@ -2251,6 +2273,12 @@
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@modelcontextprotocol/sdk/express/body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+
+    "@modelcontextprotocol/sdk/express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "@playwright/test/playwright/playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,26 @@
+import { OAuth2Server } from 'oauth2-mock-server'
+
+const MOCK_OIDC_PORT = 9876
+
+let server: OAuth2Server
+
+const globalSetup = async () => {
+  server = new OAuth2Server()
+  await server.issuer.keys.generate('RS256')
+
+  // Auto-populate token claims for every issued token
+  server.service.on('beforeTokenSigning', (token: Record<string, unknown>) => {
+    token.sub = 'e2e-test-user'
+    token.email = 'e2e@thunderbolt.test'
+    token.name = 'E2E Test User'
+    token.email_verified = true
+  })
+
+  await server.start(MOCK_OIDC_PORT, 'localhost')
+  console.log(`Mock OIDC server started on port ${MOCK_OIDC_PORT}`)
+
+  // Store reference for teardown
+  ;(globalThis as Record<string, unknown>).__oidcServer = server
+}
+
+export default globalSetup

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -2,19 +2,30 @@ import { OAuth2Server } from 'oauth2-mock-server'
 
 const MOCK_OIDC_PORT = 9876
 
-let server: OAuth2Server
-
 const globalSetup = async () => {
-  server = new OAuth2Server()
+  const server = new OAuth2Server()
   await server.issuer.keys.generate('RS256')
 
-  // Auto-populate token claims for every issued token
+  // Auto-populate token claims for every issued token (id_token + access_token)
   server.service.on('beforeTokenSigning', (token: Record<string, unknown>) => {
     token.sub = 'e2e-test-user'
     token.email = 'e2e@thunderbolt.test'
     token.name = 'E2E Test User'
     token.email_verified = true
   })
+
+  // Customize /userinfo response — Better Auth calls this to get user claims
+  server.service.on(
+    'beforeUserinfo',
+    (userInfoResponse: { body: Record<string, unknown>; statusCode: number }) => {
+      userInfoResponse.body = {
+        sub: 'e2e-test-user',
+        email: 'e2e@thunderbolt.test',
+        name: 'E2E Test User',
+        email_verified: true,
+      }
+    },
+  )
 
   await server.start(MOCK_OIDC_PORT, 'localhost')
   console.log(`Mock OIDC server started on port ${MOCK_OIDC_PORT}`)

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,6 +1,6 @@
 import { OAuth2Server } from 'oauth2-mock-server'
 
-const MOCK_OIDC_PORT = 9876
+const mockOidcPort = Number(process.env.MOCK_OIDC_PORT ?? 9876)
 
 const globalSetup = async () => {
   const server = new OAuth2Server()
@@ -27,8 +27,8 @@ const globalSetup = async () => {
     },
   )
 
-  await server.start(MOCK_OIDC_PORT, 'localhost')
-  console.log(`Mock OIDC server started on port ${MOCK_OIDC_PORT}`)
+  await server.start(mockOidcPort, 'localhost')
+  console.log(`Mock OIDC server started on port ${mockOidcPort}`)
 
   // Store reference for teardown
   ;(globalThis as Record<string, unknown>).__oidcServer = server

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,11 @@
+import type { OAuth2Server } from 'oauth2-mock-server'
+
+const globalTeardown = async () => {
+  const server = (globalThis as Record<string, unknown>).__oidcServer as OAuth2Server | undefined
+  if (server) {
+    await server.stop()
+    console.log('Mock OIDC server stopped')
+  }
+}
+
+export default globalTeardown

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,40 +1,66 @@
 import { expect, type Page } from '@playwright/test'
 
-const MOCK_OIDC_PORT = 9876
-const BACKEND_URL = 'http://localhost:8000'
-
 /**
- * Intercepts the browser redirect to the mock IdP's /authorize endpoint and
- * bounces back to the backend's OIDC callback with a mock auth code + state.
- * This simulates "user logged in at the IdP" without needing a login UI.
+ * Dismiss the onboarding wizard if it appears.
+ * The dialog blocks all pointer events with a z-50 overlay.
  */
-export const interceptOidcRedirect = (page: Page) => {
-  return page.route(`http://localhost:${MOCK_OIDC_PORT}/authorize**`, (route) => {
-    const url = new URL(route.request().url())
-    const state = url.searchParams.get('state')
-    const redirectUri = url.searchParams.get('redirect_uri')
+export const dismissOnboarding = async (page: Page) => {
+  try {
+    const continueButton = page.getByRole('button', { name: 'Continue' })
+    await expect(continueButton).toBeVisible({ timeout: 4000 })
 
-    // Bounce back to the backend callback with a mock auth code
-    route.fulfill({
-      status: 302,
-      headers: {
-        Location: `${redirectUri}?code=mock-e2e-code&state=${state}`,
-      },
-    })
-  })
+    // Step 1: agree to privacy and continue
+    const checkbox = page.locator('[role="checkbox"]').first()
+    if (await checkbox.isVisible()) {
+      await checkbox.click()
+    }
+    await continueButton.click()
+    await page.waitForTimeout(300)
+
+    // Steps 2-4: skip through them
+    for (let i = 0; i < 3; i++) {
+      const skipButton = page.getByRole('button', { name: 'Skip' })
+      try {
+        await expect(skipButton).toBeVisible({ timeout: 2000 })
+        await skipButton.click()
+        await page.waitForTimeout(300)
+      } catch {
+        break
+      }
+    }
+
+    // Step 5: finish onboarding
+    const startButton = page.getByRole('button', { name: 'Start Using Thunderbolt' })
+    try {
+      await expect(startButton).toBeVisible({ timeout: 2000 })
+      await startButton.click()
+      await page.waitForTimeout(500)
+    } catch {
+      // May have already closed
+    }
+  } catch {
+    // No onboarding dialog — already completed or skipped
+  }
 }
 
 /**
- * Navigate to the app root, handle the OIDC login flow (via route interception),
- * and wait for the authenticated chat UI to render.
+ * Navigate to the app root, let the OIDC flow complete naturally through
+ * the mock OIDC server, dismiss onboarding if needed, and wait for the
+ * authenticated chat UI to render.
+ *
+ * The flow: / → AuthGate → /oidc-redirect → POST sign-in → mock IdP /authorize
+ * (auto-approves) → backend callback → token exchange → session → app
  */
 export const loginViaOidc = async (page: Page) => {
-  await interceptOidcRedirect(page)
   await page.goto('/')
+
+  // Wait for the page to settle — either onboarding or chat UI
+  await page.waitForTimeout(3000)
+  await dismissOnboarding(page)
 
   // Wait for the OIDC flow to complete and land on the chat page
   const textarea = page.locator('textarea')
-  await expect(textarea).toBeVisible({ timeout: 20_000 })
+  await expect(textarea).toBeVisible({ timeout: 30_000 })
 }
 
 /**

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -64,16 +64,6 @@ export const loginViaOidc = async (page: Page) => {
 }
 
 /**
- * Clear browser storage to ensure a fresh state.
- */
-export const clearBrowserStorage = async (page: Page) => {
-  await page.evaluate(() => {
-    localStorage.clear()
-    sessionStorage.clear()
-  })
-}
-
-/**
  * Collect uncaught JS errors, filtering Tauri-specific noise.
  */
 export const collectPageErrors = (page: Page): string[] => {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,66 @@
+import { expect, type Page } from '@playwright/test'
+
+const MOCK_OIDC_PORT = 9876
+const BACKEND_URL = 'http://localhost:8000'
+
+/**
+ * Intercepts the browser redirect to the mock IdP's /authorize endpoint and
+ * bounces back to the backend's OIDC callback with a mock auth code + state.
+ * This simulates "user logged in at the IdP" without needing a login UI.
+ */
+export const interceptOidcRedirect = (page: Page) => {
+  return page.route(`http://localhost:${MOCK_OIDC_PORT}/authorize**`, (route) => {
+    const url = new URL(route.request().url())
+    const state = url.searchParams.get('state')
+    const redirectUri = url.searchParams.get('redirect_uri')
+
+    // Bounce back to the backend callback with a mock auth code
+    route.fulfill({
+      status: 302,
+      headers: {
+        Location: `${redirectUri}?code=mock-e2e-code&state=${state}`,
+      },
+    })
+  })
+}
+
+/**
+ * Navigate to the app root, handle the OIDC login flow (via route interception),
+ * and wait for the authenticated chat UI to render.
+ */
+export const loginViaOidc = async (page: Page) => {
+  await interceptOidcRedirect(page)
+  await page.goto('/')
+
+  // Wait for the OIDC flow to complete and land on the chat page
+  const textarea = page.locator('textarea')
+  await expect(textarea).toBeVisible({ timeout: 20_000 })
+}
+
+/**
+ * Clear browser storage to ensure a fresh state.
+ */
+export const clearBrowserStorage = async (page: Page) => {
+  await page.evaluate(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+}
+
+/**
+ * Collect uncaught JS errors, filtering Tauri-specific noise.
+ */
+export const collectPageErrors = (page: Page): string[] => {
+  const errors: string[] = []
+  page.on('pageerror', (error) => {
+    if (
+      !error.message.includes('__TAURI__') &&
+      !error.message.includes('tauri') &&
+      !error.message.includes('window.__TAURI_INTERNALS__') &&
+      !error.message.includes('convertFileSrc')
+    ) {
+      errors.push(error.message)
+    }
+  })
+  return errors
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,62 +1,16 @@
 import { expect, type Page } from '@playwright/test'
 
 /**
- * Dismiss the onboarding wizard if it appears.
- * The dialog blocks all pointer events with a z-50 overlay.
- */
-export const dismissOnboarding = async (page: Page) => {
-  try {
-    const continueButton = page.getByRole('button', { name: 'Continue' })
-    await expect(continueButton).toBeVisible({ timeout: 4000 })
-
-    // Step 1: agree to privacy and continue
-    const checkbox = page.locator('[role="checkbox"]').first()
-    if (await checkbox.isVisible()) {
-      await checkbox.click()
-    }
-    await continueButton.click()
-    await page.waitForTimeout(300)
-
-    // Steps 2-4: skip through them
-    for (let i = 0; i < 3; i++) {
-      const skipButton = page.getByRole('button', { name: 'Skip' })
-      try {
-        await expect(skipButton).toBeVisible({ timeout: 2000 })
-        await skipButton.click()
-        await page.waitForTimeout(300)
-      } catch {
-        break
-      }
-    }
-
-    // Step 5: finish onboarding
-    const startButton = page.getByRole('button', { name: 'Start Using Thunderbolt' })
-    try {
-      await expect(startButton).toBeVisible({ timeout: 2000 })
-      await startButton.click()
-      await page.waitForTimeout(500)
-    } catch {
-      // May have already closed
-    }
-  } catch {
-    // No onboarding dialog — already completed or skipped
-  }
-}
-
-/**
  * Navigate to the app root, let the OIDC flow complete naturally through
- * the mock OIDC server, dismiss onboarding if needed, and wait for the
- * authenticated chat UI to render.
+ * the mock OIDC server, and wait for the authenticated chat UI to render.
  *
- * The flow: / → AuthGate → /oidc-redirect → POST sign-in → mock IdP /authorize
- * (auto-approves) → backend callback → token exchange → session → app
+ * Onboarding is disabled via VITE_SKIP_ONBOARDING env var in playwright.config.ts.
+ *
+ * The flow: / -> AuthGate -> /oidc-redirect -> POST sign-in -> mock IdP /authorize
+ * (auto-approves) -> backend callback -> token exchange -> session -> app
  */
 export const loginViaOidc = async (page: Page) => {
   await page.goto('/')
-
-  // Wait for the page to settle — either onboarding or chat UI
-  await page.waitForTimeout(3000)
-  await dismissOnboarding(page)
 
   // Wait for the OIDC flow to complete and land on the chat page
   const textarea = page.locator('textarea')

--- a/e2e/oidc-login.spec.ts
+++ b/e2e/oidc-login.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { loginViaOidc, interceptOidcRedirect, collectPageErrors } from './helpers'
+import { loginViaOidc, collectPageErrors } from './helpers'
 
 test.describe('OIDC login flow', () => {
   test('unauthenticated user is redirected through OIDC and lands on chat', async ({ page }) => {
@@ -17,9 +17,7 @@ test.describe('OIDC login flow', () => {
 
     // Navigate to settings
     await page.goto('/settings')
-    await expect(page.locator('h1, h2').filter({ hasText: /settings/i }).first()).toBeVisible({
-      timeout: 10_000,
-    })
+    await expect(page.getByText('Settings').first()).toBeVisible({ timeout: 10_000 })
 
     // Navigate back to chat
     await page.goto('/chats/new')
@@ -45,26 +43,17 @@ test.describe('OIDC login flow', () => {
 })
 
 test.describe('OIDC redirect behavior', () => {
-  test('unauthenticated visit to / redirects to /oidc-redirect', async ({ page }) => {
-    // Do NOT set up the intercept — just observe the redirect
-    const response = await page.goto('/')
-
-    // The app should redirect to /oidc-redirect for unauthenticated users in OIDC mode
-    await expect(page).toHaveURL(/oidc-redirect/, { timeout: 10_000 })
-  })
-
-  test('direct visit to /oidc-redirect triggers IdP redirect', async ({ page }) => {
-    // Intercept the IdP redirect to verify it happens
-    let idpRedirectCaptured = false
-    await page.route('http://localhost:9876/authorize**', (route) => {
-      idpRedirectCaptured = true
-      // Abort so we don't complete the flow
-      route.abort()
+  test('unauthenticated visit triggers OIDC flow', async ({ page }) => {
+    // Visit the app without logging in — should eventually hit the mock IdP
+    const responsePromise = page.waitForResponse(/\/(authorize|openid-connect\/auth)/, {
+      timeout: 15_000,
     })
 
-    await page.goto('/oidc-redirect')
-    await page.waitForTimeout(5000)
+    await page.goto('/')
 
-    expect(idpRedirectCaptured).toBe(true)
+    const response = await responsePromise
+    const url = new URL(response.url())
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('client_id')).toBe('thunderbolt-app')
   })
 })

--- a/e2e/oidc-login.spec.ts
+++ b/e2e/oidc-login.spec.ts
@@ -34,9 +34,9 @@ test.describe('OIDC login flow', () => {
 
     // Navigate around to exercise the app
     await page.goto('/settings')
-    await page.waitForTimeout(1000)
+    await expect(page.getByText('Settings').first()).toBeVisible({ timeout: 10_000 })
     await page.goto('/chats/new')
-    await page.waitForTimeout(1000)
+    await expect(page.locator('textarea')).toBeVisible({ timeout: 10_000 })
 
     expect(errors).toHaveLength(0)
   })

--- a/e2e/oidc-login.spec.ts
+++ b/e2e/oidc-login.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test'
+import { loginViaOidc, interceptOidcRedirect, collectPageErrors } from './helpers'
+
+test.describe('OIDC login flow', () => {
+  test('unauthenticated user is redirected through OIDC and lands on chat', async ({ page }) => {
+    const errors = collectPageErrors(page)
+
+    await loginViaOidc(page)
+
+    // Should be on an authenticated chat page
+    await expect(page).toHaveURL(/\/chats\//)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('authenticated session persists across navigation', async ({ page }) => {
+    await loginViaOidc(page)
+
+    // Navigate to settings
+    await page.goto('/settings')
+    await expect(page.locator('h1, h2').filter({ hasText: /settings/i }).first()).toBeVisible({
+      timeout: 10_000,
+    })
+
+    // Navigate back to chat
+    await page.goto('/chats/new')
+    await expect(page.locator('textarea')).toBeVisible({ timeout: 10_000 })
+
+    // Should NOT be redirected to OIDC again
+    await expect(page).not.toHaveURL(/oidc-redirect/)
+  })
+
+  test('page loads without critical JS errors after OIDC login', async ({ page }) => {
+    const errors = collectPageErrors(page)
+
+    await loginViaOidc(page)
+
+    // Navigate around to exercise the app
+    await page.goto('/settings')
+    await page.waitForTimeout(1000)
+    await page.goto('/chats/new')
+    await page.waitForTimeout(1000)
+
+    expect(errors).toHaveLength(0)
+  })
+})
+
+test.describe('OIDC redirect behavior', () => {
+  test('unauthenticated visit to / redirects to /oidc-redirect', async ({ page }) => {
+    // Do NOT set up the intercept — just observe the redirect
+    const response = await page.goto('/')
+
+    // The app should redirect to /oidc-redirect for unauthenticated users in OIDC mode
+    await expect(page).toHaveURL(/oidc-redirect/, { timeout: 10_000 })
+  })
+
+  test('direct visit to /oidc-redirect triggers IdP redirect', async ({ page }) => {
+    // Intercept the IdP redirect to verify it happens
+    let idpRedirectCaptured = false
+    await page.route('http://localhost:9876/authorize**', (route) => {
+      idpRedirectCaptured = true
+      // Abort so we don't complete the flow
+      route.abort()
+    })
+
+    await page.goto('/oidc-redirect')
+    await page.waitForTimeout(5000)
+
+    expect(idpRedirectCaptured).toBe(true)
+  })
+})

--- a/e2e/oidc-session.spec.ts
+++ b/e2e/oidc-session.spec.ts
@@ -2,16 +2,6 @@ import { test, expect } from '@playwright/test'
 import { loginViaOidc } from './helpers'
 
 test.describe('OIDC session', () => {
-  test('user info from OIDC claims is accessible in the app', async ({ page }) => {
-    await loginViaOidc(page)
-
-    // Navigate to settings where user info is typically displayed
-    await page.goto('/settings')
-
-    // The mock OIDC server sets email to 'e2e@thunderbolt.test'
-    await expect(page.getByText('e2e@thunderbolt.test')).toBeVisible({ timeout: 10_000 })
-  })
-
   test('chat UI is fully functional after OIDC login', async ({ page }) => {
     await loginViaOidc(page)
 
@@ -28,5 +18,16 @@ test.describe('OIDC session', () => {
     // Look for sidebar navigation elements
     const sidebar = page.locator('aside, [data-sidebar]').first()
     await expect(sidebar).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('user is signed in after OIDC login', async ({ page }) => {
+    await loginViaOidc(page)
+
+    // Navigate to settings — should NOT show "Sign In" button
+    await page.goto('/settings')
+    await expect(page.getByText('Settings').first()).toBeVisible({ timeout: 10_000 })
+
+    // A signed-in user should not see the "Sign In" button
+    await expect(page.getByRole('button', { name: 'Sign In' })).not.toBeVisible({ timeout: 5_000 })
   })
 })

--- a/e2e/oidc-session.spec.ts
+++ b/e2e/oidc-session.spec.ts
@@ -8,7 +8,8 @@ test.describe('OIDC session', () => {
     // Verify the chat textarea is interactive
     const textarea = page.locator('textarea')
     await expect(textarea).toBeVisible()
-    await textarea.fill('Hello from e2e test')
+    await textarea.click()
+    await textarea.pressSequentially('Hello from e2e test')
     await expect(textarea).toHaveValue('Hello from e2e test')
   })
 

--- a/e2e/oidc-session.spec.ts
+++ b/e2e/oidc-session.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import { loginViaOidc } from './helpers'
+
+test.describe('OIDC session', () => {
+  test('user info from OIDC claims is accessible in the app', async ({ page }) => {
+    await loginViaOidc(page)
+
+    // Navigate to settings where user info is typically displayed
+    await page.goto('/settings')
+
+    // The mock OIDC server sets email to 'e2e@thunderbolt.test'
+    await expect(page.getByText('e2e@thunderbolt.test')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('chat UI is fully functional after OIDC login', async ({ page }) => {
+    await loginViaOidc(page)
+
+    // Verify the chat textarea is interactive
+    const textarea = page.locator('textarea')
+    await expect(textarea).toBeVisible()
+    await textarea.fill('Hello from e2e test')
+    await expect(textarea).toHaveValue('Hello from e2e test')
+  })
+
+  test('sidebar navigation works after OIDC login', async ({ page }) => {
+    await loginViaOidc(page)
+
+    // Look for sidebar navigation elements
+    const sidebar = page.locator('aside, [data-sidebar]').first()
+    await expect(sidebar).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky",
-    "size": "size-limit"
+    "size": "size-limit",
+    "e2e": "bunx playwright test",
+    "e2e:headed": "bunx playwright test --headed"
   },
   "size-limit": [
     {
@@ -122,6 +124,7 @@
     "@eslint/js": "^9.33.0",
     "@happy-dom/global-registrator": "^20.0.8",
     "@libsql/client": "^0.15.12",
+    "@playwright/test": "^1.58.2",
     "@sinonjs/fake-timers": "^15.0.0",
     "@size-limit/file": "^12.0.1",
     "@storybook/addon-a11y": "^9.1.3",
@@ -157,6 +160,7 @@
     "jsdom": "^26.1.0",
     "lint-staged": "^16.1.5",
     "msw": "^2.10.5",
+    "oauth2-mock-server": "^8.2.2",
     "playwright": "^1.55.0",
     "prettier": "^3.6.2",
     "size-limit": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "lint-staged": "^16.1.5",
     "msw": "^2.10.5",
     "oauth2-mock-server": "^8.2.2",
-    "playwright": "^1.55.0",
+    "playwright": "^1.58.2",
     "prettier": "^3.6.2",
     "size-limit": "^12.0.1",
     "storybook": "^9.1.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig, devices } from '@playwright/test'
 
 const isCI = !!process.env.CI
-const MOCK_OIDC_PORT = 9876
+const mockOidcPort = process.env.MOCK_OIDC_PORT ?? '9876'
 // Use a dedicated Vite port to avoid conflicts with dev server.
 // Backend uses the standard 8000 to match the default cloud_url setting.
-const E2E_VITE_PORT = 1421
+const e2eVitePort = 1421
 
 export default defineConfig({
   testDir: './e2e',
@@ -17,7 +17,7 @@ export default defineConfig({
   globalSetup: './e2e/global-setup.ts',
   globalTeardown: './e2e/global-teardown.ts',
   use: {
-    baseURL: `http://localhost:${E2E_VITE_PORT}`,
+    baseURL: `http://localhost:${e2eVitePort}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     // Fresh storage state per test to avoid stale IndexedDB/OPFS data
@@ -31,29 +31,30 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: `bun run dev -- --port ${E2E_VITE_PORT}`,
-      url: `http://localhost:${E2E_VITE_PORT}`,
-      reuseExistingServer: false,
+      command: `bun run dev -- --port ${e2eVitePort}`,
+      url: `http://localhost:${e2eVitePort}`,
+      reuseExistingServer: !isCI,
       timeout: 30_000,
       env: {
         VITE_AUTH_MODE: 'oidc',
+        VITE_SKIP_ONBOARDING: 'true',
       },
     },
     {
       command: 'cd backend && bun run dev',
       url: 'http://localhost:8000/v1/health',
-      reuseExistingServer: false,
+      reuseExistingServer: !isCI,
       timeout: 30_000,
       env: {
         AUTH_MODE: 'oidc',
         OIDC_CLIENT_ID: 'thunderbolt-app',
         OIDC_CLIENT_SECRET: 'thunderbolt-dev-secret',
-        OIDC_ISSUER: `http://localhost:${MOCK_OIDC_PORT}`,
+        OIDC_ISSUER: `http://localhost:${mockOidcPort}`,
         BETTER_AUTH_URL: 'http://localhost:8000',
-        APP_URL: `http://localhost:${E2E_VITE_PORT}`,
-        CORS_ORIGINS: `http://localhost:${E2E_VITE_PORT}`,
+        APP_URL: `http://localhost:${e2eVitePort}`,
+        CORS_ORIGINS: `http://localhost:${e2eVitePort}`,
         CORS_ORIGIN_REGEX: '',
-        TRUSTED_ORIGINS: `http://localhost:${E2E_VITE_PORT}`,
+        TRUSTED_ORIGINS: `http://localhost:${e2eVitePort}`,
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const isCI = !!process.env.CI
+const MOCK_OIDC_PORT = 9876
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 1 : 0,
+  workers: isCI ? 2 : 1,
+  reporter: isCI ? 'blob' : 'list',
+  timeout: 30_000,
+  globalSetup: './e2e/global-setup.ts',
+  globalTeardown: './e2e/global-teardown.ts',
+  use: {
+    baseURL: 'http://localhost:1420',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    // Fresh storage state per test to avoid stale IndexedDB/OPFS data
+    storageState: undefined,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'bun run dev',
+      url: 'http://localhost:1420',
+      reuseExistingServer: !isCI,
+      timeout: 30_000,
+      env: {
+        VITE_BYPASS_WAITLIST: 'true',
+        VITE_SKIP_ONBOARDING: 'true',
+        VITE_AUTH_MODE: 'oidc',
+      },
+    },
+    {
+      command: 'cd backend && bun run dev',
+      url: 'http://localhost:8000/v1/health',
+      reuseExistingServer: !isCI,
+      timeout: 30_000,
+      env: {
+        AUTH_MODE: 'oidc',
+        OIDC_CLIENT_ID: 'thunderbolt-app',
+        OIDC_CLIENT_SECRET: 'thunderbolt-dev-secret',
+        OIDC_ISSUER: `http://localhost:${MOCK_OIDC_PORT}`,
+        BETTER_AUTH_URL: 'http://localhost:8000',
+      },
+    },
+  ],
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, devices } from '@playwright/test'
 
 const isCI = !!process.env.CI
 const MOCK_OIDC_PORT = 9876
+// Use a dedicated Vite port to avoid conflicts with dev server.
+// Backend uses the standard 8000 to match the default cloud_url setting.
+const E2E_VITE_PORT = 1421
 
 export default defineConfig({
   testDir: './e2e',
@@ -14,7 +17,7 @@ export default defineConfig({
   globalSetup: './e2e/global-setup.ts',
   globalTeardown: './e2e/global-teardown.ts',
   use: {
-    baseURL: 'http://localhost:1420',
+    baseURL: `http://localhost:${E2E_VITE_PORT}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     // Fresh storage state per test to avoid stale IndexedDB/OPFS data
@@ -28,20 +31,18 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: 'bun run dev',
-      url: 'http://localhost:1420',
-      reuseExistingServer: !isCI,
+      command: `bun run dev -- --port ${E2E_VITE_PORT}`,
+      url: `http://localhost:${E2E_VITE_PORT}`,
+      reuseExistingServer: false,
       timeout: 30_000,
       env: {
-        VITE_BYPASS_WAITLIST: 'true',
-        VITE_SKIP_ONBOARDING: 'true',
         VITE_AUTH_MODE: 'oidc',
       },
     },
     {
       command: 'cd backend && bun run dev',
       url: 'http://localhost:8000/v1/health',
-      reuseExistingServer: !isCI,
+      reuseExistingServer: false,
       timeout: 30_000,
       env: {
         AUTH_MODE: 'oidc',
@@ -49,6 +50,10 @@ export default defineConfig({
         OIDC_CLIENT_SECRET: 'thunderbolt-dev-secret',
         OIDC_ISSUER: `http://localhost:${MOCK_OIDC_PORT}`,
         BETTER_AUTH_URL: 'http://localhost:8000',
+        APP_URL: `http://localhost:${E2E_VITE_PORT}`,
+        CORS_ORIGINS: `http://localhost:${E2E_VITE_PORT}`,
+        CORS_ORIGIN_REGEX: '',
+        TRUSTED_ORIGINS: `http://localhost:${E2E_VITE_PORT}`,
       },
     },
   ],

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -61,7 +61,7 @@ const queryClient = new QueryClient()
  * which in turn redirects to the OIDC provider. The user never sees a login page on our app.
  */
 const OidcRedirect = () => {
-  const { cloudUrl } = useSettings({ cloud_url: String })
+  const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
 
   useEffect(() => {
     if (cloudUrl.isLoading || !cloudUrl.value) {

--- a/src/components/onboarding/onboarding-dialog.tsx
+++ b/src/components/onboarding/onboarding-dialog.tsx
@@ -21,6 +21,9 @@ export const OnboardingDialog = () => {
   const { state, actions } = useOnboardingState()
 
   useEffect(() => {
+    if (import.meta.env.VITE_SKIP_ONBOARDING === 'true') {
+      return
+    }
     if (!userHasCompletedOnboarding.isLoading && !userHasCompletedOnboarding.value) {
       setIsOpen(true)
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new CI infrastructure and e2e auth flow mocking, plus changes backend startup to run PGlite migrations, which could affect local/CI boot behavior if migration paths or envs are misconfigured.
> 
> **Overview**
> Adds Playwright e2e coverage for the OIDC login/session flow using a local `oauth2-mock-server`, with a new `playwright.config.ts` that boots both Vite and the backend with OIDC-specific env and disables onboarding via `VITE_SKIP_ONBOARDING`.
> 
> Introduces a new GitHub Actions workflow to run e2e tests in **2 shards**, upload blob reports/screenshots, and merge shard results into an HTML report artifact.
> 
> Backend startup now calls `runMigrations()` to automatically apply Drizzle migrations when using PGLite (no-op for Postgres), and repo tooling is updated with new e2e scripts/deps plus `.gitignore` entries for Playwright outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb2ea09195c8baa1d70676cc7e2fd617f3734a83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->