### PR TITLE
fix: security vulnerability: remove wildcard localhost regex from CORS and combine origin sou…

### DIFF
--- a/backend/src/config/cors.test.ts
+++ b/backend/src/config/cors.test.ts
@@ -25,7 +25,7 @@ describe('CORS integration', () => {
     const origins = getCorsOrigins({
       corsOrigins: 'https://app.example.com',
       corsOriginRegex: /^(tauri:\/\/localhost|http:\/\/tauri\.localhost)$/,
-    } as any)
+    })
 
     it('should allow the explicit origin', async () => {
       const app = createTestApp(origins)
@@ -105,7 +105,7 @@ describe('CORS integration', () => {
     const origins = getCorsOrigins({
       corsOrigins: 'https://app.example.com',
       corsOriginRegex: null,
-    } as any)
+    })
 
     it('should allow the explicit origin', async () => {
       const app = createTestApp(origins)

--- a/backend/src/config/cors.test.ts
+++ b/backend/src/config/cors.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test'
+import { getCorsOrigins } from '@/config/settings'
+import cors from '@elysiajs/cors'
+import { Elysia } from 'elysia'
+
+/**
+ * Integration tests for CORS middleware behavior.
+ * Verifies that the actual HTTP headers are set correctly for various origins.
+ */
+describe('CORS integration', () => {
+  const createTestApp = (corsOrigins: (RegExp | string)[]) =>
+    new Elysia()
+      .use(
+        cors({
+          origin: corsOrigins,
+          credentials: true,
+          methods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
+          allowedHeaders: 'Content-Type,Authorization',
+        }),
+      )
+      .get('/test', () => ({ ok: true }))
+      .delete('/test', () => ({ ok: true }))
+
+  describe('with Tauri regex and explicit origin', () => {
+    const origins = getCorsOrigins({
+      corsOrigins: 'https://app.example.com',
+      corsOriginRegex: /^(tauri:\/\/localhost|http:\/\/tauri\.localhost)$/,
+    } as any)
+
+    it('should allow the explicit origin', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'https://app.example.com' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('https://app.example.com')
+      expect(res.headers.get('access-control-allow-credentials')).toBe('true')
+    })
+
+    it('should allow tauri://localhost', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'tauri://localhost' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('tauri://localhost')
+      expect(res.headers.get('access-control-allow-credentials')).toBe('true')
+    })
+
+    it('should allow http://tauri.localhost', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'http://tauri.localhost' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('http://tauri.localhost')
+      expect(res.headers.get('access-control-allow-credentials')).toBe('true')
+    })
+
+    it('should reject arbitrary localhost ports', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'http://localhost:9999' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+
+    it('should reject unknown origins', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'https://evil.com' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+
+    it('should reject preflight from arbitrary localhost ports', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          method: 'OPTIONS',
+          headers: {
+            Origin: 'http://localhost:9999',
+            'Access-Control-Request-Method': 'DELETE',
+          },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+  })
+
+  describe('with only explicit origins (no regex)', () => {
+    const origins = getCorsOrigins({
+      corsOrigins: 'https://app.example.com',
+      corsOriginRegex: null,
+    } as any)
+
+    it('should allow the explicit origin', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'https://app.example.com' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('https://app.example.com')
+    })
+
+    it('should reject other origins', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'http://localhost:9999' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+  })
+})

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
   clearSettingsCache,
+  getCorsOrigins,
   getWaitlistAutoApproveDomains,
   getCorsMethodsList,
   getCorsOriginsList,
@@ -42,6 +43,110 @@ describe('Config Settings', () => {
       const origins = getCorsOriginsList(settings as any)
 
       expect(origins).toEqual([])
+    })
+  })
+
+  describe('getCorsOrigins', () => {
+    it('should include explicit origins list', () => {
+      const settings = {
+        corsOrigins: 'https://app.example.com,https://other.example.com',
+        corsOriginRegex: null,
+      }
+      const origins = getCorsOrigins(settings as any)
+
+      expect(origins).toEqual(['https://app.example.com', 'https://other.example.com'])
+    })
+
+    it('should include regex when corsOriginRegex is set', () => {
+      const regex = /^(tauri:\/\/localhost|http:\/\/tauri\.localhost)$/
+      const settings = {
+        corsOrigins: 'https://app.example.com',
+        corsOriginRegex: regex,
+      }
+      const origins = getCorsOrigins(settings as any)
+
+      expect(origins).toHaveLength(2)
+      expect(origins).toContain('https://app.example.com')
+      expect(origins).toContain(regex)
+    })
+
+    it('should return only explicit origins when regex is null', () => {
+      const settings = {
+        corsOrigins: 'https://app.example.com',
+        corsOriginRegex: null,
+      }
+      const origins = getCorsOrigins(settings as any)
+
+      expect(origins).toEqual(['https://app.example.com'])
+      expect(origins.every((o) => typeof o === 'string')).toBe(true)
+    })
+  })
+
+  describe('CORS default regex security', () => {
+    const CORS_ENV_KEYS = ['CORS_ORIGIN_REGEX', 'CORS_ORIGINS'] as const
+
+    let savedEnv: Partial<Record<string, string | undefined>>
+
+    beforeEach(() => {
+      clearSettingsCache()
+      savedEnv = {}
+      for (const key of CORS_ENV_KEYS) {
+        savedEnv[key] = process.env[key]
+      }
+    })
+
+    afterEach(() => {
+      for (const key of CORS_ENV_KEYS) {
+        if (savedEnv[key] !== undefined) {
+          process.env[key] = savedEnv[key]
+        } else {
+          delete process.env[key]
+        }
+      }
+      clearSettingsCache()
+    })
+
+    it('should NOT match arbitrary localhost ports in the default regex', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex
+
+      // The default regex should exist (for Tauri)
+      expect(regex).toBeInstanceOf(RegExp)
+
+      // Must NOT match arbitrary localhost ports — this was the vulnerability
+      expect(regex!.test('http://localhost:9999')).toBe(false)
+      expect(regex!.test('http://localhost:4000')).toBe(false)
+      expect(regex!.test('http://localhost:8080')).toBe(false)
+    })
+
+    it('should match Tauri origins in the default regex', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex!
+
+      expect(regex.test('tauri://localhost')).toBe(true)
+      expect(regex.test('http://tauri.localhost')).toBe(true)
+    })
+
+    it('should not match non-Tauri origins in the default regex', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex!
+
+      expect(regex.test('https://evil.com')).toBe(false)
+      expect(regex.test('http://malicious.localhost')).toBe(false)
+      expect(regex.test('http://localhost')).toBe(false)
+    })
+
+    it('should not let default regex silently override explicit CORS_ORIGINS', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      process.env.CORS_ORIGINS = 'https://myapp.example.com'
+      const settings = getSettings()
+      const origins = getCorsOrigins(settings)
+
+      // The explicit origin must be present in the result
+      expect(origins).toContain('https://myapp.example.com')
     })
   })
 

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -52,7 +52,7 @@ describe('Config Settings', () => {
         corsOrigins: 'https://app.example.com,https://other.example.com',
         corsOriginRegex: null,
       }
-      const origins = getCorsOrigins(settings as any)
+      const origins = getCorsOrigins(settings)
 
       expect(origins).toEqual(['https://app.example.com', 'https://other.example.com'])
     })
@@ -63,7 +63,7 @@ describe('Config Settings', () => {
         corsOrigins: 'https://app.example.com',
         corsOriginRegex: regex,
       }
-      const origins = getCorsOrigins(settings as any)
+      const origins = getCorsOrigins(settings)
 
       expect(origins).toHaveLength(2)
       expect(origins).toContain('https://app.example.com')
@@ -75,7 +75,7 @@ describe('Config Settings', () => {
         corsOrigins: 'https://app.example.com',
         corsOriginRegex: null,
       }
-      const origins = getCorsOrigins(settings as any)
+      const origins = getCorsOrigins(settings)
 
       expect(origins).toEqual(['https://app.example.com'])
       expect(origins.every((o) => typeof o === 'string')).toBe(true)

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -51,7 +51,7 @@ const settingsSchema = z.object({
   corsOrigins: z.string().default('http://localhost:1420'),
   corsOriginRegex: z
     .string()
-    .default('^(tauri://localhost|http://tauri\\.localhost|http://localhost:\\d+)$')
+    .default('^(tauri://localhost|http://tauri\\.localhost)$')
     // Value is from CORS_ORIGIN_REGEX env var set by the server deployer, not user input.
     // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
     .transform((val) => (val ? new RegExp(val) : null)),
@@ -110,8 +110,7 @@ const parseSettings = (): Settings => {
     powersyncJwtSecret: process.env.POWERSYNC_JWT_SECRET || '',
     powersyncTokenExpirySeconds: process.env.POWERSYNC_TOKEN_EXPIRY_SECONDS || '3600',
     corsOrigins: process.env.CORS_ORIGINS || 'http://localhost:1420',
-    corsOriginRegex:
-      process.env.CORS_ORIGIN_REGEX ?? '^(tauri://localhost|http://tauri\\.localhost|http://localhost:\\d+)$',
+    corsOriginRegex: process.env.CORS_ORIGIN_REGEX ?? '^(tauri://localhost|http://tauri\\.localhost)$',
     corsAllowCredentials: process.env.CORS_ALLOW_CREDENTIALS !== 'false',
     corsAllowMethods: process.env.CORS_ALLOW_METHODS || 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:
@@ -157,11 +156,13 @@ export const getCorsOriginsList = (settings: Settings): string[] => {
     .filter((origin) => origin.length > 0)
 }
 
-/**
- * Get CORS origins as either a RegExp pattern or array of strings
- */
-export const getCorsOrigins = (settings: Settings): RegExp | string[] => {
-  return settings.corsOriginRegex ?? getCorsOriginsList(settings)
+/** Get CORS origins as an array combining explicit origins and optional regex. */
+export const getCorsOrigins = (settings: Settings): (RegExp | string)[] => {
+  const origins: (RegExp | string)[] = getCorsOriginsList(settings)
+  if (settings.corsOriginRegex) {
+    origins.push(settings.corsOriginRegex)
+  }
+  return origins
 }
 
 export const getCorsMethodsList = (settings: Settings): string[] => {

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -149,7 +149,7 @@ export const clearSettingsCache = (): void => {
 /**
  * Derived properties similar to the Python version
  */
-export const getCorsOriginsList = (settings: Settings): string[] => {
+export const getCorsOriginsList = (settings: Pick<Settings, 'corsOrigins'>): string[] => {
   return settings.corsOrigins
     .split(',')
     .map((origin) => origin.trim())
@@ -157,7 +157,7 @@ export const getCorsOriginsList = (settings: Settings): string[] => {
 }
 
 /** Get CORS origins as an array combining explicit origins and optional regex. */
-export const getCorsOrigins = (settings: Settings): (RegExp | string)[] => {
+export const getCorsOrigins = (settings: Pick<Settings, 'corsOrigins' | 'corsOriginRegex'>): (RegExp | string)[] => {
   const origins: (RegExp | string)[] = getCorsOriginsList(settings)
   if (settings.corsOriginRegex) {
     origins.push(settings.corsOriginRegex)


### PR DESCRIPTION
…rces

- Remove `http://localhost:\d+` from default corsOriginRegex to prevent arbitrary localhost ports from bypassing CORS
- Change getCorsOrigins to return a combined array of explicit origins and the optional regex, instead of one or the other
- Add unit tests for getCorsOrigins and regex security invariants
- Add integration tests verifying CORS middleware rejects unauthorized origins

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CORS allowlist behavior by tightening the default regex (dropping `http://localhost:<port>` matches) and altering `getCorsOrigins` to always combine explicit origins with an optional regex, which could block previously-allowed dev/proxy setups if they relied on wildcard localhost ports.
> 
> **Overview**
> Closes a CORS security gap by tightening the default `corsOriginRegex` to only match Tauri origins and no longer allow arbitrary `http://localhost:<port>`.
> 
> Updates `getCorsOrigins` to always return a combined `(string | RegExp)[]` (explicit `CORS_ORIGINS` plus optional regex) instead of choosing one or the other, and adds new unit + integration tests to assert the security invariants and verify actual CORS headers reject unauthorized origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e2714e903ad0750a88d2111299983e740df14b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->