### PR TITLE
THU-406: Source Map Exposes Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         env:
           NODE_ENV: production
           NODE_OPTIONS: --max-old-space-size=4096
+          ENABLE_SOURCEMAP: 'true'
 
       - name: Inject & upload source maps to PostHog
         if: github.ref == 'refs/heads/main'
@@ -97,6 +98,10 @@ jobs:
           directory: dist
           env-id: ${{ secrets.POSTHOG_CLI_ENV_ID }}
           cli-token: ${{ secrets.POSTHOG_CLI_TOKEN }}
+
+      - name: Delete source maps after upload
+        if: github.ref == 'refs/heads/main'
+        run: find dist -name '*.map' -delete
 
       - name: Compute and save metrics baseline
         if: github.ref == 'refs/heads/main'

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -45,7 +45,7 @@ POSTHOG_API_KEY=
 
 # Build — source maps are disabled by default for security (prevents exposing source code via .map files).
 # Enable in CI to upload maps to PostHog for error tracking.
-ENABLE_SOURCEMAP=true
+ENABLE_SOURCEMAP=false
 
 # OpenTelemetry (optional)
 OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -43,6 +43,10 @@ MICROSOFT_CLIENT_SECRET=
 POSTHOG_HOST=
 POSTHOG_API_KEY=
 
+# Build — source maps are disabled by default for security (prevents exposing source code via .map files).
+# Enable in CI to upload maps to PostHog for error tracking.
+ENABLE_SOURCEMAP=true
+
 # OpenTelemetry (optional)
 OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_EXPORTER_OTLP_TOKEN=

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -8,7 +8,7 @@ server {
     add_header Cross-Origin-Opener-Policy "same-origin" always;
 
     # Reverse proxy backend API
-    location /v1/ {
+    location ^~ /v1/ {
         proxy_pass http://backend:8000/v1/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -27,6 +27,11 @@ server {
         add_header Cross-Origin-Opener-Policy "same-origin" always;
     }
 
+    # Block source maps (they are uploaded to PostHog for error tracking, not served publicly)
+    location ~* \.map$ {
+        return 404;
+    }
+
     # SPA fallback — serve index.html for all non-file routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -22,7 +22,8 @@ ARG VITE_AUTH_MODE="oidc"
 ENV VITE_THUNDERBOLT_CLOUD_URL=$VITE_THUNDERBOLT_CLOUD_URL
 ENV VITE_AUTH_MODE=$VITE_AUTH_MODE
 
-RUN bunx vite build
+RUN bunx vite build && \
+    find dist -name '*.map' -delete
 
 # Stage 2: Serve with nginx
 FROM nginx:alpine

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,10 +19,14 @@ const host = process.env.TAURI_DEV_HOST
 // 2. The `analyze` npm/bun script being executed (process arguments include the word "analyze")
 const shouldAnalyze = process.env.ANALYZE?.toLowerCase() === 'true' || process.argv.includes('analyze')
 
+// Source maps are disabled by default so forks don't accidentally expose proprietary code.
+// Enable with ENABLE_SOURCEMAP=true (e.g. in CI) to upload maps to PostHog for error tracking.
+const sourcemap = process.env.ENABLE_SOURCEMAP?.toLowerCase() === 'true' ? 'hidden' : false
+
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
-    sourcemap: 'hidden',
+    sourcemap,
     rollupOptions: {
       external: ['bun:sqlite'],
     },


### PR DESCRIPTION
## Problem

Vite's `sourcemap: 'hidden'` generates `.map` files without the `//# sourceMappingURL` comment, but the files are still built into the Docker image and served by nginx. Anyone who discovers the URL pattern (`/assets/index-[hash].js.map`) can download the full unminified source code — including AI prompts, auth logic, and crypto implementations. While Thunderbolt is going open source, forks with proprietary changes would unknowingly expose their code.

## Solution

- Source map generation gated behind `ENABLE_SOURCEMAP` env var (disabled by default)
- CI sets `ENABLE_SOURCEMAP=true` to build maps for PostHog error tracking, then deletes them after upload
- Docker build strips `.map` files before copying to nginx
- Nginx returns 404 for `.map` requests as defense-in-depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build/deploy behavior around source maps (generation, deletion, and server routing), which could impact debugging and production deployments if misconfigured.
> 
> **Overview**
> Prevents accidental exposure of frontend source via `.map` files by **disabling Vite sourcemap generation by default** and gating it behind `ENABLE_SOURCEMAP`.
> 
> Updates CI to enable sourcemaps only on `main` for PostHog upload, then deletes them from `dist`; the Docker frontend build also strips `.map` files, and nginx now returns `404` for sourcemap requests (plus a stricter `^~ /v1/` proxy match).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c4215c90dfe24282a416606ef689fb8ab55cc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->