### PR TITLE
chore(security): signature requirement for bearer token authentication

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -50,6 +50,8 @@ OIDC_CLIENT_SECRET=
 OIDC_ISSUER=
 # The backend's public URL used for OIDC redirect URIs (must match what's registered with your OIDC provider)
 BETTER_AUTH_URL=http://localhost:8000
+# Required — used to sign bearer tokens and session cookies. Generate with: openssl rand -base64 32
+BETTER_AUTH_SECRET=
 
 # CORS settings — comma-separated list of exact origins (no wildcards)
 # For preview deploys, append RENDER_EXTERNAL_URL in your start script

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -8,9 +8,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { Elysia } from 'elysia'
 import { createAccountRoutes } from './account'
 
-const BETTER_AUTH_SECRET = 'better-auth-secret-12345678901234567890'
+const betterAuthSecret = 'better-auth-secret-12345678901234567890'
 const signToken = (token: string): string => {
-  const sig = createHmac('sha256', BETTER_AUTH_SECRET).update(token).digest('base64')
+  const sig = createHmac('sha256', betterAuthSecret).update(token).digest('base64')
   return `${token}.${sig}`
 }
 

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -2,10 +2,17 @@ import { createAuth } from '@/auth/auth'
 import { user } from '@/db/auth-schema'
 import { chatThreadsTable, devicesTable, settingsTable, tasksTable } from '@/db/schema'
 import { createTestDb } from '@/test-utils/db'
+import { createHmac } from 'crypto'
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { Elysia } from 'elysia'
 import { createAccountRoutes } from './account'
+
+const BETTER_AUTH_SECRET = 'better-auth-secret-12345678901234567890'
+const signToken = (token: string): string => {
+  const sig = createHmac('sha256', BETTER_AUTH_SECRET).update(token).digest('base64')
+  return `${token}.${sig}`
+}
 
 describe('Account API', () => {
   let app: ReturnType<typeof createAccountRoutes>
@@ -79,7 +86,7 @@ describe('Account API', () => {
       const response = await app.handle(
         new Request('http://localhost/v1/account', {
           method: 'DELETE',
-          headers: { Authorization: 'Bearer bearer-token-full-delete' },
+          headers: { Authorization: `Bearer ${signToken('bearer-token-full-delete')}` },
         }),
       )
 
@@ -142,7 +149,7 @@ describe('Account API', () => {
       const response = await app.handle(
         new Request('http://localhost/v1/account', {
           method: 'DELETE',
-          headers: { Authorization: 'Bearer bearer-token-cascade-delete' },
+          headers: { Authorization: `Bearer ${signToken('bearer-token-cascade-delete')}` },
         }),
       )
 

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -10,11 +10,11 @@ import { Elysia } from 'elysia'
 import { createPowerSyncRoutes } from './powersync'
 
 /** Better Auth uses this default secret in test environments */
-const BETTER_AUTH_SECRET = 'better-auth-secret-12345678901234567890'
+const betterAuthSecret = 'better-auth-secret-12345678901234567890'
 
 /** Sign a raw session token for use in `Authorization: Bearer <signed>` headers (standard base64 to match getSignedCookie expectations) */
 const signToken = (token: string): string => {
-  const sig = createHmac('sha256', BETTER_AUTH_SECRET).update(token).digest('base64')
+  const sig = createHmac('sha256', betterAuthSecret).update(token).digest('base64')
   return `${token}.${sig}`
 }
 

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -51,6 +51,7 @@ const powersyncSettings: Settings = {
   oidcClientSecret: '',
   oidcIssuer: '',
   betterAuthUrl: 'http://localhost:8000',
+  betterAuthSecret,
   rateLimitEnabled: false,
   swaggerEnabled: false,
   trustedProxy: '',
@@ -96,6 +97,41 @@ describe('PowerSync API', () => {
       expect(response.status).toBe(401)
       const data = await response.json()
       expect(data).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 401 when Bearer token is unsigned (requireSignature enforcement)', async () => {
+      const userId = 'user-unsigned-bearer'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(userTable).values({
+        id: userId,
+        name: 'Unsigned Bearer User',
+        email: 'unsigned-bearer@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: 'session-unsigned-bearer',
+        expiresAt,
+        token: 'bearer-unsigned-valid',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      // Token exists in DB but is sent unsigned — must be rejected
+      const response = await app.handle(
+        new Request('http://localhost/powersync/token', {
+          headers: {
+            Authorization: 'Bearer bearer-unsigned-valid',
+            'x-device-id': 'some-device',
+          },
+        }),
+      )
+      expect(response.status).toBe(401)
     })
 
     it('returns 403 when device is revoked', async () => {

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -3,10 +3,20 @@ import { createBetterAuthPlugin } from '@/auth/elysia-plugin'
 import { session as sessionTable, user as userTable } from '@/db/auth-schema'
 import { devicesTable, mcpServersTable, modelsTable, promptsTable, settingsTable } from '@/db/schema'
 import { createTestDb } from '@/test-utils/db'
+import { createHmac } from 'crypto'
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { Elysia } from 'elysia'
 import { createPowerSyncRoutes } from './powersync'
+
+/** Better Auth uses this default secret in test environments */
+const BETTER_AUTH_SECRET = 'better-auth-secret-12345678901234567890'
+
+/** Sign a raw session token for use in `Authorization: Bearer <signed>` headers (standard base64 to match getSignedCookie expectations) */
+const signToken = (token: string): string => {
+  const sig = createHmac('sha256', BETTER_AUTH_SECRET).update(token).digest('base64')
+  return `${token}.${sig}`
+}
 
 const powersyncSettings: Settings = {
   fireworksApiKey: '',
@@ -65,7 +75,7 @@ describe('PowerSync API', () => {
 
   const uploadHeaders = (bearer: string, deviceId = 'test-device-id') => ({
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${bearer}`,
+    Authorization: `Bearer ${signToken(bearer)}`,
     'X-Device-ID': deviceId,
   })
 
@@ -80,7 +90,7 @@ describe('PowerSync API', () => {
     it('returns 401 when Bearer token does not match any session', async () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
-          headers: { Authorization: 'Bearer invalid-token' },
+          headers: { Authorization: `Bearer ${signToken('invalid-token')}` },
         }),
       )
       expect(response.status).toBe(401)
@@ -124,7 +134,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-revoked-device',
+            Authorization: `Bearer ${signToken('bearer-revoked-device')}`,
             'x-device-id': 'revoked-device-id',
           },
         }),
@@ -166,7 +176,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-user-b',
+            Authorization: `Bearer ${signToken('bearer-user-b')}`,
             'x-device-id': sharedDeviceId,
           },
         }),
@@ -201,7 +211,7 @@ describe('PowerSync API', () => {
 
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
-          headers: { Authorization: 'Bearer bearer-no-device-id' },
+          headers: { Authorization: `Bearer ${signToken('bearer-no-device-id')}` },
         }),
       )
       expect(response.status).toBe(400)
@@ -235,7 +245,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-empty-device-id',
+            Authorization: `Bearer ${signToken('bearer-empty-device-id')}`,
             'x-device-id': '   ',
           },
         }),
@@ -280,7 +290,7 @@ describe('PowerSync API', () => {
 
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
-          headers: { Authorization: 'Bearer bearer-revoked-bypass' },
+          headers: { Authorization: `Bearer ${signToken('bearer-revoked-bypass')}` },
         }),
       )
       expect(response.status).toBe(400)
@@ -314,7 +324,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-powersync-valid',
+            Authorization: `Bearer ${signToken('bearer-powersync-valid')}`,
             'x-device-id': 'device-session-token',
           },
         }),
@@ -353,7 +363,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-device-upsert',
+            Authorization: `Bearer ${signToken('bearer-device-upsert')}`,
             'x-device-id': 'device-123',
             'x-device-name': 'My Phone',
           },
@@ -393,7 +403,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-device-no-name',
+            Authorization: `Bearer ${signToken('bearer-device-no-name')}`,
             'x-device-id': 'device-empty-name',
             'x-device-name': '',
           },
@@ -433,7 +443,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-device-long-name',
+            Authorization: `Bearer ${signToken('bearer-device-long-name')}`,
             'x-device-id': 'device-long-name',
             'x-device-name': longName,
           },
@@ -473,7 +483,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-device-100-char',
+            Authorization: `Bearer ${signToken('bearer-device-100-char')}`,
             'x-device-id': 'device-100-char',
             'x-device-name': name100,
           },
@@ -512,7 +522,7 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-device-1-char',
+            Authorization: `Bearer ${signToken('bearer-device-1-char')}`,
             'x-device-id': 'device-1-char',
             'x-device-name': 'X',
           },
@@ -568,7 +578,7 @@ describe('PowerSync API', () => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-upload-no-device',
+            Authorization: `Bearer ${signToken('bearer-upload-no-device')}`,
           },
           body: JSON.stringify({ operations: [] }),
         }),
@@ -1624,7 +1634,7 @@ describe('PowerSync cross-origin injection protection', () => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-cors-upload',
+            Authorization: `Bearer ${signToken('bearer-cors-upload')}`,
             'X-Device-ID': 'cors-test-device',
             Origin: 'http://localhost:9999',
           },
@@ -1651,7 +1661,7 @@ describe('PowerSync cross-origin injection protection', () => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-model-inject',
+            Authorization: `Bearer ${signToken('bearer-model-inject')}`,
             'X-Device-ID': 'attacker-device',
             Origin: 'http://localhost:9999',
           },
@@ -1687,7 +1697,7 @@ describe('PowerSync cross-origin injection protection', () => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-mcp-inject',
+            Authorization: `Bearer ${signToken('bearer-mcp-inject')}`,
             'X-Device-ID': 'attacker-device',
             Origin: 'http://localhost:9999',
           },
@@ -1721,7 +1731,7 @@ describe('PowerSync cross-origin injection protection', () => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-legit-origin',
+            Authorization: `Bearer ${signToken('bearer-legit-origin')}`,
             'X-Device-ID': 'legit-device',
             Origin: 'http://localhost:1420',
           },
@@ -1744,7 +1754,7 @@ describe('PowerSync cross-origin injection protection', () => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-tauri-origin',
+            Authorization: `Bearer ${signToken('bearer-tauri-origin')}`,
             'X-Device-ID': 'tauri-device',
             Origin: 'tauri://localhost',
           },
@@ -1763,7 +1773,7 @@ describe('PowerSync cross-origin injection protection', () => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-no-origin',
+            Authorization: `Bearer ${signToken('bearer-no-origin')}`,
             'X-Device-ID': 'server-device',
           },
           body: JSON.stringify({
@@ -1781,7 +1791,7 @@ describe('PowerSync cross-origin injection protection', () => {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-ext-attacker',
+            Authorization: `Bearer ${signToken('bearer-ext-attacker')}`,
             'X-Device-ID': 'attacker-device',
             Origin: 'https://attacker.com',
           },
@@ -1802,7 +1812,7 @@ describe('PowerSync cross-origin injection protection', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-cors-token',
+            Authorization: `Bearer ${signToken('bearer-cors-token')}`,
             'X-Device-ID': 'cors-token-device',
             Origin: 'http://localhost:9999',
           },
@@ -1818,7 +1828,7 @@ describe('PowerSync cross-origin injection protection', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-legit-token',
+            Authorization: `Bearer ${signToken('bearer-legit-token')}`,
             'X-Device-ID': 'legit-token-device',
             Origin: 'http://localhost:1420',
           },
@@ -1832,7 +1842,7 @@ describe('PowerSync cross-origin injection protection', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-no-origin-token',
+            Authorization: `Bearer ${signToken('bearer-no-origin-token')}`,
             'X-Device-ID': 'no-origin-device',
           },
         }),

--- a/backend/src/api/powersync.ts
+++ b/backend/src/api/powersync.ts
@@ -3,6 +3,7 @@ import type { Settings } from '@/config/settings'
 import { isOriginAllowed } from '@/config/settings'
 import { applyOperation, getActiveSessionByToken, getDeviceById, getUserById, upsertDevice } from '@/dal'
 import type { db as DbType } from '@/db/client'
+import { verifySignedBearerToken } from '@/auth/bearer-token'
 import { jwt } from '@elysiajs/jwt'
 import { Elysia, t } from 'elysia'
 
@@ -152,6 +153,9 @@ export const createPowerSyncRoutes = (auth: Auth, settings: Settings, database: 
       }
 
       // Path 2: No session; Bearer token only. Resolve session -> user; 410 if user deleted (e.g. account deleted elsewhere).
+      // The bearer plugin requires signed tokens (requireSignature: true), so we must verify
+      // the signature here too — otherwise an attacker with a raw session token can bypass
+      // signature verification by hitting Path 2 directly.
       const authHeader = request.headers.get('authorization')
       const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : null
       if (!bearerToken) {
@@ -159,7 +163,13 @@ export const createPowerSyncRoutes = (auth: Auth, settings: Settings, database: 
         return { error: 'Unauthorized' }
       }
 
-      const sessionRow = await getActiveSessionByToken(database, bearerToken)
+      const rawToken = verifySignedBearerToken(bearerToken, settings.betterAuthSecret)
+      if (!rawToken) {
+        set.status = 401
+        return { error: 'Unauthorized' }
+      }
+
+      const sessionRow = await getActiveSessionByToken(database, rawToken)
       if (!sessionRow) {
         set.status = 401
         return { error: 'Unauthorized' }

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -132,7 +132,7 @@ export const createAuth = (database: typeof DbType) => {
       }),
     },
     plugins: [
-      bearer(), // Enables Authorization: Bearer <token> for mobile apps where cookies don't work
+      bearer({ requireSignature: true }), // Enables Authorization: Bearer <token> for mobile apps where cookies don't work
       emailOTP({
         otpLength: 6,
         expiresIn: 300, // 5 minutes

--- a/backend/src/auth/bearer-token.test.ts
+++ b/backend/src/auth/bearer-token.test.ts
@@ -1,0 +1,47 @@
+import { createHmac } from 'crypto'
+import { describe, expect, it } from 'bun:test'
+import { verifySignedBearerToken } from './bearer-token'
+
+const secret = 'test-secret-at-least-32-chars-long!!'
+
+const sign = (token: string, s = secret): string => {
+  const sig = createHmac('sha256', s).update(token).digest('base64')
+  return `${token}.${sig}`
+}
+
+describe('verifySignedBearerToken', () => {
+  it('returns raw token for a valid signed token', () => {
+    expect(verifySignedBearerToken(sign('my-session-token'), secret)).toBe('my-session-token')
+  })
+
+  it('returns null when signed with wrong secret', () => {
+    const signed = sign('my-session-token', 'wrong-secret-at-least-32-chars-long!!')
+    expect(verifySignedBearerToken(signed, secret)).toBeNull()
+  })
+
+  it('returns null when token has no dot', () => {
+    expect(verifySignedBearerToken('no-dot-token', secret)).toBeNull()
+  })
+
+  it('returns null for empty signature (token.)', () => {
+    expect(verifySignedBearerToken('my-token.', secret)).toBeNull()
+  })
+
+  it('returns null for signature with incorrect length', () => {
+    expect(verifySignedBearerToken('my-token.dG9vc2hvcnQ', secret)).toBeNull()
+  })
+
+  it('returns null for dot-only input', () => {
+    expect(verifySignedBearerToken('.', secret)).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(verifySignedBearerToken('', secret)).toBeNull()
+  })
+
+  it('handles token that itself contains dots', () => {
+    const token = 'part1.part2.part3'
+    const signed = sign(token)
+    expect(verifySignedBearerToken(signed, secret)).toBe(token)
+  })
+})

--- a/backend/src/auth/bearer-token.ts
+++ b/backend/src/auth/bearer-token.ts
@@ -1,0 +1,18 @@
+import { createHmac } from 'crypto'
+
+/**
+ * Verify a signed bearer token (format: `rawToken.base64Signature`) and return the raw session token.
+ * Returns null if the token is unsigned, malformed, or the signature doesn't match.
+ */
+export const verifySignedBearerToken = (bearerValue: string, secret: string): string | null => {
+  const dotIndex = bearerValue.lastIndexOf('.')
+  if (dotIndex < 1) return null
+
+  const rawToken = bearerValue.substring(0, dotIndex)
+  const signature = bearerValue.substring(dotIndex + 1)
+
+  const expected = createHmac('sha256', secret).update(rawToken).digest('base64')
+  if (signature !== expected) return null
+
+  return rawToken
+}

--- a/backend/src/auth/bearer-token.ts
+++ b/backend/src/auth/bearer-token.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto'
+import { createHmac, timingSafeEqual } from 'crypto'
 
 /**
  * Verify a signed bearer token (format: `rawToken.base64Signature`) and return the raw session token.
@@ -12,7 +12,9 @@ export const verifySignedBearerToken = (bearerValue: string, secret: string): st
   const signature = bearerValue.substring(dotIndex + 1)
 
   const expected = createHmac('sha256', secret).update(rawToken).digest('base64')
-  if (signature !== expected) return null
+  const sigBuf = Buffer.from(signature)
+  const expBuf = Buffer.from(expected)
+  if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) return null
 
   return rawToken
 }

--- a/backend/src/auth/oidc-integration.test.ts
+++ b/backend/src/auth/oidc-integration.test.ts
@@ -60,7 +60,7 @@ const baseSettings: Settings = {
   oidcClientSecret: 'thunderbolt-dev-secret',
   oidcIssuer: '', // set per-suite once mock server is up
   betterAuthUrl: 'http://localhost:8000',
-  betterAuthSecret: '',
+  betterAuthSecret: 'test-secret-at-least-32-chars-long!!',
   rateLimitEnabled: false,
   swaggerEnabled: false,
   trustedProxy: '',

--- a/backend/src/auth/oidc-integration.test.ts
+++ b/backend/src/auth/oidc-integration.test.ts
@@ -60,6 +60,7 @@ const baseSettings: Settings = {
   oidcClientSecret: 'thunderbolt-dev-secret',
   oidcIssuer: '', // set per-suite once mock server is up
   betterAuthUrl: 'http://localhost:8000',
+  betterAuthSecret: '',
   rateLimitEnabled: false,
   swaggerEnabled: false,
   trustedProxy: '',

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -56,6 +56,7 @@ describe('Authentication Routes', () => {
       oidcClientSecret: '',
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
+      betterAuthSecret: '',
       rateLimitEnabled: false,
       swaggerEnabled: false,
       trustedProxy: '',

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -56,7 +56,7 @@ describe('Authentication Routes', () => {
       oidcClientSecret: '',
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
-      betterAuthSecret: '',
+      betterAuthSecret: 'test-secret-at-least-32-chars-long!!',
       rateLimitEnabled: false,
       swaggerEnabled: false,
       trustedProxy: '',

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -95,7 +95,7 @@ const parseSettings = (): Settings => {
     oidcClientSecret: process.env.OIDC_CLIENT_SECRET || '',
     oidcIssuer: process.env.OIDC_ISSUER || '',
     betterAuthUrl: process.env.BETTER_AUTH_URL || 'http://localhost:8000',
-    betterAuthSecret: process.env.BETTER_AUTH_SECRET || process.env.AUTH_SECRET,
+    betterAuthSecret: process.env.BETTER_AUTH_SECRET,
     logLevel: (process.env.LOG_LEVEL || 'INFO').toUpperCase(),
     port: process.env.PORT || '8000',
     appUrl: process.env.APP_URL || 'http://localhost:1420',

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -27,6 +27,7 @@ const settingsSchema = z.object({
   oidcClientSecret: z.string().default(''),
   oidcIssuer: z.string().default(''),
   betterAuthUrl: z.string().default('http://localhost:8000'),
+  betterAuthSecret: z.string().default('better-auth-secret-12345678901234567890'),
 
   // General settings
   logLevel: z.enum(['DEBUG', 'INFO', 'WARN', 'ERROR']).default('INFO'),
@@ -94,6 +95,7 @@ const parseSettings = (): Settings => {
     oidcClientSecret: process.env.OIDC_CLIENT_SECRET || '',
     oidcIssuer: process.env.OIDC_ISSUER || '',
     betterAuthUrl: process.env.BETTER_AUTH_URL || 'http://localhost:8000',
+    betterAuthSecret: process.env.BETTER_AUTH_SECRET || process.env.AUTH_SECRET || '',
     logLevel: (process.env.LOG_LEVEL || 'INFO').toUpperCase(),
     port: process.env.PORT || '8000',
     appUrl: process.env.APP_URL || 'http://localhost:1420',

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -27,7 +27,7 @@ const settingsSchema = z.object({
   oidcClientSecret: z.string().default(''),
   oidcIssuer: z.string().default(''),
   betterAuthUrl: z.string().default('http://localhost:8000'),
-  betterAuthSecret: z.string().default('better-auth-secret-12345678901234567890'),
+  betterAuthSecret: z.string().min(1),
 
   // General settings
   logLevel: z.enum(['DEBUG', 'INFO', 'WARN', 'ERROR']).default('INFO'),
@@ -95,7 +95,7 @@ const parseSettings = (): Settings => {
     oidcClientSecret: process.env.OIDC_CLIENT_SECRET || '',
     oidcIssuer: process.env.OIDC_ISSUER || '',
     betterAuthUrl: process.env.BETTER_AUTH_URL || 'http://localhost:8000',
-    betterAuthSecret: process.env.BETTER_AUTH_SECRET || process.env.AUTH_SECRET || '',
+    betterAuthSecret: process.env.BETTER_AUTH_SECRET || process.env.AUTH_SECRET,
     logLevel: (process.env.LOG_LEVEL || 'INFO').toUpperCase(),
     port: process.env.PORT || '8000',
     appUrl: process.env.APP_URL || 'http://localhost:1420',

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -66,7 +66,7 @@ describe('Link Preview Routes', () => {
       oidcClientSecret: '',
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
-      betterAuthSecret: '',
+      betterAuthSecret: 'test-secret-at-least-32-chars-long!!',
       rateLimitEnabled: false,
       swaggerEnabled: false,
       trustedProxy: '',

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -66,6 +66,7 @@ describe('Link Preview Routes', () => {
       oidcClientSecret: '',
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
+      betterAuthSecret: '',
       rateLimitEnabled: false,
       swaggerEnabled: false,
       trustedProxy: '',

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -74,6 +74,7 @@ describe('Proxy Routes', () => {
       oidcClientSecret: '',
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
+      betterAuthSecret: '',
       rateLimitEnabled: false,
       swaggerEnabled: false,
       trustedProxy: '',

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -74,7 +74,7 @@ describe('Proxy Routes', () => {
       oidcClientSecret: '',
       oidcIssuer: '',
       betterAuthUrl: 'http://localhost:8000',
-      betterAuthSecret: '',
+      betterAuthSecret: 'test-secret-at-least-32-chars-long!!',
       rateLimitEnabled: false,
       swaggerEnabled: false,
       trustedProxy: '',

--- a/backend/src/test-utils/test-setup.ts
+++ b/backend/src/test-utils/test-setup.ts
@@ -10,6 +10,9 @@ import { testDbManager } from './db'
 // queries that bypass PGlite transaction isolation, which breaks test cleanup
 process.env.RATE_LIMIT_ENABLED = 'false'
 
+// Provide Better Auth secret for tests (matches Better Auth's built-in test default)
+process.env.BETTER_AUTH_SECRET ??= 'better-auth-secret-12345678901234567890'
+
 // Initialize the database before any tests run
 console.log('🔧 Initializing test database...')
 await testDbManager.initialize()

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -17,6 +17,9 @@ POWERSYNC_PORT=8081
 # General settings
 LOG_LEVEL=INFO
 
+# Required — used to sign bearer tokens and session cookies. Generate with: openssl rand -base64 32
+BETTER_AUTH_SECRET=
+
 # Health Check Configuration
 MONITORING_TOKEN=
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       OIDC_CLIENT_ID: thunderbolt-app
       OIDC_CLIENT_SECRET: thunderbolt-enterprise-secret
       BETTER_AUTH_URL: http://localhost:${FRONTEND_PORT:-3000}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in .env}
       APP_URL: http://localhost:${FRONTEND_PORT:-3000}
       TRUSTED_ORIGINS: http://localhost:${FRONTEND_PORT:-3000}
       CORS_ORIGINS: http://localhost:${FRONTEND_PORT:-3000}

--- a/deploy/pulumi/src/services.ts
+++ b/deploy/pulumi/src/services.ts
@@ -242,6 +242,10 @@ export const createServices = (args: ServiceArgs) => {
   })
 
   // --- Backend ---
+  if (!process.env.BETTER_AUTH_SECRET) {
+    throw new Error('BETTER_AUTH_SECRET must be set before deploying the backend')
+  }
+
   const beTaskDef = new aws.ecs.TaskDefinition(`${name}-be-task`, {
     family: `${name}-backend`,
     requiresCompatibilities: ['FARGATE'],
@@ -267,7 +271,7 @@ export const createServices = (args: ServiceArgs) => {
             { name: 'OIDC_CLIENT_ID', value: 'thunderbolt-app' },
             { name: 'OIDC_CLIENT_SECRET', value: 'thunderbolt-enterprise-secret' },
             { name: 'BETTER_AUTH_URL', value: `http://${dns}` },
-            { name: 'BETTER_AUTH_SECRET', value: process.env.BETTER_AUTH_SECRET ?? '' },
+            { name: 'BETTER_AUTH_SECRET', value: process.env.BETTER_AUTH_SECRET },
             { name: 'APP_URL', value: `http://${dns}` },
             { name: 'TRUSTED_ORIGINS', value: `http://${dns}` },
             { name: 'CORS_ORIGINS', value: `http://${dns}` },

--- a/deploy/pulumi/src/services.ts
+++ b/deploy/pulumi/src/services.ts
@@ -267,6 +267,7 @@ export const createServices = (args: ServiceArgs) => {
             { name: 'OIDC_CLIENT_ID', value: 'thunderbolt-app' },
             { name: 'OIDC_CLIENT_SECRET', value: 'thunderbolt-enterprise-secret' },
             { name: 'BETTER_AUTH_URL', value: `http://${dns}` },
+            { name: 'BETTER_AUTH_SECRET', value: process.env.BETTER_AUTH_SECRET ?? '' },
             { name: 'APP_URL', value: `http://${dns}` },
             { name: 'TRUSTED_ORIGINS', value: `http://${dns}` },
             { name: 'CORS_ORIGINS', value: `http://${dns}` },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
         OIDC_CLIENT_SECRET: 'thunderbolt-dev-secret',
         OIDC_ISSUER: `http://localhost:${mockOidcPort}`,
         BETTER_AUTH_URL: 'http://localhost:8000',
+        BETTER_AUTH_SECRET: 'e2e-test-secret-at-least-32-characters-long',
         APP_URL: `http://localhost:${e2eVitePort}`,
         CORS_ORIGINS: `http://localhost:${e2eVitePort}`,
         TRUSTED_ORIGINS: `http://localhost:${e2eVitePort}`,


### PR DESCRIPTION
## Summary
Enhanced security for bearer token authentication by requiring signature validation on all bearer token requests.

## Key Changes
- Modified the `bearer()` plugin configuration to enforce signature verification by setting `requireSignature: true`
- This applies to all Authorization: Bearer token requests used by mobile apps and other clients that cannot use cookie-based authentication

## Implementation Details
The change ensures that bearer tokens must include a valid signature, adding an additional layer of security to prevent token tampering or unauthorized token usage. This is particularly important for mobile applications where cookies are not available as an alternative authentication mechanism.

https://claude.ai/code/session_0149qSx48ChhRSufEiXmAALR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication behavior by requiring HMAC-signed `Authorization: Bearer` tokens and adds server-side signature validation in PowerSync’s bearer-only flow, which is security-critical and could break existing clients if they don’t sign tokens or if secrets are misconfigured.
> 
> **Overview**
> **Bearer-token authentication now requires a signature.** The Better Auth `bearer()` plugin is configured with `requireSignature: true`, and a new `verifySignedBearerToken` helper validates `rawToken.base64Hmac` values using `BETTER_AUTH_SECRET`.
> 
> **PowerSync’s bearer-only token refresh path is hardened** to verify the bearer signature before looking up sessions, preventing signature-bypass when no cookie session is present.
> 
> **Configuration and tests are updated** to require `BETTER_AUTH_SECRET` (settings schema + `.env` examples, docker-compose, Pulumi deploy guardrails, Playwright env), and unit/API tests now sign bearer tokens and include coverage for rejecting unsigned tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d59d310e008a3b5534fffba5ce6450ae0fff0aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->