### PR TITLE
fix: validate OAuth redirect_uri origin before forwarding to provider

### DIFF
--- a/backend/src/auth/google.ts
+++ b/backend/src/auth/google.ts
@@ -1,6 +1,6 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { createAuthMacro } from '@/auth/elysia-plugin'
-import { getSettings } from '@/config/settings'
+import { getSettings, isOAuthRedirectUriAllowed } from '@/config/settings'
 import { safeErrorHandler } from '@/middleware/error-handling'
 import { Elysia, t } from 'elysia'
 import { codeRequestSchema, refreshRequestSchema, type OAuthTokenResponse } from './types'
@@ -40,6 +40,11 @@ export const createGoogleAuthRoutes = (auth: Auth, fetchFn: typeof fetch = globa
         }
 
         const validatedBody = codeRequestSchema.parse(body)
+
+        if (!isOAuthRedirectUriAllowed(validatedBody.redirect_uri, settings)) {
+          set.status = 400
+          return { error: 'Invalid redirect_uri' }
+        }
 
         const data = new URLSearchParams({
           code: validatedBody.code,

--- a/backend/src/auth/microsoft.ts
+++ b/backend/src/auth/microsoft.ts
@@ -1,6 +1,6 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { createAuthMacro } from '@/auth/elysia-plugin'
-import { getSettings } from '@/config/settings'
+import { getSettings, isOAuthRedirectUriAllowed } from '@/config/settings'
 import { safeErrorHandler } from '@/middleware/error-handling'
 import { Elysia, t } from 'elysia'
 import { codeRequestSchema, refreshRequestSchema, type OAuthTokenResponse } from './types'
@@ -43,6 +43,11 @@ export const createMicrosoftAuthRoutes = (auth: Auth, fetchFn: typeof fetch = gl
         }
 
         const validatedBody = codeRequestSchema.parse(body)
+
+        if (!isOAuthRedirectUriAllowed(validatedBody.redirect_uri, settings)) {
+          set.status = 400
+          return { error: 'Invalid redirect_uri' }
+        }
 
         const data = new URLSearchParams({
           client_id: settings.microsoftClientId,

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -175,4 +175,88 @@ describe('Authentication Routes', () => {
       expect(response.status).toBe(422)
     })
   })
+
+  describe('redirect_uri validation', () => {
+    it('rejects Google exchange with disallowed redirect_uri', async () => {
+      mockFetch.mockClear()
+      const response = await app.handle(
+        new Request('http://localhost/auth/google/exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            code: 'test-code',
+            code_verifier: 'test-verifier',
+            redirect_uri: 'https://evil.com/steal',
+          }),
+        }),
+      )
+      expect(response.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('rejects Microsoft exchange with disallowed redirect_uri', async () => {
+      mockFetch.mockClear()
+      const response = await app.handle(
+        new Request('http://localhost/auth/microsoft/exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            code: 'test-code',
+            code_verifier: 'test-verifier',
+            redirect_uri: 'https://evil.com/steal',
+          }),
+        }),
+      )
+      expect(response.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('allows Google exchange with valid localhost redirect_uri', async () => {
+      mockFetch.mockClear()
+      mockFetch.mockResolvedValueOnce(
+        createMockOAuthResponse(200, {
+          access_token: 'token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      )
+      const response = await app.handle(
+        new Request('http://localhost/auth/google/exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            code: 'test-code',
+            code_verifier: 'test-verifier',
+            redirect_uri: 'http://localhost:1420/oauth/callback',
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('allows Microsoft exchange with valid localhost redirect_uri', async () => {
+      mockFetch.mockClear()
+      mockFetch.mockResolvedValueOnce(
+        createMockOAuthResponse(200, {
+          access_token: 'token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      )
+      const response = await app.handle(
+        new Request('http://localhost/auth/microsoft/exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            code: 'test-code',
+            code_verifier: 'test-verifier',
+            redirect_uri: 'http://localhost:1420/oauth/callback',
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -5,6 +5,7 @@ import {
   getCorsMethodsList,
   getCorsOriginsList,
   getSettings,
+  isOAuthRedirectUriAllowed,
   isOriginAllowed,
 } from './settings'
 
@@ -436,6 +437,47 @@ describe('Config Settings', () => {
 
       expect(settings.powersyncTokenExpirySeconds).toBe(1800)
       expect(typeof settings.powersyncTokenExpirySeconds).toBe('number')
+    })
+  })
+
+  describe('isOAuthRedirectUriAllowed', () => {
+    const settings = { corsOrigins: 'http://localhost:1420,tauri://localhost,http://tauri.localhost' }
+
+    it('allows web dev callback', () => {
+      expect(isOAuthRedirectUriAllowed('http://localhost:1420/oauth/callback', settings)).toBe(true)
+    })
+
+    it('allows loopback with dynamic port', () => {
+      expect(isOAuthRedirectUriAllowed('http://localhost:17421', settings)).toBe(true)
+    })
+
+    it('allows Tauri desktop callback', () => {
+      expect(isOAuthRedirectUriAllowed('tauri://localhost/oauth-callback.html', settings)).toBe(true)
+    })
+
+    it('allows mobile App Link callback', () => {
+      expect(isOAuthRedirectUriAllowed('https://thunderbolt.io/oauth/callback', settings)).toBe(true)
+    })
+
+    it('allows production origin from corsOrigins', () => {
+      const prod = { corsOrigins: 'https://app.thunderbolt.io' }
+      expect(isOAuthRedirectUriAllowed('https://app.thunderbolt.io/oauth/callback', prod)).toBe(true)
+    })
+
+    it('rejects attacker domain', () => {
+      expect(isOAuthRedirectUriAllowed('https://evil.com/callback', settings)).toBe(false)
+    })
+
+    it('rejects HTTPS on localhost', () => {
+      expect(isOAuthRedirectUriAllowed('https://localhost:1420/oauth/callback', settings)).toBe(false)
+    })
+
+    it('rejects invalid URL', () => {
+      expect(isOAuthRedirectUriAllowed('not-a-url', settings)).toBe(false)
+    })
+
+    it('rejects empty string', () => {
+      expect(isOAuthRedirectUriAllowed('', settings)).toBe(false)
     })
   })
 })

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -157,6 +157,26 @@ export const isOriginAllowed = (origin: string, settings: Pick<Settings, 'corsOr
   return getCorsOriginsList(settings).includes(origin)
 }
 
+/** Validate that an OAuth redirect_uri points to a trusted origin. */
+export const isOAuthRedirectUriAllowed = (uri: string, settings: Pick<Settings, 'corsOrigins'>): boolean => {
+  try {
+    const url = new URL(uri)
+    // Construct origin manually — url.origin returns 'null' for non-standard protocols like tauri://
+    const origin = `${url.protocol}//${url.host}`
+    const allowedOrigins = [...getCorsOriginsList(settings), 'https://thunderbolt.io']
+    if (allowedOrigins.includes(origin)) {
+      return true
+    }
+    // Loopback flow uses dynamic ports — allow any HTTP localhost
+    if ((url.hostname === 'localhost' || url.hostname === '127.0.0.1') && url.protocol === 'http:') {
+      return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
 export const getCorsMethodsList = (settings: Settings): string[] => {
   return settings.corsAllowMethods
     .split(',')


### PR DESCRIPTION
## Summary
- Validate the `redirect_uri` origin on the backend before forwarding OAuth token exchange requests to Google/Microsoft
- Adds `isOAuthRedirectUriAllowed()` that checks the URI origin against CORS origins + `https://thunderbolt.io` (mobile App Link), with a localhost allowance for the loopback flow's dynamic ports
- Returns 400 if `redirect_uri` doesn't match a trusted origin — request never reaches the provider

## Context
THU-380 item #2. The backend acts as a confidential client proxy (holds `client_secret`). As a security boundary, it should validate its own inputs rather than delegating entirely to the OAuth provider.

Constructs origin manually (`${protocol}//${host}`) instead of using `url.origin` because non-standard protocols like `tauri://` return `'null'` from the URL API.

## Test plan
- [ ] `bun run type-check` passes
- [ ] `bun test backend/src/config/settings.test.ts` — 9 new unit tests for `isOAuthRedirectUriAllowed` (legitimate URIs + malicious/invalid URIs)
- [ ] `bun test backend/src/auth/routes.test.ts` — 4 new integration tests verifying the security boundary (rejected URIs never call the provider via `mockFetch`)
- [ ] Verify OAuth flows still work: web callback, Tauri desktop, mobile App Link, loopback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth token exchange routes (security-sensitive) and could break login flows if the redirect URI allowlist logic is too strict or mismatched with deployed clients.
> 
> **Overview**
> Adds server-side `redirect_uri` allowlist enforcement for Google and Microsoft OAuth `/exchange` endpoints, returning `400` and skipping the provider request when the origin is not trusted.
> 
> Introduces `isOAuthRedirectUriAllowed()` (based on `corsOrigins` plus `https://thunderbolt.io`, with an `http://localhost` loopback exception) and adds unit/integration tests covering allowed/disallowed redirect URIs and ensuring disallowed requests never call `fetch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10340d16eb2fbca514f33852873a96597da6499b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->