### PR TITLE
fix: return 401 through Elysia in waitlist middleware so CORS headers…

### DIFF
--- a/backend/src/middleware/waitlist-auth.ts
+++ b/backend/src/middleware/waitlist-auth.ts
@@ -24,7 +24,7 @@ const isPublicPath = (path: string) =>
  */
 export const createWaitlistAuthMiddleware = (settings: Settings, auth: Auth) =>
   new Elysia({ name: 'waitlist-auth' })
-    .onBeforeHandle(async ({ request }) => {
+    .onBeforeHandle(async ({ request, set }) => {
       const url = new URL(request.url)
       const path = url.pathname
 
@@ -36,10 +36,8 @@ export const createWaitlistAuthMiddleware = (settings: Settings, auth: Auth) =>
       // Waitlist enabled - require authentication
       const session = await auth.api.getSession({ headers: request.headers })
       if (!session) {
-        return new Response(JSON.stringify({ error: 'Authentication required' }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        set.status = 401
+        return { error: 'Authentication required' }
       }
 
       return


### PR DESCRIPTION
… are preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to the waitlist auth middleware’s unauthenticated response handling; primary impact is how 401 responses are constructed and may affect clients expecting the previous raw `Response` shape.
> 
> **Overview**
> Adjusts the waitlist auth middleware to return unauthenticated `401` responses through Elysia (`set.status` + JSON body) instead of constructing a manual `Response`, so framework-level response handling (e.g., CORS headers) is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37be342b0364d3409afc7f85dd1d919a0dec20a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->