### PR TITLE
fix(security): Vite Development Server Allow List

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,12 @@
 import path from 'path'
+import { fileURLToPath } from 'url'
 import type { StorybookConfig } from '@storybook/react-vite'
 
-const rootDir = path.resolve(import.meta.dirname, '..')
+// Storybook evaluates this file via CJS (esbuild-register), where
+// import.meta.dirname is undefined. Fall back to __dirname for compat.
+const currentDir =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(currentDir, '..')
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)', '../src/**/stories.@(js|jsx|mjs|ts|tsx)'],

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -47,6 +47,7 @@ const config: StorybookConfig = {
         path.resolve(rootDir, 'node_modules'),
         path.resolve(rootDir, 'dist-isolation'),
         path.resolve(rootDir, '.storybook'),
+        path.resolve(rootDir, 'index.html'),
       ],
     }
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,7 @@
+import path from 'path'
 import type { StorybookConfig } from '@storybook/react-vite'
+
+const rootDir = path.resolve(import.meta.dirname, '..')
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)', '../src/**/stories.@(js|jsx|mjs|ts|tsx)'],
@@ -27,6 +30,21 @@ const config: StorybookConfig = {
         : []
 
     config.build.rollupOptions.external = [...externalArray, 'bun:sqlite']
+
+    // Restrict @fs endpoint to frontend directories only (matches vite.config.ts)
+    config.server = config.server || {}
+    config.server.fs = {
+      strict: true,
+      allow: [
+        path.resolve(rootDir, 'src'),
+        path.resolve(rootDir, 'shared'),
+        path.resolve(rootDir, 'public'),
+        path.resolve(rootDir, 'node_modules'),
+        path.resolve(rootDir, 'dist-isolation'),
+        path.resolve(rootDir, '.storybook'),
+      ],
+    }
+
     return config
   },
 }

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -31,9 +31,6 @@ describe('vite server.fs allowlist', () => {
     } finally {
       await server?.close()
     }
-    } finally {
-      await server?.close()
-    }
   })
 
   it('enables strict filesystem access', () => {
@@ -50,6 +47,8 @@ describe('vite server.fs allowlist', () => {
       const targetDir = path.resolve(ROOT, dirName)
 
       for (const allowed of resolvedAllow) {
+        // Check both directions: the sensitive dir is an allowed path (or child),
+        // AND no allowed path is a subdirectory of the sensitive dir.
         const isAllowed =
           allowed === targetDir ||
           targetDir.startsWith(allowed + path.sep) ||

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -48,7 +48,12 @@ describe('vite server.fs allowlist', () => {
       const targetDir = path.resolve(ROOT, dirName)
 
       for (const allowed of resolvedAllow) {
-        const isAllowed = allowed === targetDir || targetDir.startsWith(allowed + path.sep)
+        // Check both directions: the sensitive dir is an allowed path (or child),
+        // AND no allowed path is a subdirectory of the sensitive dir.
+        const isAllowed =
+          allowed === targetDir ||
+          targetDir.startsWith(allowed + path.sep) ||
+          allowed.startsWith(targetDir + path.sep)
         expect(isAllowed).toBe(false)
       }
     })

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -1,0 +1,72 @@
+import { beforeAll, describe, expect, it } from 'bun:test'
+import path from 'path'
+import { createServer, loadConfigFromFile } from 'vite'
+
+const ROOT = path.resolve(import.meta.dirname)
+
+/**
+ * Vite's `server.fs` configuration must use a strict allowlist so the dev
+ * server only exposes frontend source code. Without this, the `@fs` endpoint
+ * leaks backend source, config, and other sensitive files to any HTTP client.
+ *
+ * See: https://vitejs.dev/config/server-options.html#server-fs-allow
+ */
+describe('vite server.fs allowlist', () => {
+  let resolvedAllow: string[]
+  let serverFsConfig: { strict: boolean; allow: string[] }
+
+  beforeAll(async () => {
+    const loaded = await loadConfigFromFile(
+      { command: 'serve', mode: 'development' },
+      path.join(ROOT, 'vite.config.ts'),
+    )
+    if (!loaded) throw new Error('Failed to load vite config')
+
+    // Create a minimal server to resolve the full fs config (merges Vite defaults)
+    const server = await createServer({
+      root: ROOT,
+      configFile: false,
+      server: loaded.config.server,
+      plugins: [],
+    })
+    serverFsConfig = server.config.server.fs
+    resolvedAllow = serverFsConfig.allow.map((p) => path.resolve(p))
+    await server.close()
+  })
+
+  it('enables strict filesystem access', () => {
+    expect(serverFsConfig.strict).toBe(true)
+  })
+
+  it('defines an explicit allow list', () => {
+    expect(resolvedAllow).toBeArray()
+    expect(resolvedAllow.length).toBeGreaterThan(0)
+  })
+
+  const assertDirectoryNotAllowed = (dirName: string) => {
+    it(`does not allow the ${dirName} directory`, () => {
+      const targetDir = path.resolve(ROOT, dirName)
+
+      for (const allowed of resolvedAllow) {
+        const isAllowed = allowed === targetDir || targetDir.startsWith(allowed + path.sep)
+        expect(isAllowed).toBe(false)
+      }
+    })
+  }
+
+  assertDirectoryNotAllowed('backend')
+  assertDirectoryNotAllowed('deploy')
+
+  it('does not allow the project root directly (would expose everything)', () => {
+    for (const allowed of resolvedAllow) {
+      expect(allowed).not.toBe(ROOT)
+    }
+  })
+
+  it('allows frontend source directories', () => {
+    expect(resolvedAllow).toContain(path.resolve(ROOT, 'src'))
+    expect(resolvedAllow).toContain(path.resolve(ROOT, 'shared'))
+    expect(resolvedAllow).toContain(path.resolve(ROOT, 'public'))
+    expect(resolvedAllow).toContain(path.resolve(ROOT, 'node_modules'))
+  })
+})

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -23,16 +23,14 @@ describe('vite server.fs allowlist', () => {
     if (!loaded) throw new Error('Failed to load vite config')
 
     // Create a minimal server to resolve the full fs config (merges Vite defaults)
-    const server = await createServer({
-      root: ROOT,
-      configFile: false,
-      server: loaded.config.server,
-      plugins: [],
-    })
-    serverFsConfig = server.config.server.fs
-    resolvedAllow = serverFsConfig.allow.map((p) => path.resolve(p))
-    await server.close()
-  })
+    let server
+    try {
+      server = await createServer({ root: ROOT, configFile: false, server: loaded.config.server, plugins: [] })
+      serverFsConfig = server.config.server.fs
+      resolvedAllow = serverFsConfig.allow.map((p) => path.resolve(p))
+    } finally {
+      await server?.close()
+    }
 
   it('enables strict filesystem access', () => {
     expect(serverFsConfig.strict).toBe(true)

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -31,6 +31,10 @@ describe('vite server.fs allowlist', () => {
     } finally {
       await server?.close()
     }
+    } finally {
+      await server?.close()
+    }
+  })
 
   it('enables strict filesystem access', () => {
     expect(serverFsConfig.strict).toBe(true)
@@ -46,8 +50,6 @@ describe('vite server.fs allowlist', () => {
       const targetDir = path.resolve(ROOT, dirName)
 
       for (const allowed of resolvedAllow) {
-        // Check both directions: the sensitive dir is an allowed path (or child),
-        // AND no allowed path is a subdirectory of the sensitive dir.
         const isAllowed =
           allowed === targetDir ||
           targetDir.startsWith(allowed + path.sep) ||

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,6 +103,8 @@ export default defineConfig({
         path.resolve(__dirname, 'node_modules'),
         path.resolve(__dirname, 'dist-isolation'),
         path.resolve(__dirname, '.storybook'),
+        // Vite's HTML middleware checks checkLoadingAccess() for index.html
+        path.resolve(__dirname, 'index.html'),
       ],
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,7 +103,6 @@ export default defineConfig({
         path.resolve(__dirname, 'node_modules'),
         path.resolve(__dirname, 'dist-isolation'),
         path.resolve(__dirname, '.storybook'),
-        path.resolve(__dirname, 'index.html'),
       ],
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,6 +94,18 @@ export default defineConfig({
       // 3. tell vite to ignore watching `src-tauri`
       ignored: ['**/src-tauri/**'],
     },
+    fs: {
+      strict: true,
+      allow: [
+        path.resolve(__dirname, 'src'),
+        path.resolve(__dirname, 'shared'),
+        path.resolve(__dirname, 'public'),
+        path.resolve(__dirname, 'node_modules'),
+        path.resolve(__dirname, 'dist-isolation'),
+        path.resolve(__dirname, '.storybook'),
+        path.resolve(__dirname, 'index.html'),
+      ],
+    },
   },
   optimizeDeps: {
     exclude: ['@journeyapps/wa-sqlite', '@powersync/web'],


### PR DESCRIPTION
## Summary

- Add `server.fs.strict: true` and `server.fs.allow` allowlist to `vite.config.ts`, restricting the Vite dev server's `@fs` endpoint to only serve frontend directories (`src/`, `shared/`, `public/`, `node_modules/`, `dist-isolation/`, `.storybook/`)
- Add matching `server.fs` allowlist to Storybook's `viteFinal()` in `.storybook/main.ts`, since Storybook runs a separate Vite instance that would otherwise remain unrestricted
- Previously, the entire project root was accessible via `@fs`, leaking backend source code (auth config, API routes, DB schema, inference logic, etc.) to any HTTP client
- Add comprehensive tests (`vite.config.test.ts`) that validate the allowlist configuration: strict mode enabled, backend/deploy directories blocked, project root not directly allowed, and frontend directories permitted

## Test plan

- [x] New `vite.config.test.ts` tests pass (6/6): `bun test vite.config.test.ts`
- [x] Existing test suite passes with no regressions (1943/1943): `bun test ./src ./scripts ./.github/scripts`
- [ ] Manual verification: `curl http://localhost:<port>/@fs/<project-root>/backend/src/index.ts` returns 403
- [ ] Manual verification: frontend dev server still serves app correctly (`bun run dev`)

https://claude.ai/code/session_01SbFbusR1czfAjDqCGx3m4c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens dev-server filesystem access controls; low runtime impact but could break local dev/storybook workflows if any required paths are missing from the allowlist.
> 
> **Overview**
> **Hardens dev-server file exposure via Vite’s `@fs` endpoint.** `vite.config.ts` now enables `server.fs.strict` and an explicit `server.fs.allow` list limited to frontend directories (plus `index.html`).
> 
> **Applies the same restriction to Storybook’s Vite instance.** `.storybook/main.ts` computes a compatible root dir and sets `config.server.fs` in `viteFinal()` to match the main Vite config.
> 
> **Adds a regression test.** New `vite.config.test.ts` loads the Vite config and asserts strict mode is on, the project root isn’t allowed, and sensitive directories like `backend/` and `deploy/` are not reachable while frontend dirs are permitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4e4da9b8722b604864058e22ef91f7a119f850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->