### PR TITLE
chore: Remove misleading isProUser bypass and dead pro upgrade code

### DIFF
--- a/src/integrations/thunderbolt-pro/utils.ts
+++ b/src/integrations/thunderbolt-pro/utils.ts
@@ -1,22 +1,13 @@
 import type { ThunderboltProStatus } from './types'
 
-// Hardcoded constant for testing - can be switched back and forth
-const isProUser = true // Set to false to test "Get Pro" button
+const proFeatures = ['search', 'web_fetch', 'weather', 'weather_forecast']
 
 /**
- * Get the current user's pro status
+ * All users currently have Pro access — this is an intentional business decision.
+ * When a paid tier is introduced, replace with a real entitlement check.
  */
 export const getProStatus = async (): Promise<ThunderboltProStatus> => {
-  return {
-    isProUser,
-    features: isProUser ? ['search', 'web_fetch', 'weather', 'weather_forecast'] : [],
-  }
+  return { isProUser: true, features: proFeatures }
 }
 
-/**
- * Check if user has access to pro features
- */
-export const hasProAccess = async (): Promise<boolean> => {
-  const status = await getProStatus()
-  return status.isProUser
-}
+export const hasProAccess = async (): Promise<boolean> => true

--- a/src/settings/integrations.tsx
+++ b/src/settings/integrations.tsx
@@ -165,13 +165,6 @@ export default function IntegrationsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.state])
 
-  const handleGetPro = async () => {
-    // For now, just show an alert since this is a placeholder
-    alert(
-      'Thunderbolt Pro upgrade would be handled here. For testing, toggle the IS_PRO_USER constant in src/integrations/thunderbolt-pro/utils.ts',
-    )
-  }
-
   const handleDisconnect = async (integration: Integration) => {
     try {
       await updateSettings(db, {
@@ -237,23 +230,17 @@ export default function IntegrationsPage() {
 
             {!integration.isConnected && (
               <CardContent>
-                {integration.provider === 'thunderbolt-pro' ? (
-                  <Button onClick={handleGetPro} className="w-full">
-                    {integration.connectLabel}
-                  </Button>
-                ) : (
-                  <ConnectProviderButton
-                    provider={integration.provider as OAuthProvider}
-                    isConnected={false}
-                    isProcessing={isProcessingCallback}
-                    onError={(error) => {
-                      setError(error.message)
-                    }}
-                    returnContext="integrations"
-                    className="w-full"
-                    connectLabel={integration.connectLabel}
-                  />
-                )}
+                <ConnectProviderButton
+                  provider={integration.provider as OAuthProvider}
+                  isConnected={false}
+                  isProcessing={isProcessingCallback}
+                  onError={(error) => {
+                    setError(error.message)
+                  }}
+                  returnContext="integrations"
+                  className="w-full"
+                  connectLabel={integration.connectLabel}
+                />
               </CardContent>
             )}
 


### PR DESCRIPTION
## Summary
- Removed the hardcoded `isProUser = true` variable and its misleading testing comment from `utils.ts` — researchers were flagging this as a security bypass when it's actually an intentional business decision (all users currently have Pro access)
- Removed the `handleGetPro` function containing `window.alert()` with dev instructions and the dead "Get Pro" button JSX from `integrations.tsx`
- `getProStatus()` and `hasProAccess()` API unchanged — zero breaking changes

## Context
- **THU-375**: `isProUser = true` listed as Critical — "Hardcoded isProUser = true bypass"
- **THU-380**: Confirms this is intentional but confusing to researchers
- The "Get Pro" button was never rendered (always gated by `isProUser = true`), making `handleGetPro` dead code

## Test plan
- [ ] Verify typecheck passes
- [ ] Verify all thunderbolt-pro tests pass (`bun test`)
- [ ] Verify integrations settings page shows Pro as connected
- [ ] Verify Pro tools (search, web_fetch, weather) are available in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly removes misleading test/placeholder logic and simplifies Pro access checks; main impact is UI now always uses `ConnectProviderButton` when disconnected, which could change behavior if `thunderbolt-pro` is ever not connected.
> 
> **Overview**
> **Cleans up Thunderbolt Pro entitlement and settings UI.** `getProStatus` is simplified to always return Pro access (with a shared `proFeatures` list) and `hasProAccess` is reduced to a constant `true`, removing the hardcoded toggle/testing comment.
> 
> On the Integrations settings page, the unused “Get Pro” alert handler and the special-case button rendering for `thunderbolt-pro` when disconnected are removed, standardizing the disconnected state to always render `ConnectProviderButton`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6de8d92abfa020977f5db9d0ee1be1f16431ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->