### PR TITLE
fix: sign session token in login response

### DIFF
--- a/backend/src/auth/auth.test.ts
+++ b/backend/src/auth/auth.test.ts
@@ -21,6 +21,7 @@ mock.module('@/waitlist/utils', () => ({
 import { user } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
 import { createAuth } from '@/auth/auth'
+import { verifySignedBearerToken } from '@/auth/bearer-token'
 import { normalizeEmail } from '@/lib/email'
 import { createTestDb } from '@/test-utils/db'
 import { betterAuth } from 'better-auth'
@@ -182,5 +183,122 @@ describe('Auth - user.isNew in sign-in response', () => {
     expect(result.user?.isNew).toBe(false)
     expect(result.session).toBeDefined()
     expect(result.user).toBeDefined()
+  })
+})
+
+describe('Auth - signed bearer token in login response', () => {
+  const betterAuthSecret = process.env.BETTER_AUTH_SECRET!
+
+  let auth: ReturnType<typeof createAuth>
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    mockSendSignInEmail.mockClear()
+
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+    auth = createAuth(db)
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  const signInAndGetToken = async (email: string) => {
+    await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+
+    const callArgs = (mockSendSignInEmail.mock.calls as unknown as Array<[{ otp: string }]>).at(-1)?.[0]
+    const otp = callArgs!.otp
+
+    return (await auth.api.signInEmailOTP({ body: { email, otp } })) as unknown as {
+      session: { token: string }
+      user: { id: string }
+    }
+  }
+
+  it('should return a signed session token for new user sign-in', async () => {
+    await db.insert(waitlist).values({
+      id: crypto.randomUUID(),
+      email: 'signed-new@example.com',
+      status: 'approved',
+    })
+
+    const result = await signInAndGetToken('signed-new@example.com')
+
+    expect(result.session.token).toBeDefined()
+    // Token must contain a dot (rawToken.signature format)
+    expect(result.session.token).toContain('.')
+    // Token must be verifiable with the correct secret
+    const rawToken = verifySignedBearerToken(result.session.token, betterAuthSecret)
+    expect(rawToken).not.toBeNull()
+  })
+
+  it('should return a signed session token for existing user sign-in', async () => {
+    await db.insert(user).values({
+      id: crypto.randomUUID(),
+      name: 'Existing Signed',
+      email: 'signed-existing@example.com',
+      emailVerified: true,
+      isNew: false,
+    })
+
+    const result = await signInAndGetToken('signed-existing@example.com')
+
+    expect(result.session.token).toBeDefined()
+    const rawToken = verifySignedBearerToken(result.session.token, betterAuthSecret)
+    expect(rawToken).not.toBeNull()
+  })
+
+  it('signed token should not verify with wrong secret', async () => {
+    await db.insert(user).values({
+      id: crypto.randomUUID(),
+      name: 'Wrong Secret User',
+      email: 'signed-wrong-secret@example.com',
+      emailVerified: true,
+      isNew: false,
+    })
+
+    const result = await signInAndGetToken('signed-wrong-secret@example.com')
+
+    expect(verifySignedBearerToken(result.session.token, 'completely-wrong-secret-value!!')).toBeNull()
+  })
+
+  it('raw token extracted from signed token should be a valid session identifier', async () => {
+    await db.insert(user).values({
+      id: crypto.randomUUID(),
+      name: 'Session Check User',
+      email: 'signed-session-check@example.com',
+      emailVerified: true,
+      isNew: false,
+    })
+
+    const result = await signInAndGetToken('signed-session-check@example.com')
+    const rawToken = verifySignedBearerToken(result.session.token, betterAuthSecret)
+    expect(rawToken).not.toBeNull()
+    // Raw token should be non-empty and not contain the signature
+    expect(rawToken!.length).toBeGreaterThan(0)
+    expect(rawToken!).not.toContain(result.session.token.substring(result.session.token.lastIndexOf('.') + 1))
+  })
+
+  it('different sign-ins should produce different signed tokens', async () => {
+    await db.insert(user).values({
+      id: crypto.randomUUID(),
+      name: 'Multi Sign User',
+      email: 'signed-multi@example.com',
+      emailVerified: true,
+      isNew: false,
+    })
+
+    const result1 = await signInAndGetToken('signed-multi@example.com')
+    mockSendSignInEmail.mockClear()
+    const result2 = await signInAndGetToken('signed-multi@example.com')
+
+    // Each sign-in creates a new session with a different token
+    expect(result1.session.token).not.toBe(result2.session.token)
+    // Both should still be verifiable
+    expect(verifySignedBearerToken(result1.session.token, betterAuthSecret)).not.toBeNull()
+    expect(verifySignedBearerToken(result2.session.token, betterAuthSecret)).not.toBeNull()
   })
 })

--- a/backend/src/auth/auth.test.ts
+++ b/backend/src/auth/auth.test.ts
@@ -113,80 +113,7 @@ describe('Auth - Email Normalization', () => {
   })
 })
 
-describe('Auth - user.isNew in sign-in response', () => {
-  let auth: ReturnType<typeof createAuth>
-  let db: Awaited<ReturnType<typeof createTestDb>>['db']
-  let cleanup: () => Promise<void>
-
-  beforeEach(async () => {
-    mockSendSignInEmail.mockClear()
-
-    const testEnv = await createTestDb()
-    db = testEnv.db
-    cleanup = testEnv.cleanup
-    auth = createAuth(db)
-  })
-
-  afterEach(async () => {
-    await cleanup()
-  })
-
-  it('should return user.isNew: true when user signs in for the first time', async () => {
-    await db.insert(waitlist).values({
-      id: crypto.randomUUID(),
-      email: 'newuser@example.com',
-      status: 'approved',
-    })
-
-    await auth.api.sendVerificationOTP({
-      body: { email: 'newuser@example.com', type: 'sign-in' },
-    })
-
-    expect(mockSendSignInEmail).toHaveBeenCalledTimes(1)
-    const callArgs = (mockSendSignInEmail.mock.calls as unknown as Array<[{ otp: string }]>).at(0)?.[0]
-    expect(callArgs?.otp).toBeDefined()
-    const otp = callArgs!.otp
-
-    const result = (await auth.api.signInEmailOTP({
-      body: { email: 'newuser@example.com', otp },
-    })) as unknown as { session: unknown; user: { isNew?: boolean } }
-
-    expect(result.user?.isNew).toBe(true)
-    expect(result.session).toBeDefined()
-    expect(result.user).toBeDefined()
-  })
-
-  it('should return user.isNew: false when existing user signs in again', async () => {
-    const existingUserId = crypto.randomUUID()
-
-    await db.insert(user).values({
-      id: existingUserId,
-      name: 'Existing User',
-      email: 'existing-isnewuser@example.com',
-      emailVerified: true,
-      isNew: false,
-    })
-
-    await auth.api.sendVerificationOTP({
-      body: { email: 'existing-isnewuser@example.com', type: 'sign-in' },
-    })
-
-    expect(mockSendSignInEmail).toHaveBeenCalledTimes(1)
-    const callArgs = (mockSendSignInEmail.mock.calls as unknown as Array<[{ otp: string }]>).at(0)?.[0]
-    expect(callArgs?.otp).toBeDefined()
-    const otp = callArgs!.otp
-
-    const result = (await auth.api.signInEmailOTP({
-      body: { email: 'existing-isnewuser@example.com', otp },
-    })) as unknown as { session: unknown; user: { isNew?: boolean } }
-
-    expect(result.user?.isNew).toBe(false)
-    expect(result.session).toBeDefined()
-    expect(result.user).toBeDefined()
-  })
-})
-
-describe('Auth - signed bearer token in login response', () => {
+describe('Auth - sign-in response', () => {
   const betterAuthSecret = process.env.BETTER_AUTH_SECRET!
 
   let auth: ReturnType<typeof createAuth>
@@ -214,91 +141,118 @@ describe('Auth - signed bearer token in login response', () => {
 
     return (await auth.api.signInEmailOTP({ body: { email, otp } })) as unknown as {
       session: { token: string }
-      user: { id: string }
+      user: { id: string; isNew?: boolean }
     }
   }
 
-  it('should return a signed session token for new user sign-in', async () => {
-    await db.insert(waitlist).values({
-      id: crypto.randomUUID(),
-      email: 'signed-new@example.com',
-      status: 'approved',
+  describe('user.isNew', () => {
+    it('should return user.isNew: true when user signs in for the first time', async () => {
+      await db.insert(waitlist).values({
+        id: crypto.randomUUID(),
+        email: 'newuser@example.com',
+        status: 'approved',
+      })
+
+      const result = await signInAndGetToken('newuser@example.com')
+
+      expect(result.user?.isNew).toBe(true)
+      expect(result.session).toBeDefined()
+      expect(result.user).toBeDefined()
     })
 
-    const result = await signInAndGetToken('signed-new@example.com')
+    it('should return user.isNew: false when existing user signs in again', async () => {
+      await db.insert(user).values({
+        id: crypto.randomUUID(),
+        name: 'Existing User',
+        email: 'existing-isnewuser@example.com',
+        emailVerified: true,
+        isNew: false,
+      })
 
-    expect(result.session.token).toBeDefined()
-    // Token must contain a dot (rawToken.signature format)
-    expect(result.session.token).toContain('.')
-    // Token must be verifiable with the correct secret
-    const rawToken = verifySignedBearerToken(result.session.token, betterAuthSecret)
-    expect(rawToken).not.toBeNull()
+      const result = await signInAndGetToken('existing-isnewuser@example.com')
+
+      expect(result.user?.isNew).toBe(false)
+      expect(result.session).toBeDefined()
+      expect(result.user).toBeDefined()
+    })
   })
 
-  it('should return a signed session token for existing user sign-in', async () => {
-    await db.insert(user).values({
-      id: crypto.randomUUID(),
-      name: 'Existing Signed',
-      email: 'signed-existing@example.com',
-      emailVerified: true,
-      isNew: false,
+  describe('signed bearer token', () => {
+    it('should return a signed session token for new user sign-in', async () => {
+      await db.insert(waitlist).values({
+        id: crypto.randomUUID(),
+        email: 'signed-new@example.com',
+        status: 'approved',
+      })
+
+      const result = await signInAndGetToken('signed-new@example.com')
+
+      expect(result.session.token).toBeDefined()
+      expect(result.session.token).toContain('.')
+      expect(verifySignedBearerToken(result.session.token, betterAuthSecret)).not.toBeNull()
     })
 
-    const result = await signInAndGetToken('signed-existing@example.com')
+    it('should return a signed session token for existing user sign-in', async () => {
+      await db.insert(user).values({
+        id: crypto.randomUUID(),
+        name: 'Existing Signed',
+        email: 'signed-existing@example.com',
+        emailVerified: true,
+        isNew: false,
+      })
 
-    expect(result.session.token).toBeDefined()
-    const rawToken = verifySignedBearerToken(result.session.token, betterAuthSecret)
-    expect(rawToken).not.toBeNull()
-  })
+      const result = await signInAndGetToken('signed-existing@example.com')
 
-  it('signed token should not verify with wrong secret', async () => {
-    await db.insert(user).values({
-      id: crypto.randomUUID(),
-      name: 'Wrong Secret User',
-      email: 'signed-wrong-secret@example.com',
-      emailVerified: true,
-      isNew: false,
+      expect(result.session.token).toBeDefined()
+      expect(verifySignedBearerToken(result.session.token, betterAuthSecret)).not.toBeNull()
     })
 
-    const result = await signInAndGetToken('signed-wrong-secret@example.com')
+    it('signed token should not verify with wrong secret', async () => {
+      await db.insert(user).values({
+        id: crypto.randomUUID(),
+        name: 'Wrong Secret User',
+        email: 'signed-wrong-secret@example.com',
+        emailVerified: true,
+        isNew: false,
+      })
 
-    expect(verifySignedBearerToken(result.session.token, 'completely-wrong-secret-value!!')).toBeNull()
-  })
+      const result = await signInAndGetToken('signed-wrong-secret@example.com')
 
-  it('raw token extracted from signed token should be a valid session identifier', async () => {
-    await db.insert(user).values({
-      id: crypto.randomUUID(),
-      name: 'Session Check User',
-      email: 'signed-session-check@example.com',
-      emailVerified: true,
-      isNew: false,
+      expect(verifySignedBearerToken(result.session.token, 'completely-wrong-secret-value!!')).toBeNull()
     })
 
-    const result = await signInAndGetToken('signed-session-check@example.com')
-    const rawToken = verifySignedBearerToken(result.session.token, betterAuthSecret)
-    expect(rawToken).not.toBeNull()
-    // Raw token should be non-empty and not contain the signature
-    expect(rawToken!.length).toBeGreaterThan(0)
-    expect(rawToken!).not.toContain(result.session.token.substring(result.session.token.lastIndexOf('.') + 1))
-  })
+    it('raw token extracted from signed token should be a valid session identifier', async () => {
+      await db.insert(user).values({
+        id: crypto.randomUUID(),
+        name: 'Session Check User',
+        email: 'signed-session-check@example.com',
+        emailVerified: true,
+        isNew: false,
+      })
 
-  it('different sign-ins should produce different signed tokens', async () => {
-    await db.insert(user).values({
-      id: crypto.randomUUID(),
-      name: 'Multi Sign User',
-      email: 'signed-multi@example.com',
-      emailVerified: true,
-      isNew: false,
+      const result = await signInAndGetToken('signed-session-check@example.com')
+      const rawToken = verifySignedBearerToken(result.session.token, betterAuthSecret)
+      expect(rawToken).not.toBeNull()
+      expect(rawToken!.length).toBeGreaterThan(0)
+      expect(rawToken!).not.toContain(result.session.token.substring(result.session.token.lastIndexOf('.') + 1))
     })
 
-    const result1 = await signInAndGetToken('signed-multi@example.com')
-    mockSendSignInEmail.mockClear()
-    const result2 = await signInAndGetToken('signed-multi@example.com')
+    it('different sign-ins should produce different signed tokens', async () => {
+      await db.insert(user).values({
+        id: crypto.randomUUID(),
+        name: 'Multi Sign User',
+        email: 'signed-multi@example.com',
+        emailVerified: true,
+        isNew: false,
+      })
 
-    // Each sign-in creates a new session with a different token
-    expect(result1.session.token).not.toBe(result2.session.token)
-    // Both should still be verifiable
-    expect(verifySignedBearerToken(result1.session.token, betterAuthSecret)).not.toBeNull()
-    expect(verifySignedBearerToken(result2.session.token, betterAuthSecret)).not.toBeNull()
+      const result1 = await signInAndGetToken('signed-multi@example.com')
+      mockSendSignInEmail.mockClear()
+      const result2 = await signInAndGetToken('signed-multi@example.com')
+
+      expect(result1.session.token).not.toBe(result2.session.token)
+      expect(verifySignedBearerToken(result1.session.token, betterAuthSecret)).not.toBeNull()
+      expect(verifySignedBearerToken(result2.session.token, betterAuthSecret)).not.toBeNull()
+    })
   })
 })

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -10,6 +10,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { bearer, emailOTP } from 'better-auth/plugins'
 import { genericOAuth } from 'better-auth/plugins/generic-oauth'
 import { isAutoApprovedDomain, sendWaitlistJoinedEmail, sendWaitlistNotReadyEmail } from '@/waitlist/utils'
+import { signBearerToken } from './bearer-token'
 import { buildVerifyUrl, getValidatedOrigin, parseTrustedOrigins, sendSignInEmail } from './utils'
 
 /**
@@ -126,7 +127,10 @@ export const createAuth = (database: typeof DbType) => {
         }
 
         return ctx.json({
-          session: newSession.session,
+          session: {
+            ...newSession.session,
+            token: signBearerToken(newSession.session.token, settings.betterAuthSecret),
+          },
           user: sessionUser,
         })
       }),

--- a/backend/src/auth/bearer-token.test.ts
+++ b/backend/src/auth/bearer-token.test.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'crypto'
 import { describe, expect, it } from 'bun:test'
-import { verifySignedBearerToken } from './bearer-token'
+import { signBearerToken, verifySignedBearerToken } from './bearer-token'
 
 const secret = 'test-secret-at-least-32-chars-long!!'
 
@@ -8,6 +8,72 @@ const sign = (token: string, s = secret): string => {
   const sig = createHmac('sha256', s).update(token).digest('base64')
   return `${token}.${sig}`
 }
+
+describe('signBearerToken', () => {
+  it('produces rawToken.base64Signature format', () => {
+    const signed = signBearerToken('my-token', secret)
+    const dotIndex = signed.lastIndexOf('.')
+    expect(dotIndex).toBeGreaterThan(0)
+    expect(signed.substring(0, dotIndex)).toBe('my-token')
+    // Signature is valid base64
+    const sig = signed.substring(dotIndex + 1)
+    expect(Buffer.from(sig, 'base64').toString('base64')).toBe(sig)
+  })
+
+  it('produces deterministic output for same input', () => {
+    const a = signBearerToken('deterministic-test', secret)
+    const b = signBearerToken('deterministic-test', secret)
+    expect(a).toBe(b)
+  })
+
+  it('produces different signatures for different tokens', () => {
+    const a = signBearerToken('token-a', secret)
+    const b = signBearerToken('token-b', secret)
+    expect(a).not.toBe(b)
+  })
+
+  it('produces different signatures for different secrets', () => {
+    const a = signBearerToken('same-token', secret)
+    const b = signBearerToken('same-token', 'different-secret-at-least-32-chars!!')
+    expect(a).not.toBe(b)
+  })
+
+  it('handles tokens containing dots', () => {
+    const signed = signBearerToken('part1.part2.part3', secret)
+    expect(signed.startsWith('part1.part2.part3.')).toBe(true)
+  })
+})
+
+describe('signBearerToken + verifySignedBearerToken round-trip', () => {
+  it('verify accepts tokens produced by sign', () => {
+    const raw = 'session-token-abc123'
+    const signed = signBearerToken(raw, secret)
+    expect(verifySignedBearerToken(signed, secret)).toBe(raw)
+  })
+
+  it('round-trips tokens containing dots', () => {
+    const raw = 'a.b.c.d'
+    const signed = signBearerToken(raw, secret)
+    expect(verifySignedBearerToken(signed, secret)).toBe(raw)
+  })
+
+  it('verify rejects sign output when verified with wrong secret', () => {
+    const signed = signBearerToken('my-token', secret)
+    expect(verifySignedBearerToken(signed, 'wrong-secret-at-least-32-chars-long!!')).toBeNull()
+  })
+
+  it('round-trips long tokens', () => {
+    const raw = 'a'.repeat(500)
+    const signed = signBearerToken(raw, secret)
+    expect(verifySignedBearerToken(signed, secret)).toBe(raw)
+  })
+
+  it('round-trips tokens with special characters', () => {
+    const raw = 'token+with/special=chars'
+    const signed = signBearerToken(raw, secret)
+    expect(verifySignedBearerToken(signed, secret)).toBe(raw)
+  })
+})
 
 describe('verifySignedBearerToken', () => {
   it('returns raw token for a valid signed token', () => {

--- a/backend/src/auth/bearer-token.test.ts
+++ b/backend/src/auth/bearer-token.test.ts
@@ -1,13 +1,7 @@
-import { createHmac } from 'crypto'
 import { describe, expect, it } from 'bun:test'
 import { signBearerToken, verifySignedBearerToken } from './bearer-token'
 
 const secret = 'test-secret-at-least-32-chars-long!!'
-
-const sign = (token: string, s = secret): string => {
-  const sig = createHmac('sha256', s).update(token).digest('base64')
-  return `${token}.${sig}`
-}
 
 describe('signBearerToken', () => {
   it('produces rawToken.base64Signature format', () => {
@@ -77,11 +71,11 @@ describe('signBearerToken + verifySignedBearerToken round-trip', () => {
 
 describe('verifySignedBearerToken', () => {
   it('returns raw token for a valid signed token', () => {
-    expect(verifySignedBearerToken(sign('my-session-token'), secret)).toBe('my-session-token')
+    expect(verifySignedBearerToken(signBearerToken('my-session-token', secret), secret)).toBe('my-session-token')
   })
 
   it('returns null when signed with wrong secret', () => {
-    const signed = sign('my-session-token', 'wrong-secret-at-least-32-chars-long!!')
+    const signed = signBearerToken('my-session-token', 'wrong-secret-at-least-32-chars-long!!')
     expect(verifySignedBearerToken(signed, secret)).toBeNull()
   })
 
@@ -107,7 +101,7 @@ describe('verifySignedBearerToken', () => {
 
   it('handles token that itself contains dots', () => {
     const token = 'part1.part2.part3'
-    const signed = sign(token)
+    const signed = signBearerToken(token, secret)
     expect(verifySignedBearerToken(signed, secret)).toBe(token)
   })
 })

--- a/backend/src/auth/bearer-token.ts
+++ b/backend/src/auth/bearer-token.ts
@@ -1,5 +1,11 @@
 import { createHmac, timingSafeEqual } from 'crypto'
 
+/** Sign a raw session token with HMAC-SHA256, producing `rawToken.base64Signature`. */
+export const signBearerToken = (rawToken: string, secret: string): string => {
+  const signature = createHmac('sha256', secret).update(rawToken).digest('base64')
+  return `${rawToken}.${signature}`
+}
+
 /**
  * Verify a signed bearer token (format: `rawToken.base64Signature`) and return the raw session token.
  * Returns null if the token is unsigned, malformed, or the signature doesn't match.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,7 +4,6 @@ import { createGoogleAuthRoutes } from '@/auth/google'
 import { createMicrosoftAuthRoutes } from '@/auth/microsoft'
 import { createLoggerMiddleware, createStandaloneLogger } from '@/config/logger'
 import { getCorsOriginsList, getSettings } from '@/config/settings'
-import { runMigrations } from '@/db/client'
 import { createInferenceRoutes } from '@/inference/routes'
 import { createErrorHandlingMiddleware } from '@/middleware/error-handling'
 import { createHttpLoggingMiddleware } from '@/middleware/http-logging'
@@ -114,6 +113,7 @@ const startServer = async () => {
 
   try {
     // Run PGLite migrations before creating the app (no-op for Postgres)
+    const { runMigrations } = await import('@/db/client')
     await runMigrations()
 
     const app = await createApp()

--- a/backend/src/swagger.test.ts
+++ b/backend/src/swagger.test.ts
@@ -1,16 +1,23 @@
 import { clearSettingsCache } from '@/config/settings'
 import { createApp } from '@/index'
+import { createTestDb } from '@/test-utils/db'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
 describe('Swagger', () => {
   let savedSwaggerEnabled: string | undefined
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
 
-  beforeEach(() => {
+  beforeEach(async () => {
     savedSwaggerEnabled = process.env.SWAGGER_ENABLED
     clearSettingsCache()
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await cleanup()
     if (savedSwaggerEnabled !== undefined) {
       process.env.SWAGGER_ENABLED = savedSwaggerEnabled
     } else {
@@ -21,21 +28,21 @@ describe('Swagger', () => {
 
   it('should NOT expose /v1/swagger when SWAGGER_ENABLED is unset', async () => {
     delete process.env.SWAGGER_ENABLED
-    const app = await createApp()
+    const app = await createApp({ database: db })
     const res = await app.handle(new Request('http://localhost/v1/swagger'))
     expect(res.status).toBe(404)
   })
 
   it('should expose /v1/swagger when SWAGGER_ENABLED=true', async () => {
     process.env.SWAGGER_ENABLED = 'true'
-    const app = await createApp()
+    const app = await createApp({ database: db })
     const res = await app.handle(new Request('http://localhost/v1/swagger'))
     expect(res.status).not.toBe(404)
   })
 
   it('should NOT expose /v1/swagger when SWAGGER_ENABLED=false', async () => {
     process.env.SWAGGER_ENABLED = 'false'
-    const app = await createApp()
+    const app = await createApp({ database: db })
     const res = await app.handle(new Request('http://localhost/v1/swagger'))
     expect(res.status).toBe(404)
   })


### PR DESCRIPTION
- the bearer token signature requirement was added but the login
  endpoint still returned unsigned tokens, causing post-login
  requests to fail verification
- sign the session token with signBearerToken before returning it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication session token format/handling; a mismatch between client expectations and signature verification would break authenticated requests, but the change is narrow and covered by new tests.
> 
> **Overview**
> Fixes the `/sign-in/email-otp` response to return a **signed bearer token** by wrapping `newSession.session.token` with `signBearerToken(...)` before sending it back to clients.
> 
> Adds `signBearerToken` (HMAC-SHA256 `rawToken.base64Signature`) and expands tests to cover signing/verification behavior and ensure sign-in returns verifiable signed tokens for both new and existing users. Also tweaks startup/testing reliability by lazily importing `runMigrations` in `index.ts` and updating `swagger.test.ts` to inject a test database into `createApp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd31d2c37517bdc4e01189ec83ede3b2390f5b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->