### PR TITLE
fix: make source maps private

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ const shouldAnalyze = process.env.ANALYZE?.toLowerCase() === 'true' || process.a
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
-    sourcemap: true,
+    sourcemap: 'hidden',
     rollupOptions: {
       external: ['bun:sqlite'],
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk build configuration change; main impact is on debugging/monitoring tooling that expects publicly linked `.map` files.
> 
> **Overview**
> Build output now uses Vite `sourcemap: 'hidden'` instead of `true`, so source maps are still generated but are not referenced by the emitted bundles (helping keep maps private).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70f8c8b4f8e907127e0379361fa1c40310bf6cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->