### PR TITLE
feat(mcp): add MCP OAuth callback path to AASA

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -4,7 +4,7 @@
     "details": [
       {
         "appID": "BUMSKVQ3D9.net.thunderbird.thunderbolt",
-        "paths": ["/oauth/callback", "/auth/verify"]
+        "paths": ["/oauth/callback", "/mcp/oauth/callback", "/auth/verify"]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Adds `/mcp/oauth/callback` to the Apple App Site Association file for MCP OAuth deep links on iOS/Android

This path is needed for the MCP OAuth flow on mobile — when a user authorizes an MCP server, the OAuth provider redirects back to this URL, which iOS/Android intercepts via App Links/Universal Links.

## Test plan
- [ ] Verify AASA is valid JSON after deploy
- [ ] Verify Apple CDN picks up the new path: `https://app-site-association.cdn-apple.com/a/v1/thunderbolt.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small configuration-only change that only expands the list of allowed Universal Link paths and does not affect auth logic or data handling.
> 
> **Overview**
> Enables mobile deep linking for the MCP OAuth flow by adding `/mcp/oauth/callback` to `public/.well-known/apple-app-site-association` alongside the existing OAuth callback/verification paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86dcab6963d25f3d94e390cbb1e2fdf2f9792004. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->