### PR TITLE
fix: reject weak PowerSync JWT secrets and invalid token expiry values

### DIFF
--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -418,14 +418,14 @@ describe('Config Settings', () => {
     it('should read PowerSync values from env when set', () => {
       process.env.POWERSYNC_URL = 'https://sync.example.com'
       process.env.POWERSYNC_JWT_KID = 'my-kid'
-      process.env.POWERSYNC_JWT_SECRET = 'my-secret'
+      process.env.POWERSYNC_JWT_SECRET = 'a]3kF#9xL!mP7qR2vT5wY8zA0cE4gI6j'
       process.env.POWERSYNC_TOKEN_EXPIRY_SECONDS = '7200'
 
       const settings = getSettings()
 
       expect(settings.powersyncUrl).toBe('https://sync.example.com')
       expect(settings.powersyncJwtKid).toBe('my-kid')
-      expect(settings.powersyncJwtSecret).toBe('my-secret')
+      expect(settings.powersyncJwtSecret).toBe('a]3kF#9xL!mP7qR2vT5wY8zA0cE4gI6j')
       expect(settings.powersyncTokenExpirySeconds).toBe(7200)
     })
 
@@ -436,6 +436,34 @@ describe('Config Settings', () => {
 
       expect(settings.powersyncTokenExpirySeconds).toBe(1800)
       expect(typeof settings.powersyncTokenExpirySeconds).toBe('number')
+    })
+
+    it('should reject zero token expiry', () => {
+      process.env.POWERSYNC_TOKEN_EXPIRY_SECONDS = '0'
+      expect(() => getSettings()).toThrow()
+    })
+
+    it('should reject negative token expiry', () => {
+      process.env.POWERSYNC_TOKEN_EXPIRY_SECONDS = '-1'
+      expect(() => getSettings()).toThrow()
+    })
+
+    it('should reject non-integer token expiry', () => {
+      process.env.POWERSYNC_TOKEN_EXPIRY_SECONDS = '3600.5'
+      expect(() => getSettings()).toThrow()
+    })
+
+    it('should reject short JWT secret when powersyncUrl is set', () => {
+      process.env.POWERSYNC_URL = 'https://sync.example.com'
+      process.env.POWERSYNC_JWT_SECRET = 'too-short'
+      expect(() => getSettings()).toThrow()
+    })
+
+    it('should allow empty JWT secret when powersyncUrl is empty', () => {
+      process.env.POWERSYNC_URL = ''
+      process.env.POWERSYNC_JWT_SECRET = ''
+      const settings = getSettings()
+      expect(settings.powersyncJwtSecret).toBe('')
     })
   })
 })

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -459,6 +459,12 @@ describe('Config Settings', () => {
       expect(() => getSettings()).toThrow()
     })
 
+    it('should accept exactly 32-character JWT secret when powersyncUrl is set', () => {
+      process.env.POWERSYNC_URL = 'https://sync.example.com'
+      process.env.POWERSYNC_JWT_SECRET = 'a'.repeat(32)
+      expect(() => getSettings()).not.toThrow()
+    })
+
     it('should allow empty JWT secret when powersyncUrl is empty', () => {
       process.env.POWERSYNC_URL = ''
       process.env.POWERSYNC_JWT_SECRET = ''

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -73,8 +73,8 @@ const settingsSchema = z.object({
 }).superRefine((data, ctx) => {
   if (data.powersyncUrl && data.powersyncJwtSecret.length < 32) {
     ctx.addIssue({
-      code: 'too_small',
-      origin: 'string',
+      code: z.ZodIssueCode.too_small,
+      type: 'string',
       minimum: 32,
       inclusive: true,
       message: 'powersyncJwtSecret must be at least 32 characters when powersyncUrl is set',

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -46,7 +46,7 @@ const settingsSchema = z.object({
   powersyncUrl: z.string().default(''),
   powersyncJwtKid: z.string().default(''),
   powersyncJwtSecret: z.string().default(''),
-  powersyncTokenExpirySeconds: z.coerce.number().default(3600),
+  powersyncTokenExpirySeconds: z.coerce.number().int().positive().default(3600),
 
   // CORS settings — comma-separated list of exact origins
   corsOrigins: z.string().default('http://localhost:1420,tauri://localhost,http://tauri.localhost'),
@@ -70,6 +70,17 @@ const settingsSchema = z.object({
   // Set to 'cloudflare' to trust CF-Connecting-IP, 'akamai' for True-Client-IP,
   // or leave empty to use only the direct socket IP (proxy headers are NOT trusted)
   trustedProxy: z.enum(['', 'cloudflare', 'akamai']).default(''),
+}).superRefine((data, ctx) => {
+  if (data.powersyncUrl && data.powersyncJwtSecret.length < 32) {
+    ctx.addIssue({
+      code: 'too_small',
+      origin: 'string',
+      minimum: 32,
+      inclusive: true,
+      message: 'powersyncJwtSecret must be at least 32 characters when powersyncUrl is set',
+      path: ['powersyncJwtSecret'],
+    })
+  }
 })
 
 export type Settings = z.infer<typeof settingsSchema>


### PR DESCRIPTION
## Summary
- Enforce `powersyncJwtSecret` minimum length of 32 characters when `powersyncUrl` is configured — prevents trivially weak JWT signing secrets in production
- Reject zero, negative, and non-integer values for `powersyncTokenExpirySeconds` — prevents tokens that expire immediately or have undefined behavior
- Local dev unaffected: empty JWT secret is still allowed when PowerSync URL is not set

## Context
THU-380 items #3 (CRITICAL) and #5 (HIGH) from the sharp-edges security analysis.

## Test plan
- [ ] `bun typecheck` passes
- [ ] `bun test backend/src/config/settings.test.ts` — 5 new test cases covering rejection of zero/negative/fractional expiry, short JWT secret with URL set, and empty secret without URL
- [ ] Verify local dev startup still works without `POWERSYNC_JWT_SECRET` set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens startup-time config validation for PowerSync; deployments with previously accepted (but invalid/weak) `POWERSYNC_*` values may now fail fast until corrected.
> 
> **Overview**
> **Hardens PowerSync configuration validation** by requiring `powersyncTokenExpirySeconds` to be a *positive integer* (rejecting zero/negative/fractional values) and enforcing a **minimum 32-character** `powersyncJwtSecret` when `powersyncUrl` is configured.
> 
> Updates tests to cover the new validation rules and adjusts the env-based secret test fixture to use a longer secret, while still allowing an empty secret when PowerSync is disabled (empty URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661a9c0d22b32995db42c12066e26d642171431f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->