### PR TITLE
[THU-285] PQC

### DIFF
--- a/backend/drizzle/0008_careful_black_tarantula.sql
+++ b/backend/drizzle/0008_careful_black_tarantula.sql
@@ -16,6 +16,7 @@ CREATE TABLE "envelopes" (
 --> statement-breakpoint
 ALTER TABLE "powersync"."devices" ADD COLUMN "trusted" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "powersync"."devices" ADD COLUMN "public_key" text;--> statement-breakpoint
+ALTER TABLE "powersync"."devices" ADD COLUMN "mlkem_public_key" text;--> statement-breakpoint
 ALTER TABLE "encryption_metadata" ADD CONSTRAINT "encryption_metadata_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "envelopes" ADD CONSTRAINT "envelopes_device_id_devices_id_fk" FOREIGN KEY ("device_id") REFERENCES "powersync"."devices"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "envelopes" ADD CONSTRAINT "envelopes_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint

--- a/backend/drizzle/meta/0008_snapshot.json
+++ b/backend/drizzle/meta/0008_snapshot.json
@@ -728,6 +728,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "mlkem_public_key": {
+          "name": "mlkem_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "last_seen": {
           "name": "last_seen",
           "type": "timestamp",

--- a/backend/src/api/encryption.test.ts
+++ b/backend/src/api/encryption.test.ts
@@ -62,15 +62,16 @@ describe('Encryption API', () => {
   const insertDevice = async (
     id: string,
     userId: string,
-    options: { trusted?: boolean; publicKey?: string; revokedAt?: Date } = {},
+    options: { trusted?: boolean; publicKey?: string; mlkemPublicKey?: string; revokedAt?: Date } = {},
   ) => {
-    const { trusted = false, publicKey = 'pk-test', revokedAt } = options
+    const { trusted = false, publicKey = 'pk-test', mlkemPublicKey = 'mlkem-pk-test', revokedAt } = options
     await db.insert(devicesTable).values({
       id,
       userId,
       name: 'Test Device',
       trusted,
       publicKey,
+      mlkemPublicKey,
       lastSeen: now,
       createdAt: now,
       ...(revokedAt ? { revokedAt } : {}),
@@ -131,7 +132,7 @@ describe('Encryption API', () => {
         new Request(`${BASE}/devices`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk' }),
+          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk', mlkemPublicKey: 'mlkem-pk' }),
         }),
       )
       expect(response.status).toBe(401)
@@ -145,7 +146,7 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: 'Bearer invalid-token',
           },
-          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk' }),
+          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk', mlkemPublicKey: 'mlkem-pk' }),
         }),
       )
       expect(response.status).toBe(401)
@@ -161,7 +162,7 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${p('tok-u1')}`,
           },
-          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk1', name: 'My Device' }),
+          body: JSON.stringify({ deviceId: p('d1'), publicKey: 'pk1', mlkemPublicKey: 'mlkem-pk1', name: 'My Device' }),
         }),
       )
 
@@ -191,7 +192,7 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${p('tok-u2')}`,
           },
-          body: JSON.stringify({ deviceId: p('d-new'), publicKey: 'pk2' }),
+          body: JSON.stringify({ deviceId: p('d-new'), publicKey: 'pk2', mlkemPublicKey: 'mlkem-pk2' }),
         }),
       )
 
@@ -212,7 +213,7 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${p('tok-u3')}`,
           },
-          body: JSON.stringify({ deviceId: p('d-trusted'), publicKey: 'pk3' }),
+          body: JSON.stringify({ deviceId: p('d-trusted'), publicKey: 'pk3', mlkemPublicKey: 'mlkem-pk3' }),
         }),
       )
 
@@ -233,7 +234,7 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${p('tok-u4')}`,
           },
-          body: JSON.stringify({ deviceId: p('d-pending'), publicKey: 'pk4' }),
+          body: JSON.stringify({ deviceId: p('d-pending'), publicKey: 'pk4', mlkemPublicKey: 'mlkem-pk4' }),
         }),
       )
 
@@ -254,7 +255,7 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${p('tok-u5b')}`,
           },
-          body: JSON.stringify({ deviceId: p('d-conflict'), publicKey: 'pk5' }),
+          body: JSON.stringify({ deviceId: p('d-conflict'), publicKey: 'pk5', mlkemPublicKey: 'mlkem-pk5' }),
         }),
       )
 
@@ -274,7 +275,7 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${p('tok-u6')}`,
           },
-          body: JSON.stringify({ deviceId: p('d-revoked'), publicKey: 'pk6' }),
+          body: JSON.stringify({ deviceId: p('d-revoked'), publicKey: 'pk6', mlkemPublicKey: 'mlkem-pk6' }),
         }),
       )
 
@@ -294,7 +295,12 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${p('tok-u7')}`,
           },
-          body: JSON.stringify({ deviceId: p('d-empty-name'), publicKey: 'pk7a', name: '' }),
+          body: JSON.stringify({
+            deviceId: p('d-empty-name'),
+            publicKey: 'pk7a',
+            mlkemPublicKey: 'mlkem-pk7a',
+            name: '',
+          }),
         }),
       )
 
@@ -312,7 +318,12 @@ describe('Encryption API', () => {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${p('tok-u7')}`,
           },
-          body: JSON.stringify({ deviceId: p('d-long-name'), publicKey: 'pk7b', name: 'x'.repeat(101) }),
+          body: JSON.stringify({
+            deviceId: p('d-long-name'),
+            publicKey: 'pk7b',
+            mlkemPublicKey: 'mlkem-pk7b',
+            name: 'x'.repeat(101),
+          }),
         }),
       )
       expect(longNameResponse.status).toBe(422)

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -80,25 +80,21 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
       '/devices',
       async ({ body, set, user: sessionUser }) => {
         const userId = sessionUser!.id
-        const { deviceId, publicKey, name } = body
+        const { deviceId, publicKey, mlkemPublicKey, name } = body
 
-        // Check if device already exists
         const existingDevice = await getDeviceById(database, deviceId)
 
         if (existingDevice) {
-          // Device belongs to a different user
           if (existingDevice.userId !== userId) {
             set.status = 409
             return { error: 'Device ID already taken' }
           }
 
-          // Revoked — device cannot re-register
           if (existingDevice.revokedAt != null) {
             set.status = 403
             return { error: 'Device has been revoked' }
           }
 
-          // Encryption-registered device (has publicKey): return current state
           if (existingDevice.publicKey) {
             if (existingDevice.trusted) {
               const envelope = await getEnvelopeByDeviceId(database, deviceId, userId)
@@ -109,17 +105,15 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
             }
             return { trusted: false as const }
           }
-
-          // Pre-encryption device (no publicKey): fall through to register with publicKey
         }
 
-        // New device OR pre-encryption device — register with publicKey
         const deviceName = name || 'Unknown device'
         await registerDevice(database, {
           id: deviceId,
           userId,
           name: deviceName,
           publicKey,
+          mlkemPublicKey,
         })
 
         return { trusted: false as const }
@@ -127,7 +121,8 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
       {
         body: t.Object({
           deviceId: t.String({ maxLength: 36 }),
-          publicKey: t.String({ maxLength: 500 }),
+          publicKey: t.String({ maxLength: 200 }),
+          mlkemPublicKey: t.String({ maxLength: 1700 }),
           name: t.Optional(t.String({ maxLength: 100 })),
         }),
       },
@@ -201,14 +196,12 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
               }
             }
 
-            // Store envelope
             await upsertEnvelope(txDb, {
               deviceId,
               userId,
               wrappedCk: wrappedCK,
             })
 
-            // Store canary if provided (first device setup — idempotent)
             if (canaryIv && canaryCtext) {
               const canarySecretHash = canarySecret ? await hashCanarySecret(canarySecret) : undefined
               await insertEncryptionMetadataIfNotExists(txDb, {
@@ -219,7 +212,6 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
               })
             }
 
-            // Mark device as trusted
             await markDeviceTrusted(txDb, deviceId, userId)
           })
         } catch (err) {
@@ -238,7 +230,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
       },
       {
         body: t.Object({
-          wrappedCK: t.String({ maxLength: 500 }),
+          wrappedCK: t.String({ maxLength: 2200 }),
           canaryIv: t.Optional(t.String({ maxLength: 500 })),
           canaryCtext: t.Optional(t.String({ maxLength: 500 })),
           canarySecret: t.Optional(t.String({ maxLength: 500 })),
@@ -254,7 +246,6 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
         return { error: 'X-Device-ID header is required' }
       }
 
-      // Verify device belongs to this user
       const device = await getDeviceById(database, deviceId)
       if (!device || device.userId !== userId) {
         set.status = 404

--- a/backend/src/dal/devices.ts
+++ b/backend/src/dal/devices.ts
@@ -53,7 +53,7 @@ export const markDeviceTrusted = async (database: typeof DbType, deviceId: strin
  */
 export const registerDevice = async (
   database: typeof DbType,
-  device: { id: string; userId: string; name: string; publicKey: string },
+  device: { id: string; userId: string; name: string; publicKey: string; mlkemPublicKey: string },
 ) =>
   database
     .insert(devicesTable)
@@ -62,15 +62,16 @@ export const registerDevice = async (
       userId: device.userId,
       name: device.name,
       publicKey: device.publicKey,
+      mlkemPublicKey: device.mlkemPublicKey,
       createdAt: new Date(),
       lastSeen: new Date(),
     })
-    // On conflict: update publicKey, reset trusted to false (device must go through
+    // On conflict: update public keys, reset trusted to false (device must go through
     // approval flow again), and update lastSeen. This handles both concurrent re-registration
     // races and pre-encryption devices that were backfilled as trusted without an envelope.
     .onConflictDoUpdate({
       target: devicesTable.id,
-      set: { publicKey: device.publicKey, trusted: false, lastSeen: new Date() },
+      set: { publicKey: device.publicKey, mlkemPublicKey: device.mlkemPublicKey, trusted: false, lastSeen: new Date() },
       setWhere: eq(devicesTable.userId, device.userId),
     })
     .returning()

--- a/backend/src/dal/powersync.ts
+++ b/backend/src/dal/powersync.ts
@@ -13,7 +13,7 @@ const validTables = new Set<string>(powersyncTableNames)
 
 /** DB column names that clients cannot set via PowerSync upload (server-managed fields). */
 const uploadDenyColumns: Partial<Record<PowerSyncTableName, string[]>> = {
-  devices: ['revoked_at', 'trusted', 'public_key'],
+  devices: ['revoked_at', 'trusted', 'public_key', 'mlkem_public_key'],
 }
 
 type PowerSyncOperation = {

--- a/backend/src/db/powersync-schema.ts
+++ b/backend/src/db/powersync-schema.ts
@@ -233,6 +233,7 @@ export const devicesTable = powersyncSchema.table(
     name: text('name'),
     trusted: boolean('trusted').notNull().default(false),
     publicKey: text('public_key'),
+    mlkemPublicKey: text('mlkem_public_key'),
     lastSeen: timestamp('last_seen').defaultNow(),
     createdAt: timestamp('created_at').defaultNow(),
     revokedAt: timestamp('revoked_at'),

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@hookform/resolvers": "^5.2.1",
         "@journeyapps/wa-sqlite": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.17.3",
+        "@noble/post-quantum": "^0.6.0",
         "@openrouter/ai-sdk-provider": "^1.1.2",
         "@powersync/drizzle-driver": "^0.7.2",
         "@powersync/react": "^1.9.0",
@@ -397,7 +398,11 @@
 
     "@noble/ciphers": ["@noble/ciphers@2.0.1", "", {}, "sha512-xHK3XHPUW8DTAobU+G0XT+/w+JLM7/8k1UFdB5xg/zTFPnFCobhftzw8wl4Lw2aq/Rvir5pxfZV5fEazmeCJ2g=="],
 
+    "@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
+
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "@noble/post-quantum": ["@noble/post-quantum@0.6.0", "", { "dependencies": { "@noble/ciphers": "~2.0.0", "@noble/curves": "~2.0.0", "@noble/hashes": "~2.0.0" } }, "sha512-rv4UfzjtlwrGFBso6IiofY3j4XhLrvjX6Q/w2bVWUoiPvKDIadeW7+xti0c0zND7K+yk62A2XYSLFlQZVHb5Mg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@hookform/resolvers": "^5.2.1",
     "@journeyapps/wa-sqlite": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.17.3",
+    "@noble/post-quantum": "^0.6.0",
     "@openrouter/ai-sdk-provider": "^1.1.2",
     "@powersync/drizzle-driver": "^0.7.2",
     "@powersync/react": "^1.9.0",

--- a/src/api/encryption.test.ts
+++ b/src/api/encryption.test.ts
@@ -60,13 +60,19 @@ describe('encryption API client', () => {
       const result = await registerDevice(httpClient, {
         deviceId: 'dev-1',
         publicKey: 'pk-base64',
+        mlkemPublicKey: 'mlkem-pk-base64',
         name: 'Test Device',
       })
 
       const req = getLastRequest()
       expect(req.url).toContain('/devices')
       expect(req.method).toBe('POST')
-      expect(req.body).toEqual({ deviceId: 'dev-1', publicKey: 'pk-base64', name: 'Test Device' })
+      expect(req.body).toEqual({
+        deviceId: 'dev-1',
+        publicKey: 'pk-base64',
+        mlkemPublicKey: 'mlkem-pk-base64',
+        name: 'Test Device',
+      })
       expect(req.headers.get('authorization')).toBe('Bearer test-token')
       expect(req.headers.get('x-device-id')).toBe('test-device-id')
       expect(result).toEqual(mockResponse)
@@ -79,6 +85,7 @@ describe('encryption API client', () => {
       const result = await registerDevice(httpClient, {
         deviceId: 'dev-1',
         publicKey: 'pk-base64',
+        mlkemPublicKey: 'mlkem-pk-base64',
       })
 
       expect(result).toEqual(mockResponse)

--- a/src/api/encryption.ts
+++ b/src/api/encryption.ts
@@ -1,5 +1,6 @@
 import type { KyInstance } from 'ky'
 import { getAuthToken, getDeviceId } from '@/lib/auth-token'
+import { getResponseStatus } from '@/lib/error-utils'
 
 // =============================================================================
 // Response types (matching backend)
@@ -37,7 +38,7 @@ export const authHeaders = (): Record<string, string> => {
 /** Register (or re-identify) this device with the server. */
 export const registerDevice = async (
   httpClient: KyInstance,
-  params: { deviceId: string; publicKey: string; name?: string },
+  params: { deviceId: string; publicKey: string; mlkemPublicKey: string; name?: string },
 ): Promise<RegisterDeviceResponse> =>
   httpClient
     .post('devices', {
@@ -83,19 +84,11 @@ export const fetchCanary = async (httpClient: KyInstance): Promise<FetchCanaryRe
 /** Check if the user has encryption set up (canary exists on server). */
 export const checkCanaryExists = async (httpClient: KyInstance): Promise<boolean> => {
   try {
-    await httpClient
-      .get('encryption/canary', {
-        headers: authHeaders(),
-        credentials: 'omit',
-      })
-      .json()
+    await fetchCanary(httpClient)
     return true
   } catch (err) {
-    if (err instanceof Error && 'response' in err) {
-      const status = (err as Error & { response: { status: number } }).response.status
-      if (status === 404) {
-        return false
-      }
+    if (getResponseStatus(err) === 404) {
+      return false
     }
     throw err
   }

--- a/src/components/pending-device-modal.test.tsx
+++ b/src/components/pending-device-modal.test.tsx
@@ -89,7 +89,14 @@ describe('PendingDeviceModal', () => {
 
     await db.insert(devicesTable).values([
       { id: currentDeviceId, userId: 'user-1', name: 'Current', trusted: 1 },
-      { id: pendingDeviceId1, userId: 'user-1', name: 'My Phone', trusted: 0, publicKey: 'pk-1' },
+      {
+        id: pendingDeviceId1,
+        userId: 'user-1',
+        name: 'My Phone',
+        trusted: 0,
+        publicKey: 'pk-1',
+        mlkemPublicKey: 'mlkem-pk-1',
+      },
     ])
 
     renderWithReactivity(<PendingDeviceModal />, {
@@ -107,8 +114,22 @@ describe('PendingDeviceModal', () => {
 
     await db.insert(devicesTable).values([
       { id: currentDeviceId, userId: 'user-1', name: 'Current', trusted: 1 },
-      { id: pendingDeviceId1, userId: 'user-1', name: 'Phone One', trusted: 0, publicKey: 'pk-1' },
-      { id: pendingDeviceId2, userId: 'user-1', name: 'Phone Two', trusted: 0, publicKey: 'pk-2' },
+      {
+        id: pendingDeviceId1,
+        userId: 'user-1',
+        name: 'Phone One',
+        trusted: 0,
+        publicKey: 'pk-1',
+        mlkemPublicKey: 'mlkem-pk-1',
+      },
+      {
+        id: pendingDeviceId2,
+        userId: 'user-1',
+        name: 'Phone Two',
+        trusted: 0,
+        publicKey: 'pk-2',
+        mlkemPublicKey: 'mlkem-pk-2',
+      },
     ])
 
     renderWithReactivity(<PendingDeviceModal />, {
@@ -133,7 +154,14 @@ describe('PendingDeviceModal', () => {
 
     await db.insert(devicesTable).values([
       { id: currentDeviceId, userId: 'user-1', name: 'Current', trusted: 1 },
-      { id: pendingDeviceId1, userId: 'user-1', name: 'My Phone', trusted: 0, publicKey: 'pk-1' },
+      {
+        id: pendingDeviceId1,
+        userId: 'user-1',
+        name: 'My Phone',
+        trusted: 0,
+        publicKey: 'pk-1',
+        mlkemPublicKey: 'mlkem-pk-1',
+      },
     ])
 
     renderWithReactivity(<PendingDeviceModal />, {
@@ -162,7 +190,14 @@ describe('PendingDeviceModal', () => {
 
     await db.insert(devicesTable).values([
       { id: currentDeviceId, userId: 'user-1', name: 'Current', trusted: 1 },
-      { id: pendingDeviceId1, userId: 'user-1', name: 'My Phone', trusted: 0, publicKey: 'pk-1' },
+      {
+        id: pendingDeviceId1,
+        userId: 'user-1',
+        name: 'My Phone',
+        trusted: 0,
+        publicKey: 'pk-1',
+        mlkemPublicKey: 'mlkem-pk-1',
+      },
     ])
 
     renderWithReactivity(<PendingDeviceModal />, {
@@ -192,7 +227,14 @@ describe('PendingDeviceModal', () => {
 
     await db.insert(devicesTable).values([
       { id: currentDeviceId, userId: 'user-1', name: 'Current', trusted: 1 },
-      { id: pendingDeviceId1, userId: 'user-1', name: 'My Phone', trusted: 0, publicKey: 'pk-1' },
+      {
+        id: pendingDeviceId1,
+        userId: 'user-1',
+        name: 'My Phone',
+        trusted: 0,
+        publicKey: 'pk-1',
+        mlkemPublicKey: 'mlkem-pk-1',
+      },
     ])
 
     renderWithReactivity(<PendingDeviceModal />, {

--- a/src/components/pending-device-modal.tsx
+++ b/src/components/pending-device-modal.tsx
@@ -80,8 +80,8 @@ export const PendingDeviceModal = () => {
               <Button className="w-full" variant="ghost" onClick={handleDismiss}>
                 Later
               </Button>
-              <Button className="w-full" variant="ghost" onClick={() => setConfirmDenyOpen(true)}>
-                <span className="text-destructive">Deny</span>
+              <Button className="w-full text-destructive" variant="ghost" onClick={() => setConfirmDenyOpen(true)}>
+                Deny
               </Button>
             </div>
           </div>

--- a/src/components/sync-setup/sync-setup-modal.tsx
+++ b/src/components/sync-setup/sync-setup-modal.tsx
@@ -15,7 +15,7 @@ import { useRef } from 'react'
 type SyncSetupModalProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onComplete: () => void
+  onComplete: () => void | Promise<void>
 }
 
 /**
@@ -43,12 +43,12 @@ export const SyncSetupModal = ({ open, onOpenChange, onComplete }: SyncSetupModa
     onOpenChange(false)
   }
 
-  const completeAndClose = () => {
+  const completeAndClose = async () => {
     if (hasCompletedRef.current) {
       return
     }
     hasCompletedRef.current = true
-    onComplete()
+    await onComplete()
     onOpenChange(false)
   }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,15 +1,19 @@
 // Primitives
 export {
   generateKeyPair,
+  generateMlKemKeyPair,
   generateCK,
   reimportAsNonExtractable,
   exportPublicKey,
   importPublicKey,
+  exportMlKemPublicKey,
+  importMlKemPublicKey,
   wrapCK,
   rewrapCK,
   unwrapCK,
   encrypt,
   decrypt,
+  type MlKemKeyPair,
 } from './primitives'
 
 // Canary
@@ -19,7 +23,7 @@ export { createCanary, verifyCanary } from './canary'
 export { encodeRecoveryKey, decodeRecoveryKey } from './recovery-key'
 
 // Key storage (IndexedDB)
-export { storeKeyPair, getKeyPair, storeCK, getCK, clearCK, clearAllKeys } from './key-storage'
+export { storeKeyPair, getKeyPair, storeCK, getCK, clearCK, clearAllKeys, type StoredKeyPair } from './key-storage'
 
 // Errors
 export { EncryptionError, DecryptionError, StorageError, ValidationError } from './errors'

--- a/src/crypto/key-storage.ts
+++ b/src/crypto/key-storage.ts
@@ -61,6 +61,23 @@ const getValue = async <T extends StorableValue>(id: string): Promise<T | null> 
   })
 }
 
+const getEntries = async <T extends StorableValue>(ids: string[]): Promise<Array<T | null>> => {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readonly')
+    const store = tx.objectStore(storeName)
+    const requests = ids.map((id) => store.get(id))
+    tx.oncomplete = () => {
+      db.close()
+      resolve(requests.map((r) => (r.result as T) ?? null))
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(new StorageError('Failed to get keys', { cause: tx.error }))
+    }
+  })
+}
+
 const deleteKey = async (id: string): Promise<void> => {
   const db = await openDB()
   return new Promise((resolve, reject) => {
@@ -140,16 +157,23 @@ export const storeKeyPair = async (
     { id: mlkemSecretKeyId, value: mlkemSecretKey },
   ])
 
-/** Get both key pairs from IndexedDB. Returns null if any key is missing. */
+/** Get both key pairs from IndexedDB (single transaction). Returns null if any key is missing. */
 export const getKeyPair = async (): Promise<StoredKeyPair | null> => {
-  const ecdhPrivateKey = await getValue<CryptoKey>(privateKeyId)
-  const ecdhPublicKey = await getValue<CryptoKey>(publicKeyId)
-  const mlkemPublicKey = await getValue<Uint8Array>(mlkemPublicKeyId)
-  const mlkemSecretKey = await getValue<Uint8Array>(mlkemSecretKeyId)
+  const [ecdhPrivateKey, ecdhPublicKey, mlkemPublicKey, mlkemSecretKey] = await getEntries<StorableValue>([
+    privateKeyId,
+    publicKeyId,
+    mlkemPublicKeyId,
+    mlkemSecretKeyId,
+  ])
   if (!ecdhPrivateKey || !ecdhPublicKey || !mlkemPublicKey || !mlkemSecretKey) {
     return null
   }
-  return { ecdhPrivateKey, ecdhPublicKey, mlkemPublicKey, mlkemSecretKey }
+  return {
+    ecdhPrivateKey: ecdhPrivateKey as CryptoKey,
+    ecdhPublicKey: ecdhPublicKey as CryptoKey,
+    mlkemPublicKey: mlkemPublicKey as Uint8Array,
+    mlkemSecretKey: mlkemSecretKey as Uint8Array,
+  }
 }
 
 // =============================================================================

--- a/src/crypto/key-storage.ts
+++ b/src/crypto/key-storage.ts
@@ -146,7 +146,9 @@ export const getKeyPair = async (): Promise<StoredKeyPair | null> => {
   const ecdhPublicKey = await getValue<CryptoKey>(publicKeyId)
   const mlkemPublicKey = await getValue<Uint8Array>(mlkemPublicKeyId)
   const mlkemSecretKey = await getValue<Uint8Array>(mlkemSecretKeyId)
-  if (!ecdhPrivateKey || !ecdhPublicKey || !mlkemPublicKey || !mlkemSecretKey) return null
+  if (!ecdhPrivateKey || !ecdhPublicKey || !mlkemPublicKey || !mlkemSecretKey) {
+    return null
+  }
   return { ecdhPrivateKey, ecdhPublicKey, mlkemPublicKey, mlkemSecretKey }
 }
 

--- a/src/crypto/key-storage.ts
+++ b/src/crypto/key-storage.ts
@@ -6,6 +6,8 @@ const dbVersion = 1
 
 const privateKeyId = 'thunderbolt_private_key'
 const publicKeyId = 'thunderbolt_public_key'
+const mlkemPublicKeyId = 'thunderbolt_mlkem_public_key'
+const mlkemSecretKeyId = 'thunderbolt_mlkem_secret_key'
 const ckId = 'thunderbolt_ck'
 
 // =============================================================================
@@ -25,11 +27,13 @@ const openDB = (): Promise<IDBDatabase> =>
     request.onerror = () => reject(new StorageError('Failed to open IndexedDB', { cause: request.error }))
   })
 
-const putKey = async (id: string, key: CryptoKey): Promise<void> => {
+type StorableValue = CryptoKey | Uint8Array
+
+const putValue = async (id: string, value: StorableValue): Promise<void> => {
   const db = await openDB()
   return new Promise((resolve, reject) => {
     const tx = db.transaction(storeName, 'readwrite')
-    tx.objectStore(storeName).put(key, id)
+    tx.objectStore(storeName).put(value, id)
     tx.oncomplete = () => {
       db.close()
       resolve()
@@ -41,14 +45,14 @@ const putKey = async (id: string, key: CryptoKey): Promise<void> => {
   })
 }
 
-const getKey = async (id: string): Promise<CryptoKey | null> => {
+const getValue = async <T extends StorableValue>(id: string): Promise<T | null> => {
   const db = await openDB()
   return new Promise((resolve, reject) => {
     const tx = db.transaction(storeName, 'readonly')
     const request = tx.objectStore(storeName).get(id)
     request.onsuccess = () => {
       db.close()
-      resolve((request.result as CryptoKey) ?? null)
+      resolve((request.result as T) ?? null)
     }
     request.onerror = () => {
       db.close()
@@ -73,13 +77,13 @@ const deleteKey = async (id: string): Promise<void> => {
   })
 }
 
-const putKeys = async (entries: Array<{ id: string; key: CryptoKey }>): Promise<void> => {
+const putEntries = async (entries: Array<{ id: string; value: StorableValue }>): Promise<void> => {
   const db = await openDB()
   return new Promise((resolve, reject) => {
     const tx = db.transaction(storeName, 'readwrite')
     const store = tx.objectStore(storeName)
-    for (const { id, key } of entries) {
-      store.put(key, id)
+    for (const { id, value } of entries) {
+      store.put(value, id)
     }
     tx.oncomplete = () => {
       db.close()
@@ -112,24 +116,38 @@ const deleteKeys = async (ids: string[]): Promise<void> => {
 }
 
 // =============================================================================
-// Key pair (ECDH P-256)
+// Key pair (ECDH P-256 + ML-KEM-768)
 // =============================================================================
 
-/** Store the device key pair in IndexedDB (single atomic transaction). */
-export const storeKeyPair = async (privateKey: CryptoKey, publicKey: CryptoKey): Promise<void> =>
-  putKeys([
-    { id: privateKeyId, key: privateKey },
-    { id: publicKeyId, key: publicKey },
+export type StoredKeyPair = {
+  ecdhPrivateKey: CryptoKey
+  ecdhPublicKey: CryptoKey
+  mlkemPublicKey: Uint8Array
+  mlkemSecretKey: Uint8Array
+}
+
+/** Store both ECDH and ML-KEM key pairs in IndexedDB (single atomic transaction). */
+export const storeKeyPair = async (
+  ecdhPrivateKey: CryptoKey,
+  ecdhPublicKey: CryptoKey,
+  mlkemPublicKey: Uint8Array,
+  mlkemSecretKey: Uint8Array,
+): Promise<void> =>
+  putEntries([
+    { id: privateKeyId, value: ecdhPrivateKey },
+    { id: publicKeyId, value: ecdhPublicKey },
+    { id: mlkemPublicKeyId, value: mlkemPublicKey },
+    { id: mlkemSecretKeyId, value: mlkemSecretKey },
   ])
 
-/** Get the device key pair from IndexedDB. Returns null if either key is missing. */
-export const getKeyPair = async (): Promise<{ privateKey: CryptoKey; publicKey: CryptoKey } | null> => {
-  const privateKey = await getKey(privateKeyId)
-  const publicKey = await getKey(publicKeyId)
-  if (!privateKey || !publicKey) {
-    return null
-  }
-  return { privateKey, publicKey }
+/** Get both key pairs from IndexedDB. Returns null if any key is missing. */
+export const getKeyPair = async (): Promise<StoredKeyPair | null> => {
+  const ecdhPrivateKey = await getValue<CryptoKey>(privateKeyId)
+  const ecdhPublicKey = await getValue<CryptoKey>(publicKeyId)
+  const mlkemPublicKey = await getValue<Uint8Array>(mlkemPublicKeyId)
+  const mlkemSecretKey = await getValue<Uint8Array>(mlkemSecretKeyId)
+  if (!ecdhPrivateKey || !ecdhPublicKey || !mlkemPublicKey || !mlkemSecretKey) return null
+  return { ecdhPrivateKey, ecdhPublicKey, mlkemPublicKey, mlkemSecretKey }
 }
 
 // =============================================================================
@@ -137,10 +155,10 @@ export const getKeyPair = async (): Promise<{ privateKey: CryptoKey; publicKey: 
 // =============================================================================
 
 /** Store the content key in IndexedDB. */
-export const storeCK = async (ck: CryptoKey): Promise<void> => putKey(ckId, ck)
+export const storeCK = async (ck: CryptoKey): Promise<void> => putValue(ckId, ck)
 
 /** Get the content key from IndexedDB. */
-export const getCK = async (): Promise<CryptoKey | null> => getKey(ckId)
+export const getCK = async (): Promise<CryptoKey | null> => getValue<CryptoKey>(ckId)
 
 /** Clear only the content key (key pair is preserved). */
 export const clearCK = async (): Promise<void> => deleteKey(ckId)
@@ -150,4 +168,5 @@ export const clearCK = async (): Promise<void> => deleteKey(ckId)
 // =============================================================================
 
 /** Clear all keys from IndexedDB (single atomic transaction for full data wipe / revocation). */
-export const clearAllKeys = async (): Promise<void> => deleteKeys([privateKeyId, publicKeyId, ckId])
+export const clearAllKeys = async (): Promise<void> =>
+  deleteKeys([privateKeyId, publicKeyId, mlkemPublicKeyId, mlkemSecretKeyId, ckId])

--- a/src/crypto/primitives.test.ts
+++ b/src/crypto/primitives.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'bun:test'
 import {
   generateKeyPair,
+  generateMlKemKeyPair,
   generateCK,
   reimportAsNonExtractable,
   exportPublicKey,
   importPublicKey,
+  exportMlKemPublicKey,
+  importMlKemPublicKey,
   wrapCK,
   rewrapCK,
   unwrapCK,
@@ -19,6 +22,36 @@ describe('generateKeyPair', () => {
     expect(keyPair.privateKey).toBeDefined()
     expect(keyPair.publicKey.algorithm.name).toBe('ECDH')
     expect(keyPair.privateKey.extractable).toBe(false)
+  })
+})
+
+describe('generateMlKemKeyPair', () => {
+  it('generates an ML-KEM-768 key pair with correct sizes', () => {
+    const keyPair = generateMlKemKeyPair()
+    expect(keyPair.publicKey).toBeInstanceOf(Uint8Array)
+    expect(keyPair.secretKey).toBeInstanceOf(Uint8Array)
+    expect(keyPair.publicKey.length).toBe(1184)
+    expect(keyPair.secretKey.length).toBe(2400)
+  })
+
+  it('generates different key pairs each time', () => {
+    const kp1 = generateMlKemKeyPair()
+    const kp2 = generateMlKemKeyPair()
+    expect(kp1.publicKey).not.toEqual(kp2.publicKey)
+    expect(kp1.secretKey).not.toEqual(kp2.secretKey)
+  })
+})
+
+describe('exportMlKemPublicKey / importMlKemPublicKey', () => {
+  it('round-trips an ML-KEM public key through base64', () => {
+    const keyPair = generateMlKemKeyPair()
+    const exported = exportMlKemPublicKey(keyPair.publicKey)
+    expect(typeof exported).toBe('string')
+    expect(exported.length).toBeGreaterThan(0)
+
+    const imported = importMlKemPublicKey(exported)
+    expect(imported).toBeInstanceOf(Uint8Array)
+    expect(imported).toEqual(keyPair.publicKey)
   })
 })
 
@@ -62,85 +95,108 @@ describe('wrapCK / unwrapCK', () => {
   // The first-device flow always wraps an extractable CK before re-importing.
 
   it('round-trips CK through wrap and unwrap', async () => {
-    const keyPair = await generateKeyPair()
+    const ecdhKeyPair = await generateKeyPair()
+    const mlkemKeyPair = generateMlKemKeyPair()
     const ck = await generateCK(true) // extractable for wrapping
 
-    const wrapped = await wrapCK(ck, keyPair.publicKey)
+    const wrapped = await wrapCK(ck, ecdhKeyPair.publicKey, mlkemKeyPair.publicKey)
     expect(typeof wrapped).toBe('string')
 
-    const unwrapped = await unwrapCK(wrapped, keyPair.privateKey)
+    const unwrapped = await unwrapCK(wrapped, ecdhKeyPair.privateKey, mlkemKeyPair.secretKey)
     expect(unwrapped.algorithm.name).toBe('AES-GCM')
     expect(unwrapped.extractable).toBe(false)
   })
 
   it('unwrapped CK can encrypt/decrypt the same data as original', async () => {
-    const keyPair = await generateKeyPair()
+    const ecdhKeyPair = await generateKeyPair()
+    const mlkemKeyPair = generateMlKemKeyPair()
     const ck = await generateCK(true)
 
     const encrypted = await encrypt('wrap test', ck)
-    const wrapped = await wrapCK(ck, keyPair.publicKey)
-    const unwrapped = await unwrapCK(wrapped, keyPair.privateKey)
+    const wrapped = await wrapCK(ck, ecdhKeyPair.publicKey, mlkemKeyPair.publicKey)
+    const unwrapped = await unwrapCK(wrapped, ecdhKeyPair.privateKey, mlkemKeyPair.secretKey)
 
     const decrypted = await decrypt(encrypted, unwrapped)
     expect(decrypted).toBe('wrap test')
   })
 
   it('produces different wrapped values for different key pairs', async () => {
-    const keyPair1 = await generateKeyPair()
-    const keyPair2 = await generateKeyPair()
+    const ecdhKeyPair1 = await generateKeyPair()
+    const mlkemKeyPair1 = generateMlKemKeyPair()
+    const ecdhKeyPair2 = await generateKeyPair()
+    const mlkemKeyPair2 = generateMlKemKeyPair()
     const ck = await generateCK(true)
 
-    const wrapped1 = await wrapCK(ck, keyPair1.publicKey)
-    const wrapped2 = await wrapCK(ck, keyPair2.publicKey)
+    const wrapped1 = await wrapCK(ck, ecdhKeyPair1.publicKey, mlkemKeyPair1.publicKey)
+    const wrapped2 = await wrapCK(ck, ecdhKeyPair2.publicKey, mlkemKeyPair2.publicKey)
     expect(wrapped1).not.toBe(wrapped2)
   })
 
   it('produces different wrapped values for the same key pair (ephemeral key)', async () => {
-    const keyPair = await generateKeyPair()
+    const ecdhKeyPair = await generateKeyPair()
+    const mlkemKeyPair = generateMlKemKeyPair()
     const ck = await generateCK(true)
 
-    const wrapped1 = await wrapCK(ck, keyPair.publicKey)
-    const wrapped2 = await wrapCK(ck, keyPair.publicKey)
+    const wrapped1 = await wrapCK(ck, ecdhKeyPair.publicKey, mlkemKeyPair.publicKey)
+    const wrapped2 = await wrapCK(ck, ecdhKeyPair.publicKey, mlkemKeyPair.publicKey)
     expect(wrapped1).not.toBe(wrapped2)
   })
 
-  it('produces compact ECIES envelopes', async () => {
-    const keyPair = await generateKeyPair()
+  it('produces hybrid envelopes with version byte', async () => {
+    const ecdhKeyPair = await generateKeyPair()
+    const mlkemKeyPair = generateMlKemKeyPair()
     const ck = await generateCK(true)
-    const wrapped = await wrapCK(ck, keyPair.publicKey)
+    const wrapped = await wrapCK(ck, ecdhKeyPair.publicKey, mlkemKeyPair.publicKey)
 
-    // 105 bytes raw = 140 chars base64
-    expect(wrapped.length).toBe(140)
+    // Hybrid envelope: 1 (version) + 65 (ephPub) + 1088 (mlkemCt) + 40 (wrappedCK) = 1194 bytes
+    // base64 of 1194 bytes = ceil(1194/3)*4 = 1592 chars
+    expect(wrapped.length).toBe(1592)
   })
 })
 
 describe('rewrapCK', () => {
   it('rewraps CK from one key pair to another', async () => {
-    const keyPair1 = await generateKeyPair()
-    const keyPair2 = await generateKeyPair()
+    const ecdhKeyPair1 = await generateKeyPair()
+    const mlkemKeyPair1 = generateMlKemKeyPair()
+    const ecdhKeyPair2 = await generateKeyPair()
+    const mlkemKeyPair2 = generateMlKemKeyPair()
     const ck = await generateCK(true)
 
-    // Wrap CK with keyPair1's public key (simulates the envelope on the server)
-    const wrapped = await wrapCK(ck, keyPair1.publicKey)
+    // Wrap CK with keyPair1's public keys (simulates the envelope on the server)
+    const wrapped = await wrapCK(ck, ecdhKeyPair1.publicKey, mlkemKeyPair1.publicKey)
 
     // Rewrap for keyPair2 (simulates approving a new device)
-    const rewrapped = await rewrapCK(wrapped, keyPair1.privateKey, keyPair2.publicKey)
+    const rewrapped = await rewrapCK(
+      wrapped,
+      ecdhKeyPair1.privateKey,
+      mlkemKeyPair1.secretKey,
+      ecdhKeyPair2.publicKey,
+      mlkemKeyPair2.publicKey,
+    )
     expect(typeof rewrapped).toBe('string')
 
     // keyPair2 should be able to unwrap it
-    const unwrapped = await unwrapCK(rewrapped, keyPair2.privateKey)
+    const unwrapped = await unwrapCK(rewrapped, ecdhKeyPair2.privateKey, mlkemKeyPair2.secretKey)
     expect(unwrapped.algorithm.name).toBe('AES-GCM')
   })
 
   it('rewrapped CK decrypts data encrypted with the original', async () => {
-    const keyPair1 = await generateKeyPair()
-    const keyPair2 = await generateKeyPair()
+    const ecdhKeyPair1 = await generateKeyPair()
+    const mlkemKeyPair1 = generateMlKemKeyPair()
+    const ecdhKeyPair2 = await generateKeyPair()
+    const mlkemKeyPair2 = generateMlKemKeyPair()
     const ck = await generateCK(true)
 
     const encrypted = await encrypt('rewrap test', ck)
-    const wrapped = await wrapCK(ck, keyPair1.publicKey)
-    const rewrapped = await rewrapCK(wrapped, keyPair1.privateKey, keyPair2.publicKey)
-    const unwrapped = await unwrapCK(rewrapped, keyPair2.privateKey)
+    const wrapped = await wrapCK(ck, ecdhKeyPair1.publicKey, mlkemKeyPair1.publicKey)
+    const rewrapped = await rewrapCK(
+      wrapped,
+      ecdhKeyPair1.privateKey,
+      mlkemKeyPair1.secretKey,
+      ecdhKeyPair2.publicKey,
+      mlkemKeyPair2.publicKey,
+    )
+    const unwrapped = await unwrapCK(rewrapped, ecdhKeyPair2.privateKey, mlkemKeyPair2.secretKey)
 
     const decrypted = await decrypt(encrypted, unwrapped)
     expect(decrypted).toBe('rewrap test')

--- a/src/crypto/primitives.ts
+++ b/src/crypto/primitives.ts
@@ -12,6 +12,8 @@ const hkdfHash = 'SHA-256'
 // Hybrid envelope constants
 const envelopeVersion = 0x01
 const mlkemCiphertextLength = 1088
+const aesKwWrappedKeyLength = 40 // AES-KW(256-bit key) = 32 + 8
+const minEnvelopeLength = 1 + ephemeralPubKeyLength + mlkemCiphertextLength + aesKwWrappedKeyLength
 const hybridHkdfInfo = new TextEncoder().encode('thunderbolt-hybrid-ck-wrap-v1')
 
 // =============================================================================
@@ -211,6 +213,10 @@ const unwrapCKInternal = async (
     const version = envelope[0]
     if (version !== envelopeVersion) {
       throw new DecryptionError(`Unsupported envelope version: ${version}`)
+    }
+
+    if (envelope.length < minEnvelopeLength) {
+      throw new DecryptionError(`Invalid envelope: ${envelope.length} bytes, need >= ${minEnvelopeLength}`)
     }
 
     let offset = 1

--- a/src/crypto/primitives.ts
+++ b/src/crypto/primitives.ts
@@ -180,7 +180,9 @@ export const rewrapCK = async (
     const tempCK = await unwrapCKInternal(wrappedCKBase64, ecdhPrivateKey, mlkemSecretKey, true)
     return wrapCK(tempCK, targetEcdhPublicKey, targetMlkemPublicKey)
   } catch (err) {
-    if (err instanceof EncryptionError) throw err
+    if (err instanceof EncryptionError) {
+      throw err
+    }
     throw new EncryptionError('Failed to rewrap content key', { cause: err })
   }
 }
@@ -247,7 +249,9 @@ const unwrapCKInternal = async (
       extractable ? ['encrypt', 'decrypt'] : ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
     )
   } catch (err) {
-    if (err instanceof DecryptionError) throw err
+    if (err instanceof DecryptionError) {
+      throw err
+    }
     throw new DecryptionError('Failed to unwrap content key', { cause: err })
   }
 }

--- a/src/crypto/primitives.ts
+++ b/src/crypto/primitives.ts
@@ -1,3 +1,4 @@
+import { ml_kem768 } from '@noble/post-quantum/ml-kem.js'
 import { DecryptionError, EncryptionError } from './errors'
 
 const ecdhAlgorithm = 'ECDH'
@@ -7,7 +8,11 @@ const aesAlgorithm = 'AES-GCM'
 const aesKeyLength = 256
 const ivLength = 12
 const hkdfHash = 'SHA-256'
-const hkdfInfo = new TextEncoder().encode('thunderbolt-ck-wrap-v1')
+
+// Hybrid envelope constants
+const envelopeVersion = 0x01
+const mlkemCiphertextLength = 1088
+const hybridHkdfInfo = new TextEncoder().encode('thunderbolt-hybrid-ck-wrap-v1')
 
 // =============================================================================
 // ECDH key pair (for wrapping/unwrapping CK via ECIES)
@@ -39,6 +44,24 @@ export const importPublicKey = async (base64: string): Promise<CryptoKey> => {
 }
 
 // =============================================================================
+// ML-KEM-768 key pair (post-quantum, for hybrid wrapping)
+// =============================================================================
+
+export type MlKemKeyPair = { publicKey: Uint8Array; secretKey: Uint8Array }
+
+/** Generate an ML-KEM-768 key pair for hybrid CK wrapping. */
+export const generateMlKemKeyPair = (): MlKemKeyPair => {
+  const { publicKey, secretKey } = ml_kem768.keygen()
+  return { publicKey, secretKey }
+}
+
+/** Export an ML-KEM public key to base64. */
+export const exportMlKemPublicKey = (publicKey: Uint8Array): string => uint8ArrayToBase64(publicKey)
+
+/** Import an ML-KEM public key from base64. */
+export const importMlKemPublicKey = (base64: string): Uint8Array => base64ToUint8Array(base64)
+
+// =============================================================================
 // AES-256-GCM Content Key (CK)
 // =============================================================================
 
@@ -67,23 +90,38 @@ export const reimportAsNonExtractable = async (ck: CryptoKey): Promise<CryptoKey
 }
 
 // =============================================================================
-// ECIES: Wrap / Unwrap CK with ECDH P-256 + HKDF + AES-KW
+// Hybrid ECIES: Wrap / Unwrap CK with ECDH P-256 + ML-KEM-768 + HKDF + AES-KW
+//
+// Combines a classical ECDH shared secret with an ML-KEM-768 shared secret via
+// HKDF, following the combiner pattern from Signal PQXDH and IETF hybrid guidelines.
+// Security holds as long as at least one of the two KEMs is unbroken.
 // =============================================================================
 
 /**
- * Derive an AES-KW wrapping key from an ECDH shared secret via HKDF.
- * Used internally by wrap and unwrap operations.
+ * Derive an AES-KW-256 wrapping key from the hybrid shared secrets via HKDF.
+ * ikm = ss_ecdh || ss_mlkem (64 bytes combined)
+ * salt = ephPubRaw || mlkemCiphertext (binds derivation to both KEM transcripts)
  */
-const deriveWrappingKey = async (
-  privateKey: CryptoKey,
-  publicKey: CryptoKey,
+const deriveHybridWrappingKey = async (
+  ssEcdh: ArrayBuffer,
+  ssMlkem: Uint8Array,
   ephPubRaw: Uint8Array,
+  mlkemCiphertext: Uint8Array,
   usage: 'wrapKey' | 'unwrapKey',
 ): Promise<CryptoKey> => {
-  const sharedBits = await crypto.subtle.deriveBits({ name: ecdhAlgorithm, public: publicKey }, privateKey, 256)
-  const hkdfKey = await crypto.subtle.importKey('raw', sharedBits, 'HKDF', false, ['deriveKey'])
+  // Concatenate both shared secrets as IKM
+  const combinedSS = new Uint8Array(32 + 32)
+  combinedSS.set(new Uint8Array(ssEcdh), 0)
+  combinedSS.set(ssMlkem, 32)
+
+  // Bind to both KEM transcripts via salt
+  const salt = new Uint8Array(ephPubRaw.length + mlkemCiphertext.length)
+  salt.set(ephPubRaw, 0)
+  salt.set(mlkemCiphertext, ephPubRaw.length)
+
+  const hkdfKey = await crypto.subtle.importKey('raw', combinedSS, 'HKDF', false, ['deriveKey'])
   return crypto.subtle.deriveKey(
-    { name: 'HKDF', hash: hkdfHash, salt: ephPubRaw as BufferSource, info: hkdfInfo },
+    { name: 'HKDF', hash: hkdfHash, salt: salt as BufferSource, info: hybridHkdfInfo },
     hkdfKey,
     { name: 'AES-KW', length: 256 },
     false,
@@ -92,21 +130,35 @@ const deriveWrappingKey = async (
 }
 
 /**
- * Wrap CK with a device's public key using ECIES (ephemeral ECDH + HKDF + AES-KW).
- * Returns base64-encoded envelope: ephemeralPubKey (65 bytes) || wrappedCK (40 bytes).
+ * Wrap CK using hybrid ECDH P-256 + ML-KEM-768.
+ * Envelope: [version 1B][ephPubRaw 65B][mlkemCiphertext 1088B][wrappedCK 40B]
  */
-export const wrapCK = async (ck: CryptoKey, publicKey: CryptoKey): Promise<string> => {
+export const wrapCK = async (ck: CryptoKey, ecdhPublicKey: CryptoKey, mlkemPublicKey: Uint8Array): Promise<string> => {
   try {
+    // Ephemeral ECDH P-256
     const ephemeral = await crypto.subtle.generateKey({ name: ecdhAlgorithm, namedCurve: ecdhCurve }, false, [
       'deriveBits',
     ])
     const ephPubRaw = new Uint8Array(await crypto.subtle.exportKey('raw', ephemeral.publicKey))
-    const wrappingKey = await deriveWrappingKey(ephemeral.privateKey, publicKey, ephPubRaw, 'wrapKey')
+    const ssEcdh = await crypto.subtle.deriveBits(
+      { name: ecdhAlgorithm, public: ecdhPublicKey },
+      ephemeral.privateKey,
+      256,
+    )
+
+    // ML-KEM-768 encapsulate
+    const { cipherText: mlkemCiphertext, sharedSecret: ssMlkem } = ml_kem768.encapsulate(mlkemPublicKey)
+
+    // Hybrid HKDF -> AES-KW key
+    const wrappingKey = await deriveHybridWrappingKey(ssEcdh, ssMlkem, ephPubRaw, mlkemCiphertext, 'wrapKey')
     const wrappedCKBytes = new Uint8Array(await crypto.subtle.wrapKey('raw', ck, wrappingKey, 'AES-KW'))
 
-    const envelope = new Uint8Array(ephPubRaw.length + wrappedCKBytes.length)
-    envelope.set(ephPubRaw, 0)
-    envelope.set(wrappedCKBytes, ephPubRaw.length)
+    // Assemble versioned envelope
+    const envelope = new Uint8Array(1 + ephPubRaw.length + mlkemCiphertext.length + wrappedCKBytes.length)
+    envelope[0] = envelopeVersion
+    envelope.set(ephPubRaw, 1)
+    envelope.set(mlkemCiphertext, 1 + ephPubRaw.length)
+    envelope.set(wrappedCKBytes, 1 + ephPubRaw.length + mlkemCiphertext.length)
     return uint8ArrayToBase64(envelope)
   } catch (err) {
     throw new EncryptionError('Failed to wrap content key', { cause: err })
@@ -114,44 +166,59 @@ export const wrapCK = async (ck: CryptoKey, publicKey: CryptoKey): Promise<strin
 }
 
 /**
- * Rewrap a wrapped CK for a different device's public key.
- * Internally unwraps as temporarily extractable (in-memory only, never stored),
- * then wraps with the target public key. Returns base64.
+ * Rewrap a wrapped CK for a different device's public keys.
+ * Unwraps as temporarily extractable (in-memory only), then wraps with target's keys.
  */
 export const rewrapCK = async (
   wrappedCKBase64: string,
-  privateKey: CryptoKey,
-  targetPublicKey: CryptoKey,
+  ecdhPrivateKey: CryptoKey,
+  mlkemSecretKey: Uint8Array,
+  targetEcdhPublicKey: CryptoKey,
+  targetMlkemPublicKey: Uint8Array,
 ): Promise<string> => {
   try {
-    const tempCK = await unwrapCKInternal(wrappedCKBase64, privateKey, true)
-    return wrapCK(tempCK, targetPublicKey)
+    const tempCK = await unwrapCKInternal(wrappedCKBase64, ecdhPrivateKey, mlkemSecretKey, true)
+    return wrapCK(tempCK, targetEcdhPublicKey, targetMlkemPublicKey)
   } catch (err) {
-    if (err instanceof EncryptionError) {
-      throw err
-    }
+    if (err instanceof EncryptionError) throw err
     throw new EncryptionError('Failed to rewrap content key', { cause: err })
   }
 }
 
-/** Unwrap CK from base64 using a device's private key. Returns non-extractable CryptoKey. */
-export const unwrapCK = async (wrappedBase64: string, privateKey: CryptoKey): Promise<CryptoKey> =>
-  unwrapCKInternal(wrappedBase64, privateKey, false)
+/** Unwrap CK using hybrid ECDH + ML-KEM. Returns non-extractable CryptoKey. */
+export const unwrapCK = async (
+  wrappedBase64: string,
+  ecdhPrivateKey: CryptoKey,
+  mlkemSecretKey: Uint8Array,
+): Promise<CryptoKey> => unwrapCKInternal(wrappedBase64, ecdhPrivateKey, mlkemSecretKey, false)
 
 /**
- * Internal unwrap with configurable extractability.
+ * Internal hybrid unwrap with configurable extractability.
  * extractable=true is used only in rewrapCK (temporary, in-memory only).
  */
 const unwrapCKInternal = async (
   wrappedBase64: string,
-  privateKey: CryptoKey,
+  ecdhPrivateKey: CryptoKey,
+  mlkemSecretKey: Uint8Array,
   extractable: boolean,
 ): Promise<CryptoKey> => {
   try {
     const envelope = base64ToUint8Array(wrappedBase64)
-    const ephPubRaw = envelope.slice(0, ephemeralPubKeyLength)
-    const wrappedCKBytes = envelope.slice(ephemeralPubKeyLength)
 
+    // Parse versioned envelope
+    const version = envelope[0]
+    if (version !== envelopeVersion) {
+      throw new DecryptionError(`Unsupported envelope version: ${version}`)
+    }
+
+    let offset = 1
+    const ephPubRaw = envelope.slice(offset, offset + ephemeralPubKeyLength)
+    offset += ephemeralPubKeyLength
+    const mlkemCiphertext = envelope.slice(offset, offset + mlkemCiphertextLength)
+    offset += mlkemCiphertextLength
+    const wrappedCKBytes = envelope.slice(offset)
+
+    // ECDH P-256 shared secret
     const ephemeralPublicKey = await crypto.subtle.importKey(
       'raw',
       ephPubRaw,
@@ -159,7 +226,17 @@ const unwrapCKInternal = async (
       false,
       [],
     )
-    const unwrappingKey = await deriveWrappingKey(privateKey, ephemeralPublicKey, ephPubRaw, 'unwrapKey')
+    const ssEcdh = await crypto.subtle.deriveBits(
+      { name: ecdhAlgorithm, public: ephemeralPublicKey },
+      ecdhPrivateKey,
+      256,
+    )
+
+    // ML-KEM-768 decapsulate
+    const ssMlkem = ml_kem768.decapsulate(mlkemCiphertext, mlkemSecretKey)
+
+    // Hybrid HKDF -> AES-KW key
+    const unwrappingKey = await deriveHybridWrappingKey(ssEcdh, ssMlkem, ephPubRaw, mlkemCiphertext, 'unwrapKey')
     return await crypto.subtle.unwrapKey(
       'raw',
       wrappedCKBytes,
@@ -170,6 +247,7 @@ const unwrapCKInternal = async (
       extractable ? ['encrypt', 'decrypt'] : ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
     )
   } catch (err) {
+    if (err instanceof DecryptionError) throw err
     throw new DecryptionError('Failed to unwrap content key', { cause: err })
   }
 }

--- a/src/dal/devices.ts
+++ b/src/dal/devices.ts
@@ -9,6 +9,7 @@ export type Device = {
   name: string
   trusted: number | null
   publicKey: string | null
+  mlkemPublicKey: string | null
   lastSeen: string | null
   createdAt: string | null
   revokedAt: string | null

--- a/src/db/powersync/middleware/EncryptionMiddleware.ts
+++ b/src/db/powersync/middleware/EncryptionMiddleware.ts
@@ -49,9 +49,7 @@ export const encryptionMiddleware: DataTransformMiddleware = {
       return batch
     }
     for (const bucket of batch.buckets) {
-      for (const entry of bucket.data) {
-        await decryptEntry(entry)
-      }
+      await Promise.all(bucket.data.map(decryptEntry))
     }
     return batch
   },

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -226,6 +226,7 @@ export const devicesTable = sqliteTable('devices', {
   name: text('name'),
   trusted: integer('trusted'),
   publicKey: text('public_key'),
+  mlkemPublicKey: text('mlkem_public_key'),
   lastSeen: text('last_seen'),
   createdAt: text('created_at'),
   revokedAt: text('revoked_at'),

--- a/src/hooks/use-approval-polling.ts
+++ b/src/hooks/use-approval-polling.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { getResponseStatus } from '@/lib/error-utils'
 
 type UseApprovalPollingOptions = {
   enabled: boolean
@@ -55,12 +56,7 @@ export const useApprovalPolling = ({
           onApprovedRef.current()
         }
       } catch (err) {
-        if (
-          err instanceof Error &&
-          'response' in err &&
-          (err as Error & { response: { status: number } }).response.status === 403 &&
-          !cancelled
-        ) {
+        if (getResponseStatus(err) === 403 && !cancelled) {
           clearInterval(intervalId)
           setIsPolling(false)
           onRevokedRef.current?.()

--- a/src/hooks/use-approve-device.ts
+++ b/src/hooks/use-approve-device.ts
@@ -13,10 +13,10 @@ export const useApproveDevice = (pendingDevices: Device[]) => {
   return useMutation({
     mutationFn: async (deviceId: string) => {
       const device = pendingDevices.find((d) => d.id === deviceId)
-      if (!device?.publicKey) {
-        throw new Error('Device has no public key')
+      if (!device?.publicKey || !device?.mlkemPublicKey) {
+        throw new Error('Device is missing public keys')
       }
-      await approveDevice(httpClient, deviceId, device.publicKey)
+      await approveDevice(httpClient, deviceId, device.publicKey, device.mlkemPublicKey)
     },
   })
 }

--- a/src/hooks/use-sync-enabled-toggle.ts
+++ b/src/hooks/use-sync-enabled-toggle.ts
@@ -45,6 +45,12 @@ export const useSyncEnabledToggle = () => {
     checkEncryptionMigration()
   }, [])
 
+  const enableSync = async () => {
+    await setSyncEnabled(true)
+    setSyncEnabledState(true)
+    trackEvent('settings_sync_enabled')
+  }
+
   const handleSyncToggle = async (enabled: boolean) => {
     if (!enabled) {
       await setSyncEnabled(false)
@@ -53,26 +59,20 @@ export const useSyncEnabledToggle = () => {
       return
     }
     if (!isEncryptionEnabled()) {
-      await setSyncEnabled(true)
-      setSyncEnabledState(true)
-      trackEvent('settings_sync_enabled')
+      await enableSync()
       return
     }
     // Encryption already set up (CK exists) — just enable sync, no wizard needed
     const ck = await getCK()
     if (ck) {
-      await setSyncEnabled(true)
-      setSyncEnabledState(true)
-      trackEvent('settings_sync_enabled')
+      await enableSync()
       return
     }
     setSyncSetupOpen(true)
   }
 
   const handleSyncSetupComplete = async () => {
-    await setSyncEnabled(true)
-    setSyncEnabledState(true)
-    trackEvent('settings_sync_enabled')
+    await enableSync()
     setSyncSetupOpen(false)
   }
 

--- a/src/hooks/use-sync-setup.ts
+++ b/src/hooks/use-sync-setup.ts
@@ -7,6 +7,7 @@ import {
   recoverWithKey,
 } from '@/services/encryption'
 import { checkCanaryExists } from '@/api/encryption'
+import { getResponseStatus } from '@/lib/error-utils'
 
 type SyncSetupStep =
   | 'intro'
@@ -142,14 +143,11 @@ export const useSyncSetup = () => {
       return true
     } catch (err) {
       // Another device may have completed first-device setup — check canary and switch flow
-      if (err instanceof Error && 'response' in err) {
-        const status = (err as Error & { response: { status: number } }).response.status
-        if (status === 403) {
-          const hasCanary = await checkCanaryExists(httpClient)
-          if (hasCanary) {
-            dispatch({ type: 'DETECTED_ADDITIONAL_DEVICE' })
-            return true
-          }
+      if (getResponseStatus(err) === 403) {
+        const hasCanary = await checkCanaryExists(httpClient)
+        if (hasCanary) {
+          dispatch({ type: 'DETECTED_ADDITIONAL_DEVICE' })
+          return true
         }
       }
       const message = err instanceof Error ? err.message : 'Failed to set up encryption'

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -23,29 +23,17 @@ type ClearLocalDataOptions = {
 export const clearLocalData = async (options?: ClearLocalDataOptions): Promise<void> => {
   const { disableSync = true, clearEncryptionKeys = true, clearDatabase = true, clearAuth = true } = options ?? {}
 
-  if (disableSync) {
-    try {
-      await setSyncEnabled(false)
-    } catch (error) {
-      console.error('[clearLocalData] Failed to disable sync:', error)
-    }
-  }
-
-  if (clearEncryptionKeys) {
-    try {
-      await handleFullWipe()
-    } catch (error) {
-      console.error('[clearLocalData] Failed to clear encryption keys:', error)
-    }
-  }
-
-  if (clearDatabase) {
-    try {
-      await resetAppDir()
-    } catch (error) {
-      console.error('[clearLocalData] Failed to reset app directory:', error)
-    }
-  }
+  await Promise.allSettled([
+    disableSync
+      ? setSyncEnabled(false).catch((error) => console.error('[clearLocalData] Failed to disable sync:', error))
+      : undefined,
+    clearEncryptionKeys
+      ? handleFullWipe().catch((error) => console.error('[clearLocalData] Failed to clear encryption keys:', error))
+      : undefined,
+    clearDatabase
+      ? resetAppDir().catch((error) => console.error('[clearLocalData] Failed to reset app directory:', error))
+      : undefined,
+  ])
 
   if (clearAuth) {
     clearAuthToken()

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -1,5 +1,13 @@
 import type { HandleError, HandleErrorCode } from '@/types/handle-errors'
 
+/** Extract the HTTP status code from a ky HTTPError (or similar). Returns null for non-HTTP errors. */
+export const getResponseStatus = (err: unknown): number | null => {
+  if (err instanceof Error && 'response' in err) {
+    return (err as Error & { response: { status: number } }).response.status
+  }
+  return null
+}
+
 /**
  * Creates a HandleError with optional stack trace if available
  */

--- a/src/services/encryption.test.ts
+++ b/src/services/encryption.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test'
 import ky from 'ky'
 import {
   generateKeyPair,
+  generateMlKemKeyPair,
   generateCK,
   exportPublicKey,
+  exportMlKemPublicKey,
   wrapCK,
   unwrapCK,
   encrypt,
@@ -12,18 +14,24 @@ import {
   decodeRecoveryKey,
   createCanary,
   verifyCanary,
+  type StoredKeyPair,
 } from '@/crypto'
 
 // ---------------------------------------------------------------------------
 // In-memory key storage (replaces IndexedDB)
 // ---------------------------------------------------------------------------
 
-let storedKeyPair: { privateKey: CryptoKey; publicKey: CryptoKey } | null = null
+let storedKeyPair: StoredKeyPair | null = null
 let storedCK: CryptoKey | null = null
 
 mock.module('@/crypto/key-storage', () => ({
-  storeKeyPair: async (priv: CryptoKey, pub: CryptoKey) => {
-    storedKeyPair = { privateKey: priv, publicKey: pub }
+  storeKeyPair: async (ecdhPriv: CryptoKey, ecdhPub: CryptoKey, mlkemPub: Uint8Array, mlkemSK: Uint8Array) => {
+    storedKeyPair = {
+      ecdhPrivateKey: ecdhPriv,
+      ecdhPublicKey: ecdhPub,
+      mlkemPublicKey: mlkemPub,
+      mlkemSecretKey: mlkemSK,
+    }
   },
   getKeyPair: async () => storedKeyPair,
   storeCK: async (ck: CryptoKey) => {
@@ -133,6 +141,21 @@ const respondToFetchCanary =
   }
 
 // ---------------------------------------------------------------------------
+// Helper: generate a full StoredKeyPair (ECDH + ML-KEM)
+// ---------------------------------------------------------------------------
+
+const generateFullKeyPair = async (): Promise<StoredKeyPair> => {
+  const ecdhKeyPair = await generateKeyPair()
+  const mlkemKeyPair = generateMlKemKeyPair()
+  return {
+    ecdhPrivateKey: ecdhKeyPair.privateKey,
+    ecdhPublicKey: ecdhKeyPair.publicKey,
+    mlkemPublicKey: mlkemKeyPair.publicKey,
+    mlkemSecretKey: mlkemKeyPair.secretKey,
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -159,17 +182,20 @@ describe('encryption service', () => {
       const result = await registerThisDevice(httpClient)
 
       expect(storedKeyPair).not.toBeNull()
-      expect(storedKeyPair!.publicKey.algorithm.name).toBe('ECDH')
+      expect(storedKeyPair!.ecdhPublicKey.algorithm.name).toBe('ECDH')
+      expect(storedKeyPair!.mlkemPublicKey).toBeInstanceOf(Uint8Array)
+      expect(storedKeyPair!.mlkemSecretKey).toBeInstanceOf(Uint8Array)
       expect(requests).toHaveLength(1)
       expect(requests[0].body?.deviceId).toBe('test-device-id')
       expect((requests[0].body?.publicKey as string).length).toBeGreaterThan(0)
+      expect((requests[0].body?.mlkemPublicKey as string).length).toBeGreaterThan(0)
       expect(result).toEqual({ trusted: false })
     })
 
     it('reuses existing key pair', async () => {
-      const existing = await generateKeyPair()
+      const existing = await generateFullKeyPair()
       storedKeyPair = existing
-      const exportedBefore = await exportPublicKey(existing.publicKey)
+      const exportedBefore = await exportPublicKey(existing.ecdhPublicKey)
 
       const { httpClient, requests } = createTestHttpClient(respondToRegister({ trusted: false }))
       await registerThisDevice(httpClient)
@@ -178,7 +204,7 @@ describe('encryption service', () => {
       expect(requests[0].body?.publicKey).toBe(exportedBefore)
     })
 
-    it('passes device ID, public key, and name to API', async () => {
+    it('passes device ID, public key, mlkem public key, and name to API', async () => {
       const { httpClient, requests } = createTestHttpClient(respondToRegister({ trusted: false }))
       await registerThisDevice(httpClient)
 
@@ -186,13 +212,14 @@ describe('encryption service', () => {
       expect(requests[0].method).toBe('POST')
       expect(requests[0].body?.deviceId).toBe('test-device-id')
       expect(typeof requests[0].body?.publicKey).toBe('string')
+      expect(typeof requests[0].body?.mlkemPublicKey).toBe('string')
       expect(typeof requests[0].body?.name).toBe('string')
     })
   })
 
   describe('completeFirstDeviceSetup', () => {
     it('generates CK, canary, envelope, stores keys, returns recovery key', async () => {
-      storedKeyPair = await generateKeyPair()
+      storedKeyPair = await generateFullKeyPair()
 
       const { httpClient: capturingClient, requests } = createTestHttpClient(respondToStoreEnvelope({ trusted: true }))
 
@@ -213,7 +240,7 @@ describe('encryption service', () => {
     })
 
     it('stored CK can decrypt data encrypted during setup', async () => {
-      storedKeyPair = await generateKeyPair()
+      storedKeyPair = await generateFullKeyPair()
 
       const { httpClient: capturingClient, requests } = createTestHttpClient(respondToStoreEnvelope({ trusted: true }))
 
@@ -243,23 +270,24 @@ describe('encryption service', () => {
 
   describe('approveDevice', () => {
     it('fetches own envelope, rewraps CK for pending device, stores envelope', async () => {
-      const thisKeyPair = await generateKeyPair()
+      const thisKeyPair = await generateFullKeyPair()
       storedKeyPair = thisKeyPair
 
       // Create a real CK and wrap it for this device (simulates existing envelope)
       const ck = await generateCK(true)
-      const wrappedForThis = await wrapCK(ck, thisKeyPair.publicKey)
+      const wrappedForThis = await wrapCK(ck, thisKeyPair.ecdhPublicKey, thisKeyPair.mlkemPublicKey)
 
-      // Pending device's key pair
-      const pendingKeyPair = await generateKeyPair()
-      const pendingPubBase64 = await exportPublicKey(pendingKeyPair.publicKey)
+      // Pending device's key pairs
+      const pendingKeyPair = await generateFullKeyPair()
+      const pendingEcdhPubBase64 = await exportPublicKey(pendingKeyPair.ecdhPublicKey)
+      const pendingMlkemPubBase64 = exportMlKemPublicKey(pendingKeyPair.mlkemPublicKey)
 
       const { httpClient, requests } = createTestHttpClient(
         respondToFetchEnvelope({ trusted: true, wrappedCK: wrappedForThis }),
         respondToStoreEnvelope({ trusted: true }),
       )
 
-      await approveDevice(httpClient, 'pending-dev', pendingPubBase64)
+      await approveDevice(httpClient, 'pending-dev', pendingEcdhPubBase64, pendingMlkemPubBase64)
 
       // Envelope was stored for the pending device
       const storeReq = requests.find((r) => r.url.includes('/envelope') && r.method === 'POST')
@@ -267,22 +295,26 @@ describe('encryption service', () => {
       expect(storeReq!.url).toContain('pending-dev')
 
       // The wrapped CK should be unwrappable by the pending device
-      const unwrappedCK = await unwrapCK(storeReq!.body!.wrappedCK as string, pendingKeyPair.privateKey)
+      const unwrappedCK = await unwrapCK(
+        storeReq!.body!.wrappedCK as string,
+        pendingKeyPair.ecdhPrivateKey,
+        pendingKeyPair.mlkemSecretKey,
+      )
       expect(unwrappedCK.algorithm.name).toBe('AES-GCM')
     })
 
     it('throws if key pair is missing', async () => {
       const { httpClient } = createTestHttpClient()
-      await expect(approveDevice(httpClient, 'dev', 'key')).rejects.toThrow('Key pair not found')
+      await expect(approveDevice(httpClient, 'dev', 'key', 'mlkem-key')).rejects.toThrow('Key pair not found')
     })
   })
 
   describe('checkApprovalAndUnwrap', () => {
     it('fetches envelope, unwraps CK, stores it, returns true', async () => {
-      const keyPair = await generateKeyPair()
+      const keyPair = await generateFullKeyPair()
       storedKeyPair = keyPair
       const ck = await generateCK(true)
-      const wrappedCK = await wrapCK(ck, keyPair.publicKey)
+      const wrappedCK = await wrapCK(ck, keyPair.ecdhPublicKey, keyPair.mlkemPublicKey)
 
       const { httpClient } = createTestHttpClient(respondToFetchEnvelope({ trusted: true, wrappedCK }))
 
@@ -294,7 +326,7 @@ describe('encryption service', () => {
     })
 
     it('returns false when envelope fetch returns 404 (not yet approved)', async () => {
-      storedKeyPair = await generateKeyPair()
+      storedKeyPair = await generateFullKeyPair()
 
       const mockFetch = async (): Promise<Response> =>
         new Response('Not found', { status: 404, headers: { 'Content-Type': 'application/json' } })
@@ -310,7 +342,7 @@ describe('encryption service', () => {
     })
 
     it('throws when envelope fetch fails with non-404 error', async () => {
-      storedKeyPair = await generateKeyPair()
+      storedKeyPair = await generateFullKeyPair()
 
       const mockFetch = async (): Promise<Response> =>
         new Response('Server error', { status: 500, headers: { 'Content-Type': 'application/json' } })
@@ -325,9 +357,9 @@ describe('encryption service', () => {
     })
 
     it('throws when key pair is missing', async () => {
+      const tempKeyPair = await generateFullKeyPair()
       const ck = await generateCK(true)
-      const tempKeyPair = await generateKeyPair()
-      const wrappedCK = await wrapCK(ck, tempKeyPair.publicKey)
+      const wrappedCK = await wrapCK(ck, tempKeyPair.ecdhPublicKey, tempKeyPair.mlkemPublicKey)
 
       const { httpClient } = createTestHttpClient(respondToFetchEnvelope({ trusted: true, wrappedCK }))
 
@@ -351,6 +383,7 @@ describe('encryption service', () => {
 
       // Key pair was generated and stored
       expect(storedKeyPair).not.toBeNull()
+      expect(storedKeyPair!.mlkemPublicKey).toBeInstanceOf(Uint8Array)
       // Device was registered
       expect(requests.some((r) => r.url.includes('/devices') && r.method === 'POST')).toBe(true)
       // Envelope was stored
@@ -361,7 +394,7 @@ describe('encryption service', () => {
     })
 
     it('reuses existing key pair during recovery', async () => {
-      const existing = await generateKeyPair()
+      const existing = await generateFullKeyPair()
       storedKeyPair = existing
 
       const originalCK = await generateCK(true)
@@ -393,7 +426,7 @@ describe('encryption service', () => {
 
   describe('handleFullWipe', () => {
     it('clears all keys', async () => {
-      storedKeyPair = await generateKeyPair()
+      storedKeyPair = await generateFullKeyPair()
       storedCK = await generateCK()
 
       await handleFullWipe()

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -40,7 +40,9 @@ import { getResponseStatus } from '@/lib/error-utils'
 /** Get existing key pairs from IndexedDB or generate and store new ones. */
 const getOrCreateKeyPair = async (): Promise<StoredKeyPair> => {
   const existing = await getKeyPair()
-  if (existing) return existing
+  if (existing) {
+    return existing
+  }
 
   const ecdhKeyPair = await generateKeyPair()
   const mlkemKeyPair = generateMlKemKeyPair()

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -1,10 +1,13 @@
 import type { KyInstance } from 'ky'
 import {
   generateKeyPair,
+  generateMlKemKeyPair,
   generateCK,
   reimportAsNonExtractable,
   exportPublicKey,
   importPublicKey,
+  exportMlKemPublicKey,
+  importMlKemPublicKey,
   wrapCK,
   rewrapCK,
   unwrapCK,
@@ -16,6 +19,7 @@ import {
   getKeyPair,
   storeCK,
   clearAllKeys,
+  type StoredKeyPair,
 } from '@/crypto'
 import { getDeviceId } from '@/lib/auth-token'
 import { getDeviceDisplayName } from '@/lib/platform'
@@ -27,21 +31,26 @@ import {
   type RegisterDeviceResponse,
 } from '@/api/encryption'
 import { invalidateCKCache } from '@/db/encryption'
+import { getResponseStatus } from '@/lib/error-utils'
 
 // =============================================================================
 // Shared helpers
 // =============================================================================
 
-/** Get existing key pair from IndexedDB or generate and store a new one. */
-const getOrCreateKeyPair = async (): Promise<CryptoKeyPair> => {
+/** Get existing key pairs from IndexedDB or generate and store new ones. */
+const getOrCreateKeyPair = async (): Promise<StoredKeyPair> => {
   const existing = await getKeyPair()
-  if (existing) {
-    return existing
-  }
+  if (existing) return existing
 
-  const keyPair = await generateKeyPair()
-  await storeKeyPair(keyPair.privateKey, keyPair.publicKey)
-  return keyPair
+  const ecdhKeyPair = await generateKeyPair()
+  const mlkemKeyPair = generateMlKemKeyPair()
+  await storeKeyPair(ecdhKeyPair.privateKey, ecdhKeyPair.publicKey, mlkemKeyPair.publicKey, mlkemKeyPair.secretKey)
+  return {
+    ecdhPrivateKey: ecdhKeyPair.privateKey,
+    ecdhPublicKey: ecdhKeyPair.publicKey,
+    mlkemPublicKey: mlkemKeyPair.publicKey,
+    mlkemSecretKey: mlkemKeyPair.secretKey,
+  }
 }
 
 // =============================================================================
@@ -56,12 +65,14 @@ const getOrCreateKeyPair = async (): Promise<CryptoKeyPair> => {
 export const registerThisDevice = async (httpClient: KyInstance): Promise<RegisterDeviceResponse> => {
   const keyPair = await getOrCreateKeyPair()
 
-  const publicKeyBase64 = await exportPublicKey(keyPair.publicKey)
+  const publicKeyBase64 = await exportPublicKey(keyPair.ecdhPublicKey)
+  const mlkemPublicKeyBase64 = exportMlKemPublicKey(keyPair.mlkemPublicKey)
   const deviceId = getDeviceId()
 
   return registerDevice(httpClient, {
     deviceId,
     publicKey: publicKeyBase64,
+    mlkemPublicKey: mlkemPublicKeyBase64,
     name: getDeviceDisplayName(),
   })
 }
@@ -85,8 +96,8 @@ export const completeFirstDeviceSetup = async (httpClient: KyInstance): Promise<
   const recoveryKey = await encodeRecoveryKey(extractableCK)
   const { canaryIv, canaryCtext, canarySecret } = await createCanary(extractableCK)
 
-  // Wrap CK with own public key and store on server
-  const wrappedCK = await wrapCK(extractableCK, keyPair.publicKey)
+  // Wrap CK with own public keys (hybrid ECDH + ML-KEM)
+  const wrappedCK = await wrapCK(extractableCK, keyPair.ecdhPublicKey, keyPair.mlkemPublicKey)
 
   // Re-import as non-extractable for storage
   const ck = await reimportAsNonExtractable(extractableCK)
@@ -103,6 +114,7 @@ export const completeFirstDeviceSetup = async (httpClient: KyInstance): Promise<
 
   // Store CK locally
   await storeCK(ck)
+  invalidateCKCache()
 
   return recoveryKey
 }
@@ -119,7 +131,8 @@ export const completeFirstDeviceSetup = async (httpClient: KyInstance): Promise<
 export const approveDevice = async (
   httpClient: KyInstance,
   pendingDeviceId: string,
-  pendingPublicKeyBase64: string,
+  pendingEcdhPublicKeyBase64: string,
+  pendingMlkemPublicKeyBase64: string,
 ): Promise<void> => {
   const keyPair = await getKeyPair()
   if (!keyPair) {
@@ -127,8 +140,15 @@ export const approveDevice = async (
   }
 
   const { wrappedCK: myWrappedCK } = await fetchMyEnvelope(httpClient)
-  const pendingPublicKey = await importPublicKey(pendingPublicKeyBase64)
-  const wrappedCK = await rewrapCK(myWrappedCK, keyPair.privateKey, pendingPublicKey)
+  const pendingEcdhPub = await importPublicKey(pendingEcdhPublicKeyBase64)
+  const pendingMlkemPub = importMlKemPublicKey(pendingMlkemPublicKeyBase64)
+  const wrappedCK = await rewrapCK(
+    myWrappedCK,
+    keyPair.ecdhPrivateKey,
+    keyPair.mlkemSecretKey,
+    pendingEcdhPub,
+    pendingMlkemPub,
+  )
 
   await storeEnvelope(httpClient, {
     deviceId: pendingDeviceId,
@@ -152,16 +172,14 @@ export const checkApprovalAndUnwrap = async (httpClient: KyInstance): Promise<bo
       throw new Error('Key pair not found in IndexedDB')
     }
 
-    const ck = await unwrapCK(wrappedCK, keyPair.privateKey)
+    const ck = await unwrapCK(wrappedCK, keyPair.ecdhPrivateKey, keyPair.mlkemSecretKey)
     await storeCK(ck)
+    invalidateCKCache()
     return true
   } catch (err) {
     // 404 = not yet approved, return false so caller can retry
-    if (err instanceof Error && 'response' in err) {
-      const status = (err as Error & { response: { status: number } }).response.status
-      if (status === 404) {
-        return false
-      }
+    if (getResponseStatus(err) === 404) {
+      return false
     }
     // Re-throw transient/unexpected errors so they surface properly
     throw err
@@ -188,16 +206,18 @@ export const recoverWithKey = async (httpClient: KyInstance, recoveryPhrase: str
   const keyPair = await getOrCreateKeyPair()
 
   // Register device and store envelope
-  const publicKeyBase64 = await exportPublicKey(keyPair.publicKey)
+  const publicKeyBase64 = await exportPublicKey(keyPair.ecdhPublicKey)
+  const mlkemPublicKeyBase64 = exportMlKemPublicKey(keyPair.mlkemPublicKey)
   const deviceId = getDeviceId()
 
   await registerDevice(httpClient, {
     deviceId,
     publicKey: publicKeyBase64,
+    mlkemPublicKey: mlkemPublicKeyBase64,
     name: getDeviceDisplayName(),
   })
 
-  const wrappedCK = await wrapCK(ck, keyPair.publicKey)
+  const wrappedCK = await wrapCK(ck, keyPair.ecdhPublicKey, keyPair.mlkemPublicKey)
   await storeEnvelope(httpClient, {
     deviceId,
     wrappedCK,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes core encryption key wrapping/rewrapping logic and expands backend API+DB schema for device keys and envelope sizes, which can break cross-device sync or lock users out if mis-implemented.
> 
> **Overview**
> Adds post-quantum support to the encryption/sync flow by introducing an `mlkemPublicKey` per device and switching CK envelope wrapping to a **hybrid ECDH P-256 + ML-KEM-768** scheme.
> 
> Backend now persists `mlkem_public_key` on `powersync.devices`, blocks clients from uploading it via PowerSync, and requires it in `POST /devices`; request limits were adjusted (`publicKey` smaller, `wrappedCK` larger) to fit the new envelope format.
> 
> Frontend updates key storage to persist both ECDH and ML-KEM key pairs, updates device registration/approval APIs to send and use both public keys, refactors several ky error-status checks via a new `getResponseStatus` helper, and includes small UX/perf tweaks (parallel decrypting, parallel local cleanup, modal styling, async `onComplete`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379db27c981ca652dd4f9e07edf9176c516b59e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->