### PR TITLE
chore: require 7-day minimum release age for new packages

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,5 @@
+[install]
+minimumReleaseAge = 259200 # 3 days in seconds
+
 [test]
 preload = ["./happydom.ts", "./src/testing-library.ts"]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,5 @@
 [install]
-minimumReleaseAge = 259200 # 3 days in seconds
+minimumReleaseAge = 604800 # 7 days in seconds
 
 [test]
 preload = ["./happydom.ts", "./src/testing-library.ts"]


### PR DESCRIPTION
## Summary
- Adds `minimumReleaseAge = 604800` (7 days) to `bunfig.toml`
- New package versions must be published for at least 7 days before bun will resolve them
- Existing locked versions in `bun.lock` are unaffected

## Why
Supply chain security — most malicious package versions are detected and removed within the first few days of publication. This gives the community time to flag compromised releases before they enter our dependency tree.

This is a more targeted alternative to pinning all package.json versions to exact versions, which duplicates the lockfile's job and creates maintenance burden.

## Test plan
- [ ] Verify `bun install` works normally with existing lockfile
- [ ] Verify `bun add <package>@latest` respects the age gate for newly published versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change affecting only dependency resolution for newly published versions during `bun install`/`bun add`. Potential impact is limited to installs failing or selecting older versions if a dependency was released within the last week.
> 
> **Overview**
> Adds an `[install]` policy in `bunfig.toml` to enforce `minimumReleaseAge = 604800` (7 days), preventing Bun from resolving newly published package versions until they’ve aged a week.
> 
> This hardens dependency installs against freshly published (potentially malicious) releases while leaving the existing test preload configuration unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d786cc3ab4fa4b2e58e4c6093d9f516cc69645e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->