### PR TITLE
fix: narrow OTP inputs to match button width

### DIFF
--- a/src/components/sign-in/sign-in-otp-step.tsx
+++ b/src/components/sign-in/sign-in-otp-step.tsx
@@ -81,7 +81,7 @@ export const SignInOtpStep = ({
           >
             <InputOTPGroup className="w-full gap-2">
               {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
-                <InputOTPSlot key={i} index={i} className="h-10 flex-1 rounded-lg" />
+                <InputOTPSlot key={i} index={i} className="flex-1 rounded-lg" />
               ))}
             </InputOTPGroup>
           </InputOTP>
@@ -154,16 +154,12 @@ export const SignInOtpStep = ({
           data-1p-ignore
           data-lpignore="true"
           data-form-type="other"
+          containerClassName="w-full"
         >
-          <InputOTPGroup>
-            <InputOTPSlot index={0} />
-            <InputOTPSlot index={1} />
-            <InputOTPSlot index={2} />
-            <InputOTPSlot index={3} />
-            <InputOTPSlot index={4} />
-            <InputOTPSlot index={5} />
-            <InputOTPSlot index={6} />
-            <InputOTPSlot index={7} />
+          <InputOTPGroup className="w-full gap-2">
+            {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
+              <InputOTPSlot key={i} index={i} className="flex-1 rounded-lg" />
+            ))}
           </InputOTPGroup>
         </InputOTP>
 

--- a/src/components/sign-in/sign-in-otp-step.tsx
+++ b/src/components/sign-in/sign-in-otp-step.tsx
@@ -77,10 +77,11 @@ export const SignInOtpStep = ({
             data-1p-ignore
             data-lpignore="true"
             data-form-type="other"
+            containerClassName="w-full"
           >
-            <InputOTPGroup className="gap-2">
+            <InputOTPGroup className="w-full gap-2">
               {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
-                <InputOTPSlot key={i} index={i} className="h-12 w-12 shrink-0 rounded-lg" />
+                <InputOTPSlot key={i} index={i} className="h-10 flex-1 rounded-lg" />
               ))}
             </InputOTPGroup>
           </InputOTP>

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -40,7 +40,7 @@ const InputOTPSlot = ({
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-10 w-10 items-center justify-center border text-[length:var(--font-size-body)] shadow-xs transition-all outline-none first:rounded-l-md last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
+        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-[var(--touch-height-default)] w-[var(--touch-height-default)] items-center justify-center border text-[length:var(--font-size-body)] shadow-xs transition-all outline-none first:rounded-l-md last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
         className,
       )}
       {...props}

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -40,7 +40,7 @@ const InputOTPSlot = ({
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-[var(--touch-height-default)] w-[var(--touch-height-default)] items-center justify-center border text-[length:var(--font-size-body)] shadow-xs transition-all outline-none first:rounded-l-md last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
+        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-10 w-10 items-center justify-center border text-[length:var(--font-size-body)] shadow-xs transition-all outline-none first:rounded-l-md last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
         className,
       )}
       {...props}

--- a/src/waitlist/waitlist-page.tsx
+++ b/src/waitlist/waitlist-page.tsx
@@ -58,10 +58,11 @@ export const WaitlistPage = () => {
               data-1p-ignore
               data-lpignore="true"
               data-form-type="other"
+              containerClassName="w-full"
             >
-              <InputOTPGroup className="gap-2">
+              <InputOTPGroup className="w-full gap-2">
                 {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
-                  <InputOTPSlot key={i} index={i} className="h-12 w-12 shrink-0 rounded-lg" />
+                  <InputOTPSlot key={i} index={i} className="h-10 flex-1 rounded-lg" />
                 ))}
               </InputOTPGroup>
             </InputOTP>

--- a/src/waitlist/waitlist-page.tsx
+++ b/src/waitlist/waitlist-page.tsx
@@ -62,7 +62,7 @@ export const WaitlistPage = () => {
             >
               <InputOTPGroup className="w-full gap-2">
                 {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
-                  <InputOTPSlot key={i} index={i} className="h-10 flex-1 rounded-lg" />
+                  <InputOTPSlot key={i} index={i} className="flex-1 rounded-lg" />
                 ))}
               </InputOTPGroup>
             </InputOTP>


### PR DESCRIPTION
OTP input slots were too wide on mobile, breaking the layout on both waitlist and sign-in screens. Slots now stretch flexibly to match the Continue button width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling/layout-only changes to OTP inputs on sign-in and waitlist screens; no auth logic or data handling is modified.
> 
> **Overview**
> Adjusts OTP entry layouts on the sign-in and waitlist flows to prevent oversized slots on mobile.
> 
> The `InputOTP` containers/groups are set to `w-full`, and the 8 OTP slots are rendered via a map with `flex-1` styling (instead of fixed `h-12 w-12`/individual slots) so they flex to match the available width (e.g., the Continue button).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a42d6824840cc5abcffa393f16bc1ee19f2ebfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->