### PR TITLE
fix(ci): validate version strings and prevent shell/JS injection

### DIFF
--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -107,6 +107,12 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.new_version.outputs.new_version }}
         run: |
+          # Validate version format to prevent injection via sed/shell
+          if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "❌ Invalid version format: $NEW_VERSION"
+            exit 1
+          fi
+
           echo "📝 Updating version files to $NEW_VERSION"
 
           # Update package.json

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -111,10 +111,16 @@ jobs:
           NIGHTLY_VERSION="${BASE_VERSION}-nightly.$(date -u +%Y%m%d)"
           NIGHTLY_TAG="v${NIGHTLY_VERSION}"
 
-          # Update version files locally
-          node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='$NIGHTLY_VERSION';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
-          sed -i "s/^version = \".*\"/version = \"$NIGHTLY_VERSION\"/" src-tauri/Cargo.toml
-          node -e "const fs=require('fs'),c=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));c.version='$BASE_VERSION';fs.writeFileSync('src-tauri/tauri.conf.json',JSON.stringify(c,null,2)+'\n')"
+          # Validate version format to prevent injection via sed/shell
+          if ! [[ "$NIGHTLY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "❌ Invalid version format: $NIGHTLY_VERSION"
+            exit 1
+          fi
+
+          # Update version files locally (use env vars instead of string interpolation)
+          NIGHTLY_VERSION="$NIGHTLY_VERSION" node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version=process.env.NIGHTLY_VERSION;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          sed -i "s/^version = \".*\"/version = \"${NIGHTLY_VERSION}\"/" src-tauri/Cargo.toml
+          BASE_VERSION="$BASE_VERSION" node -e "const fs=require('fs'),c=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));c.version=process.env.BASE_VERSION;fs.writeFileSync('src-tauri/tauri.conf.json',JSON.stringify(c,null,2)+'\n')"
 
           # If a nightly tag for today already exists (re-run / manual trigger),
           # remove the old tag and its GitHub release so we can replace them.


### PR DESCRIPTION
## Summary

- Add semver regex validation (`^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$`) before version strings are used in `sed` commands or shell operations in create-version-tag.yml and version-bump.yml
- Replace direct shell variable interpolation in `node -e` JavaScript strings (e.g., `p.version='$VAR'`) with `process.env` access to prevent string injection attacks via crafted version inputs
- While these workflows are only triggered by `workflow_dispatch` (not PRs), defense in depth protects against privilege escalation if a maintainer account is compromised

## Test plan

- [ ] Verify `create-version-tag` workflow still works with a valid version like `1.2.3`
- [ ] Verify nightly version format (`1.2.3-nightly.20260414`) passes validation
- [ ] Confirm invalid version strings (e.g., containing `/`, `'`, or shell metacharacters) are rejected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI release/tagging workflows; while changes are small and defensive, a bad regex or env handling could block version bumps or nightly tag creation.
> 
> **Overview**
> Adds **semver-style validation** for computed/provided version strings in `create-version-tag.yml` and the nightly path of `version-bump.yml` before using them in `sed`/shell operations.
> 
> Hardens the nightly workflow by **removing JS string interpolation** inside `node -e` snippets and instead passing values via environment variables (`process.env.*`), reducing risk of shell/JS injection from crafted version inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950577e6d558535700747bd5624c712ed581e5e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->