### PR TITLE
fix: allow PostHog proxy scripts in CSP script-src directive

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
         "img-src": "'self' asset: data: https://api.thunderbolt.io",
         "font-src": "'self' data:",
         "style-src": "'self' 'unsafe-inline'",
-        "script-src": "'self'"
+        "script-src": "'self' https://api.thunderbolt.io"
       }
     },
     "withGlobalTauri": true


### PR DESCRIPTION
- add https://api.thunderbolt.io to script-src in Tauri CSP config
- PostHog analytics proxied through the API were blocked by the restrictive script-src policy, causing silent script errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the app’s CSP to allow scripts from `https://api.thunderbolt.io`, which slightly increases exposure to remote script execution if that origin is ever compromised.
> 
> **Overview**
> Updates the Tauri CSP in `tauri.conf.json` to allow loading scripts from `https://api.thunderbolt.io` by adding it to `script-src`, unblocking analytics/proxied scripts that were previously denied by the stricter policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0196088c847fbb4bd568426d9c23b9bedaf7729e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->