### PR TITLE
feat: harden OTP authentication with session binding, cooldown, and 8 digit codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-symlinks install build build-desktop build-android build-ios clean run dev doctor doctor-q docker-up docker-down docker-status thunderbot-pull thunderbot-push thunderbot-customize
+.PHONY: help setup setup-symlinks install build build-desktop build-android build-ios clean run dev doctor doctor-q docker-up docker-down docker-nuke docker-status thunderbot-pull thunderbot-push thunderbot-customize
 
 # Color definitions
 BLUE := \033[0;34m
@@ -23,6 +23,7 @@ help:
 	@echo "  make doctor         - Verify all dev tools and env files are configured"
 	@echo "  make docker-up      - Start docker containers (PowerSync, Mongo, etc.)"
 	@echo "  make docker-down    - Stop docker containers"
+	@echo "  make docker-nuke    - Destroy all docker data and recreate from scratch"
 	@echo "  make docker-status  - Show docker container status"
 	@echo "  make thunderbot-pull - Pull latest skills from thunderbot"
 	@echo "  make thunderbot-push      - Push skill changes back to thunderbot"
@@ -161,6 +162,9 @@ docker-down:
 	@echo "$(BLUE)→ Stopping docker containers...$(NC)"
 	docker compose -f powersync-service/docker-compose.yml down
 	@echo "$(GREEN)✓ Docker containers stopped!$(NC)"
+
+docker-nuke:
+	@bash scripts/docker-nuke.sh
 
 docker-status:
 	@bash scripts/docker-status.sh

--- a/backend/drizzle/0010_low_nico_minoru.sql
+++ b/backend/drizzle/0010_low_nico_minoru.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "otp_challenge" (
+	"id" text PRIMARY KEY NOT NULL,
+	"email" text NOT NULL,
+	"challenge_token" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "otp_challenge_email_unique" UNIQUE("email")
+);

--- a/backend/drizzle/meta/0010_snapshot.json
+++ b/backend/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,2000 @@
+{
+  "id": "5675615a-f780-4577-85f8-c7bf1967b3d3",
+  "prevId": "e91a8d78-4104-43e0-a426-e45669513d2b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_batch_id_idx": {
+          "name": "waitlist_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.chat_messages": {
+      "name": "chat_messages",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache": {
+          "name": "cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_user_id": {
+          "name": "idx_chat_messages_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_messages_parent_id_chat_messages_id_fk": {
+          "name": "chat_messages_parent_id_chat_messages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_messages",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_messages_user_id_user_id_fk": {
+          "name": "chat_messages_user_id_user_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.chat_threads": {
+      "name": "chat_threads",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_triggered_by_automation": {
+          "name": "was_triggered_by_automation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_id": {
+          "name": "idx_chat_threads_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_user_id_user_id_fk": {
+          "name": "chat_threads_user_id_user_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.devices": {
+      "name": "devices",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trusted": {
+          "name": "trusted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approval_pending": {
+          "name": "approval_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mlkem_public_key": {
+          "name": "mlkem_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_devices_user_id": {
+          "name": "idx_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_servers_user_id": {
+          "name": "idx_mcp_servers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_user_id_user_id_fk": {
+          "name": "mcp_servers_user_id_user_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.model_profiles": {
+      "name": "model_profiles",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_threshold": {
+          "name": "nudge_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_system_message_mode_developer": {
+          "name": "use_system_message_mode_developer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tools_override": {
+          "name": "tools_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_previews_override": {
+          "name": "link_previews_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_mode_addendum": {
+          "name": "chat_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_mode_addendum": {
+          "name": "search_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "research_mode_addendum": {
+          "name": "research_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citation_reinforcement_enabled": {
+          "name": "citation_reinforcement_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "citation_reinforcement_prompt": {
+          "name": "citation_reinforcement_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_final_step": {
+          "name": "nudge_final_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_preventive": {
+          "name": "nudge_preventive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_retry": {
+          "name": "nudge_retry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_final_step": {
+          "name": "nudge_search_final_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_preventive": {
+          "name": "nudge_search_preventive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_retry": {
+          "name": "nudge_search_retry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_model_profiles_user_id": {
+          "name": "idx_model_profiles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_profiles_user_id_user_id_fk": {
+          "name": "model_profiles_user_id_user_id_fk",
+          "tableFrom": "model_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "model_profiles_id_user_id_pk": {
+          "name": "model_profiles_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.models": {
+      "name": "models",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "tool_usage": {
+          "name": "tool_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_confidential": {
+          "name": "is_confidential",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "start_with_reasoning": {
+          "name": "start_with_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "supports_parallel_tool_calls": {
+          "name": "supports_parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_models_user_id": {
+          "name": "idx_models_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "models_user_id_user_id_fk": {
+          "name": "models_user_id_user_id_fk",
+          "tableFrom": "models",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "models_id_user_id_pk": {
+          "name": "models_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.modes": {
+      "name": "modes",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_modes_user_id": {
+          "name": "idx_modes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "modes_user_id_user_id_fk": {
+          "name": "modes_user_id_user_id_fk",
+          "tableFrom": "modes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "modes_id_user_id_pk": {
+          "name": "modes_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.prompts": {
+      "name": "prompts",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prompts_user_id": {
+          "name": "idx_prompts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prompts_user_id_user_id_fk": {
+          "name": "prompts_user_id_user_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompts_id_user_id_pk": {
+          "name": "prompts_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.settings": {
+      "name": "settings",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_settings_user_id": {
+          "name": "idx_settings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "settings_user_id_user_id_fk": {
+          "name": "settings_user_id_user_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_id_user_id_pk": {
+          "name": "settings_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.tasks": {
+      "name": "tasks",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tasks_user_id": {
+          "name": "idx_tasks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_user_id_user_id_fk": {
+          "name": "tasks_user_id_user_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tasks_id_user_id_pk": {
+          "name": "tasks_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.triggers": {
+      "name": "triggers",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_time": {
+          "name": "trigger_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_triggers_user_id": {
+          "name": "idx_triggers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triggers_user_id_user_id_fk": {
+          "name": "triggers_user_id_user_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expire_idx": {
+          "name": "rate_limits_expire_idx",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encryption_metadata": {
+      "name": "encryption_metadata",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canary_iv": {
+          "name": "canary_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_ctext": {
+          "name": "canary_ctext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_secret_hash": {
+          "name": "canary_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encryption_metadata_user_id_user_id_fk": {
+          "name": "encryption_metadata_user_id_user_id_fk",
+          "tableFrom": "encryption_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.envelopes": {
+      "name": "envelopes",
+      "schema": "",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_ck": {
+          "name": "wrapped_ck",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_envelopes_user_id": {
+          "name": "idx_envelopes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "envelopes_device_id_devices_id_fk": {
+          "name": "envelopes_device_id_devices_id_fk",
+          "tableFrom": "envelopes",
+          "tableTo": "devices",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "envelopes_user_id_user_id_fk": {
+          "name": "envelopes_user_id_user_id_fk",
+          "tableFrom": "envelopes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_challenge": {
+      "name": "otp_challenge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_token": {
+          "name": "challenge_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "otp_challenge_email_unique": {
+          "name": "otp_challenge_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1775739729604,
       "tag": "0009_bored_piledriver",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1775769859343,
+      "tag": "0010_low_nico_minoru",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/auth/auth.test.ts
+++ b/backend/src/auth/auth.test.ts
@@ -23,6 +23,7 @@ import { waitlist } from '@/db/schema'
 import { createAuth } from '@/auth/auth'
 import { normalizeEmail } from '@/lib/email'
 import { createTestDb } from '@/test-utils/db'
+import { createTestChallenge } from '@/test-utils/otp-challenge'
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { eq } from 'drizzle-orm'
@@ -146,8 +147,10 @@ describe('Auth - user.isNew in sign-in response', () => {
     expect(callArgs?.otp).toBeDefined()
     const otp = callArgs!.otp
 
+    const challengeToken = await createTestChallenge(db, 'newuser@example.com')
     const result = (await auth.api.signInEmailOTP({
       body: { email: 'newuser@example.com', otp },
+      headers: new Headers({ 'x-challenge-token': challengeToken }),
     })) as unknown as { session: unknown; user: { isNew?: boolean } }
 
     expect(result.user?.isNew).toBe(true)
@@ -175,8 +178,10 @@ describe('Auth - user.isNew in sign-in response', () => {
     expect(callArgs?.otp).toBeDefined()
     const otp = callArgs!.otp
 
+    const challengeToken = await createTestChallenge(db, 'existing-isnewuser@example.com')
     const result = (await auth.api.signInEmailOTP({
       body: { email: 'existing-isnewuser@example.com', otp },
+      headers: new Headers({ 'x-challenge-token': challengeToken }),
     })) as unknown as { session: unknown; user: { isNew?: boolean } }
 
     expect(result.user?.isNew).toBe(false)

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -1,4 +1,13 @@
-import { approveWaitlistEntry, createWaitlistEntry, getUserByEmail, getWaitlistByEmail, markUserNotNew } from '@/dal'
+import {
+  approveWaitlistEntry,
+  createWaitlistEntry,
+  deleteOtpChallengesForEmail,
+  getOtpChallengeByEmail,
+  getUserByEmail,
+  getWaitlistByEmail,
+  markUserNotNew,
+  validateOtpChallenge,
+} from '@/dal'
 import type { db as DbType } from '@/db/client'
 import * as schema from '@/db/schema'
 import { normalizeEmail } from '@/lib/email'
@@ -10,7 +19,10 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { bearer, emailOTP } from 'better-auth/plugins'
 import { genericOAuth } from 'better-auth/plugins/generic-oauth'
 import { isAutoApprovedDomain, sendWaitlistJoinedEmail, sendWaitlistNotReadyEmail } from '@/waitlist/utils'
+import { otpExpirySeconds } from './otp-constants'
 import { buildVerifyUrl, getValidatedOrigin, parseTrustedOrigins, sendSignInEmail } from './utils'
+
+const OTP_SIGN_IN_PATH = '/sign-in/email-otp'
 
 /**
  * Trusted origins for CORS and email link validation
@@ -108,14 +120,43 @@ export const createAuth = (database: typeof DbType) => {
       },
     },
     hooks: {
+      before: createAuthMiddleware(async (ctx) => {
+        if (ctx.path !== OTP_SIGN_IN_PATH) {
+          return
+        }
+
+        const challengeToken = ctx.headers?.get('x-challenge-token')
+        const rawEmail = (ctx.body as { email?: string })?.email
+
+        if (!challengeToken || !rawEmail) {
+          throw ctx.error('UNAUTHORIZED', { message: 'Challenge token required' })
+        }
+
+        const valid = await validateOtpChallenge(database, normalizeEmail(rawEmail), challengeToken)
+        if (!valid) {
+          throw ctx.error('UNAUTHORIZED', { message: 'Invalid challenge token' })
+        }
+
+        // Token stays valid for remaining attempts. Cleaned up on successful sign-in
+        // (after hook) or by expiry. This allows the 3-attempt limit to work correctly.
+      }),
       after: createAuthMiddleware(async (ctx) => {
-        if (ctx.path !== '/sign-in/email-otp') {
+        if (ctx.path !== OTP_SIGN_IN_PATH) {
           return
         }
 
         const newSession = ctx.context.newSession
         if (!newSession?.user) {
           return
+        }
+
+        const email = (ctx.body as { email?: string })?.email
+        if (email) {
+          try {
+            await deleteOtpChallengesForEmail(database, normalizeEmail(email))
+          } catch (e) {
+            console.info('OTP challenge cleanup failed (expires naturally):', e)
+          }
         }
 
         const sessionUser = newSession.user
@@ -134,14 +175,13 @@ export const createAuth = (database: typeof DbType) => {
     plugins: [
       bearer({ requireSignature: true }), // Enables Authorization: Bearer <token> for mobile apps where cookies don't work
       emailOTP({
-        otpLength: 6,
-        expiresIn: 300, // 5 minutes
+        otpLength: 8,
+        expiresIn: otpExpirySeconds,
         allowedAttempts: 3, // Built-in rate limiting - returns TOO_MANY_ATTEMPTS after exceeded
         resendStrategy: 'reuse', // Preserves attempt counter on resend (prevents reset-by-resend attack).
-        // Known limitation: once all attempts are exhausted, Better Auth falls through to
-        // a fresh OTP with counter=0. Better Auth's HTTP rate limiter does NOT apply to
-        // server-side auth.api calls (e.g. from /waitlist/join), so OTP regeneration via
-        // that path is currently unthrottled. TODO(THU-113): proof-of-work will close this gap.
+        // Defense-in-depth: 8-digit OTP (100M keyspace) + 3 attempts + 15s cooldown between
+        // code requests + session binding (challenge token) make brute-force infeasible.
+        // TODO(THU-113): proof-of-work (ALTCHA) will add further distributed protection.
 
         async sendVerificationOTP({ email, otp, type }, ctx) {
           // We only support sign-in (no password-based auth, so no email-verification or forget-password)
@@ -181,7 +221,8 @@ export const createAuth = (database: typeof DbType) => {
           }
 
           const origin = getValidatedOrigin(trustedOrigins, ctx?.request)
-          const verifyUrl = buildVerifyUrl(origin, normalizedEmail, otp, ctx?.request)
+          const challenge = await getOtpChallengeByEmail(database, normalizedEmail)
+          const verifyUrl = buildVerifyUrl(origin, normalizedEmail, otp, ctx?.request, challenge?.challengeToken)
 
           await sendSignInEmail({ email: normalizedEmail, otp, verifyUrl })
         },

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -3,6 +3,7 @@ import {
   createOtpChallenge,
   createWaitlistEntry,
   deleteOtpChallengesForEmail,
+  getOtpChallengeByEmail,
   getUserByEmail,
   getWaitlistByEmail,
   markUserNotNew,
@@ -217,15 +218,21 @@ export const createAuth = (database: typeof DbType) => {
           }
 
           const origin = getValidatedOrigin(trustedOrigins, ctx?.request)
-          // Ensure a challenge exists — /waitlist/join creates one, but Better Auth's
-          // native send-OTP endpoint doesn't, so upsert on-demand for that path.
-          const challengeToken = crypto.randomUUID()
-          await createOtpChallenge(database, {
-            id: crypto.randomUUID(),
-            email: normalizedEmail,
-            challengeToken,
-            expiresAt: new Date(Date.now() + otpExpiryMs),
-          })
+          // Reuse existing challenge if /waitlist/join already created one.
+          // Only create on-demand for Better Auth's native send-OTP endpoint.
+          const existing = await getOtpChallengeByEmail(database, normalizedEmail)
+          let challengeToken: string
+          if (existing) {
+            challengeToken = existing.challengeToken
+          } else {
+            challengeToken = crypto.randomUUID()
+            await createOtpChallenge(database, {
+              id: crypto.randomUUID(),
+              email: normalizedEmail,
+              challengeToken,
+              expiresAt: new Date(Date.now() + otpExpiryMs),
+            })
+          }
           const verifyUrl = buildVerifyUrl(origin, normalizedEmail, otp, ctx?.request, challengeToken)
 
           await sendSignInEmail({ email: normalizedEmail, otp, verifyUrl })

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -1,5 +1,6 @@
 import {
   approveWaitlistEntry,
+  createOtpChallenge,
   createWaitlistEntry,
   deleteOtpChallengesForEmail,
   getOtpChallengeByEmail,
@@ -19,7 +20,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { bearer, emailOTP } from 'better-auth/plugins'
 import { genericOAuth } from 'better-auth/plugins/generic-oauth'
 import { isAutoApprovedDomain, sendWaitlistJoinedEmail, sendWaitlistNotReadyEmail } from '@/waitlist/utils'
-import { otpExpirySeconds } from './otp-constants'
+import { otpExpiryMs, otpExpirySeconds } from './otp-constants'
 import { buildVerifyUrl, getValidatedOrigin, parseTrustedOrigins, sendSignInEmail } from './utils'
 
 const OTP_SIGN_IN_PATH = '/sign-in/email-otp'
@@ -152,11 +153,7 @@ export const createAuth = (database: typeof DbType) => {
 
         const email = (ctx.body as { email?: string })?.email
         if (email) {
-          try {
-            await deleteOtpChallengesForEmail(database, normalizeEmail(email))
-          } catch (e) {
-            console.info('OTP challenge cleanup failed (expires naturally):', e)
-          }
+          await deleteOtpChallengesForEmail(database, normalizeEmail(email))
         }
 
         const sessionUser = newSession.user
@@ -221,8 +218,19 @@ export const createAuth = (database: typeof DbType) => {
           }
 
           const origin = getValidatedOrigin(trustedOrigins, ctx?.request)
-          const challenge = await getOtpChallengeByEmail(database, normalizedEmail)
-          const verifyUrl = buildVerifyUrl(origin, normalizedEmail, otp, ctx?.request, challenge?.challengeToken)
+          // Ensure a challenge exists — /waitlist/join creates one, but Better Auth's
+          // native send-OTP endpoint doesn't, so create on-demand for that path.
+          let challengeToken = (await getOtpChallengeByEmail(database, normalizedEmail))?.challengeToken
+          if (!challengeToken) {
+            challengeToken = crypto.randomUUID()
+            await createOtpChallenge(database, {
+              id: crypto.randomUUID(),
+              email: normalizedEmail,
+              challengeToken,
+              expiresAt: new Date(Date.now() + otpExpiryMs),
+            })
+          }
+          const verifyUrl = buildVerifyUrl(origin, normalizedEmail, otp, ctx?.request, challengeToken)
 
           await sendSignInEmail({ email: normalizedEmail, otp, verifyUrl })
         },

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -221,11 +221,8 @@ export const createAuth = (database: typeof DbType) => {
           // Reuse existing challenge if /waitlist/join already created one.
           // Only create on-demand for Better Auth's native send-OTP endpoint.
           const existing = await getOtpChallengeByEmail(database, normalizedEmail)
-          let challengeToken: string
-          if (existing) {
-            challengeToken = existing.challengeToken
-          } else {
-            challengeToken = crypto.randomUUID()
+          const challengeToken = existing?.challengeToken ?? crypto.randomUUID()
+          if (!existing) {
             await createOtpChallenge(database, {
               id: crypto.randomUUID(),
               email: normalizedEmail,

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -1,9 +1,8 @@
 import {
   approveWaitlistEntry,
-  createOtpChallenge,
+  getOrCreateOtpChallenge,
   createWaitlistEntry,
   deleteOtpChallengesForEmail,
-  getOtpChallengeByEmail,
   getUserByEmail,
   getWaitlistByEmail,
   markUserNotNew,
@@ -218,18 +217,14 @@ export const createAuth = (database: typeof DbType) => {
           }
 
           const origin = getValidatedOrigin(trustedOrigins, ctx?.request)
-          // Reuse existing challenge if /waitlist/join already created one.
-          // Only create on-demand for Better Auth's native send-OTP endpoint.
-          const existing = await getOtpChallengeByEmail(database, normalizedEmail)
-          const challengeToken = existing?.challengeToken ?? crypto.randomUUID()
-          if (!existing) {
-            await createOtpChallenge(database, {
-              id: crypto.randomUUID(),
-              email: normalizedEmail,
-              challengeToken,
-              expiresAt: new Date(Date.now() + otpExpiryMs),
-            })
-          }
+          // First-writer-wins: reuses existing challenge if /waitlist/join already
+          // created one, or creates on-demand for Better Auth's native send-OTP endpoint.
+          const challengeToken = await getOrCreateOtpChallenge(database, {
+            id: crypto.randomUUID(),
+            email: normalizedEmail,
+            challengeToken: crypto.randomUUID(),
+            expiresAt: new Date(Date.now() + otpExpiryMs),
+          })
           const verifyUrl = buildVerifyUrl(origin, normalizedEmail, otp, ctx?.request, challengeToken)
 
           await sendSignInEmail({ email: normalizedEmail, otp, verifyUrl })

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -3,7 +3,6 @@ import {
   createOtpChallenge,
   createWaitlistEntry,
   deleteOtpChallengesForEmail,
-  getOtpChallengeByEmail,
   getUserByEmail,
   getWaitlistByEmail,
   markUserNotNew,
@@ -219,17 +218,14 @@ export const createAuth = (database: typeof DbType) => {
 
           const origin = getValidatedOrigin(trustedOrigins, ctx?.request)
           // Ensure a challenge exists — /waitlist/join creates one, but Better Auth's
-          // native send-OTP endpoint doesn't, so create on-demand for that path.
-          let challengeToken = (await getOtpChallengeByEmail(database, normalizedEmail))?.challengeToken
-          if (!challengeToken) {
-            challengeToken = crypto.randomUUID()
-            await createOtpChallenge(database, {
-              id: crypto.randomUUID(),
-              email: normalizedEmail,
-              challengeToken,
-              expiresAt: new Date(Date.now() + otpExpiryMs),
-            })
-          }
+          // native send-OTP endpoint doesn't, so upsert on-demand for that path.
+          const challengeToken = crypto.randomUUID()
+          await createOtpChallenge(database, {
+            id: crypto.randomUUID(),
+            email: normalizedEmail,
+            challengeToken,
+            expiresAt: new Date(Date.now() + otpExpiryMs),
+          })
           const verifyUrl = buildVerifyUrl(origin, normalizedEmail, otp, ctx?.request, challengeToken)
 
           await sendSignInEmail({ email: normalizedEmail, otp, verifyUrl })

--- a/backend/src/auth/otp-constants.ts
+++ b/backend/src/auth/otp-constants.ts
@@ -1,0 +1,5 @@
+/** OTP expiry duration in seconds — used by Better Auth emailOTP config. */
+export const otpExpirySeconds = 600 // 10 minutes
+
+/** OTP expiry duration in milliseconds — used for challenge token expiry and cooldown. */
+export const otpExpiryMs = otpExpirySeconds * 1000

--- a/backend/src/auth/otp-security.test.ts
+++ b/backend/src/auth/otp-security.test.ts
@@ -1,0 +1,441 @@
+import { mock } from 'bun:test'
+import * as authUtils from '@/auth/utils'
+import * as waitlistUtils from '@/waitlist/utils'
+import { clearSettingsCache } from '@/config/settings'
+
+// Mock only the email-sending functions, preserve all other exports
+const mockSendSignInEmail = mock(() => Promise.resolve())
+const mockSendWaitlistNotReadyEmail = mock(() => Promise.resolve())
+const mockSendWaitlistJoinedEmail = mock(() => Promise.resolve())
+
+mock.module('@/auth/utils', () => ({
+  ...authUtils,
+  sendSignInEmail: mockSendSignInEmail,
+}))
+
+mock.module('@/waitlist/utils', () => ({
+  ...waitlistUtils,
+  sendWaitlistNotReadyEmail: mockSendWaitlistNotReadyEmail,
+  sendWaitlistJoinedEmail: mockSendWaitlistJoinedEmail,
+  sendWaitlistReminderEmail: mock(() => Promise.resolve()),
+}))
+
+// Import after mocks are set up
+import { user, verification } from '@/db/auth-schema'
+import { otpChallenge } from '@/db/schema'
+import { waitlist } from '@/db/schema'
+import { createAuth } from '@/auth/auth'
+import { createApp } from '@/index'
+import { createTestDb } from '@/test-utils/db'
+import { createTestChallenge } from '@/test-utils/otp-challenge'
+import { eq, like } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+describe('OTP Security Hardening', () => {
+  let auth: ReturnType<typeof createAuth>
+  let app: Awaited<ReturnType<typeof createApp>>
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  /** Insert an existing BetterAuth user */
+  const insertExistingUser = async (email: string) => {
+    await db.insert(user).values({
+      id: crypto.randomUUID(),
+      email,
+      name: 'Test User',
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+  }
+
+  /** Insert an approved waitlist entry */
+  const insertApprovedWaitlist = async (email: string) => {
+    await db.insert(waitlist).values({
+      id: crypto.randomUUID(),
+      email,
+      status: 'approved',
+    })
+  }
+
+  /** POST to waitlist/join via HTTP */
+  const postWaitlistJoin = (email: string, appInstance = app) =>
+    appInstance.handle(
+      new Request('http://localhost/v1/waitlist/join', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      }),
+    )
+
+  /** Create a challenge token and send OTP via auth.api (for unit-level tests) */
+  const sendOtpWithChallenge = async (email: string) => {
+    const challengeToken = await createTestChallenge(db, email)
+    await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+    const call = mockSendSignInEmail.mock.calls.at(-1) as unknown as [{ otp: string }]
+    return { otp: call[0].otp, challengeToken }
+  }
+
+  /** Call signInEmailOTP via auth.api with a challenge token header */
+  const signInWithChallenge = (email: string, otp: string, challengeToken: string) =>
+    auth.api.signInEmailOTP({
+      body: { email, otp },
+      headers: new Headers({ 'x-challenge-token': challengeToken }),
+    })
+
+  beforeEach(async () => {
+    mockSendSignInEmail.mockClear()
+    mockSendWaitlistNotReadyEmail.mockClear()
+    mockSendWaitlistJoinedEmail.mockClear()
+
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+    auth = createAuth(db)
+    app = await createApp({ database: db, otpCooldownMs: 0 })
+  })
+
+  afterEach(async () => {
+    delete process.env.WAITLIST_AUTO_APPROVE_DOMAINS
+    clearSettingsCache()
+    await cleanup()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Measure 1: 8-digit OTP
+  // ---------------------------------------------------------------------------
+  describe('Measure 1: 8-digit OTP', () => {
+    it('should generate an OTP that is exactly 8 digits', async () => {
+      await insertApprovedWaitlist('otp-len@example.com')
+      await auth.api.sendVerificationOTP({ body: { email: 'otp-len@example.com', type: 'sign-in' } })
+      const call = mockSendSignInEmail.mock.calls.at(-1) as unknown as [{ otp: string }]
+      expect(call[0].otp).toMatch(/^\d{8}$/)
+    })
+
+    it('should reject a 6-digit code even if numerically plausible', async () => {
+      const email = 'otp-length@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+      const { challengeToken } = await sendOtpWithChallenge(email)
+
+      let threw = false
+      try {
+        await signInWithChallenge(email, '123456', challengeToken)
+      } catch {
+        threw = true
+      }
+      expect(threw).toBe(true)
+    })
+
+    it('should accept a valid 8-digit OTP', async () => {
+      const email = 'otp-valid@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+      const { otp, challengeToken } = await sendOtpWithChallenge(email)
+
+      expect(otp).toHaveLength(8)
+
+      const result = await signInWithChallenge(email, otp, challengeToken)
+      expect(result.user).toBeDefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Measure 2: 3-attempt invalidation
+  // ---------------------------------------------------------------------------
+  describe('Measure 2: 3-attempt invalidation', () => {
+    it('should delete OTP record after attempts are exhausted', async () => {
+      const email = 'attempts-delete@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+      const { challengeToken } = await sendOtpWithChallenge(email)
+
+      const before = await db
+        .select()
+        .from(verification)
+        .where(like(verification.identifier, `%${email}%`))
+      expect(before.length).toBeGreaterThan(0)
+
+      for (let i = 0; i < 3; i++) {
+        try {
+          await signInWithChallenge(email, '00000000', challengeToken)
+        } catch {
+          // Expected: INVALID_OTP
+        }
+      }
+
+      // 4th attempt triggers deletion (counter >= allowedAttempts)
+      try {
+        await signInWithChallenge(email, '00000000', challengeToken)
+      } catch {
+        // Expected: TOO_MANY_ATTEMPTS
+      }
+
+      const after = await db
+        .select()
+        .from(verification)
+        .where(like(verification.identifier, `%${email}%`))
+      expect(after).toHaveLength(0)
+    })
+
+    it('should return error on 4th guess after lockout', async () => {
+      const email = 'attempts-4th@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+      const { challengeToken } = await sendOtpWithChallenge(email)
+
+      for (let i = 0; i < 3; i++) {
+        try {
+          await signInWithChallenge(email, '00000000', challengeToken)
+        } catch {
+          // Expected
+        }
+      }
+      try {
+        await signInWithChallenge(email, '00000000', challengeToken)
+        expect(true).toBe(false) // Should not reach here
+      } catch (err: unknown) {
+        // After deletion, we get INVALID_OTP, TOO_MANY_ATTEMPTS, or UNAUTHORIZED (challenge consumed)
+        expect(err).toBeDefined()
+      }
+    })
+
+    it('should allow requesting a new code after exhaustion, and old code is invalid', async () => {
+      const email = 'attempts-regen@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+      const { otp: oldOtp, challengeToken } = await sendOtpWithChallenge(email)
+
+      // Exhaust all 3 attempts
+      for (let i = 0; i < 3; i++) {
+        try {
+          await signInWithChallenge(email, '00000000', challengeToken)
+        } catch {
+          // Expected
+        }
+      }
+
+      // Request a new code with a fresh challenge token
+      mockSendSignInEmail.mockClear()
+      const { otp: newOtp, challengeToken: newToken } = await sendOtpWithChallenge(email)
+
+      // New OTP should be different (old one was exhausted, resend generates fresh)
+      expect(newOtp).not.toBe(oldOtp)
+
+      // Old OTP should NOT work
+      let oldWorked = false
+      try {
+        const result = await signInWithChallenge(email, oldOtp, newToken)
+        oldWorked = result.user !== undefined
+      } catch {
+        // Expected
+      }
+      expect(oldWorked).toBe(false)
+
+      const freshToken = await createTestChallenge(db, email)
+      const result = await signInWithChallenge(email, newOtp, freshToken)
+      expect(result.user).toBeDefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Measure 3: 15s cooldown between code requests
+  // ---------------------------------------------------------------------------
+  describe('Measure 3: 15s cooldown', () => {
+    it('should reject second /waitlist/join for same email within cooldown', async () => {
+      const cooldownApp = await createApp({ database: db, otpCooldownMs: 15_000 })
+      await insertApprovedWaitlist('cooldown@example.com')
+
+      const first = await postWaitlistJoin('cooldown@example.com', cooldownApp)
+      expect(first.status).toBe(200)
+
+      const second = await postWaitlistJoin('cooldown@example.com', cooldownApp)
+      expect(second.status).toBe(429)
+    })
+
+    it('should succeed after cooldown expires', async () => {
+      const shortCooldownApp = await createApp({ database: db, otpCooldownMs: 1 })
+      await insertApprovedWaitlist('cooldown-expire@example.com')
+
+      const first = await postWaitlistJoin('cooldown-expire@example.com', shortCooldownApp)
+      expect(first.status).toBe(200)
+
+      await new Promise((r) => setTimeout(r, 5))
+
+      const second = await postWaitlistJoin('cooldown-expire@example.com', shortCooldownApp)
+      expect(second.status).toBe(200)
+    })
+
+    it('should not block different emails during cooldown', async () => {
+      const cooldownApp = await createApp({ database: db, otpCooldownMs: 15_000 })
+      await insertApprovedWaitlist('email-a@example.com')
+      await insertApprovedWaitlist('email-b@example.com')
+
+      const first = await postWaitlistJoin('email-a@example.com', cooldownApp)
+      expect(first.status).toBe(200)
+
+      const second = await postWaitlistJoin('email-b@example.com', cooldownApp)
+      expect(second.status).toBe(200)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Measure 4: Session binding (challenge token)
+  // ---------------------------------------------------------------------------
+  describe('Measure 4: Session binding', () => {
+    it('should return challengeToken in /waitlist/join response for approved user', async () => {
+      await insertApprovedWaitlist('challenge@example.com')
+
+      const response = await postWaitlistJoin('challenge@example.com')
+      expect(response.status).toBe(200)
+
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.challengeToken).toBeDefined()
+      expect(typeof body.challengeToken).toBe('string')
+      expect(body.challengeToken.length).toBeGreaterThan(0)
+    })
+
+    it('should also return challengeToken for pending users (privacy-preserving)', async () => {
+      const response = await postWaitlistJoin('pending-challenge@example.com')
+      expect(response.status).toBe(200)
+
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.challengeToken).toBeDefined()
+    })
+
+    // These tests use auth.api (not HTTP) to avoid Better Auth's HTTP rate limiter
+    // which causes flaky 429s when CI runs the suite 5x in the same process.
+    // The before/after hooks still execute via auth.api, so challenge token
+    // validation is fully exercised.
+
+    it('should reject sign-in without challenge token', async () => {
+      const email = 'no-token@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+
+      const { otp } = await sendOtpWithChallenge(email)
+
+      let threw = false
+      try {
+        await auth.api.signInEmailOTP({ body: { email, otp } })
+      } catch {
+        threw = true
+      }
+      expect(threw).toBe(true)
+    })
+
+    it('should reject sign-in with wrong challenge token', async () => {
+      const email = 'wrong-token@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+
+      const { otp } = await sendOtpWithChallenge(email)
+
+      let threw = false
+      try {
+        await auth.api.signInEmailOTP({
+          body: { email, otp },
+          headers: new Headers({ 'x-challenge-token': 'wrong-token-value' }),
+        })
+      } catch {
+        threw = true
+      }
+      expect(threw).toBe(true)
+    })
+
+    it('should accept sign-in with correct challenge token and code', async () => {
+      const email = 'correct-token@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+
+      const { otp, challengeToken } = await sendOtpWithChallenge(email)
+
+      const result = await signInWithChallenge(email, otp, challengeToken)
+      expect(result.user).toBeDefined()
+    })
+
+    it('should reject attacker without challenge token even with correct OTP', async () => {
+      const victimEmail = 'victim@example.com'
+      await insertExistingUser(victimEmail)
+      await insertApprovedWaitlist(victimEmail)
+
+      const { otp, challengeToken: victimToken } = await sendOtpWithChallenge(victimEmail)
+
+      // Attacker tries without token
+      let attackerSucceeded = false
+      try {
+        await auth.api.signInEmailOTP({ body: { email: victimEmail, otp } })
+        attackerSucceeded = true
+      } catch {
+        // Expected: UNAUTHORIZED
+      }
+      expect(attackerSucceeded).toBe(false)
+
+      // Victim succeeds with their token
+      const result = await signInWithChallenge(victimEmail, otp, victimToken)
+      expect(result.user).toBeDefined()
+    })
+
+    it('should store challenge token in database', async () => {
+      await insertApprovedWaitlist('db-token@example.com')
+
+      const response = await postWaitlistJoin('db-token@example.com')
+      const { challengeToken } = await response.json()
+
+      const records = await db.select().from(otpChallenge).where(eq(otpChallenge.email, 'db-token@example.com'))
+      expect(records).toHaveLength(1)
+      expect(records[0].challengeToken).toBe(challengeToken)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Measure 5: 10-minute OTP expiry
+  // ---------------------------------------------------------------------------
+  describe('Measure 5: 10-minute OTP expiry', () => {
+    it('should set OTP expiry to approximately 10 minutes from now', async () => {
+      const email = 'expiry-check@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+      await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+
+      // Query all verification records for this email (using LIKE to handle any prefix format)
+      const records = await db
+        .select()
+        .from(verification)
+        .where(like(verification.identifier, `%${email}%`))
+      expect(records).toHaveLength(1)
+
+      const expiresAt = records[0].expiresAt.getTime()
+      const now = Date.now()
+      const tenMinutes = 10 * 60 * 1000
+
+      // Should be approximately 10 minutes from now (allow 30s tolerance)
+      expect(expiresAt).toBeGreaterThan(now + tenMinutes - 30_000)
+      expect(expiresAt).toBeLessThan(now + tenMinutes + 30_000)
+    })
+
+    it('should reject valid code after expiry', async () => {
+      const email = 'expiry-reject@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+      const { otp, challengeToken } = await sendOtpWithChallenge(email)
+
+      // Manually set the verification record's expiresAt to the past
+      await db
+        .update(verification)
+        .set({ expiresAt: new Date(Date.now() - 1000) })
+        .where(like(verification.identifier, `%${email}%`))
+
+      // Should reject the expired OTP
+      let threw = false
+      try {
+        await signInWithChallenge(email, otp, challengeToken)
+      } catch {
+        threw = true
+      }
+      expect(threw).toBe(true)
+    })
+  })
+})

--- a/backend/src/auth/otp-security.test.ts
+++ b/backend/src/auth/otp-security.test.ts
@@ -266,6 +266,21 @@ describe('OTP Security Hardening', () => {
       expect(second.status).toBe(200)
     })
 
+    it('should block concurrent requests for same email (race condition defense)', async () => {
+      const cooldownApp = await createApp({ database: db, otpCooldownMs: 15_000 })
+      await insertApprovedWaitlist('race@example.com')
+
+      // Fire two requests concurrently for the same email
+      const [first, second] = await Promise.all([
+        postWaitlistJoin('race@example.com', cooldownApp),
+        postWaitlistJoin('race@example.com', cooldownApp),
+      ])
+
+      const statuses = [first.status, second.status].sort()
+      // One should succeed (200) and one should be rate-limited (429)
+      expect(statuses).toEqual([200, 429])
+    })
+
     it('should not block different emails during cooldown', async () => {
       const cooldownApp = await createApp({ database: db, otpCooldownMs: 15_000 })
       await insertApprovedWaitlist('email-a@example.com')
@@ -387,6 +402,59 @@ describe('OTP Security Hardening', () => {
       const records = await db.select().from(otpChallenge).where(eq(otpChallenge.email, 'db-token@example.com'))
       expect(records).toHaveLength(1)
       expect(records[0].challengeToken).toBe(challengeToken)
+    })
+
+    it('should auto-create challenge when sendVerificationOTP is called without prior /waitlist/join', async () => {
+      const email = 'native-send@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+
+      // Call Better Auth's native send endpoint (no /waitlist/join first)
+      await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+
+      // A challenge should have been created on-demand
+      const records = await db.select().from(otpChallenge).where(eq(otpChallenge.email, email))
+      expect(records).toHaveLength(1)
+      expect(records[0].challengeToken).toBeDefined()
+    })
+
+    it('should include challenge token in verify URL when created via native send endpoint', async () => {
+      const email = 'native-url@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+
+      await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+      const call = mockSendSignInEmail.mock.calls.at(-1) as unknown as [{ verifyUrl: string }]
+      expect(call[0].verifyUrl).toContain('challengeToken=')
+    })
+
+    it('should allow sign-in with challenge created via native send endpoint', async () => {
+      const email = 'native-signin@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+
+      await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+      const otpCall = mockSendSignInEmail.mock.calls.at(-1) as unknown as [{ otp: string }]
+      const otp = otpCall[0].otp
+
+      // Get the auto-created challenge token from DB
+      const records = await db.select().from(otpChallenge).where(eq(otpChallenge.email, email))
+      const challengeToken = records[0].challengeToken
+
+      const result = await signInWithChallenge(email, otp, challengeToken)
+      expect(result.user).toBeDefined()
+    })
+
+    it('should delete challenge token after successful sign-in', async () => {
+      const email = 'cleanup@example.com'
+      await insertExistingUser(email)
+      await insertApprovedWaitlist(email)
+
+      const { otp, challengeToken } = await sendOtpWithChallenge(email)
+      await signInWithChallenge(email, otp, challengeToken)
+
+      const records = await db.select().from(otpChallenge).where(eq(otpChallenge.email, email))
+      expect(records).toHaveLength(0)
     })
   })
 

--- a/backend/src/auth/utils.tsx
+++ b/backend/src/auth/utils.tsx
@@ -57,9 +57,18 @@ export const getValidatedOrigin = (trustedOrigins: string[], request?: Request):
  * When clicked, the frontend auto-submits the OTP via the standard emailOtp sign-in endpoint
  * Uses deep link URL for mobile platforms so the link opens the app
  */
-export const buildVerifyUrl = (origin: string, email: string, otp: string, request?: Request): string => {
+export const buildVerifyUrl = (
+  origin: string,
+  email: string,
+  otp: string,
+  request?: Request,
+  challengeToken?: string,
+): string => {
   const baseUrl = isDeepLinkPlatform(request) ? deepLinkHost : origin
   const params = new URLSearchParams({ email, otp })
+  if (challengeToken) {
+    params.set('challengeToken', challengeToken)
+  }
   return `${baseUrl}/auth/verify?${params.toString()}`
 }
 

--- a/backend/src/auth/waitlist-integration.test.ts
+++ b/backend/src/auth/waitlist-integration.test.ts
@@ -26,6 +26,7 @@ import { waitlist } from '@/db/schema'
 import { createAuth } from '@/auth/auth'
 import { normalizeEmail } from '@/lib/email'
 import { createTestDb } from '@/test-utils/db'
+import { createTestChallenge } from '@/test-utils/otp-challenge'
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
@@ -300,10 +301,15 @@ describe('Auth Waitlist Integration', () => {
       const otpCall = mockSendSignInEmail.mock.calls[0] as unknown as [{ otp: string }]
       const correctOtp = otpCall[0].otp
 
+      const challengeToken = await createTestChallenge(db, email)
+
       // Make 2 wrong attempts (of 3 allowed) — counter goes to 2
       for (let i = 0; i < 2; i++) {
         try {
-          await auth.api.signInEmailOTP({ body: { email, otp: '000000' } })
+          await auth.api.signInEmailOTP({
+            body: { email, otp: '00000000' },
+            headers: new Headers({ 'x-challenge-token': challengeToken }),
+          })
         } catch {
           // Expected: INVALID_OTP
         }
@@ -317,7 +323,10 @@ describe('Auth Waitlist Integration', () => {
 
       // Make 1 more wrong attempt — this is the 3rd total, counter goes to 3
       try {
-        await auth.api.signInEmailOTP({ body: { email, otp: '000000' } })
+        await auth.api.signInEmailOTP({
+          body: { email, otp: '00000000' },
+          headers: new Headers({ 'x-challenge-token': challengeToken }),
+        })
       } catch {
         // Expected: INVALID_OTP
       }
@@ -327,7 +336,10 @@ describe('Auth Waitlist Integration', () => {
       // because the counter would only be at 1.
       let signInSucceeded = false
       try {
-        await auth.api.signInEmailOTP({ body: { email, otp: correctOtp } })
+        await auth.api.signInEmailOTP({
+          body: { email, otp: correctOtp },
+          headers: new Headers({ 'x-challenge-token': challengeToken }),
+        })
         signInSucceeded = true
       } catch {
         // Expected: locked out because counter was preserved
@@ -351,10 +363,15 @@ describe('Auth Waitlist Integration', () => {
         body: { email, type: 'sign-in' },
       })
 
+      const challengeToken = await createTestChallenge(db, email)
+
       // Use up all 3 attempts with wrong OTPs
       for (let i = 0; i < 3; i++) {
         try {
-          await auth.api.signInEmailOTP({ body: { email, otp: '000000' } })
+          await auth.api.signInEmailOTP({
+            body: { email, otp: '00000000' },
+            headers: new Headers({ 'x-challenge-token': challengeToken }),
+          })
         } catch {
           // Expected: INVALID_OTP or TOO_MANY_ATTEMPTS on 3rd
         }
@@ -362,7 +379,10 @@ describe('Auth Waitlist Integration', () => {
 
       // 4th attempt should be locked out
       try {
-        await auth.api.signInEmailOTP({ body: { email, otp: '999999' } })
+        await auth.api.signInEmailOTP({
+          body: { email, otp: '99999999' },
+          headers: new Headers({ 'x-challenge-token': challengeToken }),
+        })
         expect(true).toBe(false)
       } catch (err: unknown) {
         const code = (err as { body?: { code?: string } }).body?.code ?? ''
@@ -375,8 +395,8 @@ describe('Auth Waitlist Integration', () => {
       // Documents a known limitation: resendStrategy "reuse" only preserves the counter
       // when attempts haven't been fully exhausted. Once all 3 attempts are burned,
       // Better Auth falls through to generate a fresh OTP with counter=0.
-      // This is mitigated by Better Auth's in-memory rate limiter on the send endpoint
-      // (3 req/60s) and will be further addressed by proof-of-work (THU-113).
+      // This is mitigated by the 15s cooldown on /waitlist/join and will be
+      // further addressed by proof-of-work (THU-113).
       const email = 'exhausted-resend@example.com'
       await db.insert(user).values({
         id: crypto.randomUUID(),
@@ -394,10 +414,15 @@ describe('Auth Waitlist Integration', () => {
       const firstCall = mockSendSignInEmail.mock.calls[0] as unknown as [{ otp: string }]
       const firstOtp = firstCall[0].otp
 
+      const challengeToken = await createTestChallenge(db, email)
+
       // Exhaust all 3 attempts
       for (let i = 0; i < 3; i++) {
         try {
-          await auth.api.signInEmailOTP({ body: { email, otp: '000000' } })
+          await auth.api.signInEmailOTP({
+            body: { email, otp: '00000000' },
+            headers: new Headers({ 'x-challenge-token': challengeToken }),
+          })
         } catch {
           // Expected
         }
@@ -415,10 +440,13 @@ describe('Auth Waitlist Integration', () => {
       expect(freshOtp).not.toBe(firstOtp)
 
       // The fresh OTP works — counter was reset to 0.
-      // If this throws, the fresh OTP wasn't accepted (unexpected).
+      const freshChallengeToken = await createTestChallenge(db, email)
       let signInSucceeded = false
       try {
-        await auth.api.signInEmailOTP({ body: { email, otp: freshOtp } })
+        await auth.api.signInEmailOTP({
+          body: { email, otp: freshOtp },
+          headers: new Headers({ 'x-challenge-token': freshChallengeToken }),
+        })
         signInSucceeded = true
       } catch {
         // Unexpected failure

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -55,7 +55,7 @@ const settingsSchema = z.object({
   corsAllowHeaders: z
     .string()
     .default(
-      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Mcp-Target-Url,Mcp-Authorization,Mcp-Session-Id,Mcp-Protocol-Version',
+      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Challenge-Token,X-Mcp-Target-Url,Mcp-Authorization,Mcp-Session-Id,Mcp-Protocol-Version',
     ),
   corsExposeHeaders: z
     .string()
@@ -112,7 +112,7 @@ const parseSettings = (): Settings => {
     corsAllowMethods: process.env.CORS_ALLOW_METHODS || 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:
       process.env.CORS_ALLOW_HEADERS ||
-      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Mcp-Target-Url,Mcp-Authorization,Mcp-Session-Id,Mcp-Protocol-Version',
+      'Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Challenge-Token,X-Mcp-Target-Url,Mcp-Authorization,Mcp-Session-Id,Mcp-Protocol-Version',
     corsExposeHeaders:
       process.env.CORS_EXPOSE_HEADERS ||
       'mcp-session-id,set-auth-token,ratelimit-limit,ratelimit-remaining,ratelimit-reset,retry-after',

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -14,7 +14,12 @@ export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from '.
 export { applyOperation } from './powersync'
 
 // OTP Challenge (session binding)
-export { createOtpChallenge, validateOtpChallenge, deleteOtpChallengesForEmail } from './otp-challenge'
+export {
+  createOtpChallenge,
+  getOtpChallengeByEmail,
+  validateOtpChallenge,
+  deleteOtpChallengesForEmail,
+} from './otp-challenge'
 
 // Encryption
 export {

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -13,6 +13,14 @@ export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from '.
 // PowerSync
 export { applyOperation } from './powersync'
 
+// OTP Challenge (session binding)
+export {
+  createOtpChallenge,
+  validateOtpChallenge,
+  getOtpChallengeByEmail,
+  deleteOtpChallengesForEmail,
+} from './otp-challenge'
+
 // Encryption
 export {
   getEnvelopeByDeviceId,

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -14,12 +14,7 @@ export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from '.
 export { applyOperation } from './powersync'
 
 // OTP Challenge (session binding)
-export {
-  createOtpChallenge,
-  getOtpChallengeByEmail,
-  validateOtpChallenge,
-  deleteOtpChallengesForEmail,
-} from './otp-challenge'
+export { getOrCreateOtpChallenge, validateOtpChallenge, deleteOtpChallengesForEmail } from './otp-challenge'
 
 // Encryption
 export {

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -14,12 +14,7 @@ export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from '.
 export { applyOperation } from './powersync'
 
 // OTP Challenge (session binding)
-export {
-  createOtpChallenge,
-  validateOtpChallenge,
-  getOtpChallengeByEmail,
-  deleteOtpChallengesForEmail,
-} from './otp-challenge'
+export { createOtpChallenge, validateOtpChallenge, deleteOtpChallengesForEmail } from './otp-challenge'
 
 // Encryption
 export {

--- a/backend/src/dal/otp-challenge.test.ts
+++ b/backend/src/dal/otp-challenge.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { otpChallenge } from '@/db/schema'
+import { createTestDb } from '@/test-utils/db'
+import { getOrCreateOtpChallenge, validateOtpChallenge, deleteOtpChallengesForEmail } from './otp-challenge'
+
+describe('getOrCreateOtpChallenge', () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  const makeChallenge = (email: string, overrides?: { challengeToken?: string; expiresAt?: Date }) => ({
+    id: crypto.randomUUID(),
+    email,
+    challengeToken: overrides?.challengeToken ?? crypto.randomUUID(),
+    expiresAt: overrides?.expiresAt ?? new Date(Date.now() + 600_000),
+  })
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('should create a new challenge when none exists', async () => {
+    const data = makeChallenge('new@example.com', { challengeToken: 'token-a' })
+    const result = await getOrCreateOtpChallenge(db, data)
+
+    expect(result).toBe('token-a')
+
+    const rows = await db.select().from(otpChallenge).where(eq(otpChallenge.email, 'new@example.com'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].challengeToken).toBe('token-a')
+  })
+
+  it('should return existing token when a non-expired challenge exists (first-writer-wins)', async () => {
+    const first = makeChallenge('existing@example.com', { challengeToken: 'first-token' })
+    await getOrCreateOtpChallenge(db, first)
+
+    const second = makeChallenge('existing@example.com', { challengeToken: 'second-token' })
+    const result = await getOrCreateOtpChallenge(db, second)
+
+    expect(result).toBe('first-token')
+
+    const rows = await db.select().from(otpChallenge).where(eq(otpChallenge.email, 'existing@example.com'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].challengeToken).toBe('first-token')
+  })
+
+  it('should replace an expired challenge with a new token', async () => {
+    const expired = makeChallenge('expired@example.com', {
+      challengeToken: 'old-token',
+      expiresAt: new Date(Date.now() - 1000),
+    })
+    // Insert the expired challenge directly
+    await db.insert(otpChallenge).values(expired)
+
+    const fresh = makeChallenge('expired@example.com', { challengeToken: 'new-token' })
+    const result = await getOrCreateOtpChallenge(db, fresh)
+
+    expect(result).toBe('new-token')
+
+    const rows = await db.select().from(otpChallenge).where(eq(otpChallenge.email, 'expired@example.com'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].challengeToken).toBe('new-token')
+  })
+
+  it('should return the same token for concurrent requests (both get first-writer token)', async () => {
+    const email = 'concurrent@example.com'
+
+    const [resultA, resultB] = await Promise.all([
+      getOrCreateOtpChallenge(db, makeChallenge(email, { challengeToken: 'token-a' })),
+      getOrCreateOtpChallenge(db, makeChallenge(email, { challengeToken: 'token-b' })),
+    ])
+
+    // Both should return the same token (whichever won the insert)
+    expect(resultA).toBe(resultB)
+
+    const rows = await db.select().from(otpChallenge).where(eq(otpChallenge.email, email))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].challengeToken).toBe(resultA)
+  })
+
+  it('should not affect challenges for different emails', async () => {
+    const tokenA = await getOrCreateOtpChallenge(db, makeChallenge('a@example.com', { challengeToken: 'token-a' }))
+    const tokenB = await getOrCreateOtpChallenge(db, makeChallenge('b@example.com', { challengeToken: 'token-b' }))
+
+    expect(tokenA).toBe('token-a')
+    expect(tokenB).toBe('token-b')
+
+    const rows = await db.select().from(otpChallenge)
+    expect(rows).toHaveLength(2)
+  })
+})
+
+describe('validateOtpChallenge', () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('should return true for valid non-expired challenge', async () => {
+    const token = await getOrCreateOtpChallenge(db, {
+      id: crypto.randomUUID(),
+      email: 'valid@example.com',
+      challengeToken: 'my-token',
+      expiresAt: new Date(Date.now() + 600_000),
+    })
+
+    const result = await validateOtpChallenge(db, 'valid@example.com', token)
+    expect(result).toBe(true)
+  })
+
+  it('should return false for wrong token', async () => {
+    await getOrCreateOtpChallenge(db, {
+      id: crypto.randomUUID(),
+      email: 'wrong@example.com',
+      challengeToken: 'real-token',
+      expiresAt: new Date(Date.now() + 600_000),
+    })
+
+    const result = await validateOtpChallenge(db, 'wrong@example.com', 'fake-token')
+    expect(result).toBe(false)
+  })
+
+  it('should return false for expired challenge', async () => {
+    await db.insert(otpChallenge).values({
+      id: crypto.randomUUID(),
+      email: 'expired@example.com',
+      challengeToken: 'expired-token',
+      expiresAt: new Date(Date.now() - 1000),
+    })
+
+    const result = await validateOtpChallenge(db, 'expired@example.com', 'expired-token')
+    expect(result).toBe(false)
+  })
+})
+
+describe('deleteOtpChallengesForEmail', () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('should delete all challenges for the given email', async () => {
+    await getOrCreateOtpChallenge(db, {
+      id: crypto.randomUUID(),
+      email: 'delete@example.com',
+      challengeToken: 'token',
+      expiresAt: new Date(Date.now() + 600_000),
+    })
+
+    await deleteOtpChallengesForEmail(db, 'delete@example.com')
+
+    const rows = await db.select().from(otpChallenge).where(eq(otpChallenge.email, 'delete@example.com'))
+    expect(rows).toHaveLength(0)
+  })
+
+  it('should not affect other emails', async () => {
+    await getOrCreateOtpChallenge(db, {
+      id: crypto.randomUUID(),
+      email: 'keep@example.com',
+      challengeToken: 'keep-token',
+      expiresAt: new Date(Date.now() + 600_000),
+    })
+    await getOrCreateOtpChallenge(db, {
+      id: crypto.randomUUID(),
+      email: 'remove@example.com',
+      challengeToken: 'remove-token',
+      expiresAt: new Date(Date.now() + 600_000),
+    })
+
+    await deleteOtpChallengesForEmail(db, 'remove@example.com')
+
+    const remaining = await db.select().from(otpChallenge)
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].email).toBe('keep@example.com')
+  })
+})

--- a/backend/src/dal/otp-challenge.ts
+++ b/backend/src/dal/otp-challenge.ts
@@ -1,29 +1,37 @@
 import type { db as DbType } from '@/db/client'
 import { otpChallenge } from '@/db/schema'
-import { and, eq, gt } from 'drizzle-orm'
+import { and, eq, gt, lt } from 'drizzle-orm'
 
-/** Create a new challenge token for an email, replacing any existing one. */
-export const createOtpChallenge = async (
+/**
+ * Get or create a challenge token for an email (first-writer-wins).
+ * If a valid (non-expired) challenge already exists, returns the existing token.
+ * Only replaces the token when the existing one has expired.
+ *
+ * Uses Postgres row-level locking via ON CONFLICT ... WHERE to serialize
+ * concurrent requests, preventing a race where two instances overwrite
+ * each other's tokens.
+ */
+export const getOrCreateOtpChallenge = async (
   database: typeof DbType,
   data: { id: string; email: string; challengeToken: string; expiresAt: Date },
-) => {
+): Promise<string> => {
   await database
     .insert(otpChallenge)
     .values(data)
     .onConflictDoUpdate({
       target: otpChallenge.email,
-      set: { challengeToken: data.challengeToken, expiresAt: data.expiresAt },
+      set: { id: data.id, challengeToken: data.challengeToken, expiresAt: data.expiresAt },
+      where: lt(otpChallenge.expiresAt, new Date()),
     })
-}
 
-/** Get the current (non-expired) challenge token for an email, if any. */
-export const getOtpChallengeByEmail = async (database: typeof DbType, email: string) => {
+  // Read back the canonical token (ours if we won, existing if still valid)
   const rows = await database
-    .select()
+    .select({ challengeToken: otpChallenge.challengeToken })
     .from(otpChallenge)
-    .where(and(eq(otpChallenge.email, email), gt(otpChallenge.expiresAt, new Date())))
+    .where(eq(otpChallenge.email, data.email))
     .limit(1)
-  return rows[0] ?? null
+
+  return rows[0]?.challengeToken ?? data.challengeToken
 }
 
 /** Validate a challenge token for an email. Returns true if valid, false otherwise. */

--- a/backend/src/dal/otp-challenge.ts
+++ b/backend/src/dal/otp-challenge.ts
@@ -1,0 +1,45 @@
+import type { db as DbType } from '@/db/client'
+import { otpChallenge } from '@/db/schema'
+import { and, eq, gt } from 'drizzle-orm'
+
+/** Create a new challenge token for an email, replacing any existing one. */
+export const createOtpChallenge = async (
+  database: typeof DbType,
+  data: { id: string; email: string; challengeToken: string; expiresAt: Date },
+) => {
+  await database
+    .insert(otpChallenge)
+    .values(data)
+    .onConflictDoUpdate({
+      target: otpChallenge.email,
+      set: { challengeToken: data.challengeToken, expiresAt: data.expiresAt },
+    })
+}
+
+/** Validate a challenge token for an email. Returns the record if valid, null otherwise. */
+export const validateOtpChallenge = async (database: typeof DbType, email: string, challengeToken: string) =>
+  database
+    .select()
+    .from(otpChallenge)
+    .where(
+      and(
+        eq(otpChallenge.email, email),
+        eq(otpChallenge.challengeToken, challengeToken),
+        gt(otpChallenge.expiresAt, new Date()),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+/** Get the latest challenge token for an email. */
+export const getOtpChallengeByEmail = async (database: typeof DbType, email: string) =>
+  database
+    .select()
+    .from(otpChallenge)
+    .where(and(eq(otpChallenge.email, email), gt(otpChallenge.expiresAt, new Date())))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+/** Delete all challenge tokens for an email (cleanup after successful verification). */
+export const deleteOtpChallengesForEmail = async (database: typeof DbType, email: string) =>
+  database.delete(otpChallenge).where(eq(otpChallenge.email, email))

--- a/backend/src/dal/otp-challenge.ts
+++ b/backend/src/dal/otp-challenge.ts
@@ -16,6 +16,15 @@ export const createOtpChallenge = async (
     })
 }
 
+/** Get the current (non-expired) challenge token for an email, if any. */
+export const getOtpChallengeByEmail = async (database: typeof DbType, email: string) =>
+  database
+    .select()
+    .from(otpChallenge)
+    .where(and(eq(otpChallenge.email, email), gt(otpChallenge.expiresAt, new Date())))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
 /** Validate a challenge token for an email. Returns true if valid, false otherwise. */
 export const validateOtpChallenge = async (database: typeof DbType, email: string, challengeToken: string) =>
   database

--- a/backend/src/dal/otp-challenge.ts
+++ b/backend/src/dal/otp-challenge.ts
@@ -17,17 +17,18 @@ export const createOtpChallenge = async (
 }
 
 /** Get the current (non-expired) challenge token for an email, if any. */
-export const getOtpChallengeByEmail = async (database: typeof DbType, email: string) =>
-  database
+export const getOtpChallengeByEmail = async (database: typeof DbType, email: string) => {
+  const rows = await database
     .select()
     .from(otpChallenge)
     .where(and(eq(otpChallenge.email, email), gt(otpChallenge.expiresAt, new Date())))
     .limit(1)
-    .then((rows) => rows[0] ?? null)
+  return rows[0] ?? null
+}
 
 /** Validate a challenge token for an email. Returns true if valid, false otherwise. */
-export const validateOtpChallenge = async (database: typeof DbType, email: string, challengeToken: string) =>
-  database
+export const validateOtpChallenge = async (database: typeof DbType, email: string, challengeToken: string) => {
+  const rows = await database
     .select({ id: otpChallenge.id })
     .from(otpChallenge)
     .where(
@@ -38,7 +39,8 @@ export const validateOtpChallenge = async (database: typeof DbType, email: strin
       ),
     )
     .limit(1)
-    .then((rows) => rows.length > 0)
+  return rows.length > 0
+}
 
 /** Delete all challenge tokens for an email (cleanup after successful verification). */
 export const deleteOtpChallengesForEmail = async (database: typeof DbType, email: string) =>

--- a/backend/src/dal/otp-challenge.ts
+++ b/backend/src/dal/otp-challenge.ts
@@ -16,10 +16,10 @@ export const createOtpChallenge = async (
     })
 }
 
-/** Validate a challenge token for an email. Returns the record if valid, null otherwise. */
+/** Validate a challenge token for an email. Returns true if valid, false otherwise. */
 export const validateOtpChallenge = async (database: typeof DbType, email: string, challengeToken: string) =>
   database
-    .select()
+    .select({ id: otpChallenge.id })
     .from(otpChallenge)
     .where(
       and(
@@ -29,16 +29,7 @@ export const validateOtpChallenge = async (database: typeof DbType, email: strin
       ),
     )
     .limit(1)
-    .then((rows) => rows[0] ?? null)
-
-/** Get the latest challenge token for an email. */
-export const getOtpChallengeByEmail = async (database: typeof DbType, email: string) =>
-  database
-    .select()
-    .from(otpChallenge)
-    .where(and(eq(otpChallenge.email, email), gt(otpChallenge.expiresAt, new Date())))
-    .limit(1)
-    .then((rows) => rows[0] ?? null)
+    .then((rows) => rows.length > 0)
 
 /** Delete all challenge tokens for an email (cleanup after successful verification). */
 export const deleteOtpChallengesForEmail = async (database: typeof DbType, email: string) =>

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,7 +1,8 @@
 import { PGlite } from '@electric-sql/pglite'
 import { drizzle as drizzlePglite } from 'drizzle-orm/pglite'
-import { migrate } from 'drizzle-orm/pglite/migrator'
+import { migrate as migratePglite } from 'drizzle-orm/pglite/migrator'
 import { drizzle as drizzlePostgres } from 'drizzle-orm/postgres-js'
+import { migrate as migratePostgres } from 'drizzle-orm/postgres-js/migrator'
 import { resolve } from 'path'
 import postgres from 'postgres'
 import * as schema from './schema'
@@ -17,15 +18,20 @@ const pgliteDb = isPglite
   ? drizzlePglite({ client: new PGlite(process.env.DATABASE_URL), schema }) // undefined = in-memory
   : null
 
-export const db = pgliteDb ?? drizzlePostgres({ client: postgres(process.env.DATABASE_URL!), schema })
+const postgresDb = isPglite ? null : drizzlePostgres({ client: postgres(process.env.DATABASE_URL!), schema })
+
+export const db = pgliteDb ?? postgresDb!
 
 /**
- * Run Drizzle migrations on PGLite databases.
- * PGLite (especially in-memory) starts with an empty schema, so migrations
- * must be applied before the server can handle requests.
+ * Run Drizzle migrations on startup.
+ * Disable with SKIP_MIGRATIONS=true (e.g. when migrations are handled externally).
  */
 export const runMigrations = async () => {
-  if (!pgliteDb) return
+  if (process.env.SKIP_MIGRATIONS === 'true') return
   const migrationsFolder = resolve(import.meta.dir, '../../drizzle')
-  await migrate(pgliteDb, { migrationsFolder })
+  if (pgliteDb) {
+    await migratePglite(pgliteDb, { migrationsFolder })
+  } else if (postgresDb) {
+    await migratePostgres(postgresDb, { migrationsFolder })
+  }
 }

--- a/backend/src/db/otp-challenge-schema.ts
+++ b/backend/src/db/otp-challenge-schema.ts
@@ -1,0 +1,22 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+
+/**
+ * Tracks challenge tokens for OTP session binding.
+ * Each token is returned to the client that requested an OTP
+ * and must be presented when verifying the OTP. This prevents
+ * an attacker from brute-forcing OTPs without intercepting
+ * the victim's client response.
+ */
+export const otpChallenge = pgTable(
+  'otp_challenge',
+  {
+    id: text('id').primaryKey(),
+    email: text('email').notNull().unique(),
+    challengeToken: text('challenge_token').notNull(),
+    expiresAt: timestamp('expires_at').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    // email index is implicit via unique() constraint
+  ],
+)

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -12,3 +12,6 @@ export * from './rate-limit-schema'
 
 // Re-export encryption schema tables (server-only, not synced via PowerSync)
 export * from './encryption-schema'
+
+// Re-export OTP challenge schema (session binding for OTP verification)
+export * from './otp-challenge-schema'

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -88,7 +88,14 @@ export const createApp = async (deps?: AppDeps) => {
       .use(createInferenceRoutes(auth, createInferenceRateLimit(database, rateLimitSettings)))
       .use(createPostHogRoutes(fetchFn))
       .use(createMcpProxyRoutes(auth, fetchFn))
-      .use(createWaitlistRoutes({ database, auth, emailService: deps?.waitlistEmailService }))
+      .use(
+        createWaitlistRoutes({
+          database,
+          auth,
+          emailService: deps?.waitlistEmailService,
+          cooldownMs: deps?.otpCooldownMs,
+        }),
+      )
       .use(createPowerSyncRoutes(auth, settings, database))
       .use(createEncryptionRoutes(auth, database))
       .use(createAccountRoutes(auth, database))

--- a/backend/src/test-utils/otp-challenge.ts
+++ b/backend/src/test-utils/otp-challenge.ts
@@ -1,15 +1,12 @@
 import { otpExpiryMs } from '@/auth/otp-constants'
-import { createOtpChallenge } from '@/dal'
+import { getOrCreateOtpChallenge } from '@/dal'
 import type { db as DbType } from '@/db/client'
 
 /** Create a challenge token in the DB for auth.api signInEmailOTP calls in tests. */
-export const createTestChallenge = async (db: typeof DbType, email: string) => {
-  const token = crypto.randomUUID()
-  await createOtpChallenge(db, {
+export const createTestChallenge = async (db: typeof DbType, email: string) =>
+  getOrCreateOtpChallenge(db, {
     id: crypto.randomUUID(),
     email,
-    challengeToken: token,
+    challengeToken: crypto.randomUUID(),
     expiresAt: new Date(Date.now() + otpExpiryMs),
   })
-  return token
-}

--- a/backend/src/test-utils/otp-challenge.ts
+++ b/backend/src/test-utils/otp-challenge.ts
@@ -1,0 +1,15 @@
+import { otpExpiryMs } from '@/auth/otp-constants'
+import { createOtpChallenge } from '@/dal'
+import type { db as DbType } from '@/db/client'
+
+/** Create a challenge token in the DB for auth.api signInEmailOTP calls in tests. */
+export const createTestChallenge = async (db: typeof DbType, email: string) => {
+  const token = crypto.randomUUID()
+  await createOtpChallenge(db, {
+    id: crypto.randomUUID(),
+    email,
+    challengeToken: token,
+    expiresAt: new Date(Date.now() + otpExpiryMs),
+  })
+  return token
+}

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -11,4 +11,6 @@ export type AppDeps = {
   database?: typeof db
   auth?: Auth
   waitlistEmailService?: WaitlistEmailService
+  /** OTP request cooldown in milliseconds. Default: 15000 (15s). Set to 0 to disable in tests. */
+  otpCooldownMs?: number
 }

--- a/backend/src/waitlist/routes.test.ts
+++ b/backend/src/waitlist/routes.test.ts
@@ -19,7 +19,7 @@ describe('Waitlist API', () => {
     const testEnv = await createTestDb()
     db = testEnv.db
     cleanup = testEnv.cleanup
-    app = await createApp({ database: db })
+    app = await createApp({ database: db, otpCooldownMs: 0 })
   })
 
   afterEach(async () => {
@@ -45,7 +45,8 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(200)
       const result = await response.json()
       // Privacy: response doesn't reveal approval status
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify in database
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@example.com'))
@@ -91,7 +92,8 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(200)
       const result = await response.json()
       // Privacy: response doesn't reveal approval status
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify only one entry exists
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'duplicate@example.com'))
@@ -120,7 +122,8 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(200)
       const result = await response.json()
       // Privacy: response doesn't reveal approval status
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify only one entry exists
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'case@example.com'))
@@ -170,7 +173,8 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(200)
       const result = await response.json()
       // Privacy: same response as non-approved users - no way to enumerate approved emails
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
     })
 
     it('should return same success response for existing BetterAuth user (privacy)', async () => {
@@ -193,7 +197,8 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(200)
       const result = await response.json()
       // Privacy: same response as new users - no way to enumerate existing accounts
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify no waitlist entry was created (user is in user table, not waitlist)
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'existing@example.com'))
@@ -212,7 +217,8 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(200)
       const result = await response.json()
       // Privacy: same response regardless of auto-approval
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify in database with approved status
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@mozilla.org'))
@@ -231,7 +237,8 @@ describe('Waitlist API', () => {
 
       expect(response.status).toBe(200)
       const result = await response.json()
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify in database with approved status
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@thunderbird.net'))
@@ -250,7 +257,8 @@ describe('Waitlist API', () => {
 
       expect(response.status).toBe(200)
       const result = await response.json()
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify in database with approved status (email normalized to lowercase)
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@mozilla.org'))
@@ -269,7 +277,8 @@ describe('Waitlist API', () => {
 
       expect(response.status).toBe(200)
       const result = await response.json()
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify in database with pending status
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@other-domain.com'))
@@ -288,7 +297,8 @@ describe('Waitlist API', () => {
 
       expect(response.status).toBe(200)
       const result = await response.json()
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify in database with pending status (not auto-approved)
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@fake-mozilla.org.evil.com'))
@@ -314,7 +324,8 @@ describe('Waitlist API', () => {
 
       expect(response.status).toBe(200)
       const result = await response.json()
-      expect(result).toEqual({ success: true })
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
 
       // Verify status was upgraded to approved
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'legacy@mozilla.org'))

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -1,5 +1,12 @@
+import { otpExpiryMs } from '@/auth/otp-constants'
 import type { Auth } from '@/auth/auth'
-import { approveWaitlistEntry, createWaitlistEntry, getUserByEmail, getWaitlistByEmail } from '@/dal'
+import {
+  approveWaitlistEntry,
+  createOtpChallenge,
+  createWaitlistEntry,
+  getUserByEmail,
+  getWaitlistByEmail,
+} from '@/dal'
 import type { db } from '@/db/client'
 import { normalizeEmail } from '@/lib/email'
 import { safeErrorHandler } from '@/middleware/error-handling'
@@ -29,38 +36,76 @@ const sendApprovedMagicLinkEmail = async (auth: Auth, email: string): Promise<vo
   await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
 }
 
+/** Default cooldown between OTP requests per email (15 seconds). */
+const DEFAULT_COOLDOWN_MS = 15_000
+
 type WaitlistRoutesOptions = {
   database: typeof db
   auth: Auth
   emailService?: WaitlistEmailService
+  /** Cooldown between OTP requests per email in ms. Default: 15000. Set to 0 to disable. */
+  cooldownMs?: number
 }
 
-// TODO(THU-113): Add proof-of-work challenge (ALTCHA) to rate-limit this unauthenticated endpoint
-// without storing client IPs. Currently unthrottled: the server-side auth.api.sendVerificationOTP
-// call bypasses Better Auth's HTTP rate limiter. resendStrategy: "reuse" preserves the attempt
-// counter on resend, but once all attempts are exhausted a fresh OTP with counter=0 is generated.
-export const createWaitlistRoutes = ({ database, auth, emailService = defaultEmailService }: WaitlistRoutesOptions) =>
-  new Elysia({ prefix: '/waitlist' }).onError(safeErrorHandler).post(
+export const createWaitlistRoutes = ({
+  database,
+  auth,
+  emailService = defaultEmailService,
+  cooldownMs = DEFAULT_COOLDOWN_MS,
+}: WaitlistRoutesOptions) => {
+  // Per-instance cooldown tracker. Tracks when the last OTP request was made for each email
+  // to prevent rapid code cycling. In-memory is appropriate: 15s window, single-instance defense.
+  const emailCooldowns = new Map<string, number>()
+
+  return new Elysia({ prefix: '/waitlist' }).onError(safeErrorHandler).post(
     '/join',
-    async ({ body }) => {
+    async ({ body, set }) => {
       const email = normalizeEmail(body.email)
 
-      // Check if user already has a BetterAuth account (they're "approved" by default)
+      if (cooldownMs > 0) {
+        const now = Date.now()
+        const lastRequest = emailCooldowns.get(email)
+        if (lastRequest && now - lastRequest < cooldownMs) {
+          set.status = 429
+          return {
+            error: 'code_already_sent',
+            message: 'A verification code was recently sent. Please wait before requesting a new one.',
+          }
+        }
+        // Prune expired entries to prevent unbounded growth
+        if (emailCooldowns.size > 1000) {
+          for (const [key, ts] of emailCooldowns) {
+            if (now - ts >= cooldownMs) emailCooldowns.delete(key)
+          }
+        }
+      }
+
+      // Record cooldown immediately (before any async work) to close the race window
+      // where concurrent requests could pass the check before the timestamp is written.
+      emailCooldowns.set(email, Date.now())
+
+      // Always generate a challenge token (privacy-preserving: same response shape regardless of status)
+      const challengeToken = crypto.randomUUID()
+      await createOtpChallenge(database, {
+        id: crypto.randomUUID(),
+        email,
+        challengeToken,
+        expiresAt: new Date(Date.now() + otpExpiryMs),
+      })
+
       const existingUser = await getUserByEmail(database, email)
 
       if (existingUser) {
         await sendApprovedMagicLinkEmail(auth, email)
-        return { success: true }
+        return { success: true, challengeToken }
       }
 
-      // Check if email already exists on the waitlist
       const existing = await getWaitlistByEmail(database, email)
 
-      // If entry exists, handle based on status
       if (existing) {
         if (existing.status === 'approved') {
           await sendApprovedMagicLinkEmail(auth, email)
-          return { success: true }
+          return { success: true, challengeToken }
         }
 
         // Pending user - check if they now qualify for auto-approval (e.g., feature deployed after they joined)
@@ -70,26 +115,23 @@ export const createWaitlistRoutes = ({ database, auth, emailService = defaultEma
         } else {
           await emailService.sendReminderEmail({ email })
         }
-        return { success: true }
+        return { success: true, challengeToken }
       }
 
-      // Check if email domain is auto-approved
       const isAutoApproved = isAutoApprovedDomain(email)
 
-      // Add new entry to waitlist
       await createWaitlistEntry(database, {
         id: crypto.randomUUID(),
         email,
         status: isAutoApproved ? 'approved' : 'pending',
       })
 
-      // Send appropriate email based on auto-approval status
       if (isAutoApproved) {
         await sendApprovedMagicLinkEmail(auth, email)
       } else {
         await emailService.sendJoinedEmail({ email })
       }
-      return { success: true }
+      return { success: true, challengeToken }
     },
     {
       body: t.Object({
@@ -97,3 +139,4 @@ export const createWaitlistRoutes = ({ database, auth, emailService = defaultEma
       }),
     },
   )
+}

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -2,7 +2,7 @@ import { otpExpiryMs } from '@/auth/otp-constants'
 import type { Auth } from '@/auth/auth'
 import {
   approveWaitlistEntry,
-  createOtpChallenge,
+  getOrCreateOtpChallenge,
   createWaitlistEntry,
   getUserByEmail,
   getWaitlistByEmail,
@@ -86,12 +86,12 @@ export const createWaitlistRoutes = ({
         emailCooldowns.set(email, Date.now())
       }
 
-      // Always generate a challenge token (privacy-preserving: same response shape regardless of status)
-      const challengeToken = crypto.randomUUID()
-      await createOtpChallenge(database, {
+      // Get or create a challenge token (first-writer-wins for multi-instance safety).
+      // Privacy-preserving: same response shape regardless of user status.
+      const challengeToken = await getOrCreateOtpChallenge(database, {
         id: crypto.randomUUID(),
         email,
-        challengeToken,
+        challengeToken: crypto.randomUUID(),
         expiresAt: new Date(Date.now() + otpExpiryMs),
       })
 

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -82,7 +82,9 @@ export const createWaitlistRoutes = ({
 
       // Record cooldown immediately (before any async work) to close the race window
       // where concurrent requests could pass the check before the timestamp is written.
-      emailCooldowns.set(email, Date.now())
+      if (cooldownMs > 0) {
+        emailCooldowns.set(email, Date.now())
+      }
 
       // Always generate a challenge token (privacy-preserving: same response shape regardless of status)
       const challengeToken = crypto.randomUUID()

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "prepare": "husky",
     "size": "size-limit",
     "e2e": "bunx playwright test",
-    "e2e:headed": "bunx playwright test --headed"
+    "e2e:headed": "bunx playwright test --headed",
+    "docker:nuke": "bash scripts/docker-nuke.sh"
   },
   "size-limit": [
     {

--- a/scripts/docker-nuke.sh
+++ b/scripts/docker-nuke.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="$PROJECT_ROOT/powersync-service/docker-compose.yml"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo -e "${RED}✗ Compose file not found: $COMPOSE_FILE${NC}"
+  exit 1
+fi
+
+CONFIRMED=false
+for arg in "$@"; do
+  if [ "$arg" = "-y" ]; then
+    CONFIRMED=true
+  fi
+done
+
+if [ "$CONFIRMED" = false ]; then
+  echo -e "${YELLOW}This will destroy all docker containers, volumes, and data for this project.${NC}"
+  echo -e "${YELLOW}You will lose all local Postgres and Mongo data.${NC}"
+  echo ""
+  read -rp "Are you sure? (y/N) " answer
+  if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+echo -e "${RED}→ Stopping and removing containers + volumes...${NC}"
+docker compose -f "$COMPOSE_FILE" down -v
+
+echo -e "${GREEN}→ Recreating containers from scratch...${NC}"
+docker compose -f "$COMPOSE_FILE" up -d
+
+echo -e "${GREEN}✓ Docker environment nuked and recreated!${NC}"

--- a/src/components/magic-link-verify.tsx
+++ b/src/components/magic-link-verify.tsx
@@ -29,6 +29,7 @@ export const MagicLinkVerify = () => {
 
   const email = searchParams.get('email')
   const otp = searchParams.get('otp')
+  const challengeToken = searchParams.get('challengeToken')
 
   // Track which email+otp pair was last attempted so we suppress re-submission of
   // the same (already-consumed) OTP when refetchSession changes identity and
@@ -54,6 +55,7 @@ export const MagicLinkVerify = () => {
         const result = await authClient.signIn.emailOtp({
           email,
           otp,
+          fetchOptions: challengeToken ? { headers: { 'x-challenge-token': challengeToken } } : undefined,
         })
 
         if (result.error) {
@@ -72,7 +74,7 @@ export const MagicLinkVerify = () => {
     }
 
     verify()
-  }, [email, otp, authClient, refetchSession])
+  }, [email, otp, challengeToken, authClient, refetchSession])
 
   const handleContinue = () => {
     navigate('/', { replace: true })

--- a/src/components/sign-in-modal.test.tsx
+++ b/src/components/sign-in-modal.test.tsx
@@ -3,6 +3,7 @@ import type { ConsoleSpies } from '@/test-utils/console-spies'
 import { setupConsoleSpy } from '@/test-utils/console-spies'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { createMockAuthClient } from '@/test-utils/auth-client'
+import { createClient, type HttpClient } from '@/lib/http'
 import { getClock } from '@/testing-library'
 import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen } from '@testing-library/react'
@@ -32,9 +33,9 @@ mock.module('@/components/ui/input-otp', () => ({
           type="text"
           value={value || ''}
           onChange={(e) => {
-            const newValue = e.target.value.slice(0, maxLength || 6)
+            const newValue = e.target.value.slice(0, maxLength || 8)
             onChange?.(newValue)
-            if (newValue.length === (maxLength || 6)) {
+            if (newValue.length === (maxLength || 8)) {
               onComplete?.(newValue)
             }
           }}
@@ -54,11 +55,31 @@ mock.module('@/components/ui/input-otp', () => ({
 import { SignInModal } from './sign-in-modal'
 import { type ReactNode } from 'react'
 
+const CHALLENGE_TOKEN = 'test-challenge-token'
+const WAITLIST_RESPONSE = { success: true, challengeToken: CHALLENGE_TOKEN }
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+/** Creates a mock HTTP client with a spy-able fetch for assertions. */
+const createSpyHttpClient = (
+  fetchImpl?: (req: Request) => Promise<Response>,
+): { httpClient: HttpClient; fetchSpy: ReturnType<typeof mock> } => {
+  const defaultImpl = async () => jsonResponse(WAITLIST_RESPONSE)
+  const fetchSpy = mock(fetchImpl ?? defaultImpl)
+  const httpClient = createClient({
+    fetch: fetchSpy as unknown as typeof globalThis.fetch,
+    prefixUrl: 'http://test-api.local',
+  })
+  return { httpClient, fetchSpy }
+}
+
 describe('SignInModal', () => {
   let consoleSpies: ConsoleSpies
   let mockOnOpenChange: ReturnType<typeof mock>
-  let mockSendVerificationOtp: ReturnType<typeof mock>
   let mockSignInEmailOtp: ReturnType<typeof mock>
+  let mockHttpClient: HttpClient
+  let mockFetchSpy: ReturnType<typeof mock>
 
   beforeAll(async () => {
     await setupTestDatabase()
@@ -72,8 +93,10 @@ describe('SignInModal', () => {
 
   beforeEach(() => {
     mockOnOpenChange = mock()
-    mockSendVerificationOtp = mock(() => Promise.resolve({ error: null }))
     mockSignInEmailOtp = mock(() => Promise.resolve({ error: null }))
+    const { httpClient, fetchSpy } = createSpyHttpClient()
+    mockHttpClient = httpClient
+    mockFetchSpy = fetchSpy
   })
 
   afterEach(async () => {
@@ -81,13 +104,15 @@ describe('SignInModal', () => {
     mockOnOpenChange.mockClear()
   })
 
-  const renderModal = (props: Partial<{ open: boolean; onOpenChange: (open: boolean) => void }> = {}) => {
+  const renderModal = (
+    props: Partial<{ open: boolean; onOpenChange: (open: boolean) => void }> = {},
+    httpClient?: HttpClient,
+  ) => {
     const authClient = createMockAuthClient({
-      sendVerificationOtp: mockSendVerificationOtp,
       signInEmailOtp: mockSignInEmailOtp,
     })
     return render(<SignInModal open={true} onOpenChange={mockOnOpenChange} {...props} />, {
-      wrapper: createTestProvider({ authClient }),
+      wrapper: createTestProvider({ authClient, httpClient: httpClient ?? mockHttpClient }),
     })
   }
 
@@ -187,7 +212,7 @@ describe('SignInModal', () => {
   })
 
   describe('form submission', () => {
-    it('calls emailOtp.sendVerificationOtp with trimmed email', async () => {
+    it('calls waitlist/join endpoint with trimmed email', async () => {
       renderModal()
 
       const input = await waitForModal()
@@ -200,21 +225,23 @@ describe('SignInModal', () => {
         await getClock().tickAsync(100)
       })
 
-      expect(mockSendVerificationOtp).toHaveBeenCalledWith({
-        email: 'test@example.com',
-        type: 'sign-in',
-      })
+      expect(mockFetchSpy).toHaveBeenCalledTimes(1)
+      const request = mockFetchSpy.mock.calls[0][0] as Request
+      expect(request.url).toContain('waitlist/join')
+      const body = await request.clone().json()
+      expect(body).toEqual({ email: 'test@example.com' })
     })
 
     it('shows loading state while sending', async () => {
-      let resolvePromise: (value: { error: null }) => void
-      mockSendVerificationOtp.mockReturnValue(
-        new Promise((resolve) => {
-          resolvePromise = resolve
-        }),
+      let resolveRequest!: () => void
+      const { httpClient: pendingHttpClient } = createSpyHttpClient(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveRequest = () => resolve(jsonResponse(WAITLIST_RESPONSE))
+          }),
       )
 
-      renderModal()
+      renderModal({}, pendingHttpClient)
       const input = await waitForModal()
       const button = screen.getByRole('button', { name: 'Send Magic Link' })
 
@@ -229,7 +256,7 @@ describe('SignInModal', () => {
       expect(input).toBeDisabled()
 
       // Resolve to clean up
-      resolvePromise!({ error: null })
+      resolveRequest()
       await act(async () => {
         await getClock().runAllAsync()
       })
@@ -262,16 +289,17 @@ describe('SignInModal', () => {
         await getClock().tickAsync(100)
       })
 
-      expect(mockSendVerificationOtp).not.toHaveBeenCalled()
+      expect(mockFetchSpy).not.toHaveBeenCalled()
     })
   })
 
   describe('error handling', () => {
-    it('shows error message on API error', async () => {
-      mockSendVerificationOtp.mockResolvedValue({
-        error: { message: 'Invalid email address' },
-      })
-      renderModal()
+    it('shows error message when API call fails', async () => {
+      const { httpClient: errorHttpClient } = createSpyHttpClient(async () =>
+        jsonResponse({ error: 'Bad request' }, 400),
+      )
+
+      renderModal({}, errorHttpClient)
 
       const input = await waitForModal()
       fireEvent.change(input, { target: { value: 'test@example.com' } })
@@ -281,14 +309,15 @@ describe('SignInModal', () => {
         await getClock().tickAsync(100)
       })
 
-      expect(screen.getByText('Invalid email address')).toBeInTheDocument()
+      expect(screen.getByText('Failed to send verification code. Please check your connection.')).toBeInTheDocument()
     })
 
-    it('shows default error message when error has no message', async () => {
-      mockSendVerificationOtp.mockResolvedValue({
-        error: {},
+    it('shows error message when network request throws', async () => {
+      const { httpClient: errorHttpClient } = createSpyHttpClient(async () => {
+        throw new Error('Network error')
       })
-      renderModal()
+
+      renderModal({}, errorHttpClient)
 
       const input = await waitForModal()
       fireEvent.change(input, { target: { value: 'test@example.com' } })
@@ -298,7 +327,7 @@ describe('SignInModal', () => {
         await getClock().tickAsync(100)
       })
 
-      expect(screen.getByText('Failed to send verification code')).toBeInTheDocument()
+      expect(screen.getByText('Failed to send verification code. Please check your connection.')).toBeInTheDocument()
     })
   })
 
@@ -346,7 +375,7 @@ describe('SignInModal', () => {
       })
 
       // Should show OTP input prompt
-      expect(screen.getByText('Or enter the 6-digit code')).toBeInTheDocument()
+      expect(screen.getByText('Or enter the 8-digit code')).toBeInTheDocument()
       expect(screen.getByTestId('mock-otp-input')).toBeInTheDocument()
     })
 
@@ -364,7 +393,7 @@ describe('SignInModal', () => {
 
       // Get the mocked OTP input and enter code
       const otpInput = screen.getByTestId('otp-input')
-      fireEvent.change(otpInput, { target: { value: '123456' } })
+      fireEvent.change(otpInput, { target: { value: '12345678' } })
 
       await act(async () => {
         await getClock().tickAsync(100)
@@ -393,7 +422,7 @@ describe('SignInModal', () => {
 
       // Get the mocked OTP input and enter code
       const otpInput = screen.getByTestId('otp-input')
-      fireEvent.change(otpInput, { target: { value: '123456' } })
+      fireEvent.change(otpInput, { target: { value: '12345678' } })
 
       await act(async () => {
         await getClock().tickAsync(100)
@@ -403,7 +432,7 @@ describe('SignInModal', () => {
       expect(screen.getByText('Invalid code')).toBeInTheDocument()
     })
 
-    it('calls signIn.emailOtp with correct email and OTP', async () => {
+    it('calls signIn.emailOtp with correct email, OTP, and challenge token', async () => {
       renderModal()
 
       // Send verification code first
@@ -417,7 +446,7 @@ describe('SignInModal', () => {
 
       // Get the mocked OTP input and enter code
       const otpInput = screen.getByTestId('otp-input')
-      fireEvent.change(otpInput, { target: { value: '123456' } })
+      fireEvent.change(otpInput, { target: { value: '12345678' } })
 
       await act(async () => {
         await getClock().tickAsync(100)
@@ -425,7 +454,10 @@ describe('SignInModal', () => {
 
       expect(mockSignInEmailOtp).toHaveBeenCalledWith({
         email: 'test@example.com',
-        otp: '123456',
+        otp: '12345678',
+        fetchOptions: {
+          headers: { 'x-challenge-token': CHALLENGE_TOKEN },
+        },
       })
     })
   })
@@ -442,7 +474,7 @@ describe('SignInModal', () => {
         await getClock().tickAsync(100)
       })
 
-      expect(screen.getByText('Or enter the 6-digit code')).toBeInTheDocument()
+      expect(screen.getByText('Or enter the 8-digit code')).toBeInTheDocument()
       expect(screen.getByTestId('mock-otp-input')).toBeInTheDocument()
 
       const backButton = screen.getByRole('button', { name: 'Go back' })
@@ -453,7 +485,7 @@ describe('SignInModal', () => {
       expect(screen.getByPlaceholderText('Email address')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Send Magic Link' })).toBeInTheDocument()
       expect(screen.getByText('Sign In')).toBeInTheDocument()
-      expect(screen.queryByText('Or enter the 6-digit code')).not.toBeInTheDocument()
+      expect(screen.queryByText('Or enter the 8-digit code')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/components/sign-in-modal.test.tsx
+++ b/src/components/sign-in-modal.test.tsx
@@ -55,8 +55,8 @@ mock.module('@/components/ui/input-otp', () => ({
 import { SignInModal } from './sign-in-modal'
 import { type ReactNode } from 'react'
 
-const CHALLENGE_TOKEN = 'test-challenge-token'
-const WAITLIST_RESPONSE = { success: true, challengeToken: CHALLENGE_TOKEN }
+const challengeToken = 'test-challenge-token'
+const waitlistResponse = { success: true, challengeToken }
 
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
@@ -65,7 +65,7 @@ const jsonResponse = (body: unknown, status = 200) =>
 const createSpyHttpClient = (
   fetchImpl?: (req: Request) => Promise<Response>,
 ): { httpClient: HttpClient; fetchSpy: ReturnType<typeof mock> } => {
-  const defaultImpl = async () => jsonResponse(WAITLIST_RESPONSE)
+  const defaultImpl = async () => jsonResponse(waitlistResponse)
   const fetchSpy = mock(fetchImpl ?? defaultImpl)
   const httpClient = createClient({
     fetch: fetchSpy as unknown as typeof globalThis.fetch,
@@ -237,7 +237,7 @@ describe('SignInModal', () => {
       const { httpClient: pendingHttpClient } = createSpyHttpClient(
         () =>
           new Promise<Response>((resolve) => {
-            resolveRequest = () => resolve(jsonResponse(WAITLIST_RESPONSE))
+            resolveRequest = () => resolve(jsonResponse(waitlistResponse))
           }),
       )
 
@@ -456,7 +456,7 @@ describe('SignInModal', () => {
         email: 'test@example.com',
         otp: '12345678',
         fetchOptions: {
-          headers: { 'x-challenge-token': CHALLENGE_TOKEN },
+          headers: { 'x-challenge-token': challengeToken },
         },
       })
     })

--- a/src/components/sign-in/sign-in-form.tsx
+++ b/src/components/sign-in/sign-in-form.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@/contexts'
+import { useAuth, useHttpClient } from '@/contexts'
 import { useSettings } from '@/hooks/use-settings'
 import { isLocalhostUrl } from '@/lib/utils'
 import { type ReactNode, type RefObject, useCallback, useEffect } from 'react'
@@ -68,12 +68,14 @@ export const SignInForm = ({
   goBackRef,
 }: SignInFormProps) => {
   const authClient = useAuth()
+  const httpClient = useHttpClient()
   const { cloudUrl, preferredName } = useSettings({ cloud_url: 'http://localhost:8000/v1', preferred_name: '' })
   const isLocalhost = isLocalhostUrl(cloudUrl.value)
   const displayName = preferredName.value as string
 
   const { state, isValidEmail, actions } = useSignInFormState({
     authClient,
+    httpClient,
     onCancel,
     onEmailSent,
     initialEmail,

--- a/src/components/sign-in/sign-in-form.tsx
+++ b/src/components/sign-in/sign-in-form.tsx
@@ -37,6 +37,10 @@ type SignInFormProps = {
    */
   skipToOtp?: boolean
   /**
+   * Challenge token to use when skipToOtp is true (required for OTP verification)
+   */
+  initialChallengeToken?: string
+  /**
    * Render function for the header back button (modal variant only)
    */
   renderBackButton?: (onClick: () => void) => ReactNode
@@ -64,6 +68,7 @@ export const SignInForm = ({
   onEmailSent,
   initialEmail,
   skipToOtp,
+  initialChallengeToken,
   renderBackButton,
   goBackRef,
 }: SignInFormProps) => {
@@ -80,6 +85,7 @@ export const SignInForm = ({
     onEmailSent,
     initialEmail,
     skipToOtp,
+    initialChallengeToken,
   })
 
   // When skipping to OTP, notify parent so it can update its step tracking (e.g. back button behavior).

--- a/src/components/sign-in/sign-in-otp-step.tsx
+++ b/src/components/sign-in/sign-in-otp-step.tsx
@@ -66,7 +66,7 @@ export const SignInOtpStep = ({
         {/* OTP input + feedback at bottom */}
         <div className="flex w-full flex-col items-center gap-4">
           <InputOTP
-            maxLength={6}
+            maxLength={8}
             pattern={REGEXP_ONLY_DIGITS}
             value={otp}
             onChange={onOtpChange}
@@ -79,7 +79,7 @@ export const SignInOtpStep = ({
             data-form-type="other"
           >
             <InputOTPGroup className="gap-2">
-              {[0, 1, 2, 3, 4, 5].map((i) => (
+              {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
                 <InputOTPSlot key={i} index={i} className="h-12 w-12 shrink-0 rounded-lg" />
               ))}
             </InputOTPGroup>
@@ -90,7 +90,7 @@ export const SignInOtpStep = ({
           <Button
             type="button"
             onClick={() => onOtpComplete(otp)}
-            disabled={isVerifying || otp.length !== 6}
+            disabled={isVerifying || otp.length !== 8}
             className="h-[46px] w-full rounded-[12px] bg-foreground text-background text-base font-medium hover:bg-foreground/90 disabled:bg-muted disabled:text-muted-foreground"
           >
             {isVerifying ? (
@@ -140,9 +140,9 @@ export const SignInOtpStep = ({
 
       {/* OTP Input */}
       <div className="mt-6 flex flex-col items-center gap-3">
-        <p className="text-sm text-muted-foreground">Or enter the 6-digit code</p>
+        <p className="text-sm text-muted-foreground">Or enter the 8-digit code</p>
         <InputOTP
-          maxLength={6}
+          maxLength={8}
           pattern={REGEXP_ONLY_DIGITS}
           value={otp}
           onChange={onOtpChange}
@@ -161,6 +161,8 @@ export const SignInOtpStep = ({
             <InputOTPSlot index={3} />
             <InputOTPSlot index={4} />
             <InputOTPSlot index={5} />
+            <InputOTPSlot index={6} />
+            <InputOTPSlot index={7} />
           </InputOTPGroup>
         </InputOTP>
 

--- a/src/components/sign-in/sign-in-otp-step.tsx
+++ b/src/components/sign-in/sign-in-otp-step.tsx
@@ -44,7 +44,7 @@ export const SignInOtpStep = ({
         <div className="my-auto flex flex-col items-center text-center">
           <p className="font-sans text-[28px] font-medium leading-normal text-foreground">Check your email</p>
           <p className="mt-2 text-base text-foreground">
-            If you have access, we&apos;ve sent a 6-digit code to <span className="font-bold">{email}</span>
+            If you have access, we&apos;ve sent an 8-digit code to <span className="font-bold">{email}</span>
           </p>
           <ActionFeedbackButton
             variant="ghost"

--- a/src/components/sign-in/use-sign-in-form-state.test.ts
+++ b/src/components/sign-in/use-sign-in-form-state.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import type { FormEvent } from 'react'
 import { createClient, type HttpClient } from '@/lib/http'
 import { createMockAuthClient } from '@/test-utils/auth-client'
 import { useSignInFormState } from './use-sign-in-form-state'
@@ -43,7 +44,7 @@ describe('useSignInFormState', () => {
       result.current.actions.setEmail('test@example.com')
     })
     await act(async () => {
-      await result.current.actions.handleSubmit({ preventDefault: () => {} } as React.FormEvent)
+      await result.current.actions.handleSubmit({ preventDefault: () => {} } as FormEvent)
     })
     expect(result.current.state.status).toBe('sent')
   }
@@ -54,7 +55,9 @@ describe('useSignInFormState', () => {
       let callCount = 0
       const { httpClient } = createSpyHttpClient(async () => {
         callCount++
-        if (callCount === 1) return jsonResponse(waitlistResponse)
+        if (callCount === 1) {
+          return jsonResponse(waitlistResponse)
+        }
         return jsonResponse({ error: 'code_already_sent', message: cooldownMessage }, 429)
       })
 
@@ -68,7 +71,7 @@ describe('useSignInFormState', () => {
         result.current.actions.goBack()
       })
       await act(async () => {
-        await result.current.actions.handleSubmit({ preventDefault: () => {} } as React.FormEvent)
+        await result.current.actions.handleSubmit({ preventDefault: () => {} } as FormEvent)
       })
 
       expect(result.current.state.status).toBe('error')
@@ -86,7 +89,7 @@ describe('useSignInFormState', () => {
         result.current.actions.setEmail('test@example.com')
       })
       await act(async () => {
-        await result.current.actions.handleSubmit({ preventDefault: () => {} } as React.FormEvent)
+        await result.current.actions.handleSubmit({ preventDefault: () => {} } as FormEvent)
       })
 
       expect(result.current.state.status).toBe('error')
@@ -100,7 +103,9 @@ describe('useSignInFormState', () => {
       let callCount = 0
       const { httpClient } = createSpyHttpClient(async () => {
         callCount++
-        if (callCount === 1) return jsonResponse(waitlistResponse)
+        if (callCount === 1) {
+          return jsonResponse(waitlistResponse)
+        }
         return jsonResponse({ error: 'code_already_sent', message: cooldownMessage }, 429)
       })
 
@@ -123,7 +128,9 @@ describe('useSignInFormState', () => {
       let callCount = 0
       const { httpClient } = createSpyHttpClient(async () => {
         callCount++
-        if (callCount === 1) return jsonResponse(waitlistResponse)
+        if (callCount === 1) {
+          return jsonResponse(waitlistResponse)
+        }
         throw new TypeError('Failed to fetch')
       })
 
@@ -144,7 +151,9 @@ describe('useSignInFormState', () => {
       let callCount = 0
       const { httpClient } = createSpyHttpClient(async () => {
         callCount++
-        if (callCount === 1) return jsonResponse(waitlistResponse)
+        if (callCount === 1) {
+          return jsonResponse(waitlistResponse)
+        }
         return jsonResponse({ error: 'internal_error', message: 'Something broke' }, 500)
       })
 

--- a/src/components/sign-in/use-sign-in-form-state.test.ts
+++ b/src/components/sign-in/use-sign-in-form-state.test.ts
@@ -1,0 +1,162 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { createClient, type HttpClient } from '@/lib/http'
+import { createMockAuthClient } from '@/test-utils/auth-client'
+import { useSignInFormState } from './use-sign-in-form-state'
+
+const challengeToken = 'test-challenge-token'
+const waitlistResponse = { success: true, challengeToken }
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+const createSpyHttpClient = (
+  fetchImpl?: (req: Request) => Promise<Response>,
+): { httpClient: HttpClient; fetchSpy: ReturnType<typeof mock> } => {
+  const defaultImpl = async () => jsonResponse(waitlistResponse)
+  const fetchSpy = mock(fetchImpl ?? defaultImpl)
+  const httpClient = createClient({
+    fetch: fetchSpy as unknown as typeof globalThis.fetch,
+    prefixUrl: 'http://test-api.local',
+  })
+  return { httpClient, fetchSpy }
+}
+
+describe('useSignInFormState', () => {
+  let authClient: ReturnType<typeof createMockAuthClient>
+
+  beforeEach(() => {
+    authClient = createMockAuthClient()
+  })
+
+  const renderFormHook = (httpClient: HttpClient) =>
+    renderHook(() =>
+      useSignInFormState({
+        authClient,
+        httpClient,
+      }),
+    )
+
+  /** Helper: submit email to move the form into 'sent' status so resend is available. */
+  const submitEmail = async (result: { current: ReturnType<typeof useSignInFormState> }) => {
+    act(() => {
+      result.current.actions.setEmail('test@example.com')
+    })
+    await act(async () => {
+      await result.current.actions.handleSubmit({ preventDefault: () => {} } as React.FormEvent)
+    })
+    expect(result.current.state.status).toBe('sent')
+  }
+
+  describe('handleSubmit cooldown error', () => {
+    it('surfaces the server cooldown message on 429', async () => {
+      const cooldownMessage = 'A verification code was recently sent. Please wait before requesting a new one.'
+      let callCount = 0
+      const { httpClient } = createSpyHttpClient(async () => {
+        callCount++
+        if (callCount === 1) return jsonResponse(waitlistResponse)
+        return jsonResponse({ error: 'code_already_sent', message: cooldownMessage }, 429)
+      })
+
+      const { result } = renderFormHook(httpClient)
+
+      // First submit succeeds
+      await submitEmail(result)
+
+      // Go back and resubmit — hits cooldown
+      act(() => {
+        result.current.actions.goBack()
+      })
+      await act(async () => {
+        await result.current.actions.handleSubmit({ preventDefault: () => {} } as React.FormEvent)
+      })
+
+      expect(result.current.state.status).toBe('error')
+      expect(result.current.state.errorMessage).toBe(cooldownMessage)
+    })
+
+    it('shows generic error for network failures', async () => {
+      const { httpClient } = createSpyHttpClient(async () => {
+        throw new TypeError('Failed to fetch')
+      })
+
+      const { result } = renderFormHook(httpClient)
+
+      act(() => {
+        result.current.actions.setEmail('test@example.com')
+      })
+      await act(async () => {
+        await result.current.actions.handleSubmit({ preventDefault: () => {} } as React.FormEvent)
+      })
+
+      expect(result.current.state.status).toBe('error')
+      expect(result.current.state.errorMessage).toBe('Failed to send verification code. Please check your connection.')
+    })
+  })
+
+  describe('handleResend cooldown error', () => {
+    it('surfaces the server cooldown message on 429', async () => {
+      const cooldownMessage = 'A verification code was recently sent. Please wait before requesting a new one.'
+      let callCount = 0
+      const { httpClient } = createSpyHttpClient(async () => {
+        callCount++
+        if (callCount === 1) return jsonResponse(waitlistResponse)
+        return jsonResponse({ error: 'code_already_sent', message: cooldownMessage }, 429)
+      })
+
+      const { result } = renderFormHook(httpClient)
+
+      // First submit succeeds, moving to 'sent' state
+      await submitEmail(result)
+
+      // Resend hits cooldown
+      let resendResult: boolean | undefined
+      await act(async () => {
+        resendResult = await result.current.actions.handleResend()
+      })
+
+      expect(resendResult).toBe(false)
+      expect(result.current.state.errorMessage).toBe(cooldownMessage)
+    })
+
+    it('shows generic error for network failures', async () => {
+      let callCount = 0
+      const { httpClient } = createSpyHttpClient(async () => {
+        callCount++
+        if (callCount === 1) return jsonResponse(waitlistResponse)
+        throw new TypeError('Failed to fetch')
+      })
+
+      const { result } = renderFormHook(httpClient)
+
+      await submitEmail(result)
+
+      await act(async () => {
+        await result.current.actions.handleResend()
+      })
+
+      expect(result.current.state.errorMessage).toBe(
+        'Failed to resend verification code. Please check your connection.',
+      )
+    })
+
+    it('surfaces a non-cooldown server error message', async () => {
+      let callCount = 0
+      const { httpClient } = createSpyHttpClient(async () => {
+        callCount++
+        if (callCount === 1) return jsonResponse(waitlistResponse)
+        return jsonResponse({ error: 'internal_error', message: 'Something broke' }, 500)
+      })
+
+      const { result } = renderFormHook(httpClient)
+
+      await submitEmail(result)
+
+      await act(async () => {
+        await result.current.actions.handleResend()
+      })
+
+      expect(result.current.state.errorMessage).toBe('Something broke')
+    })
+  })
+})

--- a/src/components/sign-in/use-sign-in-form-state.test.ts
+++ b/src/components/sign-in/use-sign-in-form-state.test.ts
@@ -168,4 +168,64 @@ describe('useSignInFormState', () => {
       expect(result.current.state.errorMessage).toBe('Something broke')
     })
   })
+
+  describe('skipToOtp with initialChallengeToken', () => {
+    it('initializes with challengeToken when skipToOtp is true', () => {
+      const { httpClient } = createSpyHttpClient()
+      const { result } = renderHook(() =>
+        useSignInFormState({
+          authClient,
+          httpClient,
+          initialEmail: 'test@example.com',
+          skipToOtp: true,
+          initialChallengeToken: 'pre-existing-token',
+        }),
+      )
+
+      expect(result.current.state.status).toBe('sent')
+      expect(result.current.state.challengeToken).toBe('pre-existing-token')
+    })
+
+    it('sends challengeToken in OTP verification when skipToOtp is used', async () => {
+      const { httpClient } = createSpyHttpClient()
+      authClient.signIn.emailOtp = mock(async () => ({ data: { user: { id: '1' } }, error: null }))
+
+      const { result } = renderHook(() =>
+        useSignInFormState({
+          authClient,
+          httpClient,
+          initialEmail: 'test@example.com',
+          skipToOtp: true,
+          initialChallengeToken: 'pre-existing-token',
+        }),
+      )
+
+      await act(async () => {
+        await result.current.actions.handleOtpComplete('12345678')
+      })
+
+      expect(authClient.signIn.emailOtp).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        otp: '12345678',
+        fetchOptions: {
+          headers: { 'x-challenge-token': 'pre-existing-token' },
+        },
+      })
+    })
+
+    it('defaults challengeToken to empty string without initialChallengeToken', () => {
+      const { httpClient } = createSpyHttpClient()
+      const { result } = renderHook(() =>
+        useSignInFormState({
+          authClient,
+          httpClient,
+          initialEmail: 'test@example.com',
+          skipToOtp: true,
+        }),
+      )
+
+      expect(result.current.state.status).toBe('sent')
+      expect(result.current.state.challengeToken).toBe('')
+    })
+  })
 })

--- a/src/components/sign-in/use-sign-in-form-state.test.ts
+++ b/src/components/sign-in/use-sign-in-form-state.test.ts
@@ -188,7 +188,8 @@ describe('useSignInFormState', () => {
 
     it('sends challengeToken in OTP verification when skipToOtp is used', async () => {
       const { httpClient } = createSpyHttpClient()
-      authClient.signIn.emailOtp = mock(async () => ({ data: { user: { id: '1' } }, error: null }))
+      const emailOtpSpy = mock(async () => ({ data: { user: { id: '1' } }, error: null }))
+      authClient = createMockAuthClient({ signInEmailOtp: emailOtpSpy })
 
       const { result } = renderHook(() =>
         useSignInFormState({
@@ -204,7 +205,7 @@ describe('useSignInFormState', () => {
         await result.current.actions.handleOtpComplete('12345678')
       })
 
-      expect(authClient.signIn.emailOtp).toHaveBeenCalledWith({
+      expect(emailOtpSpy).toHaveBeenCalledWith({
         email: 'test@example.com',
         otp: '12345678',
         fetchOptions: {

--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -1,4 +1,5 @@
 import type { AuthClient } from '@/contexts'
+import type { HttpClient } from '@/lib/http'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { updateSettings } from '@/dal'
 import { getDb, getDatabaseInstance } from '@/db/database'
@@ -10,6 +11,7 @@ type FormStatus = 'idle' | 'sending' | 'sent' | 'verifying' | 'success' | 'error
 type State = {
   email: string
   otp: string
+  challengeToken: string
   status: FormStatus
   errorMessage: string
 }
@@ -18,7 +20,7 @@ type Action =
   | { type: 'SET_EMAIL'; payload: string }
   | { type: 'SET_OTP'; payload: string }
   | { type: 'START_SENDING' }
-  | { type: 'SEND_SUCCESS' }
+  | { type: 'SEND_SUCCESS'; payload: string }
   | { type: 'SEND_ERROR'; payload: string }
   | { type: 'START_VERIFYING' }
   | { type: 'VERIFY_SUCCESS' }
@@ -30,6 +32,7 @@ type Action =
 const initialState: State = {
   email: '',
   otp: '',
+  challengeToken: '',
   status: 'idle',
   errorMessage: '',
 }
@@ -43,7 +46,7 @@ const reducer = (state: State, action: Action): State => {
     case 'START_SENDING':
       return { ...state, status: 'sending', errorMessage: '' }
     case 'SEND_SUCCESS':
-      return { ...state, status: 'sent' }
+      return { ...state, status: 'sent', challengeToken: action.payload }
     case 'SEND_ERROR':
       return { ...state, status: 'error', errorMessage: action.payload }
     case 'START_VERIFYING':
@@ -65,6 +68,7 @@ const reducer = (state: State, action: Action): State => {
 
 type UseSignInFormStateOptions = {
   authClient: AuthClient
+  httpClient: HttpClient
   onCancel?: () => void
   onEmailSent?: () => void
   /** Pre-fill the email input (user still needs to click submit) */
@@ -108,6 +112,7 @@ export const onSignInSuccess = async (isNewUser: boolean): Promise<void> => {
  */
 export const useSignInFormState = ({
   authClient,
+  httpClient,
   onCancel,
   onEmailSent,
   initialEmail,
@@ -135,17 +140,11 @@ export const useSignInFormState = ({
     dispatch({ type: 'START_SENDING' })
 
     try {
-      const { error } = await authClient.emailOtp.sendVerificationOtp({
-        email: trimmedEmail,
-        type: 'sign-in',
-      })
+      const { challengeToken } = await httpClient
+        .post('waitlist/join', { json: { email: trimmedEmail } })
+        .json<{ success: boolean; challengeToken: string }>()
 
-      if (error) {
-        dispatch({ type: 'SEND_ERROR', payload: error.message || 'Failed to send verification code' })
-        return
-      }
-
-      dispatch({ type: 'SEND_SUCCESS' })
+      dispatch({ type: 'SEND_SUCCESS', payload: challengeToken })
     } catch (error) {
       console.error('Failed to send verification OTP:', error)
       dispatch({ type: 'SEND_ERROR', payload: 'Failed to send verification code. Please check your connection.' })
@@ -156,17 +155,19 @@ export const useSignInFormState = ({
   }
 
   const handleOtpComplete = async (value: string) => {
-    if (value.length !== 6) {
+    if (value.length !== 8) {
       return
     }
 
     dispatch({ type: 'START_VERIFYING' })
 
     try {
-      // Use emailOtp signIn to verify OTP and create session
       const result = await authClient.signIn.emailOtp({
         email: state.email.trim(),
         otp: value,
+        fetchOptions: {
+          headers: { 'x-challenge-token': state.challengeToken },
+        },
       })
 
       if (result.error) {
@@ -205,17 +206,11 @@ export const useSignInFormState = ({
     dispatch({ type: 'SET_ERROR', payload: '' })
 
     try {
-      const { error } = await authClient.emailOtp.sendVerificationOtp({
-        email: trimmedEmail,
-        type: 'sign-in',
-      })
+      const { challengeToken } = await httpClient
+        .post('waitlist/join', { json: { email: trimmedEmail } })
+        .json<{ success: boolean; challengeToken: string }>()
 
-      if (error) {
-        dispatch({ type: 'SET_ERROR', payload: error.message || 'Failed to resend verification code' })
-        return false
-      }
-
-      // Clear OTP input for fresh entry
+      dispatch({ type: 'SEND_SUCCESS', payload: challengeToken })
       dispatch({ type: 'SET_OTP', payload: '' })
       return true
     } catch (error) {

--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -1,10 +1,22 @@
 import type { AuthClient } from '@/contexts'
-import type { HttpClient } from '@/lib/http'
+import { HttpError, type HttpClient } from '@/lib/http'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { updateSettings } from '@/dal'
 import { getDb, getDatabaseInstance } from '@/db/database'
 import { isValidEmailFormat } from '@/lib/utils'
 import { useReducer, type FormEvent } from 'react'
+
+/** Extract a user-facing error message from an HttpError response body, or return the fallback. */
+const getServerErrorMessage = async (error: unknown, fallback: string): Promise<string> => {
+  if (!(error instanceof HttpError)) return fallback
+  try {
+    const body = await error.response.json()
+    if (typeof body?.message === 'string' && body.message) return body.message
+  } catch {
+    // Response body not JSON-parseable
+  }
+  return fallback
+}
 
 type FormStatus = 'idle' | 'sending' | 'sent' | 'verifying' | 'success' | 'error'
 
@@ -147,7 +159,11 @@ export const useSignInFormState = ({
       dispatch({ type: 'SEND_SUCCESS', payload: challengeToken })
     } catch (error) {
       console.error('Failed to send verification OTP:', error)
-      dispatch({ type: 'SEND_ERROR', payload: 'Failed to send verification code. Please check your connection.' })
+      const message = await getServerErrorMessage(
+        error,
+        'Failed to send verification code. Please check your connection.',
+      )
+      dispatch({ type: 'SEND_ERROR', payload: message })
       return
     }
 
@@ -215,7 +231,11 @@ export const useSignInFormState = ({
       return true
     } catch (error) {
       console.error('Failed to resend verification OTP:', error)
-      dispatch({ type: 'SET_ERROR', payload: 'Failed to resend verification code. Please check your connection.' })
+      const message = await getServerErrorMessage(
+        error,
+        'Failed to resend verification code. Please check your connection.',
+      )
+      dispatch({ type: 'SET_ERROR', payload: message })
       return false
     }
   }

--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -8,10 +8,14 @@ import { useReducer, type FormEvent } from 'react'
 
 /** Extract a user-facing error message from an HttpError response body, or return the fallback. */
 const getServerErrorMessage = async (error: unknown, fallback: string): Promise<string> => {
-  if (!(error instanceof HttpError)) return fallback
+  if (!(error instanceof HttpError)) {
+    return fallback
+  }
   try {
     const body = await error.response.json()
-    if (typeof body?.message === 'string' && body.message) return body.message
+    if (typeof body?.message === 'string' && body.message) {
+      return body.message
+    }
   } catch {
     // Response body not JSON-parseable
   }

--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -62,7 +62,7 @@ const reducer = (state: State, action: Action): State => {
     case 'START_SENDING':
       return { ...state, status: 'sending', errorMessage: '' }
     case 'SEND_SUCCESS':
-      return { ...state, status: 'sent', challengeToken: action.payload }
+      return { ...state, status: 'sent', challengeToken: action.payload, otp: '', errorMessage: '' }
     case 'SEND_ERROR':
       return { ...state, status: 'error', errorMessage: action.payload }
     case 'START_VERIFYING':
@@ -91,6 +91,8 @@ type UseSignInFormStateOptions = {
   initialEmail?: string
   /** Initialize directly in OTP step (OTP must already be sent before mounting) */
   skipToOtp?: boolean
+  /** Challenge token to use when skipToOtp is true (required for OTP verification) */
+  initialChallengeToken?: string
 }
 
 /** Better Auth includes `isNew` on the user object at runtime but not in its types. */
@@ -133,6 +135,7 @@ export const useSignInFormState = ({
   onEmailSent,
   initialEmail,
   skipToOtp,
+  initialChallengeToken,
 }: UseSignInFormStateOptions) => {
   // If skipToOtp is requested without an email, fall back to idle state instead of crashing
   const canSkipToOtp = skipToOtp && !!initialEmail?.trim()
@@ -141,6 +144,7 @@ export const useSignInFormState = ({
     ...initialState,
     email: initialEmail ?? '',
     status: canSkipToOtp ? 'sent' : 'idle',
+    challengeToken: canSkipToOtp ? (initialChallengeToken ?? '') : '',
   })
 
   const isValidEmail = isValidEmailFormat(state.email.trim())
@@ -222,16 +226,12 @@ export const useSignInFormState = ({
       return false
     }
 
-    // Clear any previous error
-    dispatch({ type: 'SET_ERROR', payload: '' })
-
     try {
       const { challengeToken } = await httpClient
         .post('waitlist/join', { json: { email: trimmedEmail } })
         .json<{ success: boolean; challengeToken: string }>()
 
       dispatch({ type: 'SEND_SUCCESS', payload: challengeToken })
-      dispatch({ type: 'SET_OTP', payload: '' })
       return true
     } catch (error) {
       console.error('Failed to resend verification OTP:', error)

--- a/src/crypto/recovery-key.test.ts
+++ b/src/crypto/recovery-key.test.ts
@@ -48,8 +48,19 @@ describe('decodeRecoveryKey', () => {
     const ck = await generateCK(true)
     const mnemonic = await encodeRecoveryKey(ck)
     const words = mnemonic.split(' ')
-    ;[words[0], words[1]] = [words[1], words[0]]
-    await expect(decodeRecoveryKey(words.join(' '))).rejects.toThrow('Invalid recovery phrase')
+    // Each swap has a 1/256 chance of still having a valid checksum.
+    // Try multiple swaps so the test is effectively deterministic.
+    for (let i = 0; i < words.length - 1; i++) {
+      if (words[i] === words[i + 1]) continue
+      const corrupted = [...words]
+      ;[corrupted[i], corrupted[i + 1]] = [corrupted[i + 1], corrupted[i]]
+      try {
+        await decodeRecoveryKey(corrupted.join(' '))
+      } catch {
+        return // checksum correctly rejected
+      }
+    }
+    throw new Error('All swaps produced valid checksums (astronomically unlikely)')
   })
 
   it('rejects a word not in the wordlist', async () => {

--- a/src/crypto/recovery-key.test.ts
+++ b/src/crypto/recovery-key.test.ts
@@ -51,7 +51,9 @@ describe('decodeRecoveryKey', () => {
     // Each swap has a 1/256 chance of still having a valid checksum.
     // Try multiple swaps so the test is effectively deterministic.
     for (let i = 0; i < words.length - 1; i++) {
-      if (words[i] === words[i + 1]) continue
+      if (words[i] === words[i + 1]) {
+        continue
+      }
       const corrupted = [...words]
       ;[corrupted[i], corrupted[i + 1]] = [corrupted[i + 1], corrupted[i]]
       try {

--- a/src/hooks/use-deep-link-listener.test.ts
+++ b/src/hooks/use-deep-link-listener.test.ts
@@ -112,6 +112,7 @@ describe('parseVerifyLinkCallback', () => {
     expect(result).toEqual({
       email: 'user@example.com',
       otp: '123456',
+      challengeToken: undefined,
     })
   })
 
@@ -122,6 +123,7 @@ describe('parseVerifyLinkCallback', () => {
     expect(result).toEqual({
       email: 'user@example.com',
       otp: '123456',
+      challengeToken: undefined,
     })
   })
 
@@ -174,6 +176,31 @@ describe('parseVerifyLinkCallback', () => {
     expect(result).toEqual({
       email: 'user+tag@example.com',
       otp: '123456',
+      challengeToken: undefined,
+    })
+  })
+
+  it('parses challengeToken when present', () => {
+    const url = new URL(
+      'https://thunderbolt.io/auth/verify?email=user%40example.com&otp=12345678&challengeToken=abc-123-def',
+    )
+    const result = parseVerifyLinkCallback(url)
+
+    expect(result).toEqual({
+      email: 'user@example.com',
+      otp: '12345678',
+      challengeToken: 'abc-123-def',
+    })
+  })
+
+  it('returns undefined challengeToken when not present', () => {
+    const url = new URL('https://thunderbolt.io/auth/verify?email=user%40example.com&otp=12345678')
+    const result = parseVerifyLinkCallback(url)
+
+    expect(result).toEqual({
+      email: 'user@example.com',
+      otp: '12345678',
+      challengeToken: undefined,
     })
   })
 })

--- a/src/hooks/use-deep-link-listener.ts
+++ b/src/hooks/use-deep-link-listener.ts
@@ -17,6 +17,7 @@ type OAuthCallbackData = {
 type VerifyLinkData = {
   email: string
   otp: string
+  challengeToken?: string
 }
 
 type NavigateTarget = {
@@ -87,7 +88,7 @@ export const parseVerifyLinkCallback = (url: URL): VerifyLinkData | null => {
     return null
   }
 
-  return { email, otp }
+  return { email, otp, challengeToken: url.searchParams.get('challengeToken') ?? undefined }
 }
 
 type DeepLinkDependencies = {
@@ -160,9 +161,12 @@ export const useDeepLinkListener = (handler?: DeepLinkHandler, dependencies?: De
           // Handle verify link callback deep links (email + OTP from magic link)
           const verifyData = parseVerifyLinkCallback(url)
           if (verifyData) {
-            // Navigate to the verify page with email and otp params
+            // Navigate to the verify page with email, otp, and challengeToken params
             // The MagicLinkVerify component will use these to call emailOtp sign-in
             const params = new URLSearchParams({ email: verifyData.email, otp: verifyData.otp })
+            if (verifyData.challengeToken) {
+              params.set('challengeToken', verifyData.challengeToken)
+            }
             navigate(`/auth/verify?${params.toString()}`, {
               replace: true,
             })

--- a/src/test-utils/test-provider.tsx
+++ b/src/test-utils/test-provider.tsx
@@ -1,4 +1,4 @@
-import { AuthProvider, DatabaseProvider, HttpClientProvider, type AuthClient } from '@/contexts'
+import { AuthProvider, DatabaseProvider, HttpClientProvider, type AuthClient, type HttpClient } from '@/contexts'
 import { getDb } from '@/db/database'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { type ReactNode } from 'react'
@@ -9,6 +9,7 @@ import { PowerSyncMockProvider } from './powersync-mock'
 type TestProviderOptions = {
   mockResponse?: unknown
   authClient?: AuthClient
+  httpClient?: HttpClient
   queryOptions?: {
     defaultOptions?: {
       queries?: {
@@ -55,7 +56,7 @@ export const createTestProvider = (options?: TestProviderOptions) => {
     },
   })
 
-  const mockHttpClient = createMockHttpClient(options?.mockResponse ?? [])
+  const mockHttpClient = options?.httpClient ?? createMockHttpClient(options?.mockResponse ?? [])
 
   const mockAuthClient = options?.authClient ?? createMockAuthClient()
 

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -11,6 +11,7 @@ type WaitlistStatus = 'idle' | 'joining' | 'checkEmail' | 'verifying' | 'error'
 type State = {
   email: string
   otp: string
+  challengeToken: string
   status: WaitlistStatus
   errorMessage: string
 }
@@ -19,7 +20,7 @@ type Action =
   | { type: 'SET_EMAIL'; payload: string }
   | { type: 'SET_OTP'; payload: string }
   | { type: 'START_JOINING' }
-  | { type: 'JOIN_SUCCESS' }
+  | { type: 'JOIN_SUCCESS'; payload: string }
   | { type: 'JOIN_ERROR'; payload: string }
   | { type: 'START_VERIFYING' }
   | { type: 'VERIFY_ERROR'; payload: string }
@@ -28,6 +29,7 @@ type Action =
 const initialState: State = {
   email: '',
   otp: '',
+  challengeToken: '',
   status: 'idle',
   errorMessage: '',
 }
@@ -41,7 +43,7 @@ const reducer = (state: State, action: Action): State => {
     case 'START_JOINING':
       return { ...state, status: 'joining', errorMessage: '' }
     case 'JOIN_SUCCESS':
-      return { ...state, status: 'checkEmail' }
+      return { ...state, status: 'checkEmail', challengeToken: action.payload }
     case 'JOIN_ERROR':
       return { ...state, status: 'error', errorMessage: action.payload }
     case 'START_VERIFYING':
@@ -84,9 +86,11 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
     dispatch({ type: 'START_JOINING' })
 
     try {
-      await httpClient.post('waitlist/join', { json: { email: trimmedEmail } }).json<{ success: boolean }>()
+      const { challengeToken } = await httpClient
+        .post('waitlist/join', { json: { email: trimmedEmail } })
+        .json<{ success: boolean; challengeToken: string }>()
 
-      dispatch({ type: 'JOIN_SUCCESS' })
+      dispatch({ type: 'JOIN_SUCCESS', payload: challengeToken })
     } catch (error) {
       console.error('Waitlist join error:', error)
       dispatch({ type: 'JOIN_ERROR', payload: 'Something went wrong. Please try again.' })
@@ -94,7 +98,7 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
   }
 
   const handleOtpComplete = async (value: string) => {
-    if (value.length !== 6) {
+    if (value.length !== 8) {
       return
     }
 
@@ -104,6 +108,9 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
       const result = await authClient.signIn.emailOtp({
         email: state.email.trim(),
         otp: value,
+        fetchOptions: {
+          headers: { 'x-challenge-token': state.challengeToken },
+        },
       })
 
       if (result.error) {

--- a/src/waitlist/waitlist-page.tsx
+++ b/src/waitlist/waitlist-page.tsx
@@ -47,7 +47,7 @@ export const WaitlistPage = () => {
           <div className="flex w-full flex-col items-center gap-4">
             <p className="text-sm text-muted-foreground">If you received a code to log in, enter it here:</p>
             <InputOTP
-              maxLength={6}
+              maxLength={8}
               pattern={REGEXP_ONLY_DIGITS}
               value={state.otp}
               onChange={actions.setOtp}
@@ -60,7 +60,7 @@ export const WaitlistPage = () => {
               data-form-type="other"
             >
               <InputOTPGroup className="gap-2">
-                {[0, 1, 2, 3, 4, 5].map((i) => (
+                {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
                   <InputOTPSlot key={i} index={i} className="h-12 w-12 shrink-0 rounded-lg" />
                 ))}
               </InputOTPGroup>
@@ -71,7 +71,7 @@ export const WaitlistPage = () => {
             <Button
               type="button"
               onClick={() => actions.handleOtpComplete(state.otp)}
-              disabled={isVerifying || state.otp.length !== 6}
+              disabled={isVerifying || state.otp.length !== 8}
               className="h-[46px] w-full rounded-[12px] text-base"
             >
               {isVerifying ? (


### PR DESCRIPTION
- Add challenge token (session binding) to prevent cross-client OTP brute-force
- Increase OTP length from 6 to 8 digits (100M vs 1M keyspace)
- Add 15s per-email cooldown on /waitlist/join to prevent rapid code cycling
- Extend OTP expiry to 10 minutes for usability with stronger security measures
- Add otp_challenge table and Drizzle migration for challenge token storage
- Add X-Challenge-Token to CORS allowed headers
- Include PoC scripts documenting the vulnerabilities being addressed
- Add comprehensive OTP security test suite covering all hardening measures
- Update existing auth and waitlist tests for new challenge token requirement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the email OTP authentication flow and database schema (new `otp_challenge` table) by requiring a per-request challenge token and adding new rate-limiting behavior, which is security-critical and can block sign-ins if misconfigured. Also alters OTP length/expiry and verification URL semantics across backend and frontend, increasing integration and rollout risk.
> 
> **Overview**
> **Hardens email OTP sign-in** by introducing a DB-backed `otp_challenge` (challenge token) that must be presented via `x-challenge-token` when calling the Better Auth `email-otp` sign-in endpoint; successful sign-in now cleans up the associated challenge records.
> 
> **Updates OTP issuance and delivery**: OTPs are now **8 digits** with a **10-minute expiry**, and verify links/deep links include an optional `challengeToken` query param that the frontend forwards as a header during verification.
> 
> **Adds abuse controls on `/waitlist/join`** by returning a `challengeToken` in the response and enforcing a per-email in-memory **cooldown (default 15s)** with `429` responses; frontend sign-in flows now call `/waitlist/join` (instead of direct send-OTP) to request/resend codes and surface server-provided error messages.
> 
> Includes a Drizzle migration + DAL utilities/tests for challenge tokens, expands OTP security test coverage, updates CORS allowed headers for `X-Challenge-Token`, and adds a `docker-nuke` convenience script/targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d8930abaf102765f7d21c0036e5b357ce4145c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->