### PR TITLE
fix(security): bind sessions to devices, add device limit, harden revocation

### DIFF
--- a/backend/drizzle/0012_furry_thor_girl.sql
+++ b/backend/drizzle/0012_furry_thor_girl.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session" ADD COLUMN "device_id" text;--> statement-breakpoint
+CREATE INDEX "session_deviceId_idx" ON "session" USING btree ("device_id");

--- a/backend/drizzle/meta/0012_snapshot.json
+++ b/backend/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1993 @@
+{
+  "id": "5801d64a-0298-464d-b220-736beb9ff7e9",
+  "prevId": "e5981b74-06e8-4d82-be22-dad6e6d8028f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_deviceId_idx": {
+          "name": "session_deviceId_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_batch_id_idx": {
+          "name": "waitlist_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.chat_messages": {
+      "name": "chat_messages",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache": {
+          "name": "cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_user_id": {
+          "name": "idx_chat_messages_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_user_id_user_id_fk": {
+          "name": "chat_messages_user_id_user_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.chat_threads": {
+      "name": "chat_threads",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_triggered_by_automation": {
+          "name": "was_triggered_by_automation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_id": {
+          "name": "idx_chat_threads_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_user_id_user_id_fk": {
+          "name": "chat_threads_user_id_user_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.devices": {
+      "name": "devices",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trusted": {
+          "name": "trusted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approval_pending": {
+          "name": "approval_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mlkem_public_key": {
+          "name": "mlkem_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_devices_user_id": {
+          "name": "idx_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_servers_user_id": {
+          "name": "idx_mcp_servers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_user_id_user_id_fk": {
+          "name": "mcp_servers_user_id_user_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.model_profiles": {
+      "name": "model_profiles",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_threshold": {
+          "name": "nudge_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_system_message_mode_developer": {
+          "name": "use_system_message_mode_developer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tools_override": {
+          "name": "tools_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_previews_override": {
+          "name": "link_previews_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_mode_addendum": {
+          "name": "chat_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_mode_addendum": {
+          "name": "search_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "research_mode_addendum": {
+          "name": "research_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citation_reinforcement_enabled": {
+          "name": "citation_reinforcement_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "citation_reinforcement_prompt": {
+          "name": "citation_reinforcement_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_final_step": {
+          "name": "nudge_final_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_preventive": {
+          "name": "nudge_preventive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_retry": {
+          "name": "nudge_retry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_final_step": {
+          "name": "nudge_search_final_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_preventive": {
+          "name": "nudge_search_preventive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_retry": {
+          "name": "nudge_search_retry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_model_profiles_user_id": {
+          "name": "idx_model_profiles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_profiles_user_id_user_id_fk": {
+          "name": "model_profiles_user_id_user_id_fk",
+          "tableFrom": "model_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "model_profiles_id_user_id_pk": {
+          "name": "model_profiles_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.models": {
+      "name": "models",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "tool_usage": {
+          "name": "tool_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_confidential": {
+          "name": "is_confidential",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "start_with_reasoning": {
+          "name": "start_with_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "supports_parallel_tool_calls": {
+          "name": "supports_parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_models_user_id": {
+          "name": "idx_models_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "models_user_id_user_id_fk": {
+          "name": "models_user_id_user_id_fk",
+          "tableFrom": "models",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "models_id_user_id_pk": {
+          "name": "models_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.modes": {
+      "name": "modes",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_modes_user_id": {
+          "name": "idx_modes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "modes_user_id_user_id_fk": {
+          "name": "modes_user_id_user_id_fk",
+          "tableFrom": "modes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "modes_id_user_id_pk": {
+          "name": "modes_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.prompts": {
+      "name": "prompts",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prompts_user_id": {
+          "name": "idx_prompts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prompts_user_id_user_id_fk": {
+          "name": "prompts_user_id_user_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompts_id_user_id_pk": {
+          "name": "prompts_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.settings": {
+      "name": "settings",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_settings_user_id": {
+          "name": "idx_settings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "settings_user_id_user_id_fk": {
+          "name": "settings_user_id_user_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_id_user_id_pk": {
+          "name": "settings_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.tasks": {
+      "name": "tasks",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tasks_user_id": {
+          "name": "idx_tasks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_user_id_user_id_fk": {
+          "name": "tasks_user_id_user_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tasks_id_user_id_pk": {
+          "name": "tasks_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.triggers": {
+      "name": "triggers",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_time": {
+          "name": "trigger_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_triggers_user_id": {
+          "name": "idx_triggers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triggers_user_id_user_id_fk": {
+          "name": "triggers_user_id_user_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expire_idx": {
+          "name": "rate_limits_expire_idx",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encryption_metadata": {
+      "name": "encryption_metadata",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canary_iv": {
+          "name": "canary_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_ctext": {
+          "name": "canary_ctext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_secret_hash": {
+          "name": "canary_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encryption_metadata_user_id_user_id_fk": {
+          "name": "encryption_metadata_user_id_user_id_fk",
+          "tableFrom": "encryption_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.envelopes": {
+      "name": "envelopes",
+      "schema": "",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_ck": {
+          "name": "wrapped_ck",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_envelopes_user_id": {
+          "name": "idx_envelopes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "envelopes_device_id_devices_id_fk": {
+          "name": "envelopes_device_id_devices_id_fk",
+          "tableFrom": "envelopes",
+          "tableTo": "devices",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "envelopes_user_id_user_id_fk": {
+          "name": "envelopes_user_id_user_id_fk",
+          "tableFrom": "envelopes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_challenge": {
+      "name": "otp_challenge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_token": {
+          "name": "challenge_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "otp_challenge_email_unique": {
+          "name": "otp_challenge_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776107649503,
       "tag": "0011_young_thor",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776165528264,
+      "tag": "0012_furry_thor_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -53,214 +53,13 @@ describe('Account API', () => {
     await cleanup()
   })
 
-  describe('POST /v1/account/devices', () => {
-    it('registers a new device', async () => {
-      const userId = 'test-user-register-device'
-      const now = new Date()
-      const expiresAt = new Date(now.getTime() + 3600 * 1000)
-
-      await db.insert(user).values({
-        id: userId,
-        name: 'Register Device User',
-        email: 'register-device@example.com',
-        emailVerified: true,
-        createdAt: now,
-        updatedAt: now,
-      })
-
-      await db.insert(sessionTable).values({
-        id: 'session-register-device',
-        expiresAt,
-        token: 'bearer-register-device',
-        createdAt: now,
-        updatedAt: now,
-        userId,
-      })
-
-      const response = await app.handle(
-        new Request('http://localhost/v1/account/devices', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${signToken('bearer-register-device')}`,
-          },
-          body: JSON.stringify({ id: 'new-device-123', name: 'My Phone' }),
-        }),
-      )
-      expect(response.status).toBe(201)
-
-      const devices = await db.select().from(devicesTable).where(eq(devicesTable.id, 'new-device-123'))
-      expect(devices).toHaveLength(1)
-      expect(devices[0]?.userId).toBe(userId)
-      expect(devices[0]?.name).toBe('My Phone')
-    })
-
-    it('returns 200 when device is already registered for same user', async () => {
-      const userId = 'test-user-device-exists'
-      const now = new Date()
-      const expiresAt = new Date(now.getTime() + 3600 * 1000)
-
-      await db.insert(user).values({
-        id: userId,
-        name: 'Existing Device User',
-        email: 'existing-device@example.com',
-        emailVerified: true,
-        createdAt: now,
-        updatedAt: now,
-      })
-
-      await db.insert(sessionTable).values({
-        id: 'session-existing-device',
-        expiresAt,
-        token: 'bearer-existing-device',
-        createdAt: now,
-        updatedAt: now,
-        userId,
-      })
-
-      await db.insert(devicesTable).values({
-        id: 'existing-device-id',
-        userId,
-        name: 'Existing Device',
-        lastSeen: now,
-        createdAt: now,
-      })
-
-      const response = await app.handle(
-        new Request('http://localhost/v1/account/devices', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${signToken('bearer-existing-device')}`,
-          },
-          body: JSON.stringify({ id: 'existing-device-id' }),
-        }),
-      )
-      expect(response.status).toBe(200)
-    })
-
-    it('returns 409 when device ID belongs to another user', async () => {
-      const userA = 'test-user-device-owner'
-      const userB = 'test-user-device-thief'
-      const now = new Date()
-      const expiresAt = new Date(now.getTime() + 3600 * 1000)
-
-      await db.insert(user).values([
-        {
-          id: userA,
-          name: 'User A',
-          email: 'device-owner@example.com',
-          emailVerified: true,
-          createdAt: now,
-          updatedAt: now,
-        },
-        {
-          id: userB,
-          name: 'User B',
-          email: 'device-thief@example.com',
-          emailVerified: true,
-          createdAt: now,
-          updatedAt: now,
-        },
-      ])
-
-      await db.insert(sessionTable).values({
-        id: 'session-device-thief',
-        expiresAt,
-        token: 'bearer-device-thief',
-        createdAt: now,
-        updatedAt: now,
-        userId: userB,
-      })
-
-      await db.insert(devicesTable).values({
-        id: 'owned-device',
-        userId: userA,
-        name: 'User A Device',
-        lastSeen: now,
-        createdAt: now,
-      })
-
-      const response = await app.handle(
-        new Request('http://localhost/v1/account/devices', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${signToken('bearer-device-thief')}`,
-          },
-          body: JSON.stringify({ id: 'owned-device' }),
-        }),
-      )
-      expect(response.status).toBe(409)
-      const data = await response.json()
-      expect(data).toEqual({ code: 'DEVICE_ID_TAKEN' })
-    })
-
-    it('returns 403 when device ID was revoked', async () => {
-      const userId = 'test-user-revoked-register'
-      const now = new Date()
-      const expiresAt = new Date(now.getTime() + 3600 * 1000)
-
-      await db.insert(user).values({
-        id: userId,
-        name: 'Revoked Register User',
-        email: 'revoked-register@example.com',
-        emailVerified: true,
-        createdAt: now,
-        updatedAt: now,
-      })
-
-      await db.insert(sessionTable).values({
-        id: 'session-revoked-register',
-        expiresAt,
-        token: 'bearer-revoked-register',
-        createdAt: now,
-        updatedAt: now,
-        userId,
-      })
-
-      await db.insert(devicesTable).values({
-        id: 'revoked-device-reg',
-        userId,
-        name: 'Revoked Device',
-        lastSeen: now,
-        createdAt: now,
-        revokedAt: now,
-      })
-
-      const response = await app.handle(
-        new Request('http://localhost/v1/account/devices', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${signToken('bearer-revoked-register')}`,
-          },
-          body: JSON.stringify({ id: 'revoked-device-reg' }),
-        }),
-      )
-      expect(response.status).toBe(403)
-      const data = await response.json()
-      expect(data).toEqual({ code: 'DEVICE_DISCONNECTED' })
-    })
-
-    it('returns 401 when not authenticated', async () => {
-      const response = await app.handle(
-        new Request('http://localhost/v1/account/devices', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: 'some-device' }),
-        }),
-      )
-      expect(response.status).toBe(401)
-    })
-  })
-
   describe('POST /v1/account/devices/:id/revoke', () => {
-    it('invalidates all other sessions when device is revoked', async () => {
+    it('revokes only sessions linked to the revoked device', async () => {
       const userId = p('session-revoke-user')
       const token = p('session-revoke-token')
       const attackerToken = p('session-revoke-attacker-token')
       const deviceId = p('device-to-revoke')
+      const myDeviceId = p('my-device')
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
 
@@ -273,7 +72,7 @@ describe('Account API', () => {
         updatedAt: now,
       })
 
-      // Create two sessions: one for the user revoking, one for the attacker
+      // Create two sessions: one linked to my device, one linked to the compromised device
       const sessionId = p('session-user-revoking')
       const attackerSessionId = p('session-attacker')
       await db.insert(sessionTable).values([
@@ -284,6 +83,7 @@ describe('Account API', () => {
           createdAt: now,
           updatedAt: now,
           userId,
+          deviceId: myDeviceId,
         },
         {
           id: attackerSessionId,
@@ -292,18 +92,28 @@ describe('Account API', () => {
           createdAt: now,
           updatedAt: now,
           userId,
+          deviceId,
         },
       ])
 
-      await db.insert(devicesTable).values({
-        id: deviceId,
-        userId,
-        name: 'Compromised Device',
-        lastSeen: now,
-        createdAt: now,
-      })
+      await db.insert(devicesTable).values([
+        {
+          id: myDeviceId,
+          userId,
+          name: 'My Device',
+          lastSeen: now,
+          createdAt: now,
+        },
+        {
+          id: deviceId,
+          userId,
+          name: 'Compromised Device',
+          lastSeen: now,
+          createdAt: now,
+        },
+      ])
 
-      // Revoke the device from the user's session
+      // Revoke the compromised device
       const response = await app.handle(
         new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
           method: 'POST',
@@ -312,19 +122,20 @@ describe('Account API', () => {
       )
       expect(response.status).toBe(204)
 
-      // The revoking user's session should still exist
+      // My session (linked to my device) should still exist
       const revokingSession = await db.select().from(sessionTable).where(eq(sessionTable.id, sessionId))
       expect(revokingSession).toHaveLength(1)
 
-      // The attacker's session should be deleted
+      // The compromised device's session should be deleted
       const attackerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, attackerSessionId))
       expect(attackerSession).toHaveLength(0)
     })
 
-    it('preserves revoking session even when it is the only session', async () => {
+    it('preserves revoking session when it is on a different device', async () => {
       const userId = p('single-session-user')
       const token = p('single-session-token')
       const sessionId = p('session-only-one')
+      const myDeviceId = p('my-device-single')
       const deviceId = p('device-single-session')
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
@@ -345,6 +156,7 @@ describe('Account API', () => {
         createdAt: now,
         updatedAt: now,
         userId,
+        deviceId: myDeviceId,
       })
 
       await db.insert(devicesTable).values({
@@ -363,7 +175,7 @@ describe('Account API', () => {
       )
       expect(response.status).toBe(204)
 
-      // Session should still exist
+      // Session should still exist (linked to a different device)
       const sessions = await db.select().from(sessionTable).where(eq(sessionTable.id, sessionId))
       expect(sessions).toHaveLength(1)
     })

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -53,6 +53,314 @@ describe('Account API', () => {
     await cleanup()
   })
 
+  describe('POST /v1/account/devices', () => {
+    it('registers a new device', async () => {
+      const userId = 'test-user-register-device'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(user).values({
+        id: userId,
+        name: 'Register Device User',
+        email: 'register-device@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: 'session-register-device',
+        expiresAt,
+        token: 'bearer-register-device',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-register-device',
+          },
+          body: JSON.stringify({ id: 'new-device-123', name: 'My Phone' }),
+        }),
+      )
+      expect(response.status).toBe(201)
+
+      const devices = await db.select().from(devicesTable).where(eq(devicesTable.id, 'new-device-123'))
+      expect(devices).toHaveLength(1)
+      expect(devices[0]?.userId).toBe(userId)
+      expect(devices[0]?.name).toBe('My Phone')
+    })
+
+    it('returns 200 when device is already registered for same user', async () => {
+      const userId = 'test-user-device-exists'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(user).values({
+        id: userId,
+        name: 'Existing Device User',
+        email: 'existing-device@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: 'session-existing-device',
+        expiresAt,
+        token: 'bearer-existing-device',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      await db.insert(devicesTable).values({
+        id: 'existing-device-id',
+        userId,
+        name: 'Existing Device',
+        lastSeen: now,
+        createdAt: now,
+      })
+
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-existing-device',
+          },
+          body: JSON.stringify({ id: 'existing-device-id' }),
+        }),
+      )
+      expect(response.status).toBe(200)
+    })
+
+    it('returns 409 when device ID belongs to another user', async () => {
+      const userA = 'test-user-device-owner'
+      const userB = 'test-user-device-thief'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(user).values([
+        {
+          id: userA,
+          name: 'User A',
+          email: 'device-owner@example.com',
+          emailVerified: true,
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: userB,
+          name: 'User B',
+          email: 'device-thief@example.com',
+          emailVerified: true,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ])
+
+      await db.insert(sessionTable).values({
+        id: 'session-device-thief',
+        expiresAt,
+        token: 'bearer-device-thief',
+        createdAt: now,
+        updatedAt: now,
+        userId: userB,
+      })
+
+      await db.insert(devicesTable).values({
+        id: 'owned-device',
+        userId: userA,
+        name: 'User A Device',
+        lastSeen: now,
+        createdAt: now,
+      })
+
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-device-thief',
+          },
+          body: JSON.stringify({ id: 'owned-device' }),
+        }),
+      )
+      expect(response.status).toBe(409)
+      const data = await response.json()
+      expect(data).toEqual({ code: 'DEVICE_ID_TAKEN' })
+    })
+
+    it('returns 403 when device ID was revoked', async () => {
+      const userId = 'test-user-revoked-register'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(user).values({
+        id: userId,
+        name: 'Revoked Register User',
+        email: 'revoked-register@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: 'session-revoked-register',
+        expiresAt,
+        token: 'bearer-revoked-register',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      await db.insert(devicesTable).values({
+        id: 'revoked-device-reg',
+        userId,
+        name: 'Revoked Device',
+        lastSeen: now,
+        createdAt: now,
+        revokedAt: now,
+      })
+
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer bearer-revoked-register',
+          },
+          body: JSON.stringify({ id: 'revoked-device-reg' }),
+        }),
+      )
+      expect(response.status).toBe(403)
+      const data = await response.json()
+      expect(data).toEqual({ code: 'DEVICE_DISCONNECTED' })
+    })
+
+    it('returns 401 when not authenticated', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: 'some-device' }),
+        }),
+      )
+      expect(response.status).toBe(401)
+    })
+  })
+
+  describe('POST /v1/account/devices/:id/revoke', () => {
+    it('invalidates all other sessions when device is revoked', async () => {
+      const userId = 'test-user-session-revoke'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(user).values({
+        id: userId,
+        name: 'Session Revoke User',
+        email: 'session-revoke@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      // Create two sessions: one for the user revoking, one for the attacker
+      await db.insert(sessionTable).values([
+        {
+          id: 'session-user-revoking',
+          expiresAt,
+          token: 'bearer-user-revoking',
+          createdAt: now,
+          updatedAt: now,
+          userId,
+        },
+        {
+          id: 'session-attacker',
+          expiresAt,
+          token: 'bearer-attacker',
+          createdAt: now,
+          updatedAt: now,
+          userId,
+        },
+      ])
+
+      await db.insert(devicesTable).values({
+        id: 'device-to-revoke',
+        userId,
+        name: 'Compromised Device',
+        lastSeen: now,
+        createdAt: now,
+      })
+
+      // Revoke the device from the user's session
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices/device-to-revoke/revoke', {
+          method: 'POST',
+          headers: { Authorization: 'Bearer bearer-user-revoking' },
+        }),
+      )
+      expect(response.status).toBe(204)
+
+      // The revoking user's session should still exist
+      const revokingSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-user-revoking'))
+      expect(revokingSession).toHaveLength(1)
+
+      // The attacker's session should be deleted
+      const attackerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-attacker'))
+      expect(attackerSession).toHaveLength(0)
+    })
+
+    it('preserves revoking session even when it is the only session', async () => {
+      const userId = 'test-user-single-session'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(user).values({
+        id: userId,
+        name: 'Single Session User',
+        email: 'single-session@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: 'session-only-one',
+        expiresAt,
+        token: 'bearer-only-one',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      await db.insert(devicesTable).values({
+        id: 'device-single-session',
+        userId,
+        name: 'Device',
+        lastSeen: now,
+        createdAt: now,
+      })
+
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices/device-single-session/revoke', {
+          method: 'POST',
+          headers: { Authorization: 'Bearer bearer-only-one' },
+        }),
+      )
+      expect(response.status).toBe(204)
+
+      // Session should still exist
+      const sessions = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-only-one'))
+      expect(sessions).toHaveLength(1)
+    })
+  })
+
   describe('DELETE /v1/account', () => {
     it('should return 401 when not authenticated', async () => {
       const response = await app.handle(

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -82,7 +82,7 @@ describe('Account API', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-register-device',
+            Authorization: `Bearer ${signToken('bearer-register-device')}`,
           },
           body: JSON.stringify({ id: 'new-device-123', name: 'My Phone' }),
         }),
@@ -131,7 +131,7 @@ describe('Account API', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-existing-device',
+            Authorization: `Bearer ${signToken('bearer-existing-device')}`,
           },
           body: JSON.stringify({ id: 'existing-device-id' }),
         }),
@@ -186,7 +186,7 @@ describe('Account API', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-device-thief',
+            Authorization: `Bearer ${signToken('bearer-device-thief')}`,
           },
           body: JSON.stringify({ id: 'owned-device' }),
         }),
@@ -233,7 +233,7 @@ describe('Account API', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer bearer-revoked-register',
+            Authorization: `Bearer ${signToken('bearer-revoked-register')}`,
           },
           body: JSON.stringify({ id: 'revoked-device-reg' }),
         }),
@@ -302,7 +302,7 @@ describe('Account API', () => {
       const response = await app.handle(
         new Request('http://localhost/v1/account/devices/device-to-revoke/revoke', {
           method: 'POST',
-          headers: { Authorization: 'Bearer bearer-user-revoking' },
+          headers: { Authorization: `Bearer ${signToken('bearer-user-revoking')}` },
         }),
       )
       expect(response.status).toBe(204)
@@ -350,7 +350,7 @@ describe('Account API', () => {
       const response = await app.handle(
         new Request('http://localhost/v1/account/devices/device-single-session/revoke', {
           method: 'POST',
-          headers: { Authorization: 'Bearer bearer-only-one' },
+          headers: { Authorization: `Bearer ${signToken('bearer-only-one')}` },
         }),
       )
       expect(response.status).toBe(204)
@@ -397,10 +397,10 @@ describe('Account API', () => {
       const response = await app.handle(
         new Request('http://localhost/v1/account/devices/nonexistent-device/revoke', {
           method: 'POST',
-          headers: { Authorization: 'Bearer bearer-revoker' },
+          headers: { Authorization: `Bearer ${signToken('bearer-revoker')}` },
         }),
       )
-      expect(response.status).toBe(204)
+      expect(response.status).toBe(404)
 
       // Both sessions should still exist — no device was actually revoked
       const revokerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-revoker'))
@@ -679,7 +679,7 @@ describe('Account API', () => {
       expect(response.status).toBe(404)
     })
 
-    it('returns 204 when revoking already-revoked device (idempotent)', async () => {
+    it('returns 404 when revoking already-revoked device (preserves original revokedAt)', async () => {
       const userId = p('revoke-idempotent-user')
       const token = p('revoke-idempotent-token')
       const deviceId = p('device-already-revoked')
@@ -695,14 +695,18 @@ describe('Account API', () => {
       })
 
       // First revoke
-      await app.handle(
+      const firstResponse = await app.handle(
         new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
           method: 'POST',
           headers: { Authorization: `Bearer ${signToken(token)}` },
         }),
       )
+      expect(firstResponse.status).toBe(204)
 
-      // Second revoke
+      const [afterFirst] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+      const originalRevokedAt = afterFirst.revokedAt
+
+      // Second revoke — no-op because isNull(revokedAt) guard skips already-revoked devices
       const response = await app.handle(
         new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
           method: 'POST',
@@ -710,10 +714,11 @@ describe('Account API', () => {
         }),
       )
 
-      expect(response.status).toBe(204)
+      expect(response.status).toBe(404)
 
+      // Original revokedAt timestamp is preserved
       const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
-      expect(device.revokedAt).not.toBeNull()
+      expect(device.revokedAt).toEqual(originalRevokedAt)
     })
 
     it('handles device with no envelope gracefully', async () => {

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -359,6 +359,55 @@ describe('Account API', () => {
       const sessions = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-only-one'))
       expect(sessions).toHaveLength(1)
     })
+
+    it('does not invalidate sessions when revoking a nonexistent device', async () => {
+      const userId = 'test-user-nonexistent-revoke'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(user).values({
+        id: userId,
+        name: 'Nonexistent Revoke User',
+        email: 'nonexistent-revoke@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values([
+        {
+          id: 'session-revoker',
+          expiresAt,
+          token: 'bearer-revoker',
+          createdAt: now,
+          updatedAt: now,
+          userId,
+        },
+        {
+          id: 'session-other',
+          expiresAt,
+          token: 'bearer-other',
+          createdAt: now,
+          updatedAt: now,
+          userId,
+        },
+      ])
+
+      // Revoke a device that doesn't exist
+      const response = await app.handle(
+        new Request('http://localhost/v1/account/devices/nonexistent-device/revoke', {
+          method: 'POST',
+          headers: { Authorization: 'Bearer bearer-revoker' },
+        }),
+      )
+      expect(response.status).toBe(204)
+
+      // Both sessions should still exist — no device was actually revoked
+      const revokerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-revoker'))
+      expect(revokerSession).toHaveLength(1)
+      const otherSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-other'))
+      expect(otherSession).toHaveLength(1)
+    })
   })
 
   describe('DELETE /v1/account', () => {

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -257,33 +257,38 @@ describe('Account API', () => {
 
   describe('POST /v1/account/devices/:id/revoke', () => {
     it('invalidates all other sessions when device is revoked', async () => {
-      const userId = 'test-user-session-revoke'
+      const userId = p('session-revoke-user')
+      const token = p('session-revoke-token')
+      const attackerToken = p('session-revoke-attacker-token')
+      const deviceId = p('device-to-revoke')
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
 
       await db.insert(user).values({
         id: userId,
         name: 'Session Revoke User',
-        email: 'session-revoke@example.com',
+        email: `${userId}@example.com`,
         emailVerified: true,
         createdAt: now,
         updatedAt: now,
       })
 
       // Create two sessions: one for the user revoking, one for the attacker
+      const sessionId = p('session-user-revoking')
+      const attackerSessionId = p('session-attacker')
       await db.insert(sessionTable).values([
         {
-          id: 'session-user-revoking',
+          id: sessionId,
           expiresAt,
-          token: 'bearer-user-revoking',
+          token,
           createdAt: now,
           updatedAt: now,
           userId,
         },
         {
-          id: 'session-attacker',
+          id: attackerSessionId,
           expiresAt,
-          token: 'bearer-attacker',
+          token: attackerToken,
           createdAt: now,
           updatedAt: now,
           userId,
@@ -291,7 +296,7 @@ describe('Account API', () => {
       ])
 
       await db.insert(devicesTable).values({
-        id: 'device-to-revoke',
+        id: deviceId,
         userId,
         name: 'Compromised Device',
         lastSeen: now,
@@ -300,47 +305,50 @@ describe('Account API', () => {
 
       // Revoke the device from the user's session
       const response = await app.handle(
-        new Request('http://localhost/v1/account/devices/device-to-revoke/revoke', {
+        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
           method: 'POST',
-          headers: { Authorization: `Bearer ${signToken('bearer-user-revoking')}` },
+          headers: { Authorization: `Bearer ${signToken(token)}` },
         }),
       )
       expect(response.status).toBe(204)
 
       // The revoking user's session should still exist
-      const revokingSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-user-revoking'))
+      const revokingSession = await db.select().from(sessionTable).where(eq(sessionTable.id, sessionId))
       expect(revokingSession).toHaveLength(1)
 
       // The attacker's session should be deleted
-      const attackerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-attacker'))
+      const attackerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, attackerSessionId))
       expect(attackerSession).toHaveLength(0)
     })
 
     it('preserves revoking session even when it is the only session', async () => {
-      const userId = 'test-user-single-session'
+      const userId = p('single-session-user')
+      const token = p('single-session-token')
+      const sessionId = p('session-only-one')
+      const deviceId = p('device-single-session')
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
 
       await db.insert(user).values({
         id: userId,
         name: 'Single Session User',
-        email: 'single-session@example.com',
+        email: `${userId}@example.com`,
         emailVerified: true,
         createdAt: now,
         updatedAt: now,
       })
 
       await db.insert(sessionTable).values({
-        id: 'session-only-one',
+        id: sessionId,
         expiresAt,
-        token: 'bearer-only-one',
+        token,
         createdAt: now,
         updatedAt: now,
         userId,
       })
 
       await db.insert(devicesTable).values({
-        id: 'device-single-session',
+        id: deviceId,
         userId,
         name: 'Device',
         lastSeen: now,
@@ -348,27 +356,31 @@ describe('Account API', () => {
       })
 
       const response = await app.handle(
-        new Request('http://localhost/v1/account/devices/device-single-session/revoke', {
+        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
           method: 'POST',
-          headers: { Authorization: `Bearer ${signToken('bearer-only-one')}` },
+          headers: { Authorization: `Bearer ${signToken(token)}` },
         }),
       )
       expect(response.status).toBe(204)
 
       // Session should still exist
-      const sessions = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-only-one'))
+      const sessions = await db.select().from(sessionTable).where(eq(sessionTable.id, sessionId))
       expect(sessions).toHaveLength(1)
     })
 
     it('does not invalidate sessions when revoking a nonexistent device', async () => {
-      const userId = 'test-user-nonexistent-revoke'
+      const userId = p('nonexistent-revoke-user')
+      const token = p('nonexistent-revoke-token')
+      const otherToken = p('nonexistent-revoke-other-token')
+      const sessionId = p('session-revoker')
+      const otherSessionId = p('session-other')
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
 
       await db.insert(user).values({
         id: userId,
         name: 'Nonexistent Revoke User',
-        email: 'nonexistent-revoke@example.com',
+        email: `${userId}@example.com`,
         emailVerified: true,
         createdAt: now,
         updatedAt: now,
@@ -376,17 +388,17 @@ describe('Account API', () => {
 
       await db.insert(sessionTable).values([
         {
-          id: 'session-revoker',
+          id: sessionId,
           expiresAt,
-          token: 'bearer-revoker',
+          token,
           createdAt: now,
           updatedAt: now,
           userId,
         },
         {
-          id: 'session-other',
+          id: otherSessionId,
           expiresAt,
-          token: 'bearer-other',
+          token: otherToken,
           createdAt: now,
           updatedAt: now,
           userId,
@@ -397,15 +409,15 @@ describe('Account API', () => {
       const response = await app.handle(
         new Request('http://localhost/v1/account/devices/nonexistent-device/revoke', {
           method: 'POST',
-          headers: { Authorization: `Bearer ${signToken('bearer-revoker')}` },
+          headers: { Authorization: `Bearer ${signToken(token)}` },
         }),
       )
       expect(response.status).toBe(404)
 
       // Both sessions should still exist — no device was actually revoked
-      const revokerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-revoker'))
+      const revokerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, sessionId))
       expect(revokerSession).toHaveLength(1)
-      const otherSession = await db.select().from(sessionTable).where(eq(sessionTable.id, 'session-other'))
+      const otherSession = await db.select().from(sessionTable).where(eq(sessionTable.id, otherSessionId))
       expect(otherSession).toHaveLength(1)
     })
   })

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -412,7 +412,7 @@ describe('Account API', () => {
           headers: { Authorization: `Bearer ${signToken(token)}` },
         }),
       )
-      expect(response.status).toBe(404)
+      expect(response.status).toBe(204)
 
       // Both sessions should still exist — no device was actually revoked
       const revokerSession = await db.select().from(sessionTable).where(eq(sessionTable.id, sessionId))
@@ -669,14 +669,15 @@ describe('Account API', () => {
         }),
       )
 
-      expect(response.status).toBe(404)
+      // Returns 204 (idempotent) but device is NOT actually revoked
+      expect(response.status).toBe(204)
 
       const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
       expect(device.trusted).toBe(true)
       expect(device.revokedAt).toBeNull()
     })
 
-    it('returns 404 for non-existent device', async () => {
+    it('returns 204 for non-existent device (idempotent)', async () => {
       const userId = p('revoke-nonexistent-user')
       const token = p('revoke-nonexistent-token')
       await createUserAndSession(userId, token)
@@ -688,10 +689,10 @@ describe('Account API', () => {
         }),
       )
 
-      expect(response.status).toBe(404)
+      expect(response.status).toBe(204)
     })
 
-    it('returns 404 when revoking already-revoked device (preserves original revokedAt)', async () => {
+    it('returns 204 when revoking already-revoked device (preserves original revokedAt)', async () => {
       const userId = p('revoke-idempotent-user')
       const token = p('revoke-idempotent-token')
       const deviceId = p('device-already-revoked')
@@ -726,7 +727,7 @@ describe('Account API', () => {
         }),
       )
 
-      expect(response.status).toBe(404)
+      expect(response.status).toBe(204)
 
       // Original revokedAt timestamp is preserved
       const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -35,7 +35,12 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
         const now = new Date()
         const rawName = body.name?.trim()
         const name = rawName && rawName.length > 0 && rawName.length <= 100 ? rawName : 'Unknown device'
-        await upsertDevice(database, { id: deviceId, userId: user.id, name, lastSeen: now, createdAt: now })
+        const upserted = await upsertDevice(database, { id: deviceId, userId: user.id, name, lastSeen: now, createdAt: now })
+
+        if (upserted.length === 0 || upserted[0].userId !== user.id) {
+          set.status = 409
+          return { code: 'DEVICE_ID_TAKEN' }
+        }
 
         set.status = 201
         return { registered: true }

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -1,9 +1,9 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { createAuthMacro } from '@/auth/elysia-plugin'
-import { deleteUser, revokeDevice, deleteEnvelope } from '@/dal'
+import { deleteUser, revokeDevice, deleteEnvelope, getDeviceById, revokeOtherSessions, upsertDevice } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import { safeErrorHandler } from '@/middleware/error-handling'
-import { Elysia } from 'elysia'
+import { Elysia, t } from 'elysia'
 
 /** Account API routes. All routes require authentication. */
 export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
@@ -11,13 +11,56 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
     .onError(safeErrorHandler)
     .use(createAuthMacro(auth))
     .post(
+      '/devices',
+      async ({ body, set, user }) => {
+        const deviceId = body.id.trim()
+        if (!deviceId) {
+          set.status = 400
+          return { code: 'DEVICE_ID_REQUIRED' }
+        }
+
+        const existing = await getDeviceById(database, deviceId)
+        if (existing) {
+          if (existing.userId !== user.id) {
+            set.status = 409
+            return { code: 'DEVICE_ID_TAKEN' }
+          }
+          if (existing.revokedAt != null) {
+            set.status = 403
+            return { code: 'DEVICE_DISCONNECTED' }
+          }
+          return { registered: true }
+        }
+
+        const now = new Date()
+        const rawName = body.name?.trim()
+        const name = rawName && rawName.length > 0 && rawName.length <= 100 ? rawName : 'Unknown device'
+        await upsertDevice(database, { id: deviceId, userId: user.id, name, lastSeen: now, createdAt: now })
+
+        set.status = 201
+        return { registered: true }
+      },
+      {
+        auth: true,
+        body: t.Object({
+          id: t.String(),
+          name: t.Optional(t.String()),
+        }),
+      },
+    )
+    .post(
       '/devices/:id/revoke',
-      async ({ params, set, user: sessionUser }) => {
+      async ({ params, set, user: sessionUser, session }) => {
         const userId = sessionUser!.id
         const revoked = await database.transaction(async (tx) => {
           const txDb = tx as unknown as typeof database
           await deleteEnvelope(txDb, params.id, userId)
           const rows = await revokeDevice(txDb, params.id, userId)
+
+          if (rows.length > 0) {
+            await revokeOtherSessions(database, userId, session.id)
+          }
+
           return rows.length > 0
         })
         if (!revoked) {

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -35,7 +35,13 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
         const now = new Date()
         const rawName = body.name?.trim()
         const name = rawName && rawName.length > 0 && rawName.length <= 100 ? rawName : 'Unknown device'
-        const upserted = await upsertDevice(database, { id: deviceId, userId: user.id, name, lastSeen: now, createdAt: now })
+        const upserted = await upsertDevice(database, {
+          id: deviceId,
+          userId: user.id,
+          name,
+          lastSeen: now,
+          createdAt: now,
+        })
 
         if (upserted.length === 0 || upserted[0].userId !== user.id) {
           set.status = 409
@@ -63,7 +69,7 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
           const rows = await revokeDevice(txDb, params.id, userId)
 
           if (rows.length > 0) {
-            await revokeOtherSessions(database, userId, session.id)
+            await revokeOtherSessions(txDb, userId, session.id)
           }
 
           return rows.length > 0

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -74,10 +74,6 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
 
           return rows.length > 0
         })
-        if (!revoked) {
-          set.status = 404
-          return { error: 'Device not found' }
-        }
         set.status = 204
       },
       { auth: true },

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -1,9 +1,9 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { createAuthMacro } from '@/auth/elysia-plugin'
-import { deleteUser, revokeDevice, deleteEnvelope, getDeviceById, revokeOtherSessions, upsertDevice } from '@/dal'
+import { deleteUser, revokeDevice, deleteEnvelope, revokeDeviceSessions } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import { safeErrorHandler } from '@/middleware/error-handling'
-import { Elysia, t } from 'elysia'
+import { Elysia } from 'elysia'
 
 /** Account API routes. All routes require authentication. */
 export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
@@ -11,68 +11,17 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
     .onError(safeErrorHandler)
     .use(createAuthMacro(auth))
     .post(
-      '/devices',
-      async ({ body, set, user }) => {
-        const deviceId = body.id.trim()
-        if (!deviceId) {
-          set.status = 400
-          return { code: 'DEVICE_ID_REQUIRED' }
-        }
-
-        const existing = await getDeviceById(database, deviceId)
-        if (existing) {
-          if (existing.userId !== user.id) {
-            set.status = 409
-            return { code: 'DEVICE_ID_TAKEN' }
-          }
-          if (existing.revokedAt != null) {
-            set.status = 403
-            return { code: 'DEVICE_DISCONNECTED' }
-          }
-          return { registered: true }
-        }
-
-        const now = new Date()
-        const rawName = body.name?.trim()
-        const name = rawName && rawName.length > 0 && rawName.length <= 100 ? rawName : 'Unknown device'
-        const upserted = await upsertDevice(database, {
-          id: deviceId,
-          userId: user.id,
-          name,
-          lastSeen: now,
-          createdAt: now,
-        })
-
-        if (upserted.length === 0 || upserted[0].userId !== user.id) {
-          set.status = 409
-          return { code: 'DEVICE_ID_TAKEN' }
-        }
-
-        set.status = 201
-        return { registered: true }
-      },
-      {
-        auth: true,
-        body: t.Object({
-          id: t.String(),
-          name: t.Optional(t.String()),
-        }),
-      },
-    )
-    .post(
       '/devices/:id/revoke',
-      async ({ params, set, user: sessionUser, session }) => {
+      async ({ params, set, user: sessionUser }) => {
         const userId = sessionUser!.id
-        const revoked = await database.transaction(async (tx) => {
+        await database.transaction(async (tx) => {
           const txDb = tx as unknown as typeof database
           await deleteEnvelope(txDb, params.id, userId)
           const rows = await revokeDevice(txDb, params.id, userId)
 
           if (rows.length > 0) {
-            await revokeOtherSessions(txDb, userId, session.id)
+            await revokeDeviceSessions(txDb, params.id, userId)
           }
-
-          return rows.length > 0
         })
         set.status = 204
       },

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -1,6 +1,8 @@
 import { type Auth, createAuthMacro } from '@/auth/elysia-plugin'
 import {
+  countActiveDevices,
   getDeviceById,
+  linkSessionToDevice,
   registerDevice,
   denyDevice,
   markDeviceTrusted,
@@ -11,7 +13,7 @@ import {
   insertEncryptionMetadataIfNotExists,
 } from '@/dal'
 import type { db as DbType } from '@/db/client'
-import { BadRequestError, ForbiddenError } from '@/errors/http-errors'
+import { BadRequestError, ForbiddenError, UnprocessableError } from '@/errors/http-errors'
 import { timingSafeEqual } from 'crypto'
 import { Elysia, t } from 'elysia'
 
@@ -61,7 +63,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
     .use(createAuthMacro(auth))
     .post(
       '/devices',
-      async ({ body, set, user: sessionUser }) => {
+      async ({ body, set, user: sessionUser, session }) => {
         const userId = sessionUser!.id
         const { deviceId, publicKey, mlkemPublicKey, name } = body
 
@@ -84,6 +86,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
           // Encryption-registered device (has publicKey): return current state
           if (existingDevice.publicKey) {
             if (existingDevice.trusted) {
+              await linkSessionToDevice(database, session.id, deviceId, userId)
               const envelope = await getEnvelopeByDeviceId(database, deviceId, userId)
               return {
                 trusted: true as const,
@@ -97,16 +100,36 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
           // Pre-encryption device (no publicKey): fall through to register with publicKey
         }
 
-        // New device OR pre-encryption device — register with publicKey
+        // Wrap limit check + registration in a transaction to prevent TOCTOU race
         const deviceName = name || 'Unknown device'
-        await registerDevice(database, {
-          id: deviceId,
-          userId,
-          name: deviceName,
-          publicKey,
-          mlkemPublicKey,
-        })
+        try {
+          await database.transaction(async (tx) => {
+            const txDb = tx as unknown as typeof database
 
+            if (!existingDevice) {
+              const activeCount = await countActiveDevices(txDb, userId)
+              if (activeCount >= 10) {
+                throw new UnprocessableError('Device limit reached')
+              }
+            }
+
+            await registerDevice(txDb, {
+              id: deviceId,
+              userId,
+              name: deviceName,
+              publicKey,
+              mlkemPublicKey,
+            })
+          })
+        } catch (err) {
+          if (err instanceof UnprocessableError) {
+            set.status = 422
+            return { error: err.message }
+          }
+          throw err
+        }
+
+        await linkSessionToDevice(database, session.id, deviceId, userId)
         return { trusted: false as const }
       },
       {

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -1,6 +1,5 @@
 import { type Auth, createAuthMacro } from '@/auth/elysia-plugin'
 
-const MAX_DEVICES_PER_USER = 10
 import {
   countActiveDevices,
   getDeviceById,
@@ -18,6 +17,8 @@ import type { db as DbType } from '@/db/client'
 import { BadRequestError, ForbiddenError } from '@/errors/http-errors'
 import { timingSafeEqual } from 'crypto'
 import { Elysia, t } from 'elysia'
+
+const MAX_DEVICES_PER_USER = 10
 
 /** Hash a canary secret using SHA-256. Returns hex-encoded hash. */
 const hashCanarySecret = async (secret: string): Promise<string> => {

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -1,4 +1,6 @@
 import { type Auth, createAuthMacro } from '@/auth/elysia-plugin'
+
+const MAX_DEVICES_PER_USER = 10
 import {
   countActiveDevices,
   getDeviceById,
@@ -109,7 +111,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
           const freshDevice = await getDeviceById(txDb, deviceId)
           if (!freshDevice) {
             const activeCount = await countActiveDevices(txDb, userId)
-            if (activeCount >= 10) return { limitReached: true as const }
+            if (activeCount >= MAX_DEVICES_PER_USER) return { limitReached: true as const }
           }
 
           const registered = await registerDevice(txDb, {

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -67,7 +67,7 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
         const userId = sessionUser!.id
         const { deviceId, publicKey, mlkemPublicKey, name } = body
 
-        // Check if device already exists
+        // Check if device already exists (fast-path before transaction)
         const existingDevice = await getDeviceById(database, deviceId)
 
         if (existingDevice) {
@@ -106,7 +106,9 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
           await database.transaction(async (tx) => {
             const txDb = tx as unknown as typeof database
 
-            if (!existingDevice) {
+            // Re-check device inside transaction to close race window
+            const freshDevice = await getDeviceById(txDb, deviceId)
+            if (!freshDevice) {
               const activeCount = await countActiveDevices(txDb, userId)
               if (activeCount >= 10) {
                 throw new UnprocessableError('Device limit reached')

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -13,7 +13,7 @@ import {
   insertEncryptionMetadataIfNotExists,
 } from '@/dal'
 import type { db as DbType } from '@/db/client'
-import { BadRequestError, ForbiddenError, UnprocessableError } from '@/errors/http-errors'
+import { BadRequestError, ForbiddenError } from '@/errors/http-errors'
 import { timingSafeEqual } from 'crypto'
 import { Elysia, t } from 'elysia'
 
@@ -102,33 +102,40 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
 
         // Wrap limit check + registration in a transaction to prevent TOCTOU race
         const deviceName = name || 'Unknown device'
-        try {
-          await database.transaction(async (tx) => {
-            const txDb = tx as unknown as typeof database
+        const result = await database.transaction(async (tx) => {
+          const txDb = tx as unknown as typeof database
 
-            // Re-check device inside transaction to close race window
-            const freshDevice = await getDeviceById(txDb, deviceId)
-            if (!freshDevice) {
-              const activeCount = await countActiveDevices(txDb, userId)
-              if (activeCount >= 10) {
-                throw new UnprocessableError('Device limit reached')
-              }
-            }
-
-            await registerDevice(txDb, {
-              id: deviceId,
-              userId,
-              name: deviceName,
-              publicKey,
-              mlkemPublicKey,
-            })
-          })
-        } catch (err) {
-          if (err instanceof UnprocessableError) {
-            set.status = 422
-            return { error: err.message }
+          // Re-check device inside transaction to close race window
+          const freshDevice = await getDeviceById(txDb, deviceId)
+          if (!freshDevice) {
+            const activeCount = await countActiveDevices(txDb, userId)
+            if (activeCount >= 10) return { limitReached: true as const }
           }
-          throw err
+
+          const registered = await registerDevice(txDb, {
+            id: deviceId,
+            userId,
+            name: deviceName,
+            publicKey,
+            mlkemPublicKey,
+          })
+
+          // If upsert returned no rows, another user claimed this device ID
+          if (registered.length === 0 || registered[0].userId !== userId) {
+            return { taken: true as const }
+          }
+
+          return { ok: true as const }
+        })
+
+        if ('limitReached' in result) {
+          set.status = 422
+          return { error: 'Device limit reached' }
+        }
+
+        if ('taken' in result) {
+          set.status = 409
+          return { error: 'Device ID already taken' }
         }
 
         await linkSessionToDevice(database, session.id, deviceId, userId)

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -428,6 +428,103 @@ describe('PowerSync API', () => {
       expect(data).toEqual({ code: 'DEVICE_ID_REQUIRED' })
     })
 
+    it('rejects token request for unregistered device ID', async () => {
+      const userId = 'user-unregistered-device'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(userTable).values({
+        id: userId,
+        name: 'Unregistered Device User',
+        email: 'unregistered-device@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: 'session-unregistered-device',
+        expiresAt,
+        token: 'bearer-unregistered-device',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      // Device ID 'nonexistent-device' is NOT in the DB
+      const response = await app.handle(
+        new Request('http://localhost/powersync/token', {
+          headers: {
+            Authorization: 'Bearer bearer-unregistered-device',
+            'x-device-id': 'nonexistent-device',
+          },
+        }),
+      )
+      expect(response.status).toBe(403)
+      const data = await response.json()
+      expect(data).toEqual({ code: 'DEVICE_NOT_REGISTERED' })
+    })
+
+    it('revoked device cannot bypass by using a new unregistered device ID', async () => {
+      const userId = 'user-revocation-bypass'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(userTable).values({
+        id: userId,
+        name: 'Revocation Bypass User',
+        email: 'revocation-bypass@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: 'session-revocation-bypass',
+        expiresAt,
+        token: 'bearer-revocation-bypass',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      // Register and revoke a device
+      const revokedAt = new Date()
+      await db.insert(devicesTable).values({
+        id: 'original-device',
+        userId,
+        name: 'Original Device',
+        lastSeen: new Date(revokedAt.getTime() - 60 * 1000),
+        createdAt: new Date(revokedAt.getTime() - 120 * 1000),
+        revokedAt,
+      })
+
+      // Verify the revoked device is rejected
+      const revokedResponse = await app.handle(
+        new Request('http://localhost/powersync/token', {
+          headers: {
+            Authorization: 'Bearer bearer-revocation-bypass',
+            'x-device-id': 'original-device',
+          },
+        }),
+      )
+      expect(revokedResponse.status).toBe(403)
+      expect(await revokedResponse.json()).toEqual({ code: 'DEVICE_DISCONNECTED' })
+
+      // Attempt bypass: use a NEW device ID that doesn't exist in the DB
+      const bypassResponse = await app.handle(
+        new Request('http://localhost/powersync/token', {
+          headers: {
+            Authorization: 'Bearer bearer-revocation-bypass',
+            'x-device-id': 'bypass-attempt-new-device',
+          },
+        }),
+      )
+      // Must NOT succeed — unknown device IDs should be rejected
+      expect(bypassResponse.status).toBe(403)
+      expect(await bypassResponse.json()).toEqual({ code: 'DEVICE_NOT_REGISTERED' })
+    })
+
     it('returns token and powerSyncUrl when authenticated via session with x-device-id', async () => {
       const userId = 'user-powersync-token'
       const now = new Date()
@@ -452,6 +549,14 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('device-session-token', userId)
 
+      await db.insert(devicesTable).values({
+        id: 'device-session-token',
+        userId,
+        name: 'Test Device',
+        lastSeen: now,
+        createdAt: now,
+      })
+
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
@@ -468,7 +573,7 @@ describe('PowerSync API', () => {
       expect(data.powerSyncUrl).toBe('https://powersync.example.com')
     })
 
-    it('updates device name and lastSeen when x-device-id and x-device-name are provided', async () => {
+    it('updates device name when x-device-name is provided on token request', async () => {
       const userId = 'user-device-upsert'
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
@@ -491,6 +596,14 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('device-123', userId)
+
+      await db.insert(devicesTable).values({
+        id: 'device-123',
+        userId,
+        name: 'Old Name',
+        lastSeen: now,
+        createdAt: now,
+      })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
@@ -533,6 +646,14 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('device-empty-name', userId)
 
+      await db.insert(devicesTable).values({
+        id: 'device-empty-name',
+        userId,
+        name: 'Old Name',
+        lastSeen: now,
+        createdAt: now,
+      })
+
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
@@ -572,6 +693,14 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('device-long-name', userId)
+
+      await db.insert(devicesTable).values({
+        id: 'device-long-name',
+        userId,
+        name: 'Old Name',
+        lastSeen: now,
+        createdAt: now,
+      })
 
       const longName = 'a'.repeat(101)
       const response = await app.handle(
@@ -614,6 +743,14 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('device-100-char', userId)
 
+      await db.insert(devicesTable).values({
+        id: 'device-100-char',
+        userId,
+        name: 'Old Name',
+        lastSeen: now,
+        createdAt: now,
+      })
+
       const name100 = 'a'.repeat(100)
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
@@ -654,6 +791,14 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('device-1-char', userId)
+
+      await db.insert(devicesTable).values({
+        id: 'device-1-char',
+        userId,
+        name: 'Old Name',
+        lastSeen: now,
+        createdAt: now,
+      })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
@@ -770,6 +915,44 @@ describe('PowerSync API', () => {
       expect(data.code).toBe('DEVICE_DISCONNECTED')
     })
 
+    it('rejects upload for unregistered device ID', async () => {
+      const userId = 'user-upload-unregistered'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(userTable).values({
+        id: userId,
+        name: 'Upload Unregistered User',
+        email: 'upload-unregistered@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await db.insert(sessionTable).values({
+        id: 'session-upload-unregistered',
+        expiresAt,
+        token: 'bearer-upload-unregistered',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      // Device 'unknown-upload-device' is NOT registered
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders('bearer-upload-unregistered', 'unknown-upload-device'),
+          body: JSON.stringify({
+            operations: [{ op: 'PUT' as const, type: 'settings', id: 'key', data: { value: 'x' } }],
+          }),
+        }),
+      )
+      expect(response.status).toBe(403)
+      const data = (await response.json()) as { code: string }
+      expect(data.code).toBe('DEVICE_NOT_REGISTERED')
+    })
+
     it('returns 422 when body schema is invalid (operations not an array)', async () => {
       const userId = 'user-upload-validation'
       const now = new Date()
@@ -793,6 +976,10 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
+
+      await db
+        .insert(devicesTable)
+        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -827,6 +1014,10 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
+
+      await db
+        .insert(devicesTable)
+        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -876,6 +1067,10 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
+
+      await db
+        .insert(devicesTable)
+        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -975,6 +1170,10 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
+
+      await db
+        .insert(devicesTable)
+        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       await db.insert(settingsTable).values({
         key: 'patch_setting',
@@ -1309,6 +1508,10 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('test-device-id', userId)
 
+      await db
+        .insert(devicesTable)
+        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
+
       await db.insert(settingsTable).values({
         key: 'to_delete',
         value: 'x',
@@ -1458,6 +1661,10 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
+
+      await db
+        .insert(devicesTable)
+        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -1676,6 +1883,10 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('test-device-id', userId)
 
+      await db
+        .insert(devicesTable)
+        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
+
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
           method: 'PUT',
@@ -1724,6 +1935,10 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
+
+      await db
+        .insert(devicesTable)
+        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -1794,7 +2009,7 @@ describe('PowerSync cross-origin injection protection', () => {
 
   describe('PUT /powersync/upload origin validation', () => {
     it('rejects upload from disallowed cross-origin (attacker port)', async () => {
-      await seedUser('user-cors-upload', 'bearer-cors-upload')
+      await seedUser('user-cors-upload', 'bearer-cors-upload', 'cors-test-device')
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
           method: 'PUT',
@@ -1821,7 +2036,7 @@ describe('PowerSync cross-origin injection protection', () => {
     })
 
     it('rejects model injection from attacker origin', async () => {
-      await seedUser('user-model-inject', 'bearer-model-inject')
+      await seedUser('user-model-inject', 'bearer-model-inject', 'attacker-device')
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
           method: 'PUT',
@@ -1857,7 +2072,7 @@ describe('PowerSync cross-origin injection protection', () => {
     })
 
     it('rejects MCP server injection from attacker origin', async () => {
-      await seedUser('user-mcp-inject', 'bearer-mcp-inject')
+      await seedUser('user-mcp-inject', 'bearer-mcp-inject', 'attacker-device')
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
           method: 'PUT',
@@ -1951,7 +2166,7 @@ describe('PowerSync cross-origin injection protection', () => {
     })
 
     it('rejects upload from external attacker domain', async () => {
-      await seedUser('user-ext-attacker', 'bearer-ext-attacker')
+      await seedUser('user-ext-attacker', 'bearer-ext-attacker', 'attacker-device')
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
           method: 'PUT',
@@ -1974,7 +2189,7 @@ describe('PowerSync cross-origin injection protection', () => {
 
   describe('GET /powersync/token origin validation', () => {
     it('rejects token request from disallowed origin', async () => {
-      await seedUser('user-cors-token', 'bearer-cors-token')
+      await seedUser('user-cors-token', 'bearer-cors-token', 'cors-token-device')
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -455,14 +455,14 @@ describe('PowerSync API', () => {
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-unregistered-device',
+            Authorization: `Bearer ${signToken('bearer-unregistered-device')}`,
             'x-device-id': 'nonexistent-device',
           },
         }),
       )
       expect(response.status).toBe(403)
       const data = await response.json()
-      expect(data).toEqual({ code: 'DEVICE_NOT_REGISTERED' })
+      expect(data).toEqual({ code: 'DEVICE_NOT_TRUSTED' })
     })
 
     it('revoked device cannot bypass by using a new unregistered device ID', async () => {
@@ -503,7 +503,7 @@ describe('PowerSync API', () => {
       const revokedResponse = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-revocation-bypass',
+            Authorization: `Bearer ${signToken('bearer-revocation-bypass')}`,
             'x-device-id': 'original-device',
           },
         }),
@@ -515,14 +515,14 @@ describe('PowerSync API', () => {
       const bypassResponse = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
-            Authorization: 'Bearer bearer-revocation-bypass',
+            Authorization: `Bearer ${signToken('bearer-revocation-bypass')}`,
             'x-device-id': 'bypass-attempt-new-device',
           },
         }),
       )
       // Must NOT succeed — unknown device IDs should be rejected
       expect(bypassResponse.status).toBe(403)
-      expect(await bypassResponse.json()).toEqual({ code: 'DEVICE_NOT_REGISTERED' })
+      expect(await bypassResponse.json()).toEqual({ code: 'DEVICE_NOT_TRUSTED' })
     })
 
     it('returns token and powerSyncUrl when authenticated via session with x-device-id', async () => {
@@ -548,14 +548,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('device-session-token', userId)
-
-      await db.insert(devicesTable).values({
-        id: 'device-session-token',
-        userId,
-        name: 'Test Device',
-        lastSeen: now,
-        createdAt: now,
-      })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
@@ -596,14 +588,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('device-123', userId)
-
-      await db.insert(devicesTable).values({
-        id: 'device-123',
-        userId,
-        name: 'Old Name',
-        lastSeen: now,
-        createdAt: now,
-      })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
@@ -646,14 +630,6 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('device-empty-name', userId)
 
-      await db.insert(devicesTable).values({
-        id: 'device-empty-name',
-        userId,
-        name: 'Old Name',
-        lastSeen: now,
-        createdAt: now,
-      })
-
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
           headers: {
@@ -693,14 +669,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('device-long-name', userId)
-
-      await db.insert(devicesTable).values({
-        id: 'device-long-name',
-        userId,
-        name: 'Old Name',
-        lastSeen: now,
-        createdAt: now,
-      })
 
       const longName = 'a'.repeat(101)
       const response = await app.handle(
@@ -743,14 +711,6 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('device-100-char', userId)
 
-      await db.insert(devicesTable).values({
-        id: 'device-100-char',
-        userId,
-        name: 'Old Name',
-        lastSeen: now,
-        createdAt: now,
-      })
-
       const name100 = 'a'.repeat(100)
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
@@ -791,14 +751,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('device-1-char', userId)
-
-      await db.insert(devicesTable).values({
-        id: 'device-1-char',
-        userId,
-        name: 'Old Name',
-        lastSeen: now,
-        createdAt: now,
-      })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/token', {
@@ -950,7 +902,7 @@ describe('PowerSync API', () => {
       )
       expect(response.status).toBe(403)
       const data = (await response.json()) as { code: string }
-      expect(data.code).toBe('DEVICE_NOT_REGISTERED')
+      expect(data.code).toBe('DEVICE_NOT_TRUSTED')
     })
 
     it('returns 422 when body schema is invalid (operations not an array)', async () => {
@@ -976,10 +928,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
-
-      await db
-        .insert(devicesTable)
-        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -1014,10 +962,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
-
-      await db
-        .insert(devicesTable)
-        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -1067,10 +1011,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
-
-      await db
-        .insert(devicesTable)
-        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -1170,10 +1110,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
-
-      await db
-        .insert(devicesTable)
-        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       await db.insert(settingsTable).values({
         key: 'patch_setting',
@@ -1508,10 +1444,6 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('test-device-id', userId)
 
-      await db
-        .insert(devicesTable)
-        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
-
       await db.insert(settingsTable).values({
         key: 'to_delete',
         value: 'x',
@@ -1661,10 +1593,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
-
-      await db
-        .insert(devicesTable)
-        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
@@ -1883,10 +1811,6 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('test-device-id', userId)
 
-      await db
-        .insert(devicesTable)
-        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
-
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
           method: 'PUT',
@@ -1935,10 +1859,6 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
-
-      await db
-        .insert(devicesTable)
-        .values({ id: 'test-device-id', userId, name: 'Test Device', lastSeen: now, createdAt: now })
 
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -110,6 +110,14 @@ export const createAuth = (database: typeof DbType) => {
         },
       },
     },
+    session: {
+      additionalFields: {
+        deviceId: {
+          type: 'string',
+          required: false,
+        },
+      },
+    },
     databaseHooks: {
       user: {
         create: {

--- a/backend/src/dal/devices.test.ts
+++ b/backend/src/dal/devices.test.ts
@@ -3,7 +3,7 @@ import { devicesTable } from '@/db/schema'
 import { createTestDb } from '@/test-utils/db'
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { getDeviceById, revokeDevice, upsertDevice } from './devices'
+import { countActiveDevices, getDeviceById, revokeDevice, upsertDevice } from './devices'
 
 describe('devices DAL', () => {
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
@@ -81,6 +81,43 @@ describe('devices DAL', () => {
       await revokeDevice(db, 'd5', 'other-user')
       const rows = await db.select().from(devicesTable).where(eq(devicesTable.id, 'd5'))
       expect(rows[0].revokedAt).toBeNull()
+    })
+  })
+
+  describe('countActiveDevices', () => {
+    it('counts non-revoked devices for user', async () => {
+      const now = new Date()
+      await db.insert(devicesTable).values([
+        { id: 'active-1', userId, name: 'Phone', lastSeen: now, createdAt: now },
+        { id: 'active-2', userId, name: 'Laptop', lastSeen: now, createdAt: now },
+        { id: 'revoked-1', userId, name: 'Old Phone', lastSeen: now, createdAt: now, revokedAt: now },
+      ])
+      const count = await countActiveDevices(db, userId)
+      expect(count).toBe(2)
+    })
+
+    it('returns 0 when user has no devices', async () => {
+      const count = await countActiveDevices(db, userId)
+      expect(count).toBe(0)
+    })
+
+    it('does not count devices from other users', async () => {
+      const now = new Date()
+      const otherUserId = 'other-user-count'
+      await db.insert(user).values({
+        id: otherUserId,
+        name: 'Other User',
+        email: 'other-count@test.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await db.insert(devicesTable).values([
+        { id: 'my-device', userId, name: 'Mine', lastSeen: now, createdAt: now },
+        { id: 'their-device', userId: otherUserId, name: 'Theirs', lastSeen: now, createdAt: now },
+      ])
+      const count = await countActiveDevices(db, userId)
+      expect(count).toBe(1)
     })
   })
 })

--- a/backend/src/dal/devices.ts
+++ b/backend/src/dal/devices.ts
@@ -49,12 +49,13 @@ export const markDeviceTrusted = async (database: typeof DbType, deviceId: strin
     .where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId)))
 
 /** Count active (non-revoked) devices for a user. */
-export const countActiveDevices = async (database: typeof DbType, userId: string) =>
-  database
+export const countActiveDevices = async (database: typeof DbType, userId: string) => {
+  const rows = await database
     .select({ count: count() })
     .from(devicesTable)
     .where(and(eq(devicesTable.userId, userId), isNull(devicesTable.revokedAt)))
-    .then((rows) => rows[0]?.count ?? 0)
+  return rows[0]?.count ?? 0
+}
 
 /** Deny a pending device by clearing its approval_pending flag. Does not revoke. */
 export const denyDevice = async (database: typeof DbType, deviceId: string, userId: string) =>

--- a/backend/src/dal/devices.ts
+++ b/backend/src/dal/devices.ts
@@ -1,6 +1,6 @@
 import type { db as DbType } from '@/db/client'
 import { devicesTable } from '@/db/schema'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, count, eq, isNull } from 'drizzle-orm'
 
 /** Get a device by ID. Returns userId, trusted, approvalPending, publicKey, and revokedAt, or null if not found. */
 export const getDeviceById = async (database: typeof DbType, deviceId: string) =>
@@ -47,6 +47,14 @@ export const markDeviceTrusted = async (database: typeof DbType, deviceId: strin
     .update(devicesTable)
     .set({ trusted: true, approvalPending: false })
     .where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId)))
+
+/** Count active (non-revoked) devices for a user. */
+export const countActiveDevices = async (database: typeof DbType, userId: string) =>
+  database
+    .select({ count: count() })
+    .from(devicesTable)
+    .where(and(eq(devicesTable.userId, userId), isNull(devicesTable.revokedAt)))
+    .then((rows) => rows[0]?.count ?? 0)
 
 /** Deny a pending device by clearing its approval_pending flag. Does not revoke. */
 export const denyDevice = async (database: typeof DbType, deviceId: string, userId: string) =>

--- a/backend/src/dal/devices.ts
+++ b/backend/src/dal/devices.ts
@@ -1,6 +1,6 @@
 import type { db as DbType } from '@/db/client'
 import { devicesTable } from '@/db/schema'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 
 /** Get a device by ID. Returns userId, trusted, approvalPending, publicKey, and revokedAt, or null if not found. */
 export const getDeviceById = async (database: typeof DbType, deviceId: string) =>
@@ -32,12 +32,13 @@ export const upsertDevice = async (
     })
     .returning()
 
-/** Revoke a device for a specific user. Sets revokedAt timestamp and clears approval state. */
+/** Revoke a device for a specific user. Sets revokedAt timestamp and clears approval state.
+ * Only matches non-revoked devices so re-revoking is a no-op. */
 export const revokeDevice = async (database: typeof DbType, deviceId: string, userId: string) =>
   database
     .update(devicesTable)
     .set({ revokedAt: new Date(), trusted: false, approvalPending: false })
-    .where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId)))
+    .where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId), isNull(devicesTable.revokedAt)))
     .returning()
 
 /** Mark a device as trusted and clear pending state. Called when an envelope is stored for the device. */

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -5,7 +5,7 @@ export { getDeviceById, upsertDevice, revokeDevice, denyDevice, markDeviceTruste
 export { getUserById, getUserByEmail, deleteUser, markUserNotNew } from './users'
 
 // Sessions
-export { getActiveSessionByToken } from './sessions'
+export { getActiveSessionByToken, revokeOtherSessions } from './sessions'
 
 // Waitlist
 export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from './waitlist'

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -1,11 +1,19 @@
 // Devices
-export { getDeviceById, upsertDevice, revokeDevice, denyDevice, markDeviceTrusted, registerDevice } from './devices'
+export {
+  getDeviceById,
+  upsertDevice,
+  revokeDevice,
+  denyDevice,
+  markDeviceTrusted,
+  registerDevice,
+  countActiveDevices,
+} from './devices'
 
 // Users
 export { getUserById, getUserByEmail, deleteUser, markUserNotNew } from './users'
 
 // Sessions
-export { getActiveSessionByToken, revokeOtherSessions } from './sessions'
+export { getActiveSessionByToken, linkSessionToDevice, revokeDeviceSessions } from './sessions'
 
 // Waitlist
 export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from './waitlist'

--- a/backend/src/dal/sessions.test.ts
+++ b/backend/src/dal/sessions.test.ts
@@ -1,7 +1,8 @@
 import { session, user } from '@/db/auth-schema'
 import { createTestDb } from '@/test-utils/db'
+import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { getActiveSessionByToken } from './sessions'
+import { getActiveSessionByToken, linkSessionToDevice, revokeDeviceSessions } from './sessions'
 
 describe('sessions DAL', () => {
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
@@ -61,5 +62,125 @@ describe('sessions DAL', () => {
   it('returns null for nonexistent token', async () => {
     const result = await getActiveSessionByToken(db, 'no-such-token')
     expect(result).toBeNull()
+  })
+
+  describe('linkSessionToDevice', () => {
+    it('sets deviceId on the session', async () => {
+      const now = new Date()
+      const future = new Date(now.getTime() + 3600_000)
+      await db.insert(session).values({
+        id: 'link-session',
+        expiresAt: future,
+        token: 'link-token',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      await linkSessionToDevice(db, 'link-session', 'device-abc', userId)
+
+      const [row] = await db.select().from(session).where(eq(session.id, 'link-session'))
+      expect(row.deviceId).toBe('device-abc')
+    })
+
+    it('overwrites previous deviceId', async () => {
+      const now = new Date()
+      const future = new Date(now.getTime() + 3600_000)
+      await db.insert(session).values({
+        id: 'relink-session',
+        expiresAt: future,
+        token: 'relink-token',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+        deviceId: 'old-device',
+      })
+
+      await linkSessionToDevice(db, 'relink-session', 'new-device', userId)
+
+      const [row] = await db.select().from(session).where(eq(session.id, 'relink-session'))
+      expect(row.deviceId).toBe('new-device')
+    })
+  })
+
+  describe('revokeDeviceSessions', () => {
+    it('deletes all sessions linked to the device', async () => {
+      const now = new Date()
+      const future = new Date(now.getTime() + 3600_000)
+      await db.insert(session).values([
+        {
+          id: 'dev-session-1',
+          expiresAt: future,
+          token: 'dev-token-1',
+          createdAt: now,
+          updatedAt: now,
+          userId,
+          deviceId: 'target-device',
+        },
+        {
+          id: 'dev-session-2',
+          expiresAt: future,
+          token: 'dev-token-2',
+          createdAt: now,
+          updatedAt: now,
+          userId,
+          deviceId: 'target-device',
+        },
+      ])
+
+      await revokeDeviceSessions(db, 'target-device', userId)
+
+      const remaining = await db.select().from(session).where(eq(session.userId, userId))
+      expect(remaining).toHaveLength(0)
+    })
+
+    it('does not delete sessions linked to other devices', async () => {
+      const now = new Date()
+      const future = new Date(now.getTime() + 3600_000)
+      await db.insert(session).values([
+        {
+          id: 'target-session',
+          expiresAt: future,
+          token: 'target-token',
+          createdAt: now,
+          updatedAt: now,
+          userId,
+          deviceId: 'revoked-device',
+        },
+        {
+          id: 'other-session',
+          expiresAt: future,
+          token: 'other-token',
+          createdAt: now,
+          updatedAt: now,
+          userId,
+          deviceId: 'safe-device',
+        },
+      ])
+
+      await revokeDeviceSessions(db, 'revoked-device', userId)
+
+      const remaining = await db.select().from(session).where(eq(session.userId, userId))
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0].id).toBe('other-session')
+    })
+
+    it('does not delete sessions without a deviceId', async () => {
+      const now = new Date()
+      const future = new Date(now.getTime() + 3600_000)
+      await db.insert(session).values({
+        id: 'no-device-session',
+        expiresAt: future,
+        token: 'no-device-token',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+
+      await revokeDeviceSessions(db, 'some-device', userId)
+
+      const remaining = await db.select().from(session).where(eq(session.id, 'no-device-session'))
+      expect(remaining).toHaveLength(1)
+    })
   })
 })

--- a/backend/src/dal/sessions.ts
+++ b/backend/src/dal/sessions.ts
@@ -1,6 +1,6 @@
 import type { db as DbType } from '@/db/client'
 import { session } from '@/db/auth-schema'
-import { and, eq, gt } from 'drizzle-orm'
+import { and, eq, gt, ne } from 'drizzle-orm'
 
 /** Get an active (non-expired) session by bearer token. Returns null if not found or expired. */
 export const getActiveSessionByToken = async (database: typeof DbType, token: string) =>
@@ -10,3 +10,7 @@ export const getActiveSessionByToken = async (database: typeof DbType, token: st
     .where(and(eq(session.token, token), gt(session.expiresAt, new Date())))
     .limit(1)
     .then((rows) => rows[0] ?? null)
+
+/** Revoke (delete) all sessions for a user except the specified session. */
+export const revokeOtherSessions = async (database: typeof DbType, userId: string, keepSessionId: string) =>
+  database.delete(session).where(and(eq(session.userId, userId), ne(session.id, keepSessionId)))

--- a/backend/src/dal/sessions.ts
+++ b/backend/src/dal/sessions.ts
@@ -1,6 +1,6 @@
 import type { db as DbType } from '@/db/client'
 import { session } from '@/db/auth-schema'
-import { and, eq, gt, ne } from 'drizzle-orm'
+import { and, eq, gt } from 'drizzle-orm'
 
 /** Get an active (non-expired) session by bearer token. Returns null if not found or expired. */
 export const getActiveSessionByToken = async (database: typeof DbType, token: string) =>
@@ -11,6 +11,18 @@ export const getActiveSessionByToken = async (database: typeof DbType, token: st
     .limit(1)
     .then((rows) => rows[0] ?? null)
 
-/** Revoke (delete) all sessions for a user except the specified session. */
-export const revokeOtherSessions = async (database: typeof DbType, userId: string, keepSessionId: string) =>
-  database.delete(session).where(and(eq(session.userId, userId), ne(session.id, keepSessionId)))
+/** Link a session to a device by setting the deviceId column. Only updates if session belongs to the user. */
+export const linkSessionToDevice = async (
+  database: typeof DbType,
+  sessionId: string,
+  deviceId: string,
+  userId: string,
+) =>
+  database
+    .update(session)
+    .set({ deviceId })
+    .where(and(eq(session.id, sessionId), eq(session.userId, userId)))
+
+/** Revoke (delete) all sessions linked to a specific device for a given user. */
+export const revokeDeviceSessions = async (database: typeof DbType, deviceId: string, userId: string) =>
+  database.delete(session).where(and(eq(session.deviceId, deviceId), eq(session.userId, userId)))

--- a/backend/src/db/auth-schema.ts
+++ b/backend/src/db/auth-schema.ts
@@ -30,8 +30,9 @@ export const session = pgTable(
     userId: text('user_id')
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
+    deviceId: text('device_id'),
   },
-  (table) => [index('session_userId_idx').on(table.userId)],
+  (table) => [index('session_userId_idx').on(table.userId), index('session_deviceId_idx').on(table.deviceId)],
 )
 
 export const account = pgTable(

--- a/backend/src/errors/http-errors.ts
+++ b/backend/src/errors/http-errors.ts
@@ -24,3 +24,11 @@ export class ForbiddenError extends HttpError {
     this.name = 'ForbiddenError'
   }
 }
+
+/** 422 Unprocessable Entity — request understood but cannot be processed (e.g. limit reached). */
+export class UnprocessableError extends HttpError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, 422, options)
+    this.name = 'UnprocessableError'
+  }
+}

--- a/backend/src/errors/http-errors.ts
+++ b/backend/src/errors/http-errors.ts
@@ -24,11 +24,3 @@ export class ForbiddenError extends HttpError {
     this.name = 'ForbiddenError'
   }
 }
-
-/** 422 Unprocessable Entity — request understood but cannot be processed (e.g. limit reached). */
-export class UnprocessableError extends HttpError {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, 422, options)
-    this.name = 'UnprocessableError'
-  }
-}

--- a/src/hooks/use-sync-setup.ts
+++ b/src/hooks/use-sync-setup.ts
@@ -131,6 +131,13 @@ export const useSyncSetup = () => {
       dispatch({ type: 'DETECTED_ADDITIONAL_DEVICE' })
       return 'additional-device' as const
     } catch (err) {
+      if (err instanceof HttpError && err.response.status === 422) {
+        dispatch({
+          type: 'SET_ERROR',
+          payload: 'You have reached the maximum number of devices. Revoke an existing device to add a new one.',
+        })
+        return 'error' as const
+      }
       const message = err instanceof Error ? err.message : 'Failed to register device'
       dispatch({ type: 'SET_ERROR', payload: message })
       return 'error' as const


### PR DESCRIPTION
## Summary

- **Session-device binding**: Added `deviceId` column to the session table so each session is linked to the device that created it. Revoking a device now only kills that device's sessions instead of all other sessions (nuclear approach).
- **Device limit**: Users are limited to 10 active (non-revoked) devices. The check is wrapped in a transaction to prevent TOCTOU race conditions.
- **Removed unused endpoint**: `POST /account/devices` was not called by the frontend — removed it. Device registration happens solely through `POST /devices` (encryption flow).
- **Hardened DAL functions**: `linkSessionToDevice` and `revokeDeviceSessions` now require `userId` to ensure session operations are scoped to the correct user.
- **Cleaned up dead code**: Removed `revokeOtherSessions` (replaced by device-scoped `revokeDeviceSessions`).
- **Frontend error handling**: 422 from device limit is caught and shown as a user-friendly message.

### Earlier commits on this branch
- Prevented device revocation bypass via unregistered devices
- Guarded device registration against TOCTOU race condition
- Made `revokeDevice` idempotent (204, preserves original `revokedAt`)

## Test plan
- [x] All 614 tests pass
- [x] Type check, lint, and format pass
- [ ] Manual test: revoke a device → only that device's sessions are killed, other devices stay logged in
- [ ] Manual test: register 10 devices → 11th returns 422 with friendly error in UI
- [ ] Manual test: re-register an existing device at the limit → succeeds (not a new device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication/session persistence and device revocation semantics, including new DB schema and transactional registration limits; mistakes could lock users out or leave revoked devices with valid sessions.
> 
> **Overview**
> Adds session-to-device binding by introducing `session.device_id` (plus index) and wiring auth to persist that field, enabling device-scoped session management.
> 
> Device revocation (`POST /account/devices/:id/revoke`) is now **idempotent** (always `204`), preserves existing `revokedAt`, and deletes only sessions linked to the revoked device via new DAL helpers.
> 
> Device registration (`POST /devices`) now enforces a **10 active devices/user** limit with a transaction to avoid TOCTOU races, and links the current session to the registering device; frontend setup flow surfaces `422` with a user-friendly message.
> 
> PowerSync sync gating is tightened with tests to reject unregistered device IDs and prevent revocation bypass attempts by swapping device IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df2c034accc564a27aa8270271ad9eb683de380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->