### PR TITLE
fix(auth): remove manual token storage that overwrote signed bearer token

### DIFF
--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -2,7 +2,6 @@ import type { AuthClient } from '@/contexts'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { updateSettings } from '@/dal'
 import { getDb, getDatabaseInstance } from '@/db/database'
-import { setAuthToken } from '@/lib/auth-token'
 import { isValidEmailFormat } from '@/lib/utils'
 import { useReducer, type FormEvent } from 'react'
 
@@ -173,12 +172,6 @@ export const useSignInFormState = ({
       if (result.error) {
         dispatch({ type: 'VERIFY_ERROR', payload: getOtpErrorMessage(result.error, 'code') })
         return
-      }
-
-      // Store the token for bearer auth (backend returns { session, user }; session.token is the bearer token)
-      const token = (result.data as { session?: { token?: string } } | undefined)?.session?.token
-      if (token) {
-        setAuthToken(token)
       }
 
       const isNewUser = isNewAuthUser(result.data?.user)

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -2,7 +2,6 @@ import { isNewAuthUser, onSignInSuccess } from '@/components/sign-in/use-sign-in
 import { useWelcomeStore } from '@/components/welcome-dialog'
 import type { AuthClient } from '@/contexts'
 import { useHttpClient } from '@/contexts'
-import { setAuthToken } from '@/lib/auth-token'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { isValidEmailFormat } from '@/lib/utils'
 import { useReducer, type FormEvent } from 'react'
@@ -111,15 +110,6 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
         dispatch({ type: 'VERIFY_ERROR', payload: getOtpErrorMessage(result.error, 'code') })
         return
       }
-
-      // Backend auth hook returns { session, user }; session.token is the bearer token
-      const token = (result.data as { session?: { token?: string } } | undefined)?.session?.token
-      if (!token) {
-        dispatch({ type: 'VERIFY_ERROR', payload: 'Verification failed. Please try again.' })
-        return
-      }
-
-      setAuthToken(token)
 
       const isNewUser = isNewAuthUser(result.data.user)
       await onSignInSuccess(isNewUser)


### PR DESCRIPTION
## Summary

After enabling `requireSignature: true` on the bearer plugin (#559), `get-session` returned `null` even with a valid token — leaving users stuck on the sign-in screen.

**Root cause:** The sign-in form manually stored the raw `session.token` from the response body, overwriting the signed token that the `onSuccess` handler had already saved from the `set-auth-token` header. The unsigned token was then rejected by the bearer plugin.

**Fix:** Removed the manual `setAuthToken` call. Token storage is already handled by the `onSuccess` callback in `buildFetchOptions`, which correctly stores the signed token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token persistence in the sign-in/waitlist OTP flows; mistakes could break authentication/session restoration, but the change is narrowly scoped to removing redundant writes.
> 
> **Overview**
> Removes manual `setAuthToken` writes after `authClient.signIn.emailOtp()` in both the sign-in form and waitlist OTP verification flow, so the client no longer overwrites the bearer token stored from the `set-auth-token` response header.
> 
> This aligns token storage with `buildFetchOptions.onSuccess` in `auth-context`, preventing unsigned response-body tokens from clobbering the signed token required by the bearer plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee32359491e43526fe71f85ac9dd5d134046a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->