### PR TITLE
fix(ci): add --frozen-lockfile to bun install in PR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Type check
         run: bun run tsc --noEmit
@@ -200,7 +200,7 @@ jobs:
       - name: Install backend dependencies
         run: |
           cd backend
-          bun install
+          bun install --frozen-lockfile
 
       - name: Type check backend
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,10 +39,10 @@ jobs:
             bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Install backend dependencies
-        run: cd backend && bun install
+        run: cd backend && bun install --frozen-lockfile
 
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
@@ -79,7 +79,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Download blob reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       # --- Line count (excludes tests, migrations, lockfiles) ---
       - name: Compute line count


### PR DESCRIPTION
## Summary

- Add `--frozen-lockfile` flag to all `bun install` commands in workflows triggered by `pull_request` events (ci.yml, e2e.yml, pr-metrics.yml)
- Prevents malicious PRs from modifying `bun.lock` to inject dependencies with `postinstall` scripts that could exfiltrate data or abuse CI resources
- With `--frozen-lockfile`, bun will fail if the lockfile would need to be updated, blocking lockfile injection attacks

## Test plan

- [ ] Verify CI, E2E, and PR metrics workflows still install dependencies successfully
- [ ] Confirm that a PR with a modified `bun.lock` that doesn't match `package.json` would fail the install step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just makes dependency installation stricter; the main impact is PR CI failing when `bun.lock` and manifests are out of sync.
> 
> **Overview**
> PR CI now runs `bun install --frozen-lockfile` instead of `bun install` across the `CI`, `E2E`, and `PR Metrics` GitHub Actions workflows (including backend installs).
> 
> This prevents workflows from updating `bun.lock` during runs and forces installs to match the committed lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d60c7ce65682eef94d5c3352bcbc176c3aba8aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->