### PR TITLE
refactor: extract OTP magic strings into shared constants

### DIFF
--- a/backend/src/auth/auth.test.ts
+++ b/backend/src/auth/auth.test.ts
@@ -20,7 +20,7 @@ mock.module('@/waitlist/utils', () => ({
 
 import { user } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
-import { CHALLENGE_TOKEN_HEADER } from '@/auth/otp-constants'
+import { challengeTokenHeader } from '@/auth/otp-constants'
 import { createAuth } from '@/auth/auth'
 import { normalizeEmail } from '@/lib/email'
 import { createTestDb } from '@/test-utils/db'
@@ -151,7 +151,7 @@ describe('Auth - user.isNew in sign-in response', () => {
     const challengeToken = await createTestChallenge(db, 'newuser@example.com')
     const result = (await auth.api.signInEmailOTP({
       body: { email: 'newuser@example.com', otp },
-      headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+      headers: new Headers({ [challengeTokenHeader]: challengeToken }),
     })) as unknown as { session: unknown; user: { isNew?: boolean } }
 
     expect(result.user?.isNew).toBe(true)
@@ -182,7 +182,7 @@ describe('Auth - user.isNew in sign-in response', () => {
     const challengeToken = await createTestChallenge(db, 'existing-isnewuser@example.com')
     const result = (await auth.api.signInEmailOTP({
       body: { email: 'existing-isnewuser@example.com', otp },
-      headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+      headers: new Headers({ [challengeTokenHeader]: challengeToken }),
     })) as unknown as { session: unknown; user: { isNew?: boolean } }
 
     expect(result.user?.isNew).toBe(false)

--- a/backend/src/auth/auth.test.ts
+++ b/backend/src/auth/auth.test.ts
@@ -20,6 +20,7 @@ mock.module('@/waitlist/utils', () => ({
 
 import { user } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
+import { CHALLENGE_TOKEN_HEADER } from '@/auth/otp-constants'
 import { createAuth } from '@/auth/auth'
 import { normalizeEmail } from '@/lib/email'
 import { createTestDb } from '@/test-utils/db'
@@ -150,7 +151,7 @@ describe('Auth - user.isNew in sign-in response', () => {
     const challengeToken = await createTestChallenge(db, 'newuser@example.com')
     const result = (await auth.api.signInEmailOTP({
       body: { email: 'newuser@example.com', otp },
-      headers: new Headers({ 'x-challenge-token': challengeToken }),
+      headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
     })) as unknown as { session: unknown; user: { isNew?: boolean } }
 
     expect(result.user?.isNew).toBe(true)
@@ -181,7 +182,7 @@ describe('Auth - user.isNew in sign-in response', () => {
     const challengeToken = await createTestChallenge(db, 'existing-isnewuser@example.com')
     const result = (await auth.api.signInEmailOTP({
       body: { email: 'existing-isnewuser@example.com', otp },
-      headers: new Headers({ 'x-challenge-token': challengeToken }),
+      headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
     })) as unknown as { session: unknown; user: { isNew?: boolean } }
 
     expect(result.user?.isNew).toBe(false)

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -19,7 +19,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { bearer, emailOTP } from 'better-auth/plugins'
 import { genericOAuth } from 'better-auth/plugins/generic-oauth'
 import { isAutoApprovedDomain, sendWaitlistJoinedEmail, sendWaitlistNotReadyEmail } from '@/waitlist/utils'
-import { otpExpiryMs, otpExpirySeconds } from './otp-constants'
+import { CHALLENGE_TOKEN_HEADER, otpExpiryMs, otpExpirySeconds } from './otp-constants'
 import { buildVerifyUrl, getValidatedOrigin, parseTrustedOrigins, sendSignInEmail } from './utils'
 
 const OTP_SIGN_IN_PATH = '/sign-in/email-otp'
@@ -125,7 +125,7 @@ export const createAuth = (database: typeof DbType) => {
           return
         }
 
-        const challengeToken = ctx.headers?.get('x-challenge-token')
+        const challengeToken = ctx.headers?.get(CHALLENGE_TOKEN_HEADER)
         const rawEmail = (ctx.body as { email?: string })?.email
 
         if (!challengeToken || !rawEmail) {

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -19,7 +19,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { bearer, emailOTP } from 'better-auth/plugins'
 import { genericOAuth } from 'better-auth/plugins/generic-oauth'
 import { isAutoApprovedDomain, sendWaitlistJoinedEmail, sendWaitlistNotReadyEmail } from '@/waitlist/utils'
-import { CHALLENGE_TOKEN_HEADER, otpExpiryMs, otpExpirySeconds } from './otp-constants'
+import { challengeTokenHeader, otpExpiryMs, otpExpirySeconds } from './otp-constants'
 import { buildVerifyUrl, getValidatedOrigin, parseTrustedOrigins, sendSignInEmail } from './utils'
 
 const OTP_SIGN_IN_PATH = '/sign-in/email-otp'
@@ -125,7 +125,7 @@ export const createAuth = (database: typeof DbType) => {
           return
         }
 
-        const challengeToken = ctx.headers?.get(CHALLENGE_TOKEN_HEADER)
+        const challengeToken = ctx.headers?.get(challengeTokenHeader)
         const rawEmail = (ctx.body as { email?: string })?.email
 
         if (!challengeToken || !rawEmail) {

--- a/backend/src/auth/otp-constants.ts
+++ b/backend/src/auth/otp-constants.ts
@@ -3,3 +3,6 @@ export const otpExpirySeconds = 600 // 10 minutes
 
 /** OTP expiry duration in milliseconds — used for challenge token expiry and cooldown. */
 export const otpExpiryMs = otpExpirySeconds * 1000
+
+/** HTTP header name for challenge token session binding. */
+export const CHALLENGE_TOKEN_HEADER = 'x-challenge-token'

--- a/backend/src/auth/otp-constants.ts
+++ b/backend/src/auth/otp-constants.ts
@@ -5,4 +5,4 @@ export const otpExpirySeconds = 600 // 10 minutes
 export const otpExpiryMs = otpExpirySeconds * 1000
 
 /** HTTP header name for challenge token session binding. */
-export const CHALLENGE_TOKEN_HEADER = 'x-challenge-token'
+export const challengeTokenHeader = 'x-challenge-token'

--- a/backend/src/auth/otp-security.test.ts
+++ b/backend/src/auth/otp-security.test.ts
@@ -24,6 +24,7 @@ mock.module('@/waitlist/utils', () => ({
 import { user, verification } from '@/db/auth-schema'
 import { otpChallenge } from '@/db/schema'
 import { waitlist } from '@/db/schema'
+import { CHALLENGE_TOKEN_HEADER } from '@/auth/otp-constants'
 import { createAuth } from '@/auth/auth'
 import { createApp } from '@/index'
 import { createTestDb } from '@/test-utils/db'
@@ -80,7 +81,7 @@ describe('OTP Security Hardening', () => {
   const signInWithChallenge = (email: string, otp: string, challengeToken: string) =>
     auth.api.signInEmailOTP({
       body: { email, otp },
-      headers: new Headers({ 'x-challenge-token': challengeToken }),
+      headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
     })
 
   beforeEach(async () => {
@@ -352,7 +353,7 @@ describe('OTP Security Hardening', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp },
-          headers: new Headers({ 'x-challenge-token': 'wrong-token-value' }),
+          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: 'wrong-token-value' }),
         })
       } catch {
         threw = true

--- a/backend/src/auth/otp-security.test.ts
+++ b/backend/src/auth/otp-security.test.ts
@@ -24,7 +24,7 @@ mock.module('@/waitlist/utils', () => ({
 import { user, verification } from '@/db/auth-schema'
 import { otpChallenge } from '@/db/schema'
 import { waitlist } from '@/db/schema'
-import { CHALLENGE_TOKEN_HEADER } from '@/auth/otp-constants'
+import { challengeTokenHeader } from '@/auth/otp-constants'
 import { createAuth } from '@/auth/auth'
 import { createApp } from '@/index'
 import { createTestDb } from '@/test-utils/db'
@@ -81,7 +81,7 @@ describe('OTP Security Hardening', () => {
   const signInWithChallenge = (email: string, otp: string, challengeToken: string) =>
     auth.api.signInEmailOTP({
       body: { email, otp },
-      headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+      headers: new Headers({ [challengeTokenHeader]: challengeToken }),
     })
 
   beforeEach(async () => {
@@ -353,7 +353,7 @@ describe('OTP Security Hardening', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp },
-          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: 'wrong-token-value' }),
+          headers: new Headers({ [challengeTokenHeader]: 'wrong-token-value' }),
         })
       } catch {
         threw = true

--- a/backend/src/auth/waitlist-integration.test.ts
+++ b/backend/src/auth/waitlist-integration.test.ts
@@ -23,7 +23,7 @@ mock.module('@/waitlist/utils', () => ({
 // Now import the rest
 import { user, verification } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
-import { CHALLENGE_TOKEN_HEADER } from '@/auth/otp-constants'
+import { challengeTokenHeader } from '@/auth/otp-constants'
 import { createAuth } from '@/auth/auth'
 import { normalizeEmail } from '@/lib/email'
 import { createTestDb } from '@/test-utils/db'
@@ -309,7 +309,7 @@ describe('Auth Waitlist Integration', () => {
         try {
           await auth.api.signInEmailOTP({
             body: { email, otp: '00000000' },
-            headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+            headers: new Headers({ [challengeTokenHeader]: challengeToken }),
           })
         } catch {
           // Expected: INVALID_OTP
@@ -326,7 +326,7 @@ describe('Auth Waitlist Integration', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp: '00000000' },
-          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+          headers: new Headers({ [challengeTokenHeader]: challengeToken }),
         })
       } catch {
         // Expected: INVALID_OTP
@@ -339,7 +339,7 @@ describe('Auth Waitlist Integration', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp: correctOtp },
-          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+          headers: new Headers({ [challengeTokenHeader]: challengeToken }),
         })
         signInSucceeded = true
       } catch {
@@ -371,7 +371,7 @@ describe('Auth Waitlist Integration', () => {
         try {
           await auth.api.signInEmailOTP({
             body: { email, otp: '00000000' },
-            headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+            headers: new Headers({ [challengeTokenHeader]: challengeToken }),
           })
         } catch {
           // Expected: INVALID_OTP or TOO_MANY_ATTEMPTS on 3rd
@@ -382,7 +382,7 @@ describe('Auth Waitlist Integration', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp: '99999999' },
-          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+          headers: new Headers({ [challengeTokenHeader]: challengeToken }),
         })
         expect(true).toBe(false)
       } catch (err: unknown) {
@@ -422,7 +422,7 @@ describe('Auth Waitlist Integration', () => {
         try {
           await auth.api.signInEmailOTP({
             body: { email, otp: '00000000' },
-            headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
+            headers: new Headers({ [challengeTokenHeader]: challengeToken }),
           })
         } catch {
           // Expected
@@ -446,7 +446,7 @@ describe('Auth Waitlist Integration', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp: freshOtp },
-          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: freshChallengeToken }),
+          headers: new Headers({ [challengeTokenHeader]: freshChallengeToken }),
         })
         signInSucceeded = true
       } catch {

--- a/backend/src/auth/waitlist-integration.test.ts
+++ b/backend/src/auth/waitlist-integration.test.ts
@@ -23,6 +23,7 @@ mock.module('@/waitlist/utils', () => ({
 // Now import the rest
 import { user, verification } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
+import { CHALLENGE_TOKEN_HEADER } from '@/auth/otp-constants'
 import { createAuth } from '@/auth/auth'
 import { normalizeEmail } from '@/lib/email'
 import { createTestDb } from '@/test-utils/db'
@@ -308,7 +309,7 @@ describe('Auth Waitlist Integration', () => {
         try {
           await auth.api.signInEmailOTP({
             body: { email, otp: '00000000' },
-            headers: new Headers({ 'x-challenge-token': challengeToken }),
+            headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
           })
         } catch {
           // Expected: INVALID_OTP
@@ -325,7 +326,7 @@ describe('Auth Waitlist Integration', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp: '00000000' },
-          headers: new Headers({ 'x-challenge-token': challengeToken }),
+          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
         })
       } catch {
         // Expected: INVALID_OTP
@@ -338,7 +339,7 @@ describe('Auth Waitlist Integration', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp: correctOtp },
-          headers: new Headers({ 'x-challenge-token': challengeToken }),
+          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
         })
         signInSucceeded = true
       } catch {
@@ -370,7 +371,7 @@ describe('Auth Waitlist Integration', () => {
         try {
           await auth.api.signInEmailOTP({
             body: { email, otp: '00000000' },
-            headers: new Headers({ 'x-challenge-token': challengeToken }),
+            headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
           })
         } catch {
           // Expected: INVALID_OTP or TOO_MANY_ATTEMPTS on 3rd
@@ -381,7 +382,7 @@ describe('Auth Waitlist Integration', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp: '99999999' },
-          headers: new Headers({ 'x-challenge-token': challengeToken }),
+          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
         })
         expect(true).toBe(false)
       } catch (err: unknown) {
@@ -421,7 +422,7 @@ describe('Auth Waitlist Integration', () => {
         try {
           await auth.api.signInEmailOTP({
             body: { email, otp: '00000000' },
-            headers: new Headers({ 'x-challenge-token': challengeToken }),
+            headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: challengeToken }),
           })
         } catch {
           // Expected
@@ -445,7 +446,7 @@ describe('Auth Waitlist Integration', () => {
       try {
         await auth.api.signInEmailOTP({
           body: { email, otp: freshOtp },
-          headers: new Headers({ 'x-challenge-token': freshChallengeToken }),
+          headers: new Headers({ [CHALLENGE_TOKEN_HEADER]: freshChallengeToken }),
         })
         signInSucceeded = true
       } catch {

--- a/backend/src/db/client.test.ts
+++ b/backend/src/db/client.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { existsSync } from 'fs'
+import { resolve } from 'path'
+import { getMigrationsFolder } from './client'
+
+describe('getMigrationsFolder', () => {
+  let originalMigrationsDir: string | undefined
+
+  beforeEach(() => {
+    originalMigrationsDir = process.env.MIGRATIONS_DIR
+    delete process.env.MIGRATIONS_DIR
+  })
+
+  afterEach(() => {
+    if (originalMigrationsDir === undefined) {
+      delete process.env.MIGRATIONS_DIR
+    } else {
+      process.env.MIGRATIONS_DIR = originalMigrationsDir
+    }
+  })
+
+  it('returns MIGRATIONS_DIR env var when set', () => {
+    process.env.MIGRATIONS_DIR = '/custom/migrations'
+    expect(getMigrationsFolder()).toBe('/custom/migrations')
+  })
+
+  it('falls back to resolve(cwd, "drizzle") when MIGRATIONS_DIR is not set', () => {
+    expect(getMigrationsFolder()).toBe(resolve(process.cwd(), 'drizzle'))
+  })
+
+  it('resolves to a directory that contains migration files when run from backend/', () => {
+    const folder = getMigrationsFolder()
+    expect(existsSync(folder)).toBe(true)
+    expect(existsSync(resolve(folder, 'meta'))).toBe(true)
+  })
+})

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -23,15 +23,22 @@ const postgresDb = isPglite ? null : drizzlePostgres({ client: postgres(process.
 export const db = pgliteDb ?? postgresDb!
 
 /**
- * Run Drizzle migrations on startup.
- * Disable with SKIP_MIGRATIONS=true (e.g. when migrations are handled externally).
+ * Resolve the Drizzle migrations folder.
+ * Override with MIGRATIONS_DIR env var; defaults to `<cwd>/drizzle`.
  *
  * Uses process.cwd() instead of import.meta.dir because compiled Bun binaries
  * resolve import.meta.dir to the executable's directory, not the source file's.
+ * The Docker WORKDIR is set to /app/backend, so the default resolves correctly.
+ */
+export const getMigrationsFolder = () => process.env.MIGRATIONS_DIR ?? resolve(process.cwd(), 'drizzle')
+
+/**
+ * Run Drizzle migrations on startup.
+ * Disable with SKIP_MIGRATIONS=true (e.g. when migrations are handled externally).
  */
 export const runMigrations = async () => {
   if (process.env.SKIP_MIGRATIONS === 'true') return
-  const migrationsFolder = resolve(process.cwd(), 'drizzle')
+  const migrationsFolder = getMigrationsFolder()
   if (pgliteDb) {
     await migratePglite(pgliteDb, { migrationsFolder })
   } else if (postgresDb) {

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -25,10 +25,13 @@ export const db = pgliteDb ?? postgresDb!
 /**
  * Run Drizzle migrations on startup.
  * Disable with SKIP_MIGRATIONS=true (e.g. when migrations are handled externally).
+ *
+ * Uses process.cwd() instead of import.meta.dir because compiled Bun binaries
+ * resolve import.meta.dir to the executable's directory, not the source file's.
  */
 export const runMigrations = async () => {
   if (process.env.SKIP_MIGRATIONS === 'true') return
-  const migrationsFolder = resolve(import.meta.dir, '../../drizzle')
+  const migrationsFolder = resolve(process.cwd(), 'drizzle')
   if (pgliteDb) {
     await migratePglite(pgliteDb, { migrationsFolder })
   } else if (postgresDb) {

--- a/backend/src/db/otp-challenge-schema.ts
+++ b/backend/src/db/otp-challenge-schema.ts
@@ -7,16 +7,10 @@ import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
  * an attacker from brute-forcing OTPs without intercepting
  * the victim's client response.
  */
-export const otpChallenge = pgTable(
-  'otp_challenge',
-  {
-    id: text('id').primaryKey(),
-    email: text('email').notNull().unique(),
-    challengeToken: text('challenge_token').notNull(),
-    expiresAt: timestamp('expires_at').notNull(),
-    createdAt: timestamp('created_at').defaultNow().notNull(),
-  },
-  (table) => [
-    // email index is implicit via unique() constraint
-  ],
-)
+export const otpChallenge = pgTable('otp_challenge', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull().unique(),
+  challengeToken: text('challenge_token').notNull(),
+  expiresAt: timestamp('expires_at').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -171,7 +171,7 @@ const startServer = async () => {
       process.exit(0)
     })
   } catch (error) {
-    log.error({ error }, 'Failed to start server')
+    log.error({ err: error }, 'Failed to start server')
     process.exit(1)
   }
 }

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -86,16 +86,17 @@ export const createWaitlistRoutes = ({
         emailCooldowns.set(email, Date.now())
       }
 
-      // Get or create a challenge token (first-writer-wins for multi-instance safety).
+      // Challenge token creation and user lookup are independent — run in parallel.
       // Privacy-preserving: same response shape regardless of user status.
-      const challengeToken = await getOrCreateOtpChallenge(database, {
-        id: crypto.randomUUID(),
-        email,
-        challengeToken: crypto.randomUUID(),
-        expiresAt: new Date(Date.now() + otpExpiryMs),
-      })
-
-      const existingUser = await getUserByEmail(database, email)
+      const [challengeToken, existingUser] = await Promise.all([
+        getOrCreateOtpChallenge(database, {
+          id: crypto.randomUUID(),
+          email,
+          challengeToken: crypto.randomUUID(),
+          expiresAt: new Date(Date.now() + otpExpiryMs),
+        }),
+        getUserByEmail(database, email),
+      ])
 
       if (existingUser) {
         await sendApprovedMagicLinkEmail(auth, email)

--- a/src/components/magic-link-verify.tsx
+++ b/src/components/magic-link-verify.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { CHALLENGE_TOKEN_HEADER } from '@/lib/constants'
+import { challengeTokenHeader } from '@/lib/constants'
 import { useAuth } from '@/contexts'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { useSettings } from '@/hooks/use-settings'
@@ -56,7 +56,7 @@ export const MagicLinkVerify = () => {
         const result = await authClient.signIn.emailOtp({
           email,
           otp,
-          fetchOptions: challengeToken ? { headers: { [CHALLENGE_TOKEN_HEADER]: challengeToken } } : undefined,
+          fetchOptions: challengeToken ? { headers: { [challengeTokenHeader]: challengeToken } } : undefined,
         })
 
         if (result.error) {

--- a/src/components/magic-link-verify.tsx
+++ b/src/components/magic-link-verify.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { CHALLENGE_TOKEN_HEADER } from '@/lib/constants'
 import { useAuth } from '@/contexts'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { useSettings } from '@/hooks/use-settings'
@@ -55,7 +56,7 @@ export const MagicLinkVerify = () => {
         const result = await authClient.signIn.emailOtp({
           email,
           otp,
-          fetchOptions: challengeToken ? { headers: { 'x-challenge-token': challengeToken } } : undefined,
+          fetchOptions: challengeToken ? { headers: { [CHALLENGE_TOKEN_HEADER]: challengeToken } } : undefined,
         })
 
         if (result.error) {

--- a/src/components/sign-in-modal.test.tsx
+++ b/src/components/sign-in-modal.test.tsx
@@ -3,7 +3,8 @@ import type { ConsoleSpies } from '@/test-utils/console-spies'
 import { setupConsoleSpy } from '@/test-utils/console-spies'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { createMockAuthClient } from '@/test-utils/auth-client'
-import { createClient, type HttpClient } from '@/lib/http'
+import { createSpyHttpClient, jsonResponse } from '@/test-utils/http-client'
+import type { HttpClient } from '@/lib/http'
 import { getClock } from '@/testing-library'
 import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen } from '@testing-library/react'
@@ -58,22 +59,6 @@ import { type ReactNode } from 'react'
 const challengeToken = 'test-challenge-token'
 const waitlistResponse = { success: true, challengeToken }
 
-const jsonResponse = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
-
-/** Creates a mock HTTP client with a spy-able fetch for assertions. */
-const createSpyHttpClient = (
-  fetchImpl?: (req: Request) => Promise<Response>,
-): { httpClient: HttpClient; fetchSpy: ReturnType<typeof mock> } => {
-  const defaultImpl = async () => jsonResponse(waitlistResponse)
-  const fetchSpy = mock(fetchImpl ?? defaultImpl)
-  const httpClient = createClient({
-    fetch: fetchSpy as unknown as typeof globalThis.fetch,
-    prefixUrl: 'http://test-api.local',
-  })
-  return { httpClient, fetchSpy }
-}
-
 describe('SignInModal', () => {
   let consoleSpies: ConsoleSpies
   let mockOnOpenChange: ReturnType<typeof mock>
@@ -94,7 +79,7 @@ describe('SignInModal', () => {
   beforeEach(() => {
     mockOnOpenChange = mock()
     mockSignInEmailOtp = mock(() => Promise.resolve({ error: null }))
-    const { httpClient, fetchSpy } = createSpyHttpClient()
+    const { httpClient, fetchSpy } = createSpyHttpClient(undefined, waitlistResponse)
     mockHttpClient = httpClient
     mockFetchSpy = fetchSpy
   })

--- a/src/components/sign-in/sign-in-otp-step.tsx
+++ b/src/components/sign-in/sign-in-otp-step.tsx
@@ -1,6 +1,7 @@
 import { ActionFeedbackButton } from '@/components/ui/action-feedback-button'
 import { Button } from '@/components/ui/button'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
+import { OTP_LENGTH } from '@/lib/constants'
 import { REGEXP_ONLY_DIGITS } from 'input-otp'
 import { AlertTriangle, Check, Loader2, Mail } from 'lucide-react'
 
@@ -66,7 +67,7 @@ export const SignInOtpStep = ({
         {/* OTP input + feedback at bottom */}
         <div className="flex w-full flex-col items-center gap-4">
           <InputOTP
-            maxLength={8}
+            maxLength={OTP_LENGTH}
             pattern={REGEXP_ONLY_DIGITS}
             value={otp}
             onChange={onOtpChange}
@@ -90,7 +91,7 @@ export const SignInOtpStep = ({
           <Button
             type="button"
             onClick={() => onOtpComplete(otp)}
-            disabled={isVerifying || otp.length !== 8}
+            disabled={isVerifying || otp.length !== OTP_LENGTH}
             className="h-[46px] w-full rounded-[12px] bg-foreground text-background text-base font-medium hover:bg-foreground/90 disabled:bg-muted disabled:text-muted-foreground"
           >
             {isVerifying ? (
@@ -142,7 +143,7 @@ export const SignInOtpStep = ({
       <div className="mt-6 flex flex-col items-center gap-3">
         <p className="text-sm text-muted-foreground">Or enter the 8-digit code</p>
         <InputOTP
-          maxLength={8}
+          maxLength={OTP_LENGTH}
           pattern={REGEXP_ONLY_DIGITS}
           value={otp}
           onChange={onOtpChange}

--- a/src/components/sign-in/sign-in-otp-step.tsx
+++ b/src/components/sign-in/sign-in-otp-step.tsx
@@ -1,7 +1,7 @@
 import { ActionFeedbackButton } from '@/components/ui/action-feedback-button'
 import { Button } from '@/components/ui/button'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
-import { OTP_LENGTH } from '@/lib/constants'
+import { otpLength } from '@/lib/constants'
 import { REGEXP_ONLY_DIGITS } from 'input-otp'
 import { AlertTriangle, Check, Loader2, Mail } from 'lucide-react'
 
@@ -67,7 +67,7 @@ export const SignInOtpStep = ({
         {/* OTP input + feedback at bottom */}
         <div className="flex w-full flex-col items-center gap-4">
           <InputOTP
-            maxLength={OTP_LENGTH}
+            maxLength={otpLength}
             pattern={REGEXP_ONLY_DIGITS}
             value={otp}
             onChange={onOtpChange}
@@ -91,7 +91,7 @@ export const SignInOtpStep = ({
           <Button
             type="button"
             onClick={() => onOtpComplete(otp)}
-            disabled={isVerifying || otp.length !== OTP_LENGTH}
+            disabled={isVerifying || otp.length !== otpLength}
             className="h-[46px] w-full rounded-[12px] bg-foreground text-background text-base font-medium hover:bg-foreground/90 disabled:bg-muted disabled:text-muted-foreground"
           >
             {isVerifying ? (
@@ -143,7 +143,7 @@ export const SignInOtpStep = ({
       <div className="mt-6 flex flex-col items-center gap-3">
         <p className="text-sm text-muted-foreground">Or enter the 8-digit code</p>
         <InputOTP
-          maxLength={OTP_LENGTH}
+          maxLength={otpLength}
           pattern={REGEXP_ONLY_DIGITS}
           value={otp}
           onChange={onOtpChange}

--- a/src/components/sign-in/use-sign-in-form-state.test.ts
+++ b/src/components/sign-in/use-sign-in-form-state.test.ts
@@ -1,27 +1,13 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { FormEvent } from 'react'
-import { createClient, type HttpClient } from '@/lib/http'
+import type { HttpClient } from '@/lib/http'
 import { createMockAuthClient } from '@/test-utils/auth-client'
+import { createSpyHttpClient, jsonResponse } from '@/test-utils/http-client'
 import { useSignInFormState } from './use-sign-in-form-state'
 
 const challengeToken = 'test-challenge-token'
 const waitlistResponse = { success: true, challengeToken }
-
-const jsonResponse = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
-
-const createSpyHttpClient = (
-  fetchImpl?: (req: Request) => Promise<Response>,
-): { httpClient: HttpClient; fetchSpy: ReturnType<typeof mock> } => {
-  const defaultImpl = async () => jsonResponse(waitlistResponse)
-  const fetchSpy = mock(fetchImpl ?? defaultImpl)
-  const httpClient = createClient({
-    fetch: fetchSpy as unknown as typeof globalThis.fetch,
-    prefixUrl: 'http://test-api.local',
-  })
-  return { httpClient, fetchSpy }
-}
 
 describe('useSignInFormState', () => {
   let authClient: ReturnType<typeof createMockAuthClient>
@@ -171,7 +157,7 @@ describe('useSignInFormState', () => {
 
   describe('skipToOtp with initialChallengeToken', () => {
     it('initializes with challengeToken when skipToOtp is true', () => {
-      const { httpClient } = createSpyHttpClient()
+      const { httpClient } = createSpyHttpClient(undefined, waitlistResponse)
       const { result } = renderHook(() =>
         useSignInFormState({
           authClient,
@@ -187,7 +173,7 @@ describe('useSignInFormState', () => {
     })
 
     it('sends challengeToken in OTP verification when skipToOtp is used', async () => {
-      const { httpClient } = createSpyHttpClient()
+      const { httpClient } = createSpyHttpClient(undefined, waitlistResponse)
       const emailOtpSpy = mock(async () => ({ data: { user: { id: '1' } }, error: null }))
       authClient = createMockAuthClient({ signInEmailOtp: emailOtpSpy })
 
@@ -215,7 +201,7 @@ describe('useSignInFormState', () => {
     })
 
     it('defaults challengeToken to empty string without initialChallengeToken', () => {
-      const { httpClient } = createSpyHttpClient()
+      const { httpClient } = createSpyHttpClient(undefined, waitlistResponse)
       const { result } = renderHook(() =>
         useSignInFormState({
           authClient,

--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -1,5 +1,5 @@
 import type { AuthClient } from '@/contexts'
-import { CHALLENGE_TOKEN_HEADER, OTP_LENGTH } from '@/lib/constants'
+import { challengeTokenHeader, otpLength } from '@/lib/constants'
 import { HttpError, type HttpClient } from '@/lib/http'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { updateSettings } from '@/dal'
@@ -17,8 +17,8 @@ const getServerErrorMessage = async (error: unknown, fallback: string): Promise<
     if (typeof body?.message === 'string' && body.message) {
       return body.message
     }
-  } catch {
-    // Response body not JSON-parseable
+  } catch (e) {
+    console.info('Could not parse error response body as JSON:', e)
   }
   return fallback
 }
@@ -180,7 +180,7 @@ export const useSignInFormState = ({
   }
 
   const handleOtpComplete = async (value: string) => {
-    if (value.length !== OTP_LENGTH) {
+    if (value.length !== otpLength) {
       return
     }
 
@@ -191,7 +191,7 @@ export const useSignInFormState = ({
         email: state.email.trim(),
         otp: value,
         fetchOptions: {
-          headers: { [CHALLENGE_TOKEN_HEADER]: state.challengeToken },
+          headers: { [challengeTokenHeader]: state.challengeToken },
         },
       })
 

--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -1,4 +1,5 @@
 import type { AuthClient } from '@/contexts'
+import { CHALLENGE_TOKEN_HEADER, OTP_LENGTH } from '@/lib/constants'
 import { HttpError, type HttpClient } from '@/lib/http'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { updateSettings } from '@/dal'
@@ -179,7 +180,7 @@ export const useSignInFormState = ({
   }
 
   const handleOtpComplete = async (value: string) => {
-    if (value.length !== 8) {
+    if (value.length !== OTP_LENGTH) {
       return
     }
 
@@ -190,7 +191,7 @@ export const useSignInFormState = ({
         email: state.email.trim(),
         otp: value,
         fetchOptions: {
-          headers: { 'x-challenge-token': state.challengeToken },
+          headers: { [CHALLENGE_TOKEN_HEADER]: state.challengeToken },
         },
       })
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,3 +19,9 @@ export const edgeSpacing = {
 
 /** Mobile sidebar width as a fraction of viewport width (0–1) */
 export const mobileSidebarWidthRatio = 0.8
+
+/** OTP code length — must match backend emailOTP config (otpLength). */
+export const OTP_LENGTH = 8
+
+/** HTTP header name for challenge token session binding. */
+export const CHALLENGE_TOKEN_HEADER = 'x-challenge-token'

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,7 +21,7 @@ export const edgeSpacing = {
 export const mobileSidebarWidthRatio = 0.8
 
 /** OTP code length — must match backend emailOTP config (otpLength). */
-export const OTP_LENGTH = 8
+export const otpLength = 8
 
 /** HTTP header name for challenge token session binding. */
-export const CHALLENGE_TOKEN_HEADER = 'x-challenge-token'
+export const challengeTokenHeader = 'x-challenge-token'

--- a/src/test-utils/http-client.ts
+++ b/src/test-utils/http-client.ts
@@ -1,3 +1,4 @@
+import { mock } from 'bun:test'
 import { createClient, type HttpClient } from '@/lib/http'
 
 /**
@@ -14,6 +15,24 @@ export const createMockHttpClient = (mockResponse: unknown = [], prefixUrl = 'ht
   }
 
   return createClient({ fetch: mockFetch, prefixUrl })
+}
+
+/** Build a JSON Response (for use with createSpyHttpClient). */
+export const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+/** Creates an HTTP client backed by a Bun mock spy, for asserting on requests. */
+export const createSpyHttpClient = (
+  fetchImpl?: (req: Request) => Promise<Response>,
+  defaultResponse: unknown = { success: true },
+): { httpClient: HttpClient; fetchSpy: ReturnType<typeof mock> } => {
+  const defaultImpl = async () => jsonResponse(defaultResponse)
+  const fetchSpy = mock(fetchImpl ?? defaultImpl)
+  const httpClient = createClient({
+    fetch: fetchSpy as unknown as typeof globalThis.fetch,
+    prefixUrl: 'http://test-api.local',
+  })
+  return { httpClient, fetchSpy }
 }
 
 /**

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -2,6 +2,7 @@ import { isNewAuthUser, onSignInSuccess } from '@/components/sign-in/use-sign-in
 import { useWelcomeStore } from '@/components/welcome-dialog'
 import type { AuthClient } from '@/contexts'
 import { useHttpClient } from '@/contexts'
+import { CHALLENGE_TOKEN_HEADER, OTP_LENGTH } from '@/lib/constants'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { isValidEmailFormat } from '@/lib/utils'
 import { useReducer, type FormEvent } from 'react'
@@ -98,7 +99,7 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
   }
 
   const handleOtpComplete = async (value: string) => {
-    if (value.length !== 8) {
+    if (value.length !== OTP_LENGTH) {
       return
     }
 
@@ -109,7 +110,7 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
         email: state.email.trim(),
         otp: value,
         fetchOptions: {
-          headers: { 'x-challenge-token': state.challengeToken },
+          headers: { [CHALLENGE_TOKEN_HEADER]: state.challengeToken },
         },
       })
 

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -2,7 +2,7 @@ import { isNewAuthUser, onSignInSuccess } from '@/components/sign-in/use-sign-in
 import { useWelcomeStore } from '@/components/welcome-dialog'
 import type { AuthClient } from '@/contexts'
 import { useHttpClient } from '@/contexts'
-import { CHALLENGE_TOKEN_HEADER, OTP_LENGTH } from '@/lib/constants'
+import { challengeTokenHeader, otpLength } from '@/lib/constants'
 import { getOtpErrorMessage } from '@/lib/otp-error-messages'
 import { isValidEmailFormat } from '@/lib/utils'
 import { useReducer, type FormEvent } from 'react'
@@ -99,7 +99,7 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
   }
 
   const handleOtpComplete = async (value: string) => {
-    if (value.length !== OTP_LENGTH) {
+    if (value.length !== otpLength) {
       return
     }
 
@@ -110,7 +110,7 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
         email: state.email.trim(),
         otp: value,
         fetchOptions: {
-          headers: { [CHALLENGE_TOKEN_HEADER]: state.challengeToken },
+          headers: { [challengeTokenHeader]: state.challengeToken },
         },
       })
 

--- a/src/waitlist/waitlist-page.tsx
+++ b/src/waitlist/waitlist-page.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
 import { useAuth } from '@/contexts'
-import { privacyPolicyUrl, termsOfServiceUrl } from '@/lib/constants'
+import { otpLength, privacyPolicyUrl, termsOfServiceUrl } from '@/lib/constants'
 import { REGEXP_ONLY_DIGITS } from 'input-otp'
 import { Loader2 } from 'lucide-react'
 import { useNavigate } from 'react-router'
@@ -47,7 +47,7 @@ export const WaitlistPage = () => {
           <div className="flex w-full flex-col items-center gap-4">
             <p className="text-sm text-muted-foreground">If you received a code to log in, enter it here:</p>
             <InputOTP
-              maxLength={8}
+              maxLength={otpLength}
               pattern={REGEXP_ONLY_DIGITS}
               value={state.otp}
               onChange={actions.setOtp}
@@ -71,7 +71,7 @@ export const WaitlistPage = () => {
             <Button
               type="button"
               onClick={() => actions.handleOtpComplete(state.otp)}
-              disabled={isVerifying || state.otp.length !== 8}
+              disabled={isVerifying || state.otp.length !== otpLength}
               className="h-[46px] w-full rounded-[12px] text-base"
             >
               {isVerifying ? (


### PR DESCRIPTION
- Add CHALLENGE_TOKEN_HEADER and OTP_LENGTH constants to both frontend (src/lib/constants.ts) and backend (otp-constants.ts)
- Replace all hardcoded 'x-challenge-token' header strings and magic number 8 with constant references
- Fix computed property syntax for header constant in all call sites
- Use process.cwd() for migration folder resolution in compiled binaries
- Use pino-standard 'err' key for error logging in server startup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it touches the OTP sign-in request/verification path (challenge-token header handling) and changes how migrations are located at startup, which could impact auth flows or deployment if misconfigured.
> 
> **Overview**
> **OTP constants are now centralized**: introduces `challengeTokenHeader` (backend `auth/otp-constants.ts`, frontend `lib/constants.ts`) and replaces hardcoded `'x-challenge-token'` usages across auth hooks, magic-link verify, sign-in/waitlist flows, and related tests.
> 
> **OTP length is de-magic-numbered** on the frontend by using `otpLength` instead of `8` for input validation/UI enablement.
> 
> **Operational tweaks**: `runMigrations` now resolves the migrations folder via new `getMigrationsFolder()` (env override + `process.cwd()` default) with added tests, waitlist `/join` parallelizes challenge creation + user lookup, and startup logging switches to Pino’s standard `{ err }` key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 212ae496593e0f1c7a6b569811454a8dff20ac14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->