### PR TITLE
feat: PowerSync visibility-based reconnect + manual retry

### DIFF
--- a/src/components/powersync-status.tsx
+++ b/src/components/powersync-status.tsx
@@ -180,7 +180,7 @@ export const PowerSyncStatus = () => {
                   <Button
                     variant="outline"
                     size="sm"
-                    className="shrink-0 text-xs h-7 px-2.5"
+                    className="shrink-0 text-xs h-[var(--touch-height-sm)] px-2.5"
                     disabled={isReconnecting}
                     onClick={handleRetry}
                   >

--- a/src/components/powersync-status.tsx
+++ b/src/components/powersync-status.tsx
@@ -175,8 +175,11 @@ export const PowerSyncStatus = () => {
                     disabled={isReconnecting}
                     onClick={async () => {
                       setIsReconnecting(true)
-                      await reconnectSync()
-                      setIsReconnecting(false)
+                      try {
+                        await reconnectSync()
+                      } finally {
+                        setIsReconnecting(false)
+                      }
                     }}
                   >
                     {isReconnecting ? (

--- a/src/components/powersync-status.tsx
+++ b/src/components/powersync-status.tsx
@@ -5,7 +5,8 @@ import { useSidebar } from '@/components/ui/sidebar'
 import { useSyncEnabledToggle } from '@/hooks/use-sync-enabled-toggle'
 import { edgeSpacing, mobileSidebarWidthRatio } from '@/lib/constants'
 import { cn } from '@/lib/utils'
-import { Cloud, CloudOff, Loader2 } from 'lucide-react'
+import { reconnectSync } from '@/db/powersync'
+import { Cloud, CloudOff, Loader2, RefreshCw } from 'lucide-react'
 import { SyncSetupModal } from '@/components/sync-setup/sync-setup-modal'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -25,6 +26,7 @@ export const PowerSyncStatus = () => {
   const isAuthenticated = !!session?.user
   const { openSignInModal } = useSignInModal()
   const [popoverOpen, setPopoverOpen] = useState(false)
+  const [isReconnecting, setIsReconnecting] = useState(false)
   const { isMobile } = useIsMobile()
   const { setOpenMobile } = useSidebar()
 
@@ -163,7 +165,29 @@ export const PowerSyncStatus = () => {
                   Sign In
                 </Button>
               )}
-              {statusNote && isAuthenticated && <p className="text-xs text-muted-foreground mt-1">{statusNote}</p>}
+              {statusNote && isAuthenticated && (
+                <div className="flex items-center justify-between gap-2 mt-2">
+                  <p className="text-xs text-amber-600 dark:text-amber-400">{statusNote}</p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0 text-xs h-7 px-2.5"
+                    disabled={isReconnecting}
+                    onClick={async () => {
+                      setIsReconnecting(true)
+                      await reconnectSync()
+                      setIsReconnecting(false)
+                    }}
+                  >
+                    {isReconnecting ? (
+                      <Loader2 className="size-3 animate-spin mr-1" />
+                    ) : (
+                      <RefreshCw className="size-3 mr-1" />
+                    )}
+                    Retry
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         </PopoverContent>

--- a/src/components/powersync-status.tsx
+++ b/src/components/powersync-status.tsx
@@ -78,6 +78,15 @@ export const PowerSyncStatus = () => {
   const statusNote =
     syncEnabled && !isConnected && connectionStatus !== 'connecting' ? 'Changes will sync when back online' : null
 
+  const handleRetry = async () => {
+    setIsReconnecting(true)
+    try {
+      await reconnectSync()
+    } finally {
+      setIsReconnecting(false)
+    }
+  }
+
   return (
     <>
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen} modal={isMobile}>
@@ -173,14 +182,7 @@ export const PowerSyncStatus = () => {
                     size="sm"
                     className="shrink-0 text-xs h-7 px-2.5"
                     disabled={isReconnecting}
-                    onClick={async () => {
-                      setIsReconnecting(true)
-                      try {
-                        await reconnectSync()
-                      } finally {
-                        setIsReconnecting(false)
-                      }
-                    }}
+                    onClick={handleRetry}
                   >
                     {isReconnecting ? (
                       <Loader2 className="size-3 animate-spin mr-1" />

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -61,6 +61,22 @@ export const getPowerSyncInstance = (): PowerSyncDatabase | null => {
 }
 
 /**
+ * Force a disconnect + reconnect cycle.
+ * Used for manual retry when the connection is stale or failed.
+ */
+export const reconnectSync = async (): Promise<void> => {
+  try {
+    const database = getDatabaseInstance()
+    if ('disconnectFromSync' in database && 'connectToSync' in database) {
+      await (database as { disconnectFromSync: () => Promise<void> }).disconnectFromSync()
+      await (database as { connectToSync: () => Promise<void> }).connectToSync()
+    }
+  } catch (error) {
+    console.warn('Failed to reconnect PowerSync:', error)
+  }
+}
+
+/**
  * Check if sync is enabled by user preference
  */
 export const isSyncEnabled = (): boolean => {
@@ -155,6 +171,8 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
   private powerSync: PowerSyncDatabase | null = null
   private _db: AnyDrizzleDatabase | null = null
   private _isConnected = false
+  private visibilityHandler: (() => void) | null = null
+  private hiddenAt: number | null = null
 
   get db(): AnyDrizzleDatabase {
     if (!this._db) {
@@ -219,8 +237,61 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
         crudUploadThrottleMs: 5000,
       })
       this._isConnected = true
+      console.info('PowerSync connected')
+      this.startVisibilityReconnect()
     } catch (error) {
       console.warn('Failed to connect to PowerSync Cloud:', error)
+    }
+  }
+
+  /**
+   * Reconnect PowerSync when the app returns to foreground after being hidden.
+   *
+   * Browsers/OS silently kill background HTTP streams. The pending read hangs forever,
+   * so PowerSync's `connected` status stays true even though the stream is dead.
+   * We track how long the page was hidden — if >15s, the stream is almost certainly
+   * dead, so we force disconnect + reconnect to restore it immediately.
+   *
+   * Only activated for safari-tauri config — on web (default), the SharedWorker
+   * keeps the HTTP stream alive independently of page visibility.
+   */
+  private startVisibilityReconnect(): void {
+    if (getPowerSyncDatabaseConfig() !== 'safari-tauri') {
+      return
+    }
+    if (this.visibilityHandler || typeof document === 'undefined') {
+      return
+    }
+    const hiddenThresholdMs = 2_000
+    this.visibilityHandler = () => {
+      if (document.visibilityState === 'hidden') {
+        this.hiddenAt = Date.now()
+        return
+      }
+      if (!this._isConnected || !this.powerSync || !this.hiddenAt) {
+        return
+      }
+      const hiddenDuration = Date.now() - this.hiddenAt
+      this.hiddenAt = null
+      if (hiddenDuration < hiddenThresholdMs) {
+        return
+      }
+      console.info(`[PowerSync] App was hidden for ${Math.round(hiddenDuration / 1000)}s — forcing reconnect`)
+      this.powerSync
+        .disconnect()
+        .then(() => {
+          this._isConnected = false
+          return this.connectToSync()
+        })
+        .catch((err) => console.warn('[PowerSync] Visibility reconnect failed:', err))
+    }
+    document.addEventListener('visibilitychange', this.visibilityHandler)
+  }
+
+  private stopVisibilityReconnect(): void {
+    if (this.visibilityHandler) {
+      document.removeEventListener('visibilitychange', this.visibilityHandler)
+      this.visibilityHandler = null
     }
   }
 
@@ -234,6 +305,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
     }
 
     try {
+      this.stopVisibilityReconnect()
       await this.powerSync.disconnect()
       this._isConnected = false
     } catch (error) {
@@ -298,6 +370,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
   }
 
   async close(): Promise<void> {
+    this.stopVisibilityReconnect()
     if (this.powerSync) {
       await this.powerSync.disconnectAndClear()
       this.powerSync = null

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -262,7 +262,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
     if (this.visibilityHandler || typeof document === 'undefined') {
       return
     }
-    const hiddenThresholdMs = 2_000
+    const hiddenThresholdMs = 15_000
     this.visibilityHandler = () => {
       if (document.visibilityState === 'hidden') {
         this.hiddenAt = Date.now()

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -61,15 +61,14 @@ export const getPowerSyncInstance = (): PowerSyncDatabase | null => {
 }
 
 /**
- * Force a disconnect + reconnect cycle.
- * Used for manual retry when the connection is stale or failed.
+ * Force a disconnect + reconnect cycle via the singleton database.
+ * Guarded against concurrent attempts — no-ops if a reconnect is already in-flight.
  */
 export const reconnectSync = async (): Promise<void> => {
   try {
     const database = getDatabaseInstance()
-    if ('disconnectFromSync' in database && 'connectToSync' in database) {
-      await (database as { disconnectFromSync: () => Promise<void> }).disconnectFromSync()
-      await (database as { connectToSync: () => Promise<void> }).connectToSync()
+    if ('reconnect' in database) {
+      await (database as { reconnect: () => Promise<void> }).reconnect()
     }
   } catch (error) {
     console.warn('Failed to reconnect PowerSync:', error)
@@ -246,6 +245,30 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
   }
 
   /**
+   * Force a disconnect + reconnect cycle, guarded against concurrent attempts.
+   * Used by both the visibility reconnect handler and manual retry button.
+   * No-ops if a reconnect is already in-flight or sync is disabled.
+   */
+  async reconnect(): Promise<void> {
+    if (this._isReconnecting || !this.powerSync) {
+      return
+    }
+    this._isReconnecting = true
+    try {
+      await this.powerSync.disconnect()
+      this._isConnected = false
+      if (!isSyncEnabled()) {
+        return
+      }
+      await this.connectToSync()
+    } catch (err) {
+      console.warn('[PowerSync] Reconnect failed:', err)
+    } finally {
+      this._isReconnecting = false
+    }
+  }
+
+  /**
    * Reconnect PowerSync when the app returns to foreground after being hidden.
    *
    * Browsers/OS silently kill background HTTP streams. The pending read hangs forever,
@@ -277,25 +300,8 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       if (hiddenDuration < hiddenThresholdMs) {
         return
       }
-      if (this._isReconnecting) {
-        return
-      }
       console.info(`[PowerSync] App was hidden for ${Math.round(hiddenDuration / 1000)}s — forcing reconnect`)
-      this._isReconnecting = true
-      void (async () => {
-        try {
-          await this.powerSync!.disconnect()
-          this._isConnected = false
-          if (!isSyncEnabled()) {
-            return
-          }
-          await this.connectToSync()
-        } catch (err) {
-          console.warn('[PowerSync] Visibility reconnect failed:', err)
-        } finally {
-          this._isReconnecting = false
-        }
-      })()
+      void this.reconnect()
     }
     document.addEventListener('visibilitychange', this.visibilityHandler)
   }

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -282,16 +282,20 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       }
       console.info(`[PowerSync] App was hidden for ${Math.round(hiddenDuration / 1000)}s — forcing reconnect`)
       this._isReconnecting = true
-      this.powerSync
-        .disconnect()
-        .then(() => {
+      void (async () => {
+        try {
+          await this.powerSync!.disconnect()
           this._isConnected = false
-          return this.connectToSync()
-        })
-        .catch((err) => console.warn('[PowerSync] Visibility reconnect failed:', err))
-        .finally(() => {
+          if (!isSyncEnabled()) {
+            return
+          }
+          await this.connectToSync()
+        } catch (err) {
+          console.warn('[PowerSync] Visibility reconnect failed:', err)
+        } finally {
           this._isReconnecting = false
-        })
+        }
+      })()
     }
     document.addEventListener('visibilitychange', this.visibilityHandler)
   }

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -173,6 +173,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
   private _isConnected = false
   private visibilityHandler: (() => void) | null = null
   private hiddenAt: number | null = null
+  private _isReconnecting = false
 
   get db(): AnyDrizzleDatabase {
     if (!this._db) {
@@ -276,7 +277,11 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       if (hiddenDuration < hiddenThresholdMs) {
         return
       }
+      if (this._isReconnecting) {
+        return
+      }
       console.info(`[PowerSync] App was hidden for ${Math.round(hiddenDuration / 1000)}s — forcing reconnect`)
+      this._isReconnecting = true
       this.powerSync
         .disconnect()
         .then(() => {
@@ -284,6 +289,9 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
           return this.connectToSync()
         })
         .catch((err) => console.warn('[PowerSync] Visibility reconnect failed:', err))
+        .finally(() => {
+          this._isReconnecting = false
+        })
     }
     document.addEventListener('visibilitychange', this.visibilityHandler)
   }

--- a/src/db/powersync/index.ts
+++ b/src/db/powersync/index.ts
@@ -4,6 +4,7 @@ export {
   PowerSyncDatabaseImpl,
   getPowerSyncInstance,
   isSyncEnabled,
+  reconnectSync,
   setSyncEnabled,
   syncEnabledChangeEvent,
 } from './database'


### PR DESCRIPTION
## Summary
- Auto-reconnect PowerSync when the app returns to foreground after being hidden (safari-tauri only — SharedWorker keeps streams alive on web)
- Add manual "Retry" button in sync status popover when connection is lost
- Show offline warning in amber instead of muted foreground

## Test plan
- [ ] Tauri desktop: switch apps for >2s, verify reconnect log and sync resumes
- [ ] Web: confirm visibility handler is not registered (SharedWorker handles it)
- [ ] Retry button: disconnect sync, verify button appears, click to reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection lifecycle behavior by forcing disconnect/reconnect on visibility transitions and exposing a manual retry path, which could impact sync stability or introduce reconnect loops on affected platforms.
> 
> **Overview**
> Adds a guarded `reconnect` flow to PowerSync, including a visibility-based auto-reconnect (Safari/Tauri only) that forces a disconnect/reconnect after the app has been hidden long enough to likely kill the HTTP stream.
> 
> Updates the sync status popover to show the offline note in amber and provide a **Retry** button that calls the new exported `reconnectSync()` helper, with a loading state while reconnecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce5d79aeae75bb2de0cb093c37dffad5389c7c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->