### PR TITLE
chore: add configurable Swagger/OpenAPI documentation via SWAGGER_ENABLED

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -77,6 +77,10 @@ POWERSYNC_JWT_SECRET=powersync-dev-secret-change-in-production
 POWERSYNC_JWT_KID=powersync-dev
 POWERSYNC_TOKEN_EXPIRY_SECONDS=3600
 
+# Swagger / OpenAPI docs
+# Set to true to enable the Swagger UI at /v1/swagger (disabled by default)
+SWAGGER_ENABLED=false
+
 # Rate Limiting
 # Set to false to disable rate limiting entirely
 RATE_LIMIT_ENABLED=true

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,7 +22,7 @@ cp .env.example .env
 
 ### Documentation via Swagger
 
-- API documentation is available at `/v1/swagger` when running the server
+- API documentation is available at `/v1/swagger` when `SWAGGER_ENABLED=true` is set
 - All routes are automatically documented with OpenAPI/Swagger
 - TypeScript provides inline documentation and type checking
 

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -43,6 +43,7 @@ const powersyncSettings: Settings = {
   oidcIssuer: '',
   betterAuthUrl: 'http://localhost:8000',
   rateLimitEnabled: false,
+  swaggerEnabled: false,
   trustedProxy: '',
 }
 

--- a/backend/src/auth/oidc-integration.test.ts
+++ b/backend/src/auth/oidc-integration.test.ts
@@ -62,6 +62,7 @@ const baseSettings: Settings = {
   oidcIssuer: '', // set per-suite once mock server is up
   betterAuthUrl: 'http://localhost:8000',
   rateLimitEnabled: false,
+  swaggerEnabled: false,
   trustedProxy: '',
 }
 

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -58,6 +58,7 @@ describe('Authentication Routes', () => {
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
       rateLimitEnabled: false,
+      swaggerEnabled: false,
       trustedProxy: '',
     })
 

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -393,6 +393,48 @@ describe('Config Settings', () => {
     })
   })
 
+  describe('Swagger settings', () => {
+    let savedEnv: string | undefined
+
+    beforeEach(() => {
+      clearSettingsCache()
+      savedEnv = process.env.SWAGGER_ENABLED
+    })
+
+    afterEach(() => {
+      if (savedEnv !== undefined) {
+        process.env.SWAGGER_ENABLED = savedEnv
+      } else {
+        delete process.env.SWAGGER_ENABLED
+      }
+      clearSettingsCache()
+    })
+
+    it('should default swaggerEnabled to false when env var is unset', () => {
+      delete process.env.SWAGGER_ENABLED
+      const settings = getSettings()
+      expect(settings.swaggerEnabled).toBe(false)
+    })
+
+    it('should enable swagger when SWAGGER_ENABLED is "true"', () => {
+      process.env.SWAGGER_ENABLED = 'true'
+      const settings = getSettings()
+      expect(settings.swaggerEnabled).toBe(true)
+    })
+
+    it('should keep swagger disabled for any value other than "true"', () => {
+      process.env.SWAGGER_ENABLED = 'false'
+      const settings = getSettings()
+      expect(settings.swaggerEnabled).toBe(false)
+    })
+
+    it('should keep swagger disabled when set to empty string', () => {
+      process.env.SWAGGER_ENABLED = ''
+      const settings = getSettings()
+      expect(settings.swaggerEnabled).toBe(false)
+    })
+  })
+
   describe('PowerSync settings', () => {
     const POWERSYNC_ENV_KEYS = [
       'POWERSYNC_URL',

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -66,6 +66,8 @@ const settingsSchema = z.object({
     .string()
     .default('mcp-session-id,set-auth-token,ratelimit-limit,ratelimit-remaining,ratelimit-reset,retry-after'),
 
+  swaggerEnabled: z.boolean().default(false),
+
   // Rate limiting
   rateLimitEnabled: z.boolean().default(true),
 
@@ -119,6 +121,7 @@ const parseSettings = (): Settings => {
     corsExposeHeaders:
       process.env.CORS_EXPOSE_HEADERS ||
       'mcp-session-id,set-auth-token,ratelimit-limit,ratelimit-remaining,ratelimit-reset,retry-after',
+    swaggerEnabled: process.env.SWAGGER_ENABLED === 'true',
     rateLimitEnabled: process.env.RATE_LIMIT_ENABLED !== 'false',
     trustedProxy: (process.env.TRUSTED_PROXY || '').toLowerCase(),
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import { createAccountRoutes } from '@/api/account'
 import { createPowerSyncRoutes } from '@/api/powersync'
 import type { AppDeps } from '@/types'
 import { cors } from '@elysiajs/cors'
+import { swagger } from '@elysiajs/swagger'
 import { Elysia } from 'elysia'
 
 /**
@@ -39,7 +40,6 @@ export const createApp = async (deps?: AppDeps) => {
   })
 
   if (settings.swaggerEnabled) {
-    const { swagger } = await import('@elysiajs/swagger')
     app.use(
       swagger({
         documentation: {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,7 +17,6 @@ import { createAccountRoutes } from '@/api/account'
 import { createPowerSyncRoutes } from '@/api/powersync'
 import type { AppDeps } from '@/types'
 import { cors } from '@elysiajs/cors'
-import { swagger } from '@elysiajs/swagger'
 import { Elysia } from 'elysia'
 
 /**
@@ -40,6 +39,8 @@ export const createApp = async (deps?: AppDeps) => {
   })
 
   if (settings.swaggerEnabled) {
+    // Lazy import to avoid loading swagger and its transitive deps in production
+    const { swagger } = await import('@elysiajs/swagger')
     app.use(
       swagger({
         documentation: {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -38,7 +38,7 @@ export const createApp = async (deps?: AppDeps) => {
     prefix: '/v1',
   })
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (settings.swaggerEnabled) {
     const { swagger } = await import('@elysiajs/swagger')
     app.use(
       swagger({
@@ -139,7 +139,7 @@ const startServer = async () => {
           '🦊 Elysia server started',
         )
 
-        if (process.env.NODE_ENV !== 'production') {
+        if (settings.swaggerEnabled) {
           log.info(
             {
               swaggerUrl: `http://localhost:${settings.port}/v1/swagger`,

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -68,6 +68,7 @@ describe('Link Preview Routes', () => {
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
       rateLimitEnabled: false,
+      swaggerEnabled: false,
       trustedProxy: '',
     })
 

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -76,6 +76,7 @@ describe('Proxy Routes', () => {
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
       rateLimitEnabled: false,
+      swaggerEnabled: false,
       trustedProxy: '',
     })
 

--- a/backend/src/swagger.test.ts
+++ b/backend/src/swagger.test.ts
@@ -1,0 +1,42 @@
+import { clearSettingsCache } from '@/config/settings'
+import { createApp } from '@/index'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+describe('Swagger', () => {
+  let savedSwaggerEnabled: string | undefined
+
+  beforeEach(() => {
+    savedSwaggerEnabled = process.env.SWAGGER_ENABLED
+    clearSettingsCache()
+  })
+
+  afterEach(() => {
+    if (savedSwaggerEnabled !== undefined) {
+      process.env.SWAGGER_ENABLED = savedSwaggerEnabled
+    } else {
+      delete process.env.SWAGGER_ENABLED
+    }
+    clearSettingsCache()
+  })
+
+  it('should NOT expose /v1/swagger when SWAGGER_ENABLED is unset', async () => {
+    delete process.env.SWAGGER_ENABLED
+    const app = await createApp()
+    const res = await app.handle(new Request('http://localhost/v1/swagger'))
+    expect(res.status).toBe(404)
+  })
+
+  it('should expose /v1/swagger when SWAGGER_ENABLED=true', async () => {
+    process.env.SWAGGER_ENABLED = 'true'
+    const app = await createApp()
+    const res = await app.handle(new Request('http://localhost/v1/swagger'))
+    expect(res.status).not.toBe(404)
+  })
+
+  it('should NOT expose /v1/swagger when SWAGGER_ENABLED=false', async () => {
+    process.env.SWAGGER_ENABLED = 'false'
+    const app = await createApp()
+    const res = await app.handle(new Request('http://localhost/v1/swagger'))
+    expect(res.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds a new `SWAGGER_ENABLED` environment variable to control whether the Swagger/OpenAPI documentation is exposed at the `/v1/swagger` endpoint. Previously, Swagger was automatically enabled in non-production environments. Now it's disabled by default and must be explicitly enabled via configuration.

## Key Changes
- **New environment variable**: `SWAGGER_ENABLED` (defaults to `false`) controls Swagger UI availability
- **Updated settings schema**: Added `swaggerEnabled` boolean field to the configuration system with proper parsing of the environment variable
- **Conditional Swagger initialization**: Changed from checking `NODE_ENV !== 'production'` to checking `settings.swaggerEnabled` in both app initialization and server startup logging
- **Comprehensive test coverage**: 
  - Added 4 unit tests in `settings.test.ts` covering default behavior, enabled state, and edge cases
  - Added 3 integration tests in new `swagger.test.ts` verifying the endpoint is properly exposed/hidden based on the setting
- **Documentation updates**: Updated `.env.example` with the new setting and clarified in `README.md` that Swagger requires explicit enablement

## Implementation Details
- The `SWAGGER_ENABLED` environment variable uses strict string matching (`=== 'true'`) to enable Swagger, ensuring any other value (including `'false'`, empty string, or unset) disables it
- Settings cache is properly cleared in tests to ensure environment variable changes are reflected
- The change provides better security by default (Swagger disabled) while maintaining flexibility for development and documentation purposes

https://claude.ai/code/session_01UURwaH7B89qT6cNjnquj3w

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change that only affects whether the Swagger endpoint is registered and logged; primary risk is developers unexpectedly losing `/v1/swagger` until the new env var is set.
> 
> **Overview**
> **Swagger/OpenAPI docs are now opt-in.** The backend adds a `SWAGGER_ENABLED` setting (default `false`) and switches Swagger registration and startup logging from `NODE_ENV !== 'production'` to `settings.swaggerEnabled`, with a lazy import of `@elysiajs/swagger` only when enabled.
> 
> Docs/config are updated (`.env.example`, README), tests are updated to include `swaggerEnabled` in mocked settings, and new unit/integration tests verify env parsing and that `/v1/swagger` returns `404` unless `SWAGGER_ENABLED=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68be80c15fd687b2c65ded9dbaf4a8338fc87b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->