### PR TITLE
THU-296: Add authentication for inference routes

### DIFF
--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -1,6 +1,7 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { deleteUser, revokeDevice } from '@/dal'
 import type { db as DbType } from '@/db/client'
+import { createSessionGuard } from '@/middleware/session-guard'
 import { Elysia } from 'elysia'
 
 /**
@@ -9,22 +10,7 @@ import { Elysia } from 'elysia'
  */
 export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
   return new Elysia({ prefix: '/account' })
-    .derive(async ({ request, set }) => {
-      const session = await auth.api.getSession({ headers: request.headers })
-
-      if (!session) {
-        set.status = 401
-        return { user: null }
-      }
-
-      return { user: session.user }
-    })
-    .onBeforeHandle(({ user: sessionUser, set }) => {
-      if (!sessionUser) {
-        set.status = 401
-        return { error: 'Unauthorized' }
-      }
-    })
+    .use(createSessionGuard(auth))
     .post('/devices/:id/revoke', async ({ params, set, user: sessionUser }) => {
       const userId = sessionUser!.id
       await revokeDevice(database, params.id, userId)

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -80,7 +80,7 @@ export const createApp = async (deps?: AppDeps) => {
       .use(createMainRoutes(fetchFn))
       .use(createGoogleAuthRoutes(fetchFn))
       .use(createMicrosoftAuthRoutes(fetchFn))
-      .use(createProToolsRoutes(fetchFn))
+      .use(createProToolsRoutes(auth, fetchFn))
       .use(createInferenceRoutes(auth))
       .use(createPostHogRoutes(fetchFn))
       .use(createWaitlistRoutes({ database, auth, emailService: deps?.waitlistEmailService }))

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -81,7 +81,7 @@ export const createApp = async (deps?: AppDeps) => {
       .use(createGoogleAuthRoutes(fetchFn))
       .use(createMicrosoftAuthRoutes(fetchFn))
       .use(createProToolsRoutes(fetchFn))
-      .use(createInferenceRoutes())
+      .use(createInferenceRoutes(auth))
       .use(createPostHogRoutes(fetchFn))
       .use(createWaitlistRoutes({ database, auth, emailService: deps?.waitlistEmailService }))
       .use(createPowerSyncRoutes(auth, settings, database))

--- a/backend/src/inference/routes.test.ts
+++ b/backend/src/inference/routes.test.ts
@@ -1,27 +1,13 @@
-import type { Auth } from '@/auth/elysia-plugin'
 import * as posthogClient from '@/posthog/client'
 import type { ConsoleSpies } from '@/test-utils/console-spies'
 import { setupConsoleSpy } from '@/test-utils/console-spies'
+import { mockAuth, mockAuthUnauthenticated } from '@/test-utils/mock-auth'
 import * as streamingUtils from '@/utils/streaming'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
 import { Elysia } from 'elysia'
 import type OpenAI from 'openai'
 import * as inferenceClient from './client'
 import { createInferenceRoutes, supportedModels } from './routes'
-
-/** Mock auth that always returns a valid session */
-const mockAuth = {
-  api: {
-    getSession: () => Promise.resolve({ user: { id: 'test-user' }, session: {} }),
-  },
-} as unknown as Auth
-
-/** Mock auth that always returns null (unauthenticated) */
-const mockAuthUnauthenticated = {
-  api: {
-    getSession: () => Promise.resolve(null),
-  },
-} as unknown as Auth
 
 describe('Inference Routes', () => {
   let app: Elysia

--- a/backend/src/inference/routes.test.ts
+++ b/backend/src/inference/routes.test.ts
@@ -1,3 +1,4 @@
+import type { Auth } from '@/auth/elysia-plugin'
 import * as posthogClient from '@/posthog/client'
 import type { ConsoleSpies } from '@/test-utils/console-spies'
 import { setupConsoleSpy } from '@/test-utils/console-spies'
@@ -7,6 +8,13 @@ import { Elysia } from 'elysia'
 import type OpenAI from 'openai'
 import * as inferenceClient from './client'
 import { createInferenceRoutes, supportedModels } from './routes'
+
+/** Mock auth that always returns a valid session */
+const mockAuth = {
+  api: {
+    getSession: () => Promise.resolve({ user: { id: 'test-user' }, session: {} }),
+  },
+} as unknown as Auth
 
 describe('Inference Routes', () => {
   let app: Elysia
@@ -54,7 +62,7 @@ describe('Inference Routes', () => {
     isPostHogConfiguredSpy = spyOn(posthogClient, 'isPostHogConfigured').mockReturnValue(false)
     createSSEStreamSpy = spyOn(streamingUtils, 'createSSEStreamFromCompletion').mockReturnValue(createMockSSEStream())
 
-    app = new Elysia().use(createInferenceRoutes())
+    app = new Elysia().use(createInferenceRoutes(mockAuth))
   })
 
   afterAll(() => {

--- a/backend/src/inference/routes.test.ts
+++ b/backend/src/inference/routes.test.ts
@@ -16,6 +16,13 @@ const mockAuth = {
   },
 } as unknown as Auth
 
+/** Mock auth that always returns null (unauthenticated) */
+const mockAuthUnauthenticated = {
+  api: {
+    getSession: () => Promise.resolve(null),
+  },
+} as unknown as Auth
+
 describe('Inference Routes', () => {
   let app: Elysia
   let getInferenceClientSpy: ReturnType<typeof spyOn>
@@ -365,6 +372,28 @@ describe('Inference Routes', () => {
 
       // Reset for other tests
       isPostHogConfiguredSpy.mockReturnValue(false)
+    })
+  })
+
+  describe('authentication', () => {
+    it('should return 401 when session is null', async () => {
+      mockCreateCompletion.mockClear()
+      const unauthenticatedApp = new Elysia().use(createInferenceRoutes(mockAuthUnauthenticated))
+
+      const response = await unauthenticatedApp.handle(
+        new Request('http://localhost/chat/completions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            model: 'mistral-large-3',
+            messages: [{ role: 'user', content: 'Hello' }],
+            stream: true,
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(401)
+      expect(mockCreateCompletion).not.toHaveBeenCalled()
     })
   })
 

--- a/backend/src/inference/routes.ts
+++ b/backend/src/inference/routes.ts
@@ -1,3 +1,4 @@
+import type { Auth } from '@/auth/elysia-plugin'
 import { safeErrorHandler } from '@/middleware/error-handling'
 import { isPostHogConfigured } from '@/posthog/client'
 import { createSSEStreamFromCompletion } from '@/utils/streaming'
@@ -42,11 +43,25 @@ export const supportedModels: Record<string, ModelConfig> = {
 /**
  * Inference API routes
  */
-export const createInferenceRoutes = () => {
+export const createInferenceRoutes = (auth: Auth) => {
   return new Elysia({
     prefix: '/chat',
   })
     .onError(safeErrorHandler)
+    .derive(async ({ request, set }) => {
+      const session = await auth.api.getSession({ headers: request.headers })
+      if (!session) {
+        set.status = 401
+        return { user: null }
+      }
+      return { user: session.user }
+    })
+    .onBeforeHandle(({ user, set }) => {
+      if (!user) {
+        set.status = 401
+        return { error: 'Unauthorized' }
+      }
+    })
     .post('/completions', async (ctx) => {
       const body = await ctx.request.json()
 

--- a/backend/src/inference/routes.ts
+++ b/backend/src/inference/routes.ts
@@ -1,5 +1,6 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { safeErrorHandler } from '@/middleware/error-handling'
+import { createSessionGuard } from '@/middleware/session-guard'
 import { isPostHogConfigured } from '@/posthog/client'
 import { createSSEStreamFromCompletion } from '@/utils/streaming'
 import type { OpenAI as PostHogOpenAI } from '@posthog/ai'
@@ -48,20 +49,7 @@ export const createInferenceRoutes = (auth: Auth) => {
     prefix: '/chat',
   })
     .onError(safeErrorHandler)
-    .derive(async ({ request, set }) => {
-      const session = await auth.api.getSession({ headers: request.headers })
-      if (!session) {
-        set.status = 401
-        return { user: null }
-      }
-      return { user: session.user }
-    })
-    .onBeforeHandle(({ user, set }) => {
-      if (!user) {
-        set.status = 401
-        return { error: 'Unauthorized' }
-      }
-    })
+    .use(createSessionGuard(auth))
     .post('/completions', async (ctx) => {
       const body = await ctx.request.json()
 

--- a/backend/src/middleware/session-guard.ts
+++ b/backend/src/middleware/session-guard.ts
@@ -7,13 +7,9 @@ import { Elysia } from 'elysia'
  */
 export const createSessionGuard = (auth: Auth) =>
   new Elysia()
-    .derive(async ({ request, set }) => {
+    .derive(async ({ request }) => {
       const session = await auth.api.getSession({ headers: request.headers })
-      if (!session) {
-        set.status = 401
-        return { user: null }
-      }
-      return { user: session.user }
+      return { user: session?.user ?? null }
     })
     .onBeforeHandle(({ user, set }) => {
       if (!user) {

--- a/backend/src/middleware/session-guard.ts
+++ b/backend/src/middleware/session-guard.ts
@@ -1,0 +1,24 @@
+import type { Auth } from '@/auth/elysia-plugin'
+import { Elysia } from 'elysia'
+
+/**
+ * Shared session guard plugin. Derives the authenticated user from the
+ * request session and rejects unauthenticated requests with 401.
+ */
+export const createSessionGuard = (auth: Auth) =>
+  new Elysia()
+    .derive(async ({ request, set }) => {
+      const session = await auth.api.getSession({ headers: request.headers })
+      if (!session) {
+        set.status = 401
+        return { user: null }
+      }
+      return { user: session.user }
+    })
+    .onBeforeHandle(({ user, set }) => {
+      if (!user) {
+        set.status = 401
+        return { error: 'Unauthorized' }
+      }
+    })
+    .as('scoped')

--- a/backend/src/pro/routes.test.ts
+++ b/backend/src/pro/routes.test.ts
@@ -1,22 +1,8 @@
-import type { Auth } from '@/auth/elysia-plugin'
 import type { ConsoleSpies } from '@/test-utils/console-spies'
 import { setupConsoleSpy } from '@/test-utils/console-spies'
+import { mockAuth, mockAuthUnauthenticated } from '@/test-utils/mock-auth'
 import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
 import { createProToolsRoutes } from './routes'
-
-/** Mock auth that always returns a valid session */
-const mockAuth = {
-  api: {
-    getSession: () => Promise.resolve({ user: { id: 'test-user' }, session: {} }),
-  },
-} as unknown as Auth
-
-/** Mock auth that returns no session (unauthenticated) */
-const mockAuthUnauthenticated = {
-  api: {
-    getSession: () => Promise.resolve(null),
-  },
-} as unknown as Auth
 
 describe('Pro Tools Routes', () => {
   let app: ReturnType<typeof createProToolsRoutes>

--- a/backend/src/pro/routes.test.ts
+++ b/backend/src/pro/routes.test.ts
@@ -1,7 +1,15 @@
+import type { Auth } from '@/auth/elysia-plugin'
 import type { ConsoleSpies } from '@/test-utils/console-spies'
 import { setupConsoleSpy } from '@/test-utils/console-spies'
 import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
 import { createProToolsRoutes } from './routes'
+
+/** Mock auth that always returns a valid session */
+const mockAuth = {
+  api: {
+    getSession: () => Promise.resolve({ user: { id: 'test-user' }, session: {} }),
+  },
+} as unknown as Auth
 
 describe('Pro Tools Routes', () => {
   let app: ReturnType<typeof createProToolsRoutes>
@@ -81,7 +89,7 @@ describe('Pro Tools Routes', () => {
       return Promise.resolve(new Response('{}', { status: 200 }))
     })
 
-    app = createProToolsRoutes(mockFetch as unknown as typeof fetch)
+    app = createProToolsRoutes(mockAuth, mockFetch as unknown as typeof fetch)
   })
 
   afterAll(async () => {

--- a/backend/src/pro/routes.test.ts
+++ b/backend/src/pro/routes.test.ts
@@ -11,6 +11,13 @@ const mockAuth = {
   },
 } as unknown as Auth
 
+/** Mock auth that returns no session (unauthenticated) */
+const mockAuthUnauthenticated = {
+  api: {
+    getSession: () => Promise.resolve(null),
+  },
+} as unknown as Auth
+
 describe('Pro Tools Routes', () => {
   let app: ReturnType<typeof createProToolsRoutes>
   let mockFetch: ReturnType<typeof mock>
@@ -177,6 +184,22 @@ describe('Pro Tools Routes', () => {
     const data = await response.json()
     expect(data).toHaveProperty('success')
     expect(data).toHaveProperty('data')
+  })
+
+  describe('authentication', () => {
+    it('should return 401 when session is null', async () => {
+      const unauthenticatedApp = createProToolsRoutes(mockAuthUnauthenticated, mockFetch as unknown as typeof fetch)
+
+      const response = await unauthenticatedApp.handle(
+        new Request('http://localhost/pro/search', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: 'test', max_results: 5 }),
+        }),
+      )
+
+      expect(response.status).toBe(401)
+    })
   })
 
   it('should require valid body for requests', async () => {

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -1,3 +1,4 @@
+import type { Auth } from '@/auth/elysia-plugin'
 import { safeErrorHandler } from '@/middleware/error-handling'
 import { Elysia, t } from 'elysia'
 import { exaPlugin } from './exa'
@@ -25,12 +26,26 @@ type WeatherPreferences = {
 /**
  * Create pro tools routes
  */
-export const createProToolsRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
+export const createProToolsRoutes = (auth: Auth, fetchFn: typeof fetch = globalThis.fetch) => {
   // Initialize the tool clients with injected fetch
   const weatherClient = new OpenMeteoWeather(fetchFn)
 
   return new Elysia({ prefix: '/pro' })
     .onError(safeErrorHandler)
+    .derive(async ({ request, set }) => {
+      const session = await auth.api.getSession({ headers: request.headers })
+      if (!session) {
+        set.status = 401
+        return { user: null }
+      }
+      return { user: session.user }
+    })
+    .onBeforeHandle(({ user, set }) => {
+      if (!user) {
+        set.status = 401
+        return { error: 'Unauthorized' }
+      }
+    })
     .use(exaPlugin)
     .use(createProxyRoutes(fetchFn))
     .use(createLinkPreviewRoutes(fetchFn))

--- a/backend/src/pro/routes.ts
+++ b/backend/src/pro/routes.ts
@@ -1,5 +1,6 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { safeErrorHandler } from '@/middleware/error-handling'
+import { createSessionGuard } from '@/middleware/session-guard'
 import { Elysia, t } from 'elysia'
 import { exaPlugin } from './exa'
 import { createLinkPreviewRoutes } from './link-preview'
@@ -32,20 +33,7 @@ export const createProToolsRoutes = (auth: Auth, fetchFn: typeof fetch = globalT
 
   return new Elysia({ prefix: '/pro' })
     .onError(safeErrorHandler)
-    .derive(async ({ request, set }) => {
-      const session = await auth.api.getSession({ headers: request.headers })
-      if (!session) {
-        set.status = 401
-        return { user: null }
-      }
-      return { user: session.user }
-    })
-    .onBeforeHandle(({ user, set }) => {
-      if (!user) {
-        set.status = 401
-        return { error: 'Unauthorized' }
-      }
-    })
+    .use(createSessionGuard(auth))
     .use(exaPlugin)
     .use(createProxyRoutes(fetchFn))
     .use(createLinkPreviewRoutes(fetchFn))

--- a/backend/src/test-utils/mock-auth.ts
+++ b/backend/src/test-utils/mock-auth.ts
@@ -1,0 +1,15 @@
+import type { Auth } from '@/auth/elysia-plugin'
+
+/** Resolves to a valid session with a test user */
+export const mockAuth = {
+  api: {
+    getSession: () => Promise.resolve({ user: { id: 'test-user' }, session: {} }),
+  },
+} as unknown as Auth
+
+/** Resolves to null (unauthenticated) */
+export const mockAuthUnauthenticated = {
+  api: {
+    getSession: () => Promise.resolve(null),
+  },
+} as unknown as Auth

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -10,6 +10,7 @@ import {
 } from '@/ai/step-logic'
 import { getModel, getModelProfile, getSettings } from '@/dal'
 import { getDb } from '@/db/database'
+import { getAuthToken } from '@/lib/auth-token'
 import { fetch } from '@/lib/fetch'
 import { createToolset, getAvailableTools } from '@/lib/tools'
 import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
@@ -63,16 +64,14 @@ export const createModel = async (modelConfig: Model) => {
     case 'thunderbolt': {
       const db = getDb()
       const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
-      // Include credentials so the session cookie is sent with inference requests
-      const backendFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
-        fetch(input, { ...init, credentials: 'include' })) as typeof fetch
+      const token = getAuthToken() ?? ''
       // GPT OSS (vendor: 'openai') uses createOpenAI with .chat() to force Chat Completions API
       // (AI SDK 5 defaults createOpenAI to Responses API which our backend doesn't support)
       if (modelConfig.vendor === 'openai') {
-        const provider = createOpenAI({ baseURL: cloudUrl, apiKey: 'thunderbolt', fetch: backendFetch })
+        const provider = createOpenAI({ baseURL: cloudUrl, apiKey: token, fetch })
         return provider.chat(modelConfig.model)
       }
-      const provider = createOpenAICompatible({ name: 'thunderbolt', baseURL: cloudUrl, fetch: backendFetch })
+      const provider = createOpenAICompatible({ name: 'thunderbolt', baseURL: cloudUrl, apiKey: token, fetch })
       return provider(modelConfig.model)
     }
     case 'anthropic': {

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -64,7 +64,7 @@ export const createModel = async (modelConfig: Model) => {
     case 'thunderbolt': {
       const db = getDb()
       const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
-      const token = getAuthToken() || undefined
+      const token = getAuthToken() || 'thunderbolt'
       // GPT OSS (vendor: 'openai') uses createOpenAI with .chat() to force Chat Completions API
       // (AI SDK 5 defaults createOpenAI to Responses API which our backend doesn't support)
       if (modelConfig.vendor === 'openai') {

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -63,13 +63,15 @@ export const createModel = async (modelConfig: Model) => {
     case 'thunderbolt': {
       const db = getDb()
       const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
+      // Include credentials so the session cookie is sent with inference requests
+      const backendFetch: typeof globalThis.fetch = (input, init) => fetch(input, { ...init, credentials: 'include' })
       // GPT OSS (vendor: 'openai') uses createOpenAI with .chat() to force Chat Completions API
       // (AI SDK 5 defaults createOpenAI to Responses API which our backend doesn't support)
       if (modelConfig.vendor === 'openai') {
-        const provider = createOpenAI({ baseURL: cloudUrl, apiKey: 'thunderbolt', fetch })
+        const provider = createOpenAI({ baseURL: cloudUrl, apiKey: 'thunderbolt', fetch: backendFetch })
         return provider.chat(modelConfig.model)
       }
-      const provider = createOpenAICompatible({ name: 'thunderbolt', baseURL: cloudUrl, fetch })
+      const provider = createOpenAICompatible({ name: 'thunderbolt', baseURL: cloudUrl, fetch: backendFetch })
       return provider(modelConfig.model)
     }
     case 'anthropic': {

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -64,7 +64,7 @@ export const createModel = async (modelConfig: Model) => {
     case 'thunderbolt': {
       const db = getDb()
       const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
-      const token = getAuthToken() ?? ''
+      const token = getAuthToken() || undefined
       // GPT OSS (vendor: 'openai') uses createOpenAI with .chat() to force Chat Completions API
       // (AI SDK 5 defaults createOpenAI to Responses API which our backend doesn't support)
       if (modelConfig.vendor === 'openai') {

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -64,7 +64,8 @@ export const createModel = async (modelConfig: Model) => {
       const db = getDb()
       const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
       // Include credentials so the session cookie is sent with inference requests
-      const backendFetch: typeof globalThis.fetch = (input, init) => fetch(input, { ...init, credentials: 'include' })
+      const backendFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
+        fetch(input, { ...init, credentials: 'include' })) as typeof fetch
       // GPT OSS (vendor: 'openai') uses createOpenAI with .chat() to force Chat Completions API
       // (AI SDK 5 defaults createOpenAI to Responses API which our backend doesn't support)
       if (modelConfig.vendor === 'openai') {

--- a/src/integrations/thunderbolt-pro/api.ts
+++ b/src/integrations/thunderbolt-pro/api.ts
@@ -15,7 +15,10 @@ import type {
 } from './schemas'
 
 const requestTimeout = 10000
-const authHeaders = () => ({ Authorization: `Bearer ${getAuthToken() ?? ''}` })
+const authHeaders = () => {
+  const token = getAuthToken()
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
 
 type HttpClient = Pick<KyInstance, 'get' | 'post'>
 

--- a/src/integrations/thunderbolt-pro/api.ts
+++ b/src/integrations/thunderbolt-pro/api.ts
@@ -1,5 +1,6 @@
 import { getSettings } from '@/dal'
 import { getDb } from '@/db/database'
+import { getAuthToken } from '@/lib/auth-token'
 import { WeatherForecastDataSchema, type WeatherForecastData } from '@/widgets/weather-forecast'
 import ky, { type KyInstance } from 'ky'
 import type {
@@ -14,6 +15,7 @@ import type {
 } from './schemas'
 
 const requestTimeout = 10000
+const authHeaders = () => ({ Authorization: `Bearer ${getAuthToken() ?? ''}` })
 
 type HttpClient = Pick<KyInstance, 'get' | 'post'>
 
@@ -26,7 +28,7 @@ export const search = async (params: SearchParams, httpClient: HttpClient = ky):
     const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
     const response = await httpClient
       .post(`${cloudUrl}/pro/search`, {
-        credentials: 'include',
+        headers: authHeaders(),
         timeout: requestTimeout,
         json: {
           query: params.query,
@@ -57,7 +59,7 @@ export const fetchContent = async (
     const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
     const response = await httpClient
       .post(`${cloudUrl}/pro/fetch-content`, {
-        credentials: 'include',
+        headers: authHeaders(),
         timeout: requestTimeout,
         json: {
           url: params.url,
@@ -89,7 +91,7 @@ export const fetchLinkPreview = async (
     const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
     const response = await httpClient
       .get(`${cloudUrl}/pro/link-preview/${encodeURIComponent(params.url)}`, {
-        credentials: 'include',
+        headers: authHeaders(),
         timeout: requestTimeout,
       })
       .json<{ data: LinkPreviewData | null; success: boolean; error?: string }>()
@@ -118,7 +120,7 @@ export const getCurrentWeather = async (params: WeatherParams, httpClient: HttpC
 
     const response = await httpClient
       .post(`${cloudUrl}/pro/weather/current`, {
-        credentials: 'include',
+        headers: authHeaders(),
         timeout: requestTimeout,
         json: {
           location: params.location,
@@ -158,7 +160,7 @@ export const getWeatherForecast = async (
 
     const response = await httpClient
       .post(`${cloudUrl}/pro/weather/forecast`, {
-        credentials: 'include',
+        headers: authHeaders(),
         timeout: requestTimeout,
         json: {
           location: params.location,
@@ -197,7 +199,7 @@ export const searchLocations = async (params: SearchLocationParams, httpClient: 
 
     const response = await httpClient
       .post(`${cloudUrl}/pro/locations/search`, {
-        credentials: 'include',
+        headers: authHeaders(),
         timeout: requestTimeout,
         json: {
           query: params.query,

--- a/src/integrations/thunderbolt-pro/api.ts
+++ b/src/integrations/thunderbolt-pro/api.ts
@@ -26,6 +26,7 @@ export const search = async (params: SearchParams, httpClient: HttpClient = ky):
     const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
     const response = await httpClient
       .post(`${cloudUrl}/pro/search`, {
+        credentials: 'include',
         timeout: requestTimeout,
         json: {
           query: params.query,
@@ -56,6 +57,7 @@ export const fetchContent = async (
     const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
     const response = await httpClient
       .post(`${cloudUrl}/pro/fetch-content`, {
+        credentials: 'include',
         timeout: requestTimeout,
         json: {
           url: params.url,
@@ -87,6 +89,7 @@ export const fetchLinkPreview = async (
     const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
     const response = await httpClient
       .get(`${cloudUrl}/pro/link-preview/${encodeURIComponent(params.url)}`, {
+        credentials: 'include',
         timeout: requestTimeout,
       })
       .json<{ data: LinkPreviewData | null; success: boolean; error?: string }>()
@@ -115,6 +118,7 @@ export const getCurrentWeather = async (params: WeatherParams, httpClient: HttpC
 
     const response = await httpClient
       .post(`${cloudUrl}/pro/weather/current`, {
+        credentials: 'include',
         timeout: requestTimeout,
         json: {
           location: params.location,
@@ -154,6 +158,7 @@ export const getWeatherForecast = async (
 
     const response = await httpClient
       .post(`${cloudUrl}/pro/weather/forecast`, {
+        credentials: 'include',
         timeout: requestTimeout,
         json: {
           location: params.location,
@@ -192,6 +197,7 @@ export const searchLocations = async (params: SearchLocationParams, httpClient: 
 
     const response = await httpClient
       .post(`${cloudUrl}/pro/locations/search`, {
+        credentials: 'include',
         timeout: requestTimeout,
         json: {
           query: params.query,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds mandatory session checks to previously unauthenticated backend endpoints (`/chat` and `/pro`), which can break clients that aren’t sending auth headers and affect core AI/pro functionality.
> 
> **Overview**
> **Adds a shared authentication gate for backend route groups.** Introduces `createSessionGuard` middleware and applies it to `account`, **newly** to inference (`/chat/completions`) and pro tools (`/pro/*`) routes, returning `401` for missing sessions.
> 
> Updates server wiring and tests to pass `auth` into `createInferenceRoutes`/`createProToolsRoutes` and adds unauthenticated-path test coverage.
> 
> On the client side, starts sending the stored bearer token when calling Thunderbolt backends: uses `getAuthToken()` as the AI SDK key for the Thunderbolt provider and attaches `Authorization: Bearer ...` headers to all Thunderbolt Pro integration requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b403f515ca8aead5955d8460f94b24dd9f7ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->