### PR TITLE
fix(ci): harden GitHub Actions security for open-source readiness

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -17,6 +17,15 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      ANDROID_UPLOAD_KEY:
+        required: true
+      ANDROID_UPLOAD_KEY_ALIAS:
+        required: true
+      ANDROID_UPLOAD_KEY_PASSWORD:
+        required: true
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:
+        required: true
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Detect changed files
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.3
         with:
           filters: |
             rust:
@@ -45,22 +45,22 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: |
             ~/.bun/install/cache
@@ -93,7 +93,7 @@ jobs:
 
       - name: Inject & upload source maps to PostHog
         if: github.ref == 'refs/heads/main'
-        uses: PostHog/upload-source-maps@v0.4.6
+        uses: PostHog/upload-source-maps@e798a054427efc710af080354f8450d3c154c584 # v0.4.6
         with:
           directory: dist
           env-id: ${{ secrets.POSTHOG_CLI_ENV_ID }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Cache metrics baseline
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .metrics-baseline
           key: pr-metrics-main-${{ github.sha }}
@@ -125,16 +125,16 @@ jobs:
     if: needs.detect-changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: rustfmt, clippy
           cache: false
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry/index/
@@ -145,7 +145,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: src-tauri/target/
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('src-tauri/Cargo.lock') }}-${{ hashFiles('src-tauri/src/**/*.rs') }}
@@ -180,15 +180,15 @@ jobs:
   backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies (backend)
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Type check
         run: bun run tsc --noEmit
@@ -200,7 +200,7 @@ jobs:
       - name: Install backend dependencies
         run: |
           cd backend
-          bun install
+          bun install --frozen-lockfile
 
       - name: Type check backend
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Detect file changes to optimize CI performance (THU-28)
   # Skip Rust build step when no Rust-related files have changed

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   # Interactive @claude mentions
   claude-interactive:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,12 +32,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Execute Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@39431830520a7ae6c0c572f11a7707e7043325e3 # v1.0.95
         with:
           anthropic_api_key: ${{ secrets.CI_ANTHROPIC_API_KEY }}
 
@@ -51,7 +51,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -109,7 +109,7 @@ jobs:
           done
 
       - name: PR Review with Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@39431830520a7ae6c0c572f11a7707e7043325e3 # v1.0.95
         with:
           anthropic_api_key: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           allowed_bots: 'dependabot[bot],renovate[bot],cursor[bot]'

--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -107,6 +107,12 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.new_version.outputs.new_version }}
         run: |
+          # Validate version format to prevent injection via sed/shell
+          if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "❌ Invalid version format: $NEW_VERSION"
+            exit 1
+          fi
+
           echo "📝 Updating version files to $NEW_VERSION"
 
           # Update package.json

--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
           git config --local user.name "GitHub Action"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -18,6 +18,9 @@ on:
           - minor
           - major
 
+permissions:
+  contents: write
+
 jobs:
   create_tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -50,6 +50,9 @@ concurrency:
   group: desktop-release-${{ inputs.version }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   draft:
     name: Create Draft Release

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -13,6 +13,27 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      APPLE_DEVELOPER_CERTIFICATE:
+        required: true
+      APPLE_DEVELOPER_CERTIFICATE_PASSWORD:
+        required: true
+      APPLE_SIGNING_IDENTITY:
+        required: true
+      APP_STORE_CONNECT_API_KEY:
+        required: true
+      APP_STORE_CONNECT_API_KEY_ID:
+        required: true
+      APP_STORE_CONNECT_ISSUER_ID:
+        required: true
+      APPLE_TEAM_ID:
+        required: true
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: true
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: true
+      CRABNEBULA_CLOUD_API_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -37,7 +37,7 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: v${{ inputs.version }}
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create GitHub Release (Stable)
         if: ${{ !inputs.nightly }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ inputs.version }}
           name: Release v${{ inputs.version }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create GitHub Release (Nightly)
         if: ${{ inputs.nightly }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ inputs.version }}
           name: Nightly Build v${{ inputs.version }}
@@ -85,7 +85,7 @@ jobs:
       # Skip CrabNebula for nightly builds to prevent auto-updater from pushing unstable builds
       - name: Create CrabNebula Draft Release
         if: ${{ !inputs.nightly }}
-        uses: crabnebula-dev/cloud-release@v0.2.0
+        uses: crabnebula-dev/cloud-release@6889c5cd31fdc8c1d0b2f631bb6d53223db622bd # v0.2.0
         with:
           command: release draft thunderbird/thunderbolt ${{ inputs.version }}
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
@@ -118,25 +118,25 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: v${{ inputs.version }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 'lts/*'
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           toolchain: stable
           cache: false
           rustflags: ''
 
       - name: Cache cargo dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: |
             ~/.cargo/registry
@@ -316,7 +316,7 @@ jobs:
 
       - name: Upload Linux artifacts to GitHub Release
         if: matrix.os == 'ubuntu-24.04'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ inputs.version }}
           draft: true
@@ -329,7 +329,7 @@ jobs:
 
       - name: Upload Windows artifacts to GitHub Release
         if: matrix.os == 'windows-latest'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ inputs.version }}
           draft: true
@@ -349,7 +349,7 @@ jobs:
 
       - name: Upload macOS artifacts to GitHub Release
         if: matrix.os == 'macos-latest'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ inputs.version }}
           draft: true
@@ -364,7 +364,7 @@ jobs:
       # Skip CrabNebula for nightly builds
       - name: Upload to CrabNebula Cloud
         if: ${{ !inputs.nightly }}
-        uses: crabnebula-dev/cloud-release@v0.2.0
+        uses: crabnebula-dev/cloud-release@6889c5cd31fdc8c1d0b2f631bb6d53223db622bd # v0.2.0
         with:
           command: release upload thunderbird/thunderbolt ${{ inputs.version }} --framework tauri
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
@@ -374,14 +374,14 @@ jobs:
     needs: [draft, build]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: v${{ inputs.version }}
           fetch-depth: 0
 
       - name: Publish GitHub Release (Stable)
         if: ${{ !inputs.nightly }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ inputs.version }}
           draft: false
@@ -408,7 +408,7 @@ jobs:
 
       - name: Publish GitHub Release (Nightly)
         if: ${{ inputs.nightly }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ inputs.version }}
           draft: false
@@ -434,7 +434,7 @@ jobs:
       # Publish release on CrabNebula Cloud for auto-updates (skip for nightly to prevent unstable auto-updates)
       - name: Publish to CrabNebula Cloud
         if: ${{ !inputs.nightly }}
-        uses: crabnebula-dev/cloud-release@v0.2.0
+        uses: crabnebula-dev/cloud-release@6889c5cd31fdc8c1d0b2f631bb6d53223db622bd # v0.2.0
         with:
           command: release publish thunderbird/thunderbolt ${{ inputs.version }} --framework tauri
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@ concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,15 +21,15 @@ jobs:
       matrix:
         shard: [1/2, 2/2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.bun/install/cache
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload blob report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: blob-report-${{ strategy.job-index }}
           path: blob-report/
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload test screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-screenshots-${{ strategy.job-index }}
           path: test-results/
@@ -71,10 +71,10 @@ jobs:
     needs: e2e
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -82,7 +82,7 @@ jobs:
         run: bun install
 
       - name: Download blob reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: blob-report-*
           path: all-blob-reports
@@ -92,7 +92,7 @@ jobs:
         run: bunx playwright merge-reports --reporter html ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-report
           path: playwright-report/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,10 +39,10 @@ jobs:
             bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Install backend dependencies
-        run: cd backend && bun install
+        run: cd backend && bun install --frozen-lockfile
 
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
@@ -79,7 +79,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Download blob reports
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/enterprise-deploy.yml
+++ b/.github/workflows/enterprise-deploy.yml
@@ -32,6 +32,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 

--- a/.github/workflows/enterprise-deploy.yml
+++ b/.github/workflows/enterprise-deploy.yml
@@ -43,11 +43,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ inputs.region }}
@@ -63,7 +63,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
       - name: Deploy
-        uses: pulumi/actions@v6
+        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
         with:
           command: up
           stack-name: ${{ inputs.stack_name }}
@@ -83,11 +83,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ inputs.region }}
@@ -97,7 +97,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Destroy
-        uses: pulumi/actions@v6
+        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
         with:
           command: destroy
           stack-name: ${{ inputs.stack_name }}

--- a/.github/workflows/enterprise-publish.yml
+++ b/.github/workflows/enterprise-publish.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Generate CalVer tag
         id: version
@@ -33,7 +33,7 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
       # -- Build and push Docker images --
 
       - name: Build and push frontend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/docker/frontend.Dockerfile
@@ -55,7 +55,7 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/frontend:latest
 
       - name: Build and push backend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/docker/backend.Dockerfile
@@ -65,7 +65,7 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/backend:latest
 
       - name: Build and push postgres
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/docker/postgres.Dockerfile
@@ -75,7 +75,7 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/postgres:latest
 
       - name: Build and push keycloak
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/docker/keycloak.Dockerfile
@@ -85,7 +85,7 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/keycloak:latest
 
       - name: Build and push powersync
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/docker/powersync.Dockerfile

--- a/.github/workflows/enterprise-publish.yml
+++ b/.github/workflows/enterprise-publish.yml
@@ -10,6 +10,8 @@ on:
       - 'src/**'
       - 'package.json'
 
+permissions: {}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository }}

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -17,6 +17,21 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      APPLE_CERTIFICATE_P12:
+        required: true
+      APPLE_CERTIFICATE_PASSWORD:
+        required: true
+      APP_STORE_PROVISIONING_PROFILE:
+        required: true
+      APP_STORE_CONNECT_API_KEY:
+        required: true
+      APP_STORE_CONNECT_API_KEY_ID:
+        required: true
+      APP_STORE_CONNECT_ISSUER_ID:
+        required: true
+      APPLE_TEAM_ID:
+        required: true
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -68,6 +68,9 @@ concurrency:
   group: ios-release-${{ inputs.version }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_and_deploy_ios:
     if: ${{ !inputs.skip_build }}

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       # --- Line count (excludes tests, migrations, lockfiles) ---
       - name: Compute line count

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -16,15 +16,15 @@ jobs:
   metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.bun/install/cache
@@ -78,7 +78,7 @@ jobs:
 
       # --- Restore main baseline for deltas ---
       - name: Restore main baseline
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .metrics-baseline
           key: pr-metrics-main-${{ github.event.pull_request.base.sha }}
@@ -107,7 +107,7 @@ jobs:
       - name: Run Lighthouse
         id: lighthouse
         if: steps.preview.outputs.ready == 'true'
-        uses: treosh/lighthouse-ci-action@v12
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
           urls: ${{ steps.preview.outputs.url }}
           runs: 1
@@ -128,7 +128,7 @@ jobs:
 
       # --- Post or update the metrics comment ---
       - name: Post metrics comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           LINES_ADDED: ${{ steps.lines.outputs.added }}
           LINES_REMOVED: ${{ steps.lines.outputs.removed }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
   version_bump:
     name: Version Bump
     uses: ./.github/workflows/version-bump.yml
-    secrets: inherit
     with:
       platform: ${{ inputs.platform || 'all' }}
       version: ${{ inputs.version }}
@@ -55,7 +54,17 @@ jobs:
     needs: version_bump
     if: needs.version_bump.result == 'success' && (inputs.platform == 'all' || inputs.platform == 'desktop' || github.event_name == 'schedule')
     uses: ./.github/workflows/desktop-release.yml
-    secrets: inherit
+    secrets:
+      APPLE_DEVELOPER_CERTIFICATE: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE }}
+      APPLE_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      CRABNEBULA_CLOUD_API_KEY: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
     with:
       version: ${{ needs.version_bump.outputs.new_version }}
       nightly: ${{ github.event_name == 'schedule' }}
@@ -65,7 +74,14 @@ jobs:
     needs: version_bump
     if: needs.version_bump.result == 'success' && (inputs.platform == 'all' || inputs.platform == 'ios' || github.event_name == 'schedule')
     uses: ./.github/workflows/ios-release.yml
-    secrets: inherit
+    secrets:
+      APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APP_STORE_PROVISIONING_PROFILE: ${{ secrets.APP_STORE_PROVISIONING_PROFILE }}
+      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     with:
       version: ${{ needs.version_bump.outputs.new_version }}
       nightly: ${{ github.event_name == 'schedule' }}
@@ -75,7 +91,11 @@ jobs:
     needs: version_bump
     if: needs.version_bump.result == 'success' && (inputs.platform == 'all' || inputs.platform == 'android' || github.event_name == 'schedule')
     uses: ./.github/workflows/android-release.yml
-    secrets: inherit
+    secrets:
+      ANDROID_UPLOAD_KEY: ${{ secrets.ANDROID_UPLOAD_KEY }}
+      ANDROID_UPLOAD_KEY_ALIAS: ${{ secrets.ANDROID_UPLOAD_KEY_ALIAS }}
+      ANDROID_UPLOAD_KEY_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEY_PASSWORD }}
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
     with:
       version: ${{ needs.version_bump.outputs.new_version }}
       nightly: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,6 +15,9 @@ on:
           - macos-intel
           - linux
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ fromJSON('{"windows-arm":"windows-latest","windows-x64":"windows-latest","macos-silicon":"macos-latest","macos-intel":"macos-latest","linux":"ubuntu-24.04"}')[inputs.platform] }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -20,16 +20,16 @@ jobs:
     runs-on: ${{ fromJSON('{"windows-arm":"windows-latest","windows-x64":"windows-latest","macos-silicon":"macos-latest","macos-intel":"macos-latest","linux":"ubuntu-24.04"}')[inputs.platform] }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 'lts/*'
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install stable toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           toolchain: stable
           cache: false
@@ -80,7 +80,7 @@ jobs:
           CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER: ${{ inputs.platform == 'macos-intel' && 'clang' || '' }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.platform }}-build
           path: |

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -55,6 +55,9 @@ on:
         description: 'The tag name that was created'
         value: ${{ jobs.version_bump.outputs.tag_name }}
 
+permissions:
+  contents: write
+
 jobs:
   version_bump:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -111,10 +111,16 @@ jobs:
           NIGHTLY_VERSION="${BASE_VERSION}-nightly.$(date -u +%Y%m%d)"
           NIGHTLY_TAG="v${NIGHTLY_VERSION}"
 
-          # Update version files locally
-          node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='$NIGHTLY_VERSION';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
-          sed -i "s/^version = \".*\"/version = \"$NIGHTLY_VERSION\"/" src-tauri/Cargo.toml
-          node -e "const fs=require('fs'),c=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));c.version='$BASE_VERSION';fs.writeFileSync('src-tauri/tauri.conf.json',JSON.stringify(c,null,2)+'\n')"
+          # Validate version format to prevent injection via sed/shell
+          if ! [[ "$NIGHTLY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "❌ Invalid version format: $NIGHTLY_VERSION"
+            exit 1
+          fi
+
+          # Update version files locally (use env vars instead of string interpolation)
+          NIGHTLY_VERSION="$NIGHTLY_VERSION" node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version=process.env.NIGHTLY_VERSION;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          sed -i "s/^version = \".*\"/version = \"${NIGHTLY_VERSION}\"/" src-tauri/Cargo.toml
+          BASE_VERSION="$BASE_VERSION" node -e "const fs=require('fs'),c=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));c.version=process.env.BASE_VERSION;fs.writeFileSync('src-tauri/tauri.conf.json',JSON.stringify(c,null,2)+'\n')"
 
           # If a nightly tag for today already exists (re-run / manual trigger),
           # remove the old tag and its GitHub release so we can replace them.

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
           git config --local user.name "GitHub Action"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       # Regular releases: use existing create-release script
       - name: Run create-release script


### PR DESCRIPTION
## Summary

Hardens all GitHub Actions workflows for open-source readiness, preventing supply chain attacks, secret exfiltration, and privilege escalation from malicious pull requests.

- **Pin all third-party actions to commit SHAs** — Replaces mutable version tags (`@v1`, `@v2`) with immutable commit SHAs across all 14 workflows. Prevents supply chain attacks where a compromised action maintainer pushes malicious code to a tag.
- **Add `--frozen-lockfile` to PR workflow `bun install`** — Prevents malicious PRs from injecting dependencies via modified `bun.lock` with `postinstall` scripts in CI, E2E, and PR metrics workflows.
- **Replace `secrets: inherit` with explicit secret forwarding** — Each release platform workflow (desktop/iOS/Android) now declares and receives only the secrets it needs. Reduces blast radius — a compromised Android build can no longer access Apple signing keys.
- **Validate version strings before shell/sed usage** — Adds semver regex validation and replaces shell variable interpolation in `node -e` JavaScript strings with `process.env` access to prevent injection via crafted version inputs.
- **Add explicit permissions to all workflows** — Applies principle of least privilege with top-level `permissions:` blocks on all 10 workflows that were missing them. Workflows with job-level permissions get `permissions: {}` at the top to prevent default token privilege leakage.

## Test plan

- [ ] Verify CI workflows pass on this PR (ci.yml, e2e.yml, security.yml, pr-metrics.yml)
- [ ] Verify `workflow_dispatch` workflows still work (test-build, create-version-tag) — these use the same pinned action SHAs
- [ ] Confirm release workflow runs successfully on next release (explicit secrets must match repo secret names exactly)
- [ ] Spot-check that all pinned SHAs resolve to the expected action versions via `gh api repos/<owner>/<repo>/git/commits/<sha>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many GitHub Actions workflows (CI, release, deploy) and changes permissions/secret wiring; misconfiguration could break builds or releases despite being security-focused.
> 
> **Overview**
> **Hardens GitHub Actions workflows for supply-chain and token/secret least-privilege.** Third-party actions are pinned to immutable commit SHAs across workflows, and many workflows now set explicit top-level `permissions` (or `permissions: {}`) to avoid default token scopes.
> 
> Release workflows no longer use `secrets: inherit`; instead, `release.yml` forwards only the required secrets, and `android-release.yml`, `ios-release.yml`, and `desktop-release.yml` declare required `workflow_call` secrets.
> 
> CI/E2E/metrics installs now use `bun install --frozen-lockfile` to prevent lockfile drift in CI, and version/tag workflows add semver validation plus safer env-based `node -e` usage to reduce shell/sed injection risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03df65ea737d1cae505ee5cd32d93b0da4594d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->