### PR TITLE
ci: replace secrets: inherit with explicit secret forwarding

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -17,6 +17,15 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      ANDROID_UPLOAD_KEY:
+        required: true
+      ANDROID_UPLOAD_KEY_ALIAS:
+        required: true
+      ANDROID_UPLOAD_KEY_PASSWORD:
+        required: true
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:
+        required: true
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -13,6 +13,27 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      APPLE_DEVELOPER_CERTIFICATE:
+        required: true
+      APPLE_DEVELOPER_CERTIFICATE_PASSWORD:
+        required: true
+      APPLE_SIGNING_IDENTITY:
+        required: true
+      APP_STORE_CONNECT_API_KEY:
+        required: true
+      APP_STORE_CONNECT_API_KEY_ID:
+        required: true
+      APP_STORE_CONNECT_ISSUER_ID:
+        required: true
+      APPLE_TEAM_ID:
+        required: true
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: true
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: true
+      CRABNEBULA_CLOUD_API_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -17,6 +17,21 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      APPLE_CERTIFICATE_P12:
+        required: true
+      APPLE_CERTIFICATE_PASSWORD:
+        required: true
+      APP_STORE_PROVISIONING_PROFILE:
+        required: true
+      APP_STORE_CONNECT_API_KEY:
+        required: true
+      APP_STORE_CONNECT_API_KEY_ID:
+        required: true
+      APP_STORE_CONNECT_ISSUER_ID:
+        required: true
+      APPLE_TEAM_ID:
+        required: true
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
   version_bump:
     name: Version Bump
     uses: ./.github/workflows/version-bump.yml
-    secrets: inherit
     with:
       platform: ${{ inputs.platform || 'all' }}
       version: ${{ inputs.version }}
@@ -55,7 +54,17 @@ jobs:
     needs: version_bump
     if: needs.version_bump.result == 'success' && (inputs.platform == 'all' || inputs.platform == 'desktop' || github.event_name == 'schedule')
     uses: ./.github/workflows/desktop-release.yml
-    secrets: inherit
+    secrets:
+      APPLE_DEVELOPER_CERTIFICATE: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE }}
+      APPLE_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      CRABNEBULA_CLOUD_API_KEY: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
     with:
       version: ${{ needs.version_bump.outputs.new_version }}
       nightly: ${{ github.event_name == 'schedule' }}
@@ -65,7 +74,14 @@ jobs:
     needs: version_bump
     if: needs.version_bump.result == 'success' && (inputs.platform == 'all' || inputs.platform == 'ios' || github.event_name == 'schedule')
     uses: ./.github/workflows/ios-release.yml
-    secrets: inherit
+    secrets:
+      APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APP_STORE_PROVISIONING_PROFILE: ${{ secrets.APP_STORE_PROVISIONING_PROFILE }}
+      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     with:
       version: ${{ needs.version_bump.outputs.new_version }}
       nightly: ${{ github.event_name == 'schedule' }}
@@ -75,7 +91,11 @@ jobs:
     needs: version_bump
     if: needs.version_bump.result == 'success' && (inputs.platform == 'all' || inputs.platform == 'android' || github.event_name == 'schedule')
     uses: ./.github/workflows/android-release.yml
-    secrets: inherit
+    secrets:
+      ANDROID_UPLOAD_KEY: ${{ secrets.ANDROID_UPLOAD_KEY }}
+      ANDROID_UPLOAD_KEY_ALIAS: ${{ secrets.ANDROID_UPLOAD_KEY_ALIAS }}
+      ANDROID_UPLOAD_KEY_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEY_PASSWORD }}
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
     with:
       version: ${{ needs.version_bump.outputs.new_version }}
       nightly: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Summary

- Replace `secrets: inherit` in release.yml with explicit per-platform secret declarations
- Each downstream workflow (desktop, iOS, Android) now declares exactly which secrets it needs in its `on.workflow_call.secrets` block
- The parent release.yml passes only the secrets each platform actually uses
- Reduces blast radius — a compromised Android build can no longer access Apple signing keys, and vice versa
- version-bump.yml only uses `GITHUB_TOKEN` (automatic), so no secrets are forwarded to it

## Test plan

- [ ] Verify the next release workflow run succeeds (explicit secret names must exactly match repo secret names)
- [ ] Confirm each platform workflow only receives its own secrets by reviewing the `secrets:` blocks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release pipeline secret scoping; main risk is misnamed/missing secrets causing release workflows to fail at runtime, but logic is otherwise straightforward.
> 
> **Overview**
> **Tightens secret exposure in the release pipeline** by removing `secrets: inherit` from `release.yml` and explicitly forwarding only the per-platform secrets needed by `desktop-release.yml`, `ios-release.yml`, and `android-release.yml`.
> 
> Each called workflow now declares its required secrets under `on.workflow_call.secrets`, so GitHub validates secret presence and prevents other platform jobs from accessing unrelated signing/upload credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795b6d052e70397a166cb1f47ba4f84b33ed4b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->