### PR TITLE
THU-406: OTP Hardening

### DIFF
--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -10,7 +10,7 @@ import {
 } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import * as schema from '@/db/schema'
-import { eq } from 'drizzle-orm'
+import { eq, like } from 'drizzle-orm'
 import { normalizeEmail } from '@/lib/email'
 import { getSettings } from '@/config/settings'
 import { getTrustedIpHeaders } from '@/utils/request'
@@ -219,7 +219,7 @@ export const createAuth = (database: typeof DbType) => {
                 // Clean up the OTP that Better Auth already persisted (it generates before calling this callback)
                 await database
                   .delete(schema.verification)
-                  .where(eq(schema.verification.identifier, `sign-in-otp-${normalizedEmail}`))
+                  .where(like(schema.verification.identifier, `%${normalizedEmail}%`))
                 return
               }
             } else if (waitlistEntry.status !== 'approved') {
@@ -231,7 +231,7 @@ export const createAuth = (database: typeof DbType) => {
                 // Clean up the OTP that Better Auth already persisted (it generates before calling this callback)
                 await database
                   .delete(schema.verification)
-                  .where(eq(schema.verification.identifier, `sign-in-otp-${normalizedEmail}`))
+                  .where(like(schema.verification.identifier, `%${normalizedEmail}%`))
                 return
               }
             }

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -217,7 +217,9 @@ export const createAuth = (database: typeof DbType) => {
               if (!autoApproved) {
                 await sendWaitlistJoinedEmail({ email: normalizedEmail })
                 // Clean up the OTP that Better Auth already persisted (it generates before calling this callback)
-                await database.delete(schema.verification).where(eq(schema.verification.identifier, normalizedEmail))
+                await database
+                  .delete(schema.verification)
+                  .where(eq(schema.verification.identifier, `sign-in-otp-${normalizedEmail}`))
                 return
               }
             } else if (waitlistEntry.status !== 'approved') {
@@ -227,7 +229,9 @@ export const createAuth = (database: typeof DbType) => {
                 console.info('Handling sign-in for non-approved email (sending waitlist email)')
                 await sendWaitlistNotReadyEmail({ email: normalizedEmail })
                 // Clean up the OTP that Better Auth already persisted (it generates before calling this callback)
-                await database.delete(schema.verification).where(eq(schema.verification.identifier, normalizedEmail))
+                await database
+                  .delete(schema.verification)
+                  .where(eq(schema.verification.identifier, `sign-in-otp-${normalizedEmail}`))
                 return
               }
             }

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -3,6 +3,7 @@ import {
   getOrCreateOtpChallenge,
   createWaitlistEntry,
   deleteOtpChallengesForEmail,
+  deletePersistedSignInOtp,
   getUserByEmail,
   getWaitlistByEmail,
   markUserNotNew,
@@ -10,7 +11,6 @@ import {
 } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import * as schema from '@/db/schema'
-import { eq } from 'drizzle-orm'
 import { normalizeEmail } from '@/lib/email'
 import { getSettings } from '@/config/settings'
 import { getTrustedIpHeaders } from '@/utils/request'
@@ -216,11 +216,7 @@ export const createAuth = (database: typeof DbType) => {
               })
               if (!autoApproved) {
                 await sendWaitlistJoinedEmail({ email: normalizedEmail })
-                // Clean up the OTP that Better Auth already persisted (it generates before calling this callback).
-                // Better Auth's toOTPIdentifier returns `${type}-otp-${email}` (confirmed in email-otp/utils.mjs).
-                await database
-                  .delete(schema.verification)
-                  .where(eq(schema.verification.identifier, `sign-in-otp-${normalizedEmail}`))
+                await deletePersistedSignInOtp(database, normalizedEmail)
                 return
               }
             } else if (waitlistEntry.status !== 'approved') {
@@ -229,11 +225,7 @@ export const createAuth = (database: typeof DbType) => {
               } else {
                 console.info('Handling sign-in for non-approved email (sending waitlist email)')
                 await sendWaitlistNotReadyEmail({ email: normalizedEmail })
-                // Clean up the OTP that Better Auth already persisted (it generates before calling this callback).
-                // Better Auth's toOTPIdentifier returns `${type}-otp-${email}` (confirmed in email-otp/utils.mjs).
-                await database
-                  .delete(schema.verification)
-                  .where(eq(schema.verification.identifier, `sign-in-otp-${normalizedEmail}`))
+                await deletePersistedSignInOtp(database, normalizedEmail)
                 return
               }
             }

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -10,6 +10,7 @@ import {
 } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import * as schema from '@/db/schema'
+import { eq } from 'drizzle-orm'
 import { normalizeEmail } from '@/lib/email'
 import { getSettings } from '@/config/settings'
 import { getTrustedIpHeaders } from '@/utils/request'
@@ -132,9 +133,21 @@ export const createAuth = (database: typeof DbType) => {
           throw ctx.error('UNAUTHORIZED', { message: 'Challenge token required' })
         }
 
-        const valid = await validateOtpChallenge(database, normalizeEmail(rawEmail), challengeToken)
+        const normalizedEmail = normalizeEmail(rawEmail)
+
+        const valid = await validateOtpChallenge(database, normalizedEmail, challengeToken)
         if (!valid) {
           throw ctx.error('UNAUTHORIZED', { message: 'Invalid challenge token' })
+        }
+
+        // Block sign-in for non-approved waitlist users (defense-in-depth).
+        // Even if a challenge token was somehow obtained, pending users cannot sign in.
+        const existingUser = await getUserByEmail(database, normalizedEmail)
+        if (!existingUser) {
+          const waitlistEntry = await getWaitlistByEmail(database, normalizedEmail)
+          if (!waitlistEntry || waitlistEntry.status !== 'approved') {
+            throw ctx.error('UNAUTHORIZED', { message: 'Not approved' })
+          }
         }
 
         // Token stays valid for remaining attempts. Cleaned up on successful sign-in
@@ -203,6 +216,8 @@ export const createAuth = (database: typeof DbType) => {
               })
               if (!autoApproved) {
                 await sendWaitlistJoinedEmail({ email: normalizedEmail })
+                // Clean up the OTP that Better Auth already persisted (it generates before calling this callback)
+                await database.delete(schema.verification).where(eq(schema.verification.identifier, normalizedEmail))
                 return
               }
             } else if (waitlistEntry.status !== 'approved') {
@@ -211,6 +226,8 @@ export const createAuth = (database: typeof DbType) => {
               } else {
                 console.info('Handling sign-in for non-approved email (sending waitlist email)')
                 await sendWaitlistNotReadyEmail({ email: normalizedEmail })
+                // Clean up the OTP that Better Auth already persisted (it generates before calling this callback)
+                await database.delete(schema.verification).where(eq(schema.verification.identifier, normalizedEmail))
                 return
               }
             }

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -10,7 +10,7 @@ import {
 } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import * as schema from '@/db/schema'
-import { eq, like } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { normalizeEmail } from '@/lib/email'
 import { getSettings } from '@/config/settings'
 import { getTrustedIpHeaders } from '@/utils/request'
@@ -146,7 +146,7 @@ export const createAuth = (database: typeof DbType) => {
         if (!existingUser) {
           const waitlistEntry = await getWaitlistByEmail(database, normalizedEmail)
           if (!waitlistEntry || waitlistEntry.status !== 'approved') {
-            throw ctx.error('UNAUTHORIZED', { message: 'Not approved' })
+            throw ctx.error('UNAUTHORIZED', { message: 'Sign-in not available' })
           }
         }
 
@@ -216,10 +216,11 @@ export const createAuth = (database: typeof DbType) => {
               })
               if (!autoApproved) {
                 await sendWaitlistJoinedEmail({ email: normalizedEmail })
-                // Clean up the OTP that Better Auth already persisted (it generates before calling this callback)
+                // Clean up the OTP that Better Auth already persisted (it generates before calling this callback).
+                // Better Auth's toOTPIdentifier returns `${type}-otp-${email}` (confirmed in email-otp/utils.mjs).
                 await database
                   .delete(schema.verification)
-                  .where(like(schema.verification.identifier, `%${normalizedEmail}%`))
+                  .where(eq(schema.verification.identifier, `sign-in-otp-${normalizedEmail}`))
                 return
               }
             } else if (waitlistEntry.status !== 'approved') {
@@ -228,10 +229,11 @@ export const createAuth = (database: typeof DbType) => {
               } else {
                 console.info('Handling sign-in for non-approved email (sending waitlist email)')
                 await sendWaitlistNotReadyEmail({ email: normalizedEmail })
-                // Clean up the OTP that Better Auth already persisted (it generates before calling this callback)
+                // Clean up the OTP that Better Auth already persisted (it generates before calling this callback).
+                // Better Auth's toOTPIdentifier returns `${type}-otp-${email}` (confirmed in email-otp/utils.mjs).
                 await database
                   .delete(schema.verification)
-                  .where(like(schema.verification.identifier, `%${normalizedEmail}%`))
+                  .where(eq(schema.verification.identifier, `sign-in-otp-${normalizedEmail}`))
                 return
               }
             }

--- a/backend/src/auth/otp-security.test.ts
+++ b/backend/src/auth/otp-security.test.ts
@@ -454,16 +454,28 @@ describe('OTP Security Hardening', () => {
       // Manufacture a valid challenge token directly, bypassing /waitlist/join
       const challengeToken = await createTestChallenge(db, email)
 
-      // Manually insert an OTP verification record (simulating Better Auth persisting it)
-      await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+      // sendVerificationOTP cleans up the OTP for pending users (Layer 3 defense).
+      // Re-insert a valid verification record so the OTP *would* succeed if the
+      // before-hook (Layer 2) weren't blocking it — this isolates the before-hook check.
+      const otp = '12345678'
+      const identifier = `sign-in-otp-${email}`
+      await db.insert(verification).values({
+        id: crypto.randomUUID(),
+        identifier,
+        value: otp,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
 
-      let threw = false
+      let errorMessage = ''
       try {
-        await signInWithChallenge(email, '00000000', challengeToken)
-      } catch {
-        threw = true
+        await signInWithChallenge(email, otp, challengeToken)
+      } catch (err: unknown) {
+        errorMessage = err instanceof Error ? err.message : String(err)
       }
-      expect(threw).toBe(true)
+      // The before-hook blocks with "Sign-in not available", not "INVALID_OTP"
+      expect(errorMessage).toContain('Sign-in not available')
     })
 
     it('should delete challenge token after successful sign-in', async () => {

--- a/backend/src/auth/otp-security.test.ts
+++ b/backend/src/auth/otp-security.test.ts
@@ -312,13 +312,13 @@ describe('OTP Security Hardening', () => {
       expect(body.challengeToken.length).toBeGreaterThan(0)
     })
 
-    it('should also return challengeToken for pending users (privacy-preserving)', async () => {
+    it('should NOT return challengeToken for pending users (waitlist bypass prevention)', async () => {
       const response = await postWaitlistJoin('pending-challenge@example.com')
       expect(response.status).toBe(200)
 
       const body = await response.json()
       expect(body.success).toBe(true)
-      expect(body.challengeToken).toBeDefined()
+      expect(body.challengeToken).toBeUndefined()
     })
 
     // These tests use auth.api (not HTTP) to avoid Better Auth's HTTP rate limiter

--- a/backend/src/auth/otp-security.test.ts
+++ b/backend/src/auth/otp-security.test.ts
@@ -446,6 +446,26 @@ describe('OTP Security Hardening', () => {
       expect(result.user).toBeDefined()
     })
 
+    it('should block sign-in for pending user even with a valid challenge token (before-hook defense)', async () => {
+      const email = 'pending-with-token@example.com'
+      // Insert a pending waitlist entry (no existing user, not approved)
+      await db.insert(waitlist).values({ id: crypto.randomUUID(), email, status: 'pending' })
+
+      // Manufacture a valid challenge token directly, bypassing /waitlist/join
+      const challengeToken = await createTestChallenge(db, email)
+
+      // Manually insert an OTP verification record (simulating Better Auth persisting it)
+      await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
+
+      let threw = false
+      try {
+        await signInWithChallenge(email, '00000000', challengeToken)
+      } catch {
+        threw = true
+      }
+      expect(threw).toBe(true)
+    })
+
     it('should delete challenge token after successful sign-in', async () => {
       const email = 'cleanup@example.com'
       await insertExistingUser(email)

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -14,7 +14,12 @@ export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from '.
 export { applyOperation } from './powersync'
 
 // OTP Challenge (session binding)
-export { getOrCreateOtpChallenge, validateOtpChallenge, deleteOtpChallengesForEmail } from './otp-challenge'
+export {
+  getOrCreateOtpChallenge,
+  validateOtpChallenge,
+  deleteOtpChallengesForEmail,
+  deletePersistedSignInOtp,
+} from './otp-challenge'
 
 // Encryption
 export {

--- a/backend/src/dal/otp-challenge.ts
+++ b/backend/src/dal/otp-challenge.ts
@@ -1,5 +1,5 @@
 import type { db as DbType } from '@/db/client'
-import { otpChallenge } from '@/db/schema'
+import { otpChallenge, verification } from '@/db/schema'
 import { and, eq, gt, lt } from 'drizzle-orm'
 
 /**
@@ -53,3 +53,10 @@ export const validateOtpChallenge = async (database: typeof DbType, email: strin
 /** Delete all challenge tokens for an email (cleanup after successful verification). */
 export const deleteOtpChallengesForEmail = async (database: typeof DbType, email: string) =>
   database.delete(otpChallenge).where(eq(otpChallenge.email, email))
+
+/**
+ * Delete the OTP that Better Auth persisted in the verification table.
+ * Better Auth's toOTPIdentifier returns `${type}-otp-${email}` (confirmed in email-otp/utils.mjs).
+ */
+export const deletePersistedSignInOtp = async (database: typeof DbType, email: string) =>
+  database.delete(verification).where(eq(verification.identifier, `sign-in-otp-${email}`))

--- a/backend/src/waitlist/routes.test.ts
+++ b/backend/src/waitlist/routes.test.ts
@@ -33,7 +33,7 @@ describe('Waitlist API', () => {
   })
 
   describe('POST /v1/waitlist/join', () => {
-    it('should add email to waitlist with pending status', async () => {
+    it('should add email to waitlist with pending status and no challenge token', async () => {
       const response = await app.handle(
         new Request('http://localhost/v1/waitlist/join', {
           method: 'POST',
@@ -44,9 +44,9 @@ describe('Waitlist API', () => {
 
       expect(response.status).toBe(200)
       const result = await response.json()
-      // Privacy: response doesn't reveal approval status
       expect(result.success).toBe(true)
-      expect(result.challengeToken).toBeDefined()
+      // Pending users must NOT receive a challenge token (waitlist bypass prevention)
+      expect(result.challengeToken).toBeUndefined()
 
       // Verify in database
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@example.com'))
@@ -91,9 +91,9 @@ describe('Waitlist API', () => {
 
       expect(response.status).toBe(200)
       const result = await response.json()
-      // Privacy: response doesn't reveal approval status
       expect(result.success).toBe(true)
-      expect(result.challengeToken).toBeDefined()
+      // Pending user resubmitting — still no challenge token
+      expect(result.challengeToken).toBeUndefined()
 
       // Verify only one entry exists
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'duplicate@example.com'))
@@ -121,9 +121,9 @@ describe('Waitlist API', () => {
 
       expect(response.status).toBe(200)
       const result = await response.json()
-      // Privacy: response doesn't reveal approval status
       expect(result.success).toBe(true)
-      expect(result.challengeToken).toBeDefined()
+      // Pending user — no challenge token
+      expect(result.challengeToken).toBeUndefined()
 
       // Verify only one entry exists
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'case@example.com'))
@@ -278,7 +278,8 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(200)
       const result = await response.json()
       expect(result.success).toBe(true)
-      expect(result.challengeToken).toBeDefined()
+      // Pending user — no challenge token
+      expect(result.challengeToken).toBeUndefined()
 
       // Verify in database with pending status
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@other-domain.com'))
@@ -298,7 +299,8 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(200)
       const result = await response.json()
       expect(result.success).toBe(true)
-      expect(result.challengeToken).toBeDefined()
+      // Pending user — no challenge token
+      expect(result.challengeToken).toBeUndefined()
 
       // Verify in database with pending status (not auto-approved)
       const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'test@fake-mozilla.org.evil.com'))

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -86,54 +86,49 @@ export const createWaitlistRoutes = ({
         emailCooldowns.set(email, Date.now())
       }
 
-      // Challenge token creation and user lookup are independent — run in parallel.
-      // Privacy-preserving: same response shape regardless of user status.
-      const [challengeToken, existingUser] = await Promise.all([
-        getOrCreateOtpChallenge(database, {
-          id: crypto.randomUUID(),
-          email,
-          challengeToken: crypto.randomUUID(),
-          expiresAt: new Date(Date.now() + otpExpiryMs),
-        }),
-        getUserByEmail(database, email),
-      ])
+      // Determine whether this user is approved (existing user, approved waitlist, or auto-approved domain).
+      // Only approved users receive a challenge token and OTP email.
+      const existingUser = await getUserByEmail(database, email)
+      let isApproved = !!existingUser
 
-      if (existingUser) {
-        await sendApprovedMagicLinkEmail(auth, email)
-        return { success: true, challengeToken }
-      }
+      if (!existingUser) {
+        const existing = await getWaitlistByEmail(database, email)
 
-      const existing = await getWaitlistByEmail(database, email)
-
-      if (existing) {
-        if (existing.status === 'approved') {
-          await sendApprovedMagicLinkEmail(auth, email)
-          return { success: true, challengeToken }
-        }
-
-        // Pending user - check if they now qualify for auto-approval (e.g., feature deployed after they joined)
-        if (isAutoApprovedDomain(email)) {
-          await approveWaitlistEntry(database, existing.id)
-          await sendApprovedMagicLinkEmail(auth, email)
+        if (existing) {
+          if (existing.status === 'approved') {
+            isApproved = true
+          } else if (isAutoApprovedDomain(email)) {
+            await approveWaitlistEntry(database, existing.id)
+            isApproved = true
+          } else {
+            await emailService.sendReminderEmail({ email })
+          }
         } else {
-          await emailService.sendReminderEmail({ email })
+          const autoApproved = isAutoApprovedDomain(email)
+          await createWaitlistEntry(database, {
+            id: crypto.randomUUID(),
+            email,
+            status: autoApproved ? 'approved' : 'pending',
+          })
+          if (autoApproved) {
+            isApproved = true
+          } else {
+            await emailService.sendJoinedEmail({ email })
+          }
         }
-        return { success: true, challengeToken }
       }
 
-      const isAutoApproved = isAutoApprovedDomain(email)
+      if (!isApproved) {
+        return { success: true }
+      }
 
-      await createWaitlistEntry(database, {
+      const challengeToken = await getOrCreateOtpChallenge(database, {
         id: crypto.randomUUID(),
         email,
-        status: isAutoApproved ? 'approved' : 'pending',
+        challengeToken: crypto.randomUUID(),
+        expiresAt: new Date(Date.now() + otpExpiryMs),
       })
-
-      if (isAutoApproved) {
-        await sendApprovedMagicLinkEmail(auth, email)
-      } else {
-        await emailService.sendJoinedEmail({ email })
-      }
+      await sendApprovedMagicLinkEmail(auth, email)
       return { success: true, challengeToken }
     },
     {

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -36,6 +36,46 @@ const sendApprovedMagicLinkEmail = async (auth: Auth, email: string): Promise<vo
   await auth.api.sendVerificationOTP({ body: { email, type: 'sign-in' } })
 }
 
+/**
+ * Resolve whether an email is approved to receive an OTP.
+ * Handles side effects (creating waitlist entries, sending emails) along the way.
+ * Returns true for existing users, approved waitlist entries, and auto-approved domains.
+ */
+const resolveApproval = async (
+  database: typeof db,
+  email: string,
+  emailService: WaitlistEmailService,
+): Promise<boolean> => {
+  const existingUser = await getUserByEmail(database, email)
+  if (existingUser) return true
+
+  const existing = await getWaitlistByEmail(database, email)
+
+  if (existing) {
+    if (existing.status === 'approved') return true
+
+    if (isAutoApprovedDomain(email)) {
+      await approveWaitlistEntry(database, existing.id)
+      return true
+    }
+
+    await emailService.sendReminderEmail({ email })
+    return false
+  }
+
+  const autoApproved = isAutoApprovedDomain(email)
+  await createWaitlistEntry(database, {
+    id: crypto.randomUUID(),
+    email,
+    status: autoApproved ? 'approved' : 'pending',
+  })
+
+  if (autoApproved) return true
+
+  await emailService.sendJoinedEmail({ email })
+  return false
+}
+
 /** Default cooldown between OTP requests per email (15 seconds). */
 const DEFAULT_COOLDOWN_MS = 15_000
 
@@ -86,39 +126,9 @@ export const createWaitlistRoutes = ({
         emailCooldowns.set(email, Date.now())
       }
 
-      // Determine whether this user is approved (existing user, approved waitlist, or auto-approved domain).
-      // Only approved users receive a challenge token and OTP email.
-      const existingUser = await getUserByEmail(database, email)
-      let isApproved = !!existingUser
+      const approved = await resolveApproval(database, email, emailService)
 
-      if (!existingUser) {
-        const existing = await getWaitlistByEmail(database, email)
-
-        if (existing) {
-          if (existing.status === 'approved') {
-            isApproved = true
-          } else if (isAutoApprovedDomain(email)) {
-            await approveWaitlistEntry(database, existing.id)
-            isApproved = true
-          } else {
-            await emailService.sendReminderEmail({ email })
-          }
-        } else {
-          const autoApproved = isAutoApprovedDomain(email)
-          await createWaitlistEntry(database, {
-            id: crypto.randomUUID(),
-            email,
-            status: autoApproved ? 'approved' : 'pending',
-          })
-          if (autoApproved) {
-            isApproved = true
-          } else {
-            await emailService.sendJoinedEmail({ email })
-          }
-        }
-      }
-
-      if (!isApproved) {
+      if (!approved) {
         return { success: true }
       }
 

--- a/src/components/sign-in/use-sign-in-form-state.ts
+++ b/src/components/sign-in/use-sign-in-form-state.ts
@@ -163,9 +163,9 @@ export const useSignInFormState = ({
     try {
       const { challengeToken } = await httpClient
         .post('waitlist/join', { json: { email: trimmedEmail } })
-        .json<{ success: boolean; challengeToken: string }>()
+        .json<{ success: boolean; challengeToken?: string }>()
 
-      dispatch({ type: 'SEND_SUCCESS', payload: challengeToken })
+      dispatch({ type: 'SEND_SUCCESS', payload: challengeToken ?? '' })
     } catch (error) {
       console.error('Failed to send verification OTP:', error)
       const message = await getServerErrorMessage(
@@ -230,9 +230,9 @@ export const useSignInFormState = ({
     try {
       const { challengeToken } = await httpClient
         .post('waitlist/join', { json: { email: trimmedEmail } })
-        .json<{ success: boolean; challengeToken: string }>()
+        .json<{ success: boolean; challengeToken?: string }>()
 
-      dispatch({ type: 'SEND_SUCCESS', payload: challengeToken })
+      dispatch({ type: 'SEND_SUCCESS', payload: challengeToken ?? '' })
       return true
     } catch (error) {
       console.error('Failed to resend verification OTP:', error)

--- a/src/waitlist/use-waitlist-state.ts
+++ b/src/waitlist/use-waitlist-state.ts
@@ -89,9 +89,9 @@ export const useWaitlistState = ({ authClient, onVerified }: UseWaitlistStateOpt
     try {
       const { challengeToken } = await httpClient
         .post('waitlist/join', { json: { email: trimmedEmail } })
-        .json<{ success: boolean; challengeToken: string }>()
+        .json<{ success: boolean; challengeToken?: string }>()
 
-      dispatch({ type: 'JOIN_SUCCESS', payload: challengeToken })
+      dispatch({ type: 'JOIN_SUCCESS', payload: challengeToken ?? '' })
     } catch (error) {
       console.error('Waitlist join error:', error)
       dispatch({ type: 'JOIN_ERROR', payload: 'Something went wrong. Please try again.' })


### PR DESCRIPTION
## Problem

The waitlist could be bypassed due to three compounding bugs: (1) `/waitlist/join` always returned a challenge token, even for pending users; (2) Better Auth persisted the OTP before the waitlist check callback ran, so the code existed in the DB even though no email was sent; (3) the sign-in hook only validated the challenge token without checking waitlist approval status. Together, a pending user could obtain a challenge token, trigger OTP generation, and sign in with full API access.

## Solution

**Backend (3 layers of defense):**
1. Challenge token is only created and returned for approved/existing users. Pending users get `{ success: true }` with no token.
2. Sign-in before hook now checks waitlist approval status after validating the challenge token — blocks pending users even if they somehow obtain a token.
3. Orphaned OTPs for pending users are deleted from the verification table after the early return in `sendVerificationOTP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches sign-in/waitlist gating logic in the authentication flow; mistakes could block legitimate logins or reintroduce an auth bypass. Also adds DB cleanup of persisted OTPs, so incorrect identifiers/conditions could delete the wrong records or leave exploitable ones behind.
> 
> **Overview**
> **Closes a waitlist-bypass path in the email-OTP flow.** `/waitlist/join` now only creates/returns a `challengeToken` for existing users or approved/auto-approved waitlist entries; pending users still get `{ success: true }` but *no* token.
> 
> Adds defense-in-depth checks: the auth *before* hook now blocks OTP sign-in for non-approved users even if they present a valid `challengeToken`, and `sendVerificationOTP` deletes Better Auth’s persisted `sign-in-otp-${email}` verification record when returning early for pending users.
> 
> Updates DAL exports and tests accordingly, and adjusts frontend callers to treat `challengeToken` as optional (defaulting to an empty string).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a3f98cb683b3bf234b642b137621b1014efc84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->