### PR TITLE
fix: add 60-second buffer to Microsoft token refresh to prevent expiry race

### DIFF
--- a/src/integrations/microsoft/tools.test.ts
+++ b/src/integrations/microsoft/tools.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test'
+import { isTokenFresh } from './tools'
+
+describe('isTokenFresh', () => {
+  const now = 1_700_000_000_000
+
+  it('returns true when token has more than 60 seconds until expiry', () => {
+    const expiresAt = now + 120_000
+    expect(isTokenFresh(expiresAt, now)).toBe(true)
+  })
+
+  it('returns false when token has less than 60 seconds until expiry', () => {
+    const expiresAt = now + 30_000
+    expect(isTokenFresh(expiresAt, now)).toBe(false)
+  })
+
+  it('returns false when token has exactly 60 seconds until expiry', () => {
+    const expiresAt = now + 60_000
+    expect(isTokenFresh(expiresAt, now)).toBe(false)
+  })
+
+  it('returns true when token has 61 seconds until expiry', () => {
+    const expiresAt = now + 61_000
+    expect(isTokenFresh(expiresAt, now)).toBe(true)
+  })
+
+  it('returns false when token is already expired', () => {
+    const expiresAt = now - 10_000
+    expect(isTokenFresh(expiresAt, now)).toBe(false)
+  })
+
+  it('returns false when expires_at is undefined', () => {
+    expect(isTokenFresh(undefined, now)).toBe(false)
+  })
+})

--- a/src/integrations/microsoft/tools.ts
+++ b/src/integrations/microsoft/tools.ts
@@ -157,32 +157,39 @@ const getMicrosoftCredentials = async () => {
   }
 }
 
+/**
+ * Check whether a token is still valid with a 60-second safety buffer.
+ * Returns true when the token can be reused without refreshing.
+ */
+export const isTokenFresh = (expiresAt: number | undefined, now: number): boolean =>
+  expiresAt !== undefined && expiresAt - 60_000 > now
+
 /** Refresh access token if needed */
 const ensureValidToken = async (
   httpClient: HttpClient,
   credentials: { access_token: string; refresh_token: string; expires_at?: number },
 ) => {
   const now = Date.now()
-  if (credentials.expires_at && credentials.expires_at < now) {
-    if (!credentials.refresh_token) {
-      throw new Error('Access token expired and no refresh token available')
-    }
-
-    const { refreshAccessToken } = await import('@/lib/auth')
-    const newTokens = await refreshAccessToken(httpClient, 'microsoft', credentials.refresh_token)
-    const updated = {
-      ...credentials,
-      access_token: newTokens.access_token,
-      expires_at: Date.now() + newTokens.expires_in * 1000,
-    }
-
-    const db = getDb()
-    await updateSettings(db, { integrations_microsoft_credentials: JSON.stringify(updated) })
-
-    return newTokens.access_token
+  if (isTokenFresh(credentials.expires_at, now)) {
+    return credentials.access_token
   }
 
-  return credentials.access_token
+  if (!credentials.refresh_token) {
+    throw new Error('Access token expired and no refresh token available')
+  }
+
+  const { refreshAccessToken } = await import('@/lib/auth')
+  const newTokens = await refreshAccessToken(httpClient, 'microsoft', credentials.refresh_token)
+  const updated = {
+    ...credentials,
+    access_token: newTokens.access_token,
+    expires_at: Date.now() + newTokens.expires_in * 1000,
+  }
+
+  const db = getDb()
+  await updateSettings(db, { integrations_microsoft_credentials: JSON.stringify(updated) })
+
+  return newTokens.access_token
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Microsoft's `ensureValidToken` checked `expires_at < now` (exact expiry), while Google's equivalent uses a 60-second buffer (`expires_at - 60_000 > now`). Without the buffer, tokens could expire between the freshness check and the actual API call due to network latency or clock skew, causing intermittent 401 errors.
- Extracted a pure `isTokenFresh` helper that applies the 60-second safety buffer, aligning Microsoft token refresh logic with the Google pattern.
- Also fixes the case where `expires_at` is `undefined` — previously the token was reused without verification; now it triggers a refresh (matching Google's behavior).

## Test plan

- [x] `isTokenFresh` returns `true` for tokens with >60s remaining
- [x] `isTokenFresh` returns `false` for tokens with <60s remaining
- [x] `isTokenFresh` returns `false` at exactly the 60s boundary
- [x] `isTokenFresh` returns `false` for already-expired tokens
- [x] `isTokenFresh` returns `false` when `expires_at` is `undefined`
- [x] All tests pass 5x consecutively for stability
- [x] TypeScript type-check passes

Closes THU-375 #4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Microsoft credential refresh logic and when stored tokens are reused, which can affect authentication reliability and potentially increase refresh frequency if miscomputed.
> 
> **Overview**
> Adds a pure `isTokenFresh` helper that applies a **60-second expiry buffer** and updates Microsoft `ensureValidToken` to reuse the access token only when it is safely valid; otherwise it refreshes (including when `expires_at` is missing) and persists updated credentials.
> 
> Introduces Bun tests covering the >60s, <60s, boundary, expired, and `undefined` expiry cases to prevent regressions in token freshness behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982de3b030411f68161374222af5ddb6589f4839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->