### PR TITLE
THU-370: Fix keyboard corner theme mismatched color

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,13 +17,7 @@
         "height": 1000,
         "minHeight": 600,
         "minWidth": 600,
-        "visible": false,
-        "backgroundColor": [
-          10,
-          10,
-          10,
-          255
-        ]
+        "visible": false
       }
     ],
     "security": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects the initial Tauri window appearance at startup.
> 
> **Overview**
> Removes the `backgroundColor` setting from `src-tauri/tauri.conf.json`’s window configuration, leaving the window *initially hidden* (`visible: false`) but no longer forcing an RGBA background color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70d259ac8a44f850580f3397151edaa54e986081. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->