### PR TITLE
fix(security): add XSS-prevention headers to proxy responses

### DIFF
--- a/backend/src/mcp-proxy/routes.test.ts
+++ b/backend/src/mcp-proxy/routes.test.ts
@@ -306,6 +306,43 @@ describe('MCP Proxy Routes', () => {
     expect(calledUrl).toContain('/tools/call')
   })
 
+  it('adds security headers to prevent XSS via proxied content', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response('<html><script>alert("xss")</script></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        }),
+      ),
+    )
+
+    const response = await app.handle(
+      new Request('http://localhost/mcp-proxy/', {
+        method: 'POST',
+        headers: { 'x-mcp-target-url': 'https://mcp.example.com' },
+      }),
+    )
+
+    expect(response.headers.get('content-security-policy')).toBe('sandbox')
+    expect(response.headers.get('content-disposition')).toBe('attachment')
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+
+  it('adds security headers for non-HTML content types too', async () => {
+    mockFetch.mockImplementation(() => Promise.resolve(createMockResponse('{"ok":true}')))
+
+    const response = await app.handle(
+      new Request('http://localhost/mcp-proxy/', {
+        method: 'POST',
+        headers: { 'x-mcp-target-url': 'https://mcp.example.com' },
+      }),
+    )
+
+    expect(response.headers.get('content-security-policy')).toBe('sandbox')
+    expect(response.headers.get('content-disposition')).toBe('attachment')
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+
   it('sets cross-origin-resource-policy on response', async () => {
     mockFetch.mockImplementation(() => Promise.resolve(createMockResponse('{"ok":true}')))
 

--- a/backend/src/mcp-proxy/routes.ts
+++ b/backend/src/mcp-proxy/routes.ts
@@ -103,6 +103,12 @@ const handleProxy = async (
 
     const responseHeaders = extractResponseHeaders(response.headers)
     responseHeaders.delete('set-cookie')
+
+    // Prevent XSS: proxied content must never execute scripts in our origin
+    responseHeaders.set('content-security-policy', 'sandbox')
+    responseHeaders.set('content-disposition', 'attachment')
+    responseHeaders.set('x-content-type-options', 'nosniff')
+
     responseHeaders.set('cross-origin-resource-policy', 'cross-origin')
 
     return new Response(body, {

--- a/backend/src/posthog/routes.test.ts
+++ b/backend/src/posthog/routes.test.ts
@@ -1,0 +1,101 @@
+import type { ConsoleSpies } from '@/test-utils/console-spies'
+import { setupConsoleSpy } from '@/test-utils/console-spies'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+import { Elysia } from 'elysia'
+import { createPostHogRoutes } from './routes'
+import * as settingsModule from '@/config/settings'
+
+describe('PostHog Proxy Routes', () => {
+  let app: { handle: Elysia['handle'] }
+  let getSettingsSpy: ReturnType<typeof spyOn>
+  let consoleSpies: ConsoleSpies
+  let mockFetch: ReturnType<typeof mock>
+
+  beforeAll(() => {
+    consoleSpies = setupConsoleSpy()
+
+    getSettingsSpy = spyOn(settingsModule, 'getSettings').mockReturnValue({
+      fireworksApiKey: '',
+      mistralApiKey: '',
+      anthropicApiKey: '',
+      exaApiKey: '',
+      thunderboltInferenceUrl: '',
+      thunderboltInferenceApiKey: '',
+      monitoringToken: '',
+      googleClientId: '',
+      googleClientSecret: '',
+      microsoftClientId: '',
+      microsoftClientSecret: '',
+      logLevel: 'INFO',
+      port: 8000,
+      appUrl: 'http://localhost:1420',
+      posthogHost: 'https://us.i.posthog.com',
+      posthogApiKey: 'test-key',
+      corsOrigins: 'http://localhost:1420',
+      corsAllowCredentials: true,
+      corsAllowMethods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
+      corsAllowHeaders: 'Content-Type,Authorization',
+      corsExposeHeaders: '',
+      waitlistEnabled: false,
+      waitlistAutoApproveDomains: '',
+      powersyncUrl: '',
+      powersyncJwtKid: '',
+      powersyncJwtSecret: '',
+      powersyncTokenExpirySeconds: 3600,
+      authMode: 'consumer' as const,
+      oidcClientId: '',
+      oidcClientSecret: '',
+      oidcIssuer: '',
+      betterAuthUrl: 'http://localhost:8000',
+      betterAuthSecret: 'test-secret-at-least-32-chars-long!!',
+      rateLimitEnabled: false,
+      swaggerEnabled: false,
+      trustedProxy: '',
+    } as ReturnType<typeof settingsModule.getSettings>)
+
+    mockFetch = mock(() =>
+      Promise.resolve(new Response('{"status":1}', { status: 200, headers: { 'content-type': 'application/json' } })),
+    )
+
+    app = new Elysia().use(createPostHogRoutes(mockFetch as unknown as typeof fetch))
+  })
+
+  afterAll(() => {
+    getSettingsSpy?.mockRestore()
+    consoleSpies.restore()
+  })
+
+  beforeEach(() => {
+    mockFetch.mockClear()
+    consoleSpies.error.mockClear()
+  })
+
+  it('adds security headers to prevent XSS via proxied content', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response('<html><script>alert("xss")</script></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+      ),
+    )
+
+    const response = await app.handle(new Request('http://localhost/posthog/some/path', { method: 'GET' }))
+
+    expect(response.headers.get('content-security-policy')).toBe('sandbox')
+    expect(response.headers.get('content-disposition')).toBe('attachment')
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+
+  it('adds security headers for JSON responses too', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'application/json' } })),
+    )
+
+    const response = await app.handle(new Request('http://localhost/posthog/batch', { method: 'POST' }))
+
+    expect(response.headers.get('content-security-policy')).toBe('sandbox')
+    expect(response.headers.get('content-disposition')).toBe('attachment')
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+})

--- a/backend/src/posthog/routes.ts
+++ b/backend/src/posthog/routes.ts
@@ -47,6 +47,11 @@ export const createPostHogRoutes = (fetchFn: typeof fetch = globalThis.fetch) =>
 
         const responseHeaders = extractResponseHeaders(response.headers)
 
+        // Prevent XSS: proxied content must never execute scripts in our origin
+        responseHeaders.set('content-security-policy', 'sandbox')
+        responseHeaders.set('content-disposition', 'attachment')
+        responseHeaders.set('x-content-type-options', 'nosniff')
+
         responseHeaders.set('cross-origin-resource-policy', 'cross-origin')
 
         return new Response(response.body, {

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -1055,7 +1055,7 @@ describe('Link Preview Routes', () => {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('content-security-policy')).toBe('sandbox')
-      expect(response.headers.get('content-disposition')).toBe('attachment')
+      expect(response.headers.get('content-disposition')).toBeNull()
       expect(response.headers.get('x-content-type-options')).toBe('nosniff')
     })
   })
@@ -1315,7 +1315,7 @@ describe('Link Preview Routes', () => {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('content-security-policy')).toBe('sandbox')
-      expect(response.headers.get('content-disposition')).toBe('attachment')
+      expect(response.headers.get('content-disposition')).toBeNull()
       expect(response.headers.get('x-content-type-options')).toBe('nosniff')
     })
   })

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -1034,6 +1034,30 @@ describe('Link Preview Routes', () => {
         expect(response.headers.get('content-type')).toBe('image/jpeg')
       })
     })
+
+    it('should add security headers to prevent XSS via proxied content', async () => {
+      const pageUrl = 'https://example.com/page'
+      const imageUrl = 'https://example.com/image.png'
+      const html = `<html><head><meta property="og:image" content="${imageUrl}" /></head></html>`
+
+      let callCount = 0
+      mockFetch.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve(createMockHtmlResponse(html))
+        }
+        return Promise.resolve(createMockImageResponse('image/png'))
+      })
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/image/${pageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-security-policy')).toBe('sandbox')
+      expect(response.headers.get('content-disposition')).toBe('attachment')
+      expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+    })
   })
 
   describe('GET /link-preview/proxy-image/*', () => {

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -1279,5 +1279,20 @@ describe('Link Preview Routes', () => {
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toBe('image/png; charset=utf-8')
     })
+
+    it('should add security headers to prevent XSS via proxied content', async () => {
+      const imageUrl = 'https://example.com/image.png'
+
+      mockFetch.mockImplementation(() => Promise.resolve(createMockImageResponse('image/png')))
+
+      const response = await app.handle(
+        new Request(`http://localhost/link-preview/proxy-image/${imageUrl}`, { method: 'GET' }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-security-policy')).toBe('sandbox')
+      expect(response.headers.get('content-disposition')).toBe('attachment')
+      expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+    })
   })
 })

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -97,7 +97,6 @@ const fetchAndProxyImage = async (
           'Content-Type': contentType,
           'Cache-Control': 'public, max-age=86400',
           'Content-Security-Policy': 'sandbox',
-          'Content-Disposition': 'attachment',
           'X-Content-Type-Options': 'nosniff',
           'Cross-Origin-Resource-Policy': 'cross-origin',
         },

--- a/backend/src/pro/link-preview.ts
+++ b/backend/src/pro/link-preview.ts
@@ -96,6 +96,9 @@ const fetchAndProxyImage = async (
         headers: {
           'Content-Type': contentType,
           'Cache-Control': 'public, max-age=86400',
+          'Content-Security-Policy': 'sandbox',
+          'Content-Disposition': 'attachment',
+          'X-Content-Type-Options': 'nosniff',
           'Cross-Origin-Resource-Policy': 'cross-origin',
         },
       })

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -380,6 +380,48 @@ describe('Proxy Routes', () => {
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
+    it('should add security headers to prevent XSS via proxied content', async () => {
+      const targetUrl = 'https://example.com/page.html'
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          createMockResponse('<html><script>alert("xss")</script></html>', {
+            headers: {
+              'content-type': 'text/html; charset=utf-8',
+            },
+          }),
+        ),
+      )
+
+      const response = await app.handle(new Request(`http://localhost/proxy/${targetUrl}`, { method: 'GET' }))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-security-policy')).toBe('sandbox')
+      expect(response.headers.get('content-disposition')).toBe('attachment')
+      expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+    })
+
+    it('should add security headers for non-HTML content types too', async () => {
+      const targetUrl = 'https://example.com/data.json'
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          createMockResponse('{"key":"value"}', {
+            headers: {
+              'content-type': 'application/json',
+            },
+          }),
+        ),
+      )
+
+      const response = await app.handle(new Request(`http://localhost/proxy/${targetUrl}`, { method: 'GET' }))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-security-policy')).toBe('sandbox')
+      expect(response.headers.get('content-disposition')).toBe('attachment')
+      expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+    })
+
     it('should not forward headers that are not in the allowed list', async () => {
       const targetUrl = 'https://example.com/resource'
 

--- a/backend/src/pro/proxy.ts
+++ b/backend/src/pro/proxy.ts
@@ -91,6 +91,11 @@ export const createProxyRoutes = (fetchFn: typeof fetch = globalThis.fetch) => {
           }
         })
 
+        // Prevent XSS: proxied content must never execute scripts in our origin
+        responseHeaders.set('content-security-policy', 'sandbox')
+        responseHeaders.set('content-disposition', 'attachment')
+        responseHeaders.set('x-content-type-options', 'nosniff')
+
         // Add cross-origin resource policy header (CORS plugin handles Access-Control-* headers)
         responseHeaders.set('cross-origin-resource-policy', 'cross-origin')
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",


### PR DESCRIPTION
- Set Content-Security-Policy: sandbox, Content-Disposition: attachment, and X-Content-Type-Options: nosniff on both MCP proxy and pro proxy
- Prevents proxied content from executing scripts in our origin
- Add tests covering HTML and non-HTML content types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds/overrides response headers on multiple proxy endpoints, which may change how browsers handle proxied resources (e.g., forcing downloads via `Content-Disposition: attachment`). Low implementation complexity but touches security-related HTTP behavior across several routes.
> 
> **Overview**
> **Hardens all proxy-style endpoints against XSS from proxied content** by injecting `Content-Security-Policy: sandbox` and `X-Content-Type-Options: nosniff` on responses, and adding `Content-Disposition: attachment` where generic proxying occurs.
> 
> Applies this to the `mcp-proxy`, `posthog` proxy, and `pro/proxy` routes, and adds/updates tests to assert these headers for both HTML and non-HTML responses; `link-preview` image responses get the new CSP/nosniff headers (without forcing attachment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e493b065b8edec22376f836df528468810ed34f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->