### PR TITLE
fix(security): strip Thunderbolt session token from MCP proxy forwarded headers

### DIFF
--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -60,7 +60,7 @@ const settingsSchema = z.object({
   corsAllowHeaders: z
     .string()
     .default(
-      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Mcp-Target-Url,Mcp-Session-Id,Mcp-Protocol-Version',
+      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Mcp-Target-Url,Mcp-Authorization,Mcp-Session-Id,Mcp-Protocol-Version',
     ),
   corsExposeHeaders: z
     .string()
@@ -115,7 +115,7 @@ const parseSettings = (): Settings => {
     corsAllowMethods: process.env.CORS_ALLOW_METHODS || 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:
       process.env.CORS_ALLOW_HEADERS ||
-      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Mcp-Target-Url,Mcp-Session-Id,Mcp-Protocol-Version',
+      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Mcp-Target-Url,Mcp-Authorization,Mcp-Session-Id,Mcp-Protocol-Version',
     corsExposeHeaders:
       process.env.CORS_EXPOSE_HEADERS ||
       'mcp-session-id,set-auth-token,ratelimit-limit,ratelimit-remaining,ratelimit-reset,retry-after',

--- a/backend/src/mcp-proxy/routes.test.ts
+++ b/backend/src/mcp-proxy/routes.test.ts
@@ -41,7 +41,8 @@ describe('MCP Proxy Routes', () => {
     corsOriginRegex: null,
     corsAllowCredentials: true,
     corsAllowMethods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
-    corsAllowHeaders: 'Content-Type,Authorization,X-Mcp-Target-Url,Mcp-Session-Id,Mcp-Protocol-Version',
+    corsAllowHeaders:
+      'Content-Type,Authorization,X-Mcp-Target-Url,Mcp-Authorization,Mcp-Session-Id,Mcp-Protocol-Version',
     corsExposeHeaders: 'mcp-session-id,set-auth-token',
     waitlistEnabled: false,
     waitlistAutoApproveDomains: '',
@@ -228,7 +229,7 @@ describe('MCP Proxy Routes', () => {
 
   // --- Header Forwarding ---
 
-  it('forwards Authorization and MCP headers, strips host/cookie/proxy headers', async () => {
+  it('strips Thunderbolt auth and rewrites Mcp-Authorization for remote server', async () => {
     mockFetch.mockImplementation(() => Promise.resolve(createMockResponse('{"ok":true}')))
 
     await app.handle(
@@ -236,7 +237,8 @@ describe('MCP Proxy Routes', () => {
         method: 'POST',
         headers: {
           'x-mcp-target-url': 'https://mcp.example.com',
-          authorization: 'Bearer test-token',
+          authorization: 'Bearer thunderbolt-session-token',
+          'mcp-authorization': 'Bearer mcp-server-api-key',
           'mcp-session-id': 'session-123',
           'content-type': 'application/json',
         },
@@ -245,18 +247,47 @@ describe('MCP Proxy Routes', () => {
     )
 
     const [, callOpts] = mockFetch.mock.calls[0]
-    // Headers may be a Headers instance or plain object depending on the safeFetch path
     const hdrs =
       typeof callOpts.headers?.get === 'function'
         ? Object.fromEntries((callOpts.headers as Headers).entries())
         : callOpts.headers
 
-    expect(hdrs.authorization).toBe('Bearer test-token')
+    // Mcp-Authorization is rewritten to Authorization for the remote server
+    expect(hdrs.authorization).toBe('Bearer mcp-server-api-key')
+    // MCP headers are preserved
     expect(hdrs['mcp-session-id']).toBe('session-123')
-    // host is set by safeFetch for IP pinning (original hostname for TLS SNI)
-    // cookie and x-mcp-target-url are stripped by filterHeaders
+    // Thunderbolt session token must NOT reach the remote server
     expect(hdrs['cookie']).toBeUndefined()
     expect(hdrs['x-mcp-target-url']).toBeUndefined()
+    // Mcp-Authorization is consumed by the proxy, not forwarded as-is
+    expect(hdrs['mcp-authorization']).toBeUndefined()
+  })
+
+  it('strips Thunderbolt auth even when no Mcp-Authorization is provided', async () => {
+    mockFetch.mockImplementation(() => Promise.resolve(createMockResponse('{"ok":true}')))
+
+    await app.handle(
+      new Request('http://localhost/mcp-proxy/', {
+        method: 'POST',
+        headers: {
+          'x-mcp-target-url': 'https://mcp.example.com',
+          authorization: 'Bearer thunderbolt-session-token',
+          'mcp-session-id': 'session-123',
+          'content-type': 'application/json',
+        },
+        body: '{}',
+      }),
+    )
+
+    const [, callOpts] = mockFetch.mock.calls[0]
+    const hdrs =
+      typeof callOpts.headers?.get === 'function'
+        ? Object.fromEntries((callOpts.headers as Headers).entries())
+        : callOpts.headers
+
+    // Thunderbolt session token must NOT reach the remote server
+    expect(hdrs.authorization).toBeUndefined()
+    expect(hdrs['mcp-session-id']).toBe('session-123')
   })
 
   // --- Routing ---

--- a/backend/src/mcp-proxy/routes.ts
+++ b/backend/src/mcp-proxy/routes.ts
@@ -13,7 +13,7 @@ const maxBodyBytes = 10 * 1024 * 1024
 /** Proxy request timeout (30s — MCP operations can be slower than typical API calls). */
 const proxyTimeoutMs = 30_000
 
-/** Headers to strip from proxied MCP requests. Keeps Authorization and MCP headers. */
+/** Headers to strip from proxied MCP requests (mcp-authorization is rewritten to authorization below). */
 const mcpRequestDenylist = [
   'host',
   'connection',
@@ -21,6 +21,8 @@ const mcpRequestDenylist = [
   'upgrade',
   'content-length',
   'cookie',
+  'authorization',
+  'mcp-authorization',
   'x-mcp-target-url',
   /^proxy-/i,
   /^x-forwarded-/i,
@@ -51,6 +53,11 @@ const handleProxy = async (
   const base = targetBaseUrl.replace(/\/+$/, '')
   const url = subPath ? `${base}/${subPath}${queryString}` : `${base}${queryString}`
   const headers = filterHeaders(ctx.headers, mcpRequestDenylist)
+
+  const mcpAuth = ctx.headers['mcp-authorization']
+  if (mcpAuth) {
+    headers['authorization'] = mcpAuth
+  }
 
   // Enforce request body size limit
   const requestContentLength = ctx.headers['content-length']


### PR DESCRIPTION
The MCP proxy was forwarding the user's Authorization header (containing the Thunderbolt session token) to external MCP servers, enabling account takeover. Now the proxy strips Authorization from forwarded headers and rewrites Mcp-Authorization → Authorization so clients can still authenticate to remote MCP servers via a separate header channel.

https://claude.ai/code/session_0168HNE8x3DQ9x3U399L3XwD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes request authentication/header handling in the MCP proxy to prevent leaking user session tokens to external servers; mistakes could break MCP server auth or inadvertently reintroduce token forwarding.
> 
> **Overview**
> **Prevents the MCP proxy from forwarding Thunderbolt user session tokens to external MCP servers.** The proxy now strips incoming `Authorization` and consumes `Mcp-Authorization`, rewriting it into the outbound `Authorization` header only for the remote MCP server.
> 
> CORS defaults/tests are updated to allow the new `Mcp-Authorization` header, and proxy route tests now assert both the rewrite behavior and that Thunderbolt `Authorization` is absent when forwarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141bb9a722c0dbacf0db9b17ba01528fe3d5deb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->