### PR TITLE
fix(security): prevent cross-origin PowerSync data injection via CORS and Origin validation

### DIFF
--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -1576,7 +1576,7 @@ describe('PowerSync API', () => {
 describe('PowerSync cross-origin injection protection', () => {
   const corsSettings: Settings = {
     ...powersyncSettings,
-    corsOriginRegex: /^(tauri:\/\/localhost|http:\/\/tauri\.localhost|http:\/\/localhost:1420)$/,
+    corsOriginRegex: /^(tauri:\/\/localhost|http:\/\/tauri\.localhost)$/,
     corsOrigins: 'http://localhost:1420',
   }
 

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -1,7 +1,7 @@
 import type { Settings } from '@/config/settings'
 import { createBetterAuthPlugin } from '@/auth/elysia-plugin'
 import { session as sessionTable, user as userTable } from '@/db/auth-schema'
-import { devicesTable, promptsTable, settingsTable } from '@/db/schema'
+import { devicesTable, mcpServersTable, modelsTable, promptsTable, settingsTable } from '@/db/schema'
 import { createTestDb } from '@/test-utils/db'
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -1569,6 +1569,276 @@ describe('PowerSync API', () => {
       expect(response.status).toBe(200)
       const data = (await response.json()) as { success: boolean }
       expect(data.success).toBe(true)
+    })
+  })
+})
+
+describe('PowerSync cross-origin injection protection', () => {
+  const corsSettings: Settings = {
+    ...powersyncSettings,
+    corsOriginRegex: /^(tauri:\/\/localhost|http:\/\/tauri\.localhost|http:\/\/localhost:1420)$/,
+    corsOrigins: 'http://localhost:1420',
+  }
+
+  let app: Elysia
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  const seedUser = async (userId: string, token: string) => {
+    const now = new Date()
+    const expiresAt = new Date(now.getTime() + 3600 * 1000)
+    await db.insert(userTable).values({
+      id: userId,
+      name: 'CORS Test User',
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await db.insert(sessionTable).values({
+      id: `session-${userId}`,
+      expiresAt,
+      token,
+      createdAt: now,
+      updatedAt: now,
+      userId,
+    })
+  }
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+    const { auth } = createBetterAuthPlugin(db)
+    app = new Elysia().use(createPowerSyncRoutes(auth, corsSettings, db)) as unknown as Elysia
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('PUT /powersync/upload origin validation', () => {
+    it('rejects upload from disallowed cross-origin (attacker port)', async () => {
+      await seedUser('user-cors-upload', 'bearer-cors-upload')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-cors-upload',
+            'X-Device-ID': 'cors-test-device',
+            Origin: 'http://localhost:9999',
+          },
+          body: JSON.stringify({
+            operations: [
+              { op: 'PUT' as const, type: 'settings', id: 'cloud_url', data: { value: 'https://attacker.com/v1' } },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(403)
+      const data = (await response.json()) as { code: string }
+      expect(data.code).toBe('ORIGIN_NOT_ALLOWED')
+
+      // Verify nothing was written
+      const rows = await db.select().from(settingsTable).where(eq(settingsTable.key, 'cloud_url'))
+      expect(rows).toHaveLength(0)
+    })
+
+    it('rejects model injection from attacker origin', async () => {
+      await seedUser('user-model-inject', 'bearer-model-inject')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-model-inject',
+            'X-Device-ID': 'attacker-device',
+            Origin: 'http://localhost:9999',
+          },
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'models',
+                id: 'evil-model',
+                data: {
+                  provider: 'custom',
+                  name: 'GPT-5 Ultra (Free)',
+                  model: 'gpt-5',
+                  url: 'https://attacker.com/v1',
+                  enabled: 1,
+                  tool_usage: 1,
+                },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(403)
+
+      const rows = await db.select().from(modelsTable).where(eq(modelsTable.id, 'evil-model'))
+      expect(rows).toHaveLength(0)
+    })
+
+    it('rejects MCP server injection from attacker origin', async () => {
+      await seedUser('user-mcp-inject', 'bearer-mcp-inject')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-mcp-inject',
+            'X-Device-ID': 'attacker-device',
+            Origin: 'http://localhost:9999',
+          },
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'mcp_servers',
+                id: 'evil-mcp',
+                data: {
+                  name: 'Enhanced Tools',
+                  type: 'http',
+                  url: 'https://attacker.com/mcp',
+                  enabled: 1,
+                },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(403)
+
+      const rows = await db.select().from(mcpServersTable).where(eq(mcpServersTable.id, 'evil-mcp'))
+      expect(rows).toHaveLength(0)
+    })
+
+    it('allows upload from legitimate origin (http://localhost:1420)', async () => {
+      await seedUser('user-legit-origin', 'bearer-legit-origin')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-legit-origin',
+            'X-Device-ID': 'legit-device',
+            Origin: 'http://localhost:1420',
+          },
+          body: JSON.stringify({
+            operations: [{ op: 'PUT' as const, type: 'settings', id: 'theme', data: { value: 'dark' } }],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+
+      const rows = await db.select().from(settingsTable).where(eq(settingsTable.key, 'theme'))
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.value).toBe('dark')
+    })
+
+    it('allows upload from Tauri origin', async () => {
+      await seedUser('user-tauri-origin', 'bearer-tauri-origin')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-tauri-origin',
+            'X-Device-ID': 'tauri-device',
+            Origin: 'tauri://localhost',
+          },
+          body: JSON.stringify({
+            operations: [{ op: 'PUT' as const, type: 'settings', id: 'tauri_setting', data: { value: 'yes' } }],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+    })
+
+    it('allows upload without Origin header (non-browser clients)', async () => {
+      await seedUser('user-no-origin', 'bearer-no-origin')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-no-origin',
+            'X-Device-ID': 'server-device',
+          },
+          body: JSON.stringify({
+            operations: [{ op: 'PUT' as const, type: 'settings', id: 'server_setting', data: { value: 'ok' } }],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+    })
+
+    it('rejects upload from external attacker domain', async () => {
+      await seedUser('user-ext-attacker', 'bearer-ext-attacker')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-ext-attacker',
+            'X-Device-ID': 'attacker-device',
+            Origin: 'https://attacker.com',
+          },
+          body: JSON.stringify({
+            operations: [
+              { op: 'PUT' as const, type: 'settings', id: 'cloud_url', data: { value: 'https://attacker.com/v1' } },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(403)
+    })
+  })
+
+  describe('GET /powersync/token origin validation', () => {
+    it('rejects token request from disallowed origin', async () => {
+      await seedUser('user-cors-token', 'bearer-cors-token')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/token', {
+          headers: {
+            Authorization: 'Bearer bearer-cors-token',
+            'X-Device-ID': 'cors-token-device',
+            Origin: 'http://localhost:9999',
+          },
+        }),
+      )
+      expect(response.status).toBe(403)
+      const data = (await response.json()) as { code: string }
+      expect(data.code).toBe('ORIGIN_NOT_ALLOWED')
+    })
+
+    it('allows token request from legitimate origin', async () => {
+      await seedUser('user-legit-token', 'bearer-legit-token')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/token', {
+          headers: {
+            Authorization: 'Bearer bearer-legit-token',
+            'X-Device-ID': 'legit-token-device',
+            Origin: 'http://localhost:1420',
+          },
+        }),
+      )
+      expect(response.status).toBe(200)
+    })
+
+    it('allows token request without Origin header', async () => {
+      await seedUser('user-no-origin-token', 'bearer-no-origin-token')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/token', {
+          headers: {
+            Authorization: 'Bearer bearer-no-origin-token',
+            'X-Device-ID': 'no-origin-device',
+          },
+        }),
+      )
+      expect(response.status).toBe(200)
     })
   })
 })

--- a/backend/src/api/powersync.ts
+++ b/backend/src/api/powersync.ts
@@ -1,5 +1,6 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import type { Settings } from '@/config/settings'
+import { isOriginAllowed } from '@/config/settings'
 import { applyOperation, getActiveSessionByToken, getDeviceById, getUserById, upsertDevice } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import { jwt } from '@elysiajs/jwt'
@@ -43,6 +44,16 @@ const validateDeviceNotRevoked = async (
   }
 
   return { ok: true }
+}
+
+/**
+ * Defense-in-depth: rejects cross-origin requests whose Origin doesn't match allowed CORS origins.
+ * Absent Origin (non-browser / server-to-server clients) is allowed.
+ */
+const validateOrigin = (request: Request, appSettings: Settings): boolean => {
+  const origin = request.headers.get('origin')
+  if (!origin) return true
+  return isOriginAllowed(origin, appSettings)
 }
 
 /**
@@ -120,6 +131,11 @@ export const createPowerSyncRoutes = (auth: Auth, settings: Settings, database: 
       return { user: session?.user ?? null }
     })
     .get('/token', async ({ powersyncJwt, request, set, user }) => {
+      if (!validateOrigin(request, settings)) {
+        set.status = 403
+        return { error: 'Forbidden', code: 'ORIGIN_NOT_ALLOWED' }
+      }
+
       if (!settings.powersyncUrl || !settings.powersyncJwtSecret) {
         set.status = 503
         return { error: 'PowerSync is not configured' }
@@ -167,6 +183,11 @@ export const createPowerSyncRoutes = (auth: Auth, settings: Settings, database: 
     .put(
       '/upload',
       async ({ body, request, set, user }) => {
+        if (!validateOrigin(request, settings)) {
+          set.status = 403
+          return { error: 'Forbidden', code: 'ORIGIN_NOT_ALLOWED' }
+        }
+
         // Requires authenticated user; applies batched CRUD from PowerSync.
         if (!user) {
           set.status = 401

--- a/backend/src/config/cors.test.ts
+++ b/backend/src/config/cors.test.ts
@@ -25,7 +25,7 @@ describe('CORS integration', () => {
     const origins = getCorsOrigins({
       corsOrigins: 'https://app.example.com',
       corsOriginRegex: /^(tauri:\/\/localhost|http:\/\/tauri\.localhost)$/,
-    } as any)
+    })
 
     it('should allow the explicit origin', async () => {
       const app = createTestApp(origins)
@@ -105,7 +105,7 @@ describe('CORS integration', () => {
     const origins = getCorsOrigins({
       corsOrigins: 'https://app.example.com',
       corsOriginRegex: null,
-    } as any)
+    })
 
     it('should allow the explicit origin', async () => {
       const app = createTestApp(origins)

--- a/backend/src/config/cors.test.ts
+++ b/backend/src/config/cors.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test'
+import { getCorsOrigins } from '@/config/settings'
+import cors from '@elysiajs/cors'
+import { Elysia } from 'elysia'
+
+/**
+ * Integration tests for CORS middleware behavior.
+ * Verifies that the actual HTTP headers are set correctly for various origins.
+ */
+describe('CORS integration', () => {
+  const createTestApp = (corsOrigins: (RegExp | string)[]) =>
+    new Elysia()
+      .use(
+        cors({
+          origin: corsOrigins,
+          credentials: true,
+          methods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
+          allowedHeaders: 'Content-Type,Authorization',
+        }),
+      )
+      .get('/test', () => ({ ok: true }))
+      .delete('/test', () => ({ ok: true }))
+
+  describe('with Tauri regex and explicit origin', () => {
+    const origins = getCorsOrigins({
+      corsOrigins: 'https://app.example.com',
+      corsOriginRegex: /^(tauri:\/\/localhost|http:\/\/tauri\.localhost)$/,
+    } as any)
+
+    it('should allow the explicit origin', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'https://app.example.com' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('https://app.example.com')
+      expect(res.headers.get('access-control-allow-credentials')).toBe('true')
+    })
+
+    it('should allow tauri://localhost', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'tauri://localhost' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('tauri://localhost')
+      expect(res.headers.get('access-control-allow-credentials')).toBe('true')
+    })
+
+    it('should allow http://tauri.localhost', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'http://tauri.localhost' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('http://tauri.localhost')
+      expect(res.headers.get('access-control-allow-credentials')).toBe('true')
+    })
+
+    it('should reject arbitrary localhost ports', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'http://localhost:9999' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+
+    it('should reject unknown origins', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'https://evil.com' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+
+    it('should reject preflight from arbitrary localhost ports', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          method: 'OPTIONS',
+          headers: {
+            Origin: 'http://localhost:9999',
+            'Access-Control-Request-Method': 'DELETE',
+          },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+  })
+
+  describe('with only explicit origins (no regex)', () => {
+    const origins = getCorsOrigins({
+      corsOrigins: 'https://app.example.com',
+      corsOriginRegex: null,
+    } as any)
+
+    it('should allow the explicit origin', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'https://app.example.com' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('https://app.example.com')
+    })
+
+    it('should reject other origins', async () => {
+      const app = createTestApp(origins)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'http://localhost:9999' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+  })
+})

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -13,35 +13,35 @@ describe('Config Settings', () => {
   describe('getCorsOriginsList', () => {
     it('should split comma-separated origins', () => {
       const settings = { corsOrigins: 'http://localhost:3000,https://example.com,https://app.example.com' }
-      const origins = getCorsOriginsList(settings as any)
+      const origins = getCorsOriginsList(settings)
 
       expect(origins).toEqual(['http://localhost:3000', 'https://example.com', 'https://app.example.com'])
     })
 
     it('should handle single origin', () => {
       const settings = { corsOrigins: 'http://localhost:3000' }
-      const origins = getCorsOriginsList(settings as any)
+      const origins = getCorsOriginsList(settings)
 
       expect(origins).toEqual(['http://localhost:3000'])
     })
 
     it('should trim whitespace from origins', () => {
       const settings = { corsOrigins: ' http://localhost:3000 , https://example.com , https://app.example.com ' }
-      const origins = getCorsOriginsList(settings as any)
+      const origins = getCorsOriginsList(settings)
 
       expect(origins).toEqual(['http://localhost:3000', 'https://example.com', 'https://app.example.com'])
     })
 
     it('should filter out empty origins', () => {
       const settings = { corsOrigins: 'http://localhost:3000,,https://example.com,' }
-      const origins = getCorsOriginsList(settings as any)
+      const origins = getCorsOriginsList(settings)
 
       expect(origins).toEqual(['http://localhost:3000', 'https://example.com'])
     })
 
     it('should handle empty string', () => {
       const settings = { corsOrigins: '' }
-      const origins = getCorsOriginsList(settings as any)
+      const origins = getCorsOriginsList(settings)
 
       expect(origins).toEqual([])
     })

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -5,6 +5,7 @@ import {
   getCorsMethodsList,
   getCorsOriginsList,
   getSettings,
+  isOriginAllowed,
 } from './settings'
 
 describe('Config Settings', () => {
@@ -252,6 +253,88 @@ describe('Config Settings', () => {
     it('should reject invalid trustedProxy values', () => {
       process.env.TRUSTED_PROXY = 'nginx'
       expect(() => getSettings()).toThrow()
+    })
+  })
+
+  describe('CORS origin regex security', () => {
+    const CORS_ENV_KEYS = ['CORS_ORIGIN_REGEX', 'CORS_ORIGINS'] as const
+
+    let savedEnv: Partial<Record<string, string>>
+
+    beforeEach(() => {
+      clearSettingsCache()
+      savedEnv = {}
+      for (const key of CORS_ENV_KEYS) {
+        if (process.env[key] !== undefined) {
+          savedEnv[key] = process.env[key]
+        }
+      }
+    })
+
+    afterEach(() => {
+      for (const key of CORS_ENV_KEYS) {
+        if (savedEnv[key] !== undefined) {
+          process.env[key] = savedEnv[key]
+        } else {
+          delete process.env[key]
+        }
+      }
+      clearSettingsCache()
+    })
+
+    it('default regex does NOT match arbitrary localhost ports', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex!
+      expect(regex.test('http://localhost:9999')).toBe(false)
+      expect(regex.test('http://localhost:3000')).toBe(false)
+      expect(regex.test('http://localhost:8080')).toBe(false)
+    })
+
+    it('default regex matches the dev frontend port (1420)', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex!
+      expect(regex.test('http://localhost:1420')).toBe(true)
+    })
+
+    it('default regex matches Tauri origins', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex!
+      expect(regex.test('tauri://localhost')).toBe(true)
+      expect(regex.test('http://tauri.localhost')).toBe(true)
+    })
+
+    it('default regex rejects attacker origins', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex!
+      expect(regex.test('https://attacker.com')).toBe(false)
+      expect(regex.test('http://evil.localhost')).toBe(false)
+      expect(regex.test('http://localhost:9999')).toBe(false)
+    })
+  })
+
+  describe('isOriginAllowed', () => {
+    it('returns true when origin matches regex', () => {
+      const settings = { corsOriginRegex: /^http:\/\/localhost:1420$/ } as any
+      expect(isOriginAllowed('http://localhost:1420', settings)).toBe(true)
+    })
+
+    it('returns false when origin does not match regex', () => {
+      const settings = { corsOriginRegex: /^http:\/\/localhost:1420$/ } as any
+      expect(isOriginAllowed('http://localhost:9999', settings)).toBe(false)
+    })
+
+    it('returns true when origin is in the string list', () => {
+      const settings = { corsOriginRegex: null, corsOrigins: 'http://localhost:1420,https://app.example.com' } as any
+      expect(isOriginAllowed('https://app.example.com', settings)).toBe(true)
+    })
+
+    it('returns false when origin is not in the string list', () => {
+      const settings = { corsOriginRegex: null, corsOrigins: 'http://localhost:1420' } as any
+      expect(isOriginAllowed('http://localhost:9999', settings)).toBe(false)
     })
   })
 

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -53,7 +53,7 @@ describe('Config Settings', () => {
         corsOrigins: 'https://app.example.com,https://other.example.com',
         corsOriginRegex: null,
       }
-      const origins = getCorsOrigins(settings as any)
+      const origins = getCorsOrigins(settings)
 
       expect(origins).toEqual(['https://app.example.com', 'https://other.example.com'])
     })
@@ -64,7 +64,7 @@ describe('Config Settings', () => {
         corsOrigins: 'https://app.example.com',
         corsOriginRegex: regex,
       }
-      const origins = getCorsOrigins(settings as any)
+      const origins = getCorsOrigins(settings)
 
       expect(origins).toHaveLength(2)
       expect(origins).toContain('https://app.example.com')
@@ -76,7 +76,7 @@ describe('Config Settings', () => {
         corsOrigins: 'https://app.example.com',
         corsOriginRegex: null,
       }
-      const origins = getCorsOrigins(settings as any)
+      const origins = getCorsOrigins(settings)
 
       expect(origins).toEqual(['https://app.example.com'])
       expect(origins.every((o) => typeof o === 'string')).toBe(true)

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
   clearSettingsCache,
+  getCorsOrigins,
   getWaitlistAutoApproveDomains,
   getCorsMethodsList,
   getCorsOriginsList,
@@ -43,6 +44,110 @@ describe('Config Settings', () => {
       const origins = getCorsOriginsList(settings as any)
 
       expect(origins).toEqual([])
+    })
+  })
+
+  describe('getCorsOrigins', () => {
+    it('should include explicit origins list', () => {
+      const settings = {
+        corsOrigins: 'https://app.example.com,https://other.example.com',
+        corsOriginRegex: null,
+      }
+      const origins = getCorsOrigins(settings as any)
+
+      expect(origins).toEqual(['https://app.example.com', 'https://other.example.com'])
+    })
+
+    it('should include regex when corsOriginRegex is set', () => {
+      const regex = /^(tauri:\/\/localhost|http:\/\/tauri\.localhost)$/
+      const settings = {
+        corsOrigins: 'https://app.example.com',
+        corsOriginRegex: regex,
+      }
+      const origins = getCorsOrigins(settings as any)
+
+      expect(origins).toHaveLength(2)
+      expect(origins).toContain('https://app.example.com')
+      expect(origins).toContain(regex)
+    })
+
+    it('should return only explicit origins when regex is null', () => {
+      const settings = {
+        corsOrigins: 'https://app.example.com',
+        corsOriginRegex: null,
+      }
+      const origins = getCorsOrigins(settings as any)
+
+      expect(origins).toEqual(['https://app.example.com'])
+      expect(origins.every((o) => typeof o === 'string')).toBe(true)
+    })
+  })
+
+  describe('CORS default regex security', () => {
+    const CORS_ENV_KEYS = ['CORS_ORIGIN_REGEX', 'CORS_ORIGINS'] as const
+
+    let savedEnv: Partial<Record<string, string | undefined>>
+
+    beforeEach(() => {
+      clearSettingsCache()
+      savedEnv = {}
+      for (const key of CORS_ENV_KEYS) {
+        savedEnv[key] = process.env[key]
+      }
+    })
+
+    afterEach(() => {
+      for (const key of CORS_ENV_KEYS) {
+        if (savedEnv[key] !== undefined) {
+          process.env[key] = savedEnv[key]
+        } else {
+          delete process.env[key]
+        }
+      }
+      clearSettingsCache()
+    })
+
+    it('should NOT match arbitrary localhost ports in the default regex', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex
+
+      // The default regex should exist (for Tauri)
+      expect(regex).toBeInstanceOf(RegExp)
+
+      // Must NOT match arbitrary localhost ports — this was the vulnerability
+      expect(regex!.test('http://localhost:9999')).toBe(false)
+      expect(regex!.test('http://localhost:4000')).toBe(false)
+      expect(regex!.test('http://localhost:8080')).toBe(false)
+    })
+
+    it('should match Tauri origins in the default regex', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex!
+
+      expect(regex.test('tauri://localhost')).toBe(true)
+      expect(regex.test('http://tauri.localhost')).toBe(true)
+    })
+
+    it('should not match non-Tauri origins in the default regex', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      const settings = getSettings()
+      const regex = settings.corsOriginRegex!
+
+      expect(regex.test('https://evil.com')).toBe(false)
+      expect(regex.test('http://malicious.localhost')).toBe(false)
+      expect(regex.test('http://localhost')).toBe(false)
+    })
+
+    it('should not let default regex silently override explicit CORS_ORIGINS', () => {
+      delete process.env.CORS_ORIGIN_REGEX
+      process.env.CORS_ORIGINS = 'https://myapp.example.com'
+      const settings = getSettings()
+      const origins = getCorsOrigins(settings)
+
+      // The explicit origin must be present in the result
+      expect(origins).toContain('https://myapp.example.com')
     })
   })
 
@@ -256,85 +361,35 @@ describe('Config Settings', () => {
     })
   })
 
-  describe('CORS origin regex security', () => {
-    const CORS_ENV_KEYS = ['CORS_ORIGIN_REGEX', 'CORS_ORIGINS'] as const
-
-    let savedEnv: Partial<Record<string, string>>
-
-    beforeEach(() => {
-      clearSettingsCache()
-      savedEnv = {}
-      for (const key of CORS_ENV_KEYS) {
-        if (process.env[key] !== undefined) {
-          savedEnv[key] = process.env[key]
-        }
-      }
-    })
-
-    afterEach(() => {
-      for (const key of CORS_ENV_KEYS) {
-        if (savedEnv[key] !== undefined) {
-          process.env[key] = savedEnv[key]
-        } else {
-          delete process.env[key]
-        }
-      }
-      clearSettingsCache()
-    })
-
-    it('default regex does NOT match arbitrary localhost ports', () => {
-      delete process.env.CORS_ORIGIN_REGEX
-      const settings = getSettings()
-      const regex = settings.corsOriginRegex!
-      expect(regex.test('http://localhost:9999')).toBe(false)
-      expect(regex.test('http://localhost:3000')).toBe(false)
-      expect(regex.test('http://localhost:8080')).toBe(false)
-    })
-
-    it('default regex matches the dev frontend port (1420)', () => {
-      delete process.env.CORS_ORIGIN_REGEX
-      const settings = getSettings()
-      const regex = settings.corsOriginRegex!
-      expect(regex.test('http://localhost:1420')).toBe(true)
-    })
-
-    it('default regex matches Tauri origins', () => {
-      delete process.env.CORS_ORIGIN_REGEX
-      const settings = getSettings()
-      const regex = settings.corsOriginRegex!
-      expect(regex.test('tauri://localhost')).toBe(true)
-      expect(regex.test('http://tauri.localhost')).toBe(true)
-    })
-
-    it('default regex rejects attacker origins', () => {
-      delete process.env.CORS_ORIGIN_REGEX
-      const settings = getSettings()
-      const regex = settings.corsOriginRegex!
-      expect(regex.test('https://attacker.com')).toBe(false)
-      expect(regex.test('http://evil.localhost')).toBe(false)
-      expect(regex.test('http://localhost:9999')).toBe(false)
-    })
-  })
-
   describe('isOriginAllowed', () => {
     it('returns true when origin matches regex', () => {
-      const settings = { corsOriginRegex: /^http:\/\/localhost:1420$/ } as any
+      const settings = { corsOrigins: '', corsOriginRegex: /^http:\/\/localhost:1420$/ }
       expect(isOriginAllowed('http://localhost:1420', settings)).toBe(true)
     })
 
     it('returns false when origin does not match regex', () => {
-      const settings = { corsOriginRegex: /^http:\/\/localhost:1420$/ } as any
+      const settings = { corsOrigins: '', corsOriginRegex: /^http:\/\/localhost:1420$/ }
       expect(isOriginAllowed('http://localhost:9999', settings)).toBe(false)
     })
 
-    it('returns true when origin is in the string list', () => {
-      const settings = { corsOriginRegex: null, corsOrigins: 'http://localhost:1420,https://app.example.com' } as any
+    it('returns true when origin is in the explicit origins list', () => {
+      const settings = { corsOrigins: 'http://localhost:1420,https://app.example.com', corsOriginRegex: null }
       expect(isOriginAllowed('https://app.example.com', settings)).toBe(true)
     })
 
-    it('returns false when origin is not in the string list', () => {
-      const settings = { corsOriginRegex: null, corsOrigins: 'http://localhost:1420' } as any
+    it('returns false when origin is not in any allowed source', () => {
+      const settings = { corsOrigins: 'http://localhost:1420', corsOriginRegex: null }
       expect(isOriginAllowed('http://localhost:9999', settings)).toBe(false)
+    })
+
+    it('returns true when origin matches regex but not explicit list', () => {
+      const settings = { corsOrigins: 'https://app.example.com', corsOriginRegex: /^tauri:\/\/localhost$/ }
+      expect(isOriginAllowed('tauri://localhost', settings)).toBe(true)
+    })
+
+    it('returns true when origin matches explicit list but not regex', () => {
+      const settings = { corsOrigins: 'http://localhost:1420', corsOriginRegex: /^tauri:\/\/localhost$/ }
+      expect(isOriginAllowed('http://localhost:1420', settings)).toBe(true)
     })
   })
 

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -51,7 +51,7 @@ const settingsSchema = z.object({
   corsOrigins: z.string().default('http://localhost:1420'),
   corsOriginRegex: z
     .string()
-    .default('^(tauri://localhost|http://tauri\\.localhost|http://localhost:1420)$')
+    .default('^(tauri://localhost|http://tauri\\.localhost)$')
     // Value is from CORS_ORIGIN_REGEX env var set by the server deployer, not user input.
     // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
     .transform((val) => (val ? new RegExp(val) : null)),
@@ -110,8 +110,7 @@ const parseSettings = (): Settings => {
     powersyncJwtSecret: process.env.POWERSYNC_JWT_SECRET || '',
     powersyncTokenExpirySeconds: process.env.POWERSYNC_TOKEN_EXPIRY_SECONDS || '3600',
     corsOrigins: process.env.CORS_ORIGINS || 'http://localhost:1420',
-    corsOriginRegex:
-      process.env.CORS_ORIGIN_REGEX ?? '^(tauri://localhost|http://tauri\\.localhost|http://localhost:1420)$',
+    corsOriginRegex: process.env.CORS_ORIGIN_REGEX ?? '^(tauri://localhost|http://tauri\\.localhost)$',
     corsAllowCredentials: process.env.CORS_ALLOW_CREDENTIALS !== 'false',
     corsAllowMethods: process.env.CORS_ALLOW_METHODS || 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:
@@ -150,27 +149,30 @@ export const clearSettingsCache = (): void => {
 /**
  * Derived properties similar to the Python version
  */
-export const getCorsOriginsList = (settings: Settings): string[] => {
+export const getCorsOriginsList = (settings: Pick<Settings, 'corsOrigins'>): string[] => {
   return settings.corsOrigins
     .split(',')
     .map((origin) => origin.trim())
     .filter((origin) => origin.length > 0)
 }
 
-/**
- * Get CORS origins as either a RegExp pattern or array of strings
- */
-export const getCorsOrigins = (settings: Settings): RegExp | string[] => {
-  return settings.corsOriginRegex ?? getCorsOriginsList(settings)
+/** Get CORS origins as an array combining explicit origins and optional regex. */
+export const getCorsOrigins = (settings: Pick<Settings, 'corsOrigins' | 'corsOriginRegex'>): (RegExp | string)[] => {
+  const origins: (RegExp | string)[] = getCorsOriginsList(settings)
+  if (settings.corsOriginRegex) {
+    origins.push(settings.corsOriginRegex)
+  }
+  return origins
 }
 
 /**
  * Check whether a given origin is allowed by the configured CORS origins.
  */
-export const isOriginAllowed = (origin: string, settings: Settings): boolean => {
-  const allowed = getCorsOrigins(settings)
-  if (allowed instanceof RegExp) return allowed.test(origin)
-  return allowed.includes(origin)
+export const isOriginAllowed = (
+  origin: string,
+  settings: Pick<Settings, 'corsOrigins' | 'corsOriginRegex'>,
+): boolean => {
+  return getCorsOrigins(settings).some((entry) => (entry instanceof RegExp ? entry.test(origin) : entry === origin))
 }
 
 export const getCorsMethodsList = (settings: Settings): string[] => {

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -51,7 +51,7 @@ const settingsSchema = z.object({
   corsOrigins: z.string().default('http://localhost:1420'),
   corsOriginRegex: z
     .string()
-    .default('^(tauri://localhost|http://tauri\\.localhost|http://localhost:\\d+)$')
+    .default('^(tauri://localhost|http://tauri\\.localhost|http://localhost:1420)$')
     // Value is from CORS_ORIGIN_REGEX env var set by the server deployer, not user input.
     // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
     .transform((val) => (val ? new RegExp(val) : null)),
@@ -111,7 +111,7 @@ const parseSettings = (): Settings => {
     powersyncTokenExpirySeconds: process.env.POWERSYNC_TOKEN_EXPIRY_SECONDS || '3600',
     corsOrigins: process.env.CORS_ORIGINS || 'http://localhost:1420',
     corsOriginRegex:
-      process.env.CORS_ORIGIN_REGEX ?? '^(tauri://localhost|http://tauri\\.localhost|http://localhost:\\d+)$',
+      process.env.CORS_ORIGIN_REGEX ?? '^(tauri://localhost|http://tauri\\.localhost|http://localhost:1420)$',
     corsAllowCredentials: process.env.CORS_ALLOW_CREDENTIALS !== 'false',
     corsAllowMethods: process.env.CORS_ALLOW_METHODS || 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:
@@ -162,6 +162,15 @@ export const getCorsOriginsList = (settings: Settings): string[] => {
  */
 export const getCorsOrigins = (settings: Settings): RegExp | string[] => {
   return settings.corsOriginRegex ?? getCorsOriginsList(settings)
+}
+
+/**
+ * Check whether a given origin is allowed by the configured CORS origins.
+ */
+export const isOriginAllowed = (origin: string, settings: Settings): boolean => {
+  const allowed = getCorsOrigins(settings)
+  if (allowed instanceof RegExp) return allowed.test(origin)
+  return allowed.includes(origin)
 }
 
 export const getCorsMethodsList = (settings: Settings): string[] => {


### PR DESCRIPTION
Tighten the default CORS regex from matching any localhost port (http://localhost:\d+) to only the known dev frontend port (http://localhost:1420). Add defense-in-depth server-side Origin header validation on PowerSync /token and /upload endpoints to block cross-origin requests even if CORS middleware is misconfigured.

https://claude.ai/code/session_01SfbxvbQkhBQ7cB5vNu9bv5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive request validation on `GET /powersync/token` and `PUT /powersync/upload`; misconfiguration could block legitimate browser clients if CORS settings are incorrect, but changes are small and well-covered by tests.
> 
> **Overview**
> **Prevents cross-origin PowerSync data injection** by adding explicit `Origin` header validation on `GET /powersync/token` and `PUT /powersync/upload`, returning `403` with `ORIGIN_NOT_ALLOWED` for disallowed origins while still permitting requests without an `Origin` header.
> 
> **Tightens CORS defaults** by removing permissive matching of arbitrary `http://localhost:<port>` from the default `corsOriginRegex`, and updates CORS helpers to combine explicit `corsOrigins` with the optional regex. Adds new unit/integration tests covering the new origin-allowlist logic and CORS header behavior, plus end-to-end tests ensuring PowerSync writes are blocked from attacker origins (including model/MCP server injection attempts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4a964e60a851a348dd5fe8d5e5e4062dc9b927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->