### PR TITLE
fix: replace GPL-licensed tauri-plugin-m3 with native Tauri commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,6 @@
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
-        "tauri-plugin-m3": "^0.2.2",
         "uuid": "^11.1.0",
         "web-haptics": "^0.0.6",
         "zod": "^4.0.17",
@@ -1897,8 +1896,6 @@
 
     "tar": ["tar@7.5.1", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g=="],
 
-    "tauri-plugin-m3": ["tauri-plugin-m3@0.2.2", "", { "dependencies": { "@tauri-apps/api": "2.8" } }, "sha512-soFyj24kKAXdlck9cURxngO2pRw0zx5vF7alDGYTc/AxGQFVTGhmxxyVJBshZGZPDzGq7JYmp2wYgepIN0OerQ=="],
-
     "test-exclude": ["test-exclude@7.0.1", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^9.0.4" } }, "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg=="],
 
     "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
@@ -2230,8 +2227,6 @@
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "tauri-plugin-m3/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
 
     "test-exclude/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "tauri-plugin-m3": "^0.2.2",
+
     "uuid": "^11.1.0",
     "web-haptics": "^0.0.6",
     "zod": "^4.0.17",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4742,18 +4742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-m3"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeac0af6bfde596e60db4d1a6757817a84d497982d441f450a83e3de1e08d542"
-dependencies = [
- "serde",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5056,7 +5044,6 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-haptics",
  "tauri-plugin-http",
- "tauri-plugin-m3",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,8 +46,6 @@ tauri-plugin-devtools = "2.0.1"
 tauri-plugin-http = "2.5.4"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-fs = "2.4.4"
-tauri-plugin-m3 = "0.2.2"
-
 tauri-plugin-deep-link = "2.3"
 tauri-plugin-haptics = "2.3"
 tauri-plugin-updater = "2.3"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,11 @@
 fn main() {
-    tauri_build::build()
+    tauri_build::try_build(
+        tauri_build::Attributes::new().plugin(
+            "platform-utils",
+            tauri_build::InlinedPlugin::new()
+                .commands(&["get_android_insets", "set_bar_color"])
+                .default_permission(tauri_build::DefaultPermissionRule::AllowAllCommands),
+        ),
+    )
+    .expect("failed to run tauri-build");
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -28,7 +28,7 @@
     "core:window:allow-destroy",
     "process:allow-exit",
     "process:allow-restart",
-    "m3:default",
+
     {
       "identifier": "http:default",
       "allow": [

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -28,7 +28,7 @@
     "core:window:allow-destroy",
     "process:allow-exit",
     "process:allow-restart",
-
+    "platform-utils:default",
     {
       "identifier": "http:default",
       "allow": [

--- a/src-tauri/gen/android/app/src/main/java/net/thunderbird/thunderbolt/PlatformUtilsPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/net/thunderbird/thunderbolt/PlatformUtilsPlugin.kt
@@ -2,7 +2,6 @@ package net.thunderbird.thunderbolt
 
 import android.app.Activity
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import app.tauri.annotation.Command

--- a/src-tauri/gen/android/app/src/main/java/net/thunderbird/thunderbolt/PlatformUtilsPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/net/thunderbird/thunderbolt/PlatformUtilsPlugin.kt
@@ -15,40 +15,44 @@ class PlatformUtilsPlugin(private val activity: Activity) : Plugin(activity) {
 
     @Command
     fun getAndroidInsets(invoke: Invoke) {
-        val rootView = activity.window.decorView
-        val insets = ViewCompat.getRootWindowInsets(rootView)
+        activity.runOnUiThread {
+            val rootView = activity.window.decorView
+            val insets = ViewCompat.getRootWindowInsets(rootView)
 
-        if (insets == null) {
-            invoke.resolve()
-            return
+            if (insets == null) {
+                invoke.resolve()
+                return@runOnUiThread
+            }
+
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val density = activity.resources.displayMetrics.density
+
+            val result = JSObject()
+            result.put("adjustedInsetTop", (systemBars.top / density).toDouble())
+            result.put("adjustedInsetBottom", (systemBars.bottom / density).toDouble())
+            invoke.resolve(result)
         }
-
-        val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-        val density = activity.resources.displayMetrics.density
-
-        val result = JSObject()
-        result.put("adjustedInsetTop", (systemBars.top / density).toDouble())
-        result.put("adjustedInsetBottom", (systemBars.bottom / density).toDouble())
-        invoke.resolve(result)
     }
 
     @Command
     fun setBarColor(invoke: Invoke) {
-        val style = invoke.getString("style") ?: "system"
-        val window = activity.window
-        val controller = WindowInsetsControllerCompat(window, window.decorView)
+        activity.runOnUiThread {
+            val style = invoke.getString("style") ?: "system"
+            val window = activity.window
+            val controller = WindowInsetsControllerCompat(window, window.decorView)
 
-        when (style) {
-            "dark" -> {
-                controller.isAppearanceLightStatusBars = true
-                controller.isAppearanceLightNavigationBars = true
+            when (style) {
+                "dark" -> {
+                    controller.isAppearanceLightStatusBars = true
+                    controller.isAppearanceLightNavigationBars = true
+                }
+                "light" -> {
+                    controller.isAppearanceLightStatusBars = false
+                    controller.isAppearanceLightNavigationBars = false
+                }
             }
-            "light" -> {
-                controller.isAppearanceLightStatusBars = false
-                controller.isAppearanceLightNavigationBars = false
-            }
+
+            invoke.resolve()
         }
-
-        invoke.resolve()
     }
 }

--- a/src-tauri/gen/android/app/src/main/java/net/thunderbird/thunderbolt/PlatformUtilsPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/net/thunderbird/thunderbolt/PlatformUtilsPlugin.kt
@@ -1,0 +1,55 @@
+package net.thunderbird.thunderbolt
+
+import android.app.Activity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import app.tauri.annotation.Command
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSObject
+import app.tauri.plugin.Plugin
+
+@TauriPlugin
+class PlatformUtilsPlugin(private val activity: Activity) : Plugin(activity) {
+
+    @Command
+    fun getAndroidInsets(invoke: Invoke) {
+        val rootView = activity.window.decorView
+        val insets = ViewCompat.getRootWindowInsets(rootView)
+
+        if (insets == null) {
+            invoke.resolve()
+            return
+        }
+
+        val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+        val density = activity.resources.displayMetrics.density
+
+        val result = JSObject()
+        result.put("adjustedInsetTop", (systemBars.top / density).toDouble())
+        result.put("adjustedInsetBottom", (systemBars.bottom / density).toDouble())
+        invoke.resolve(result)
+    }
+
+    @Command
+    fun setBarColor(invoke: Invoke) {
+        val style = invoke.getString("style") ?: "system"
+        val window = activity.window
+        val controller = WindowInsetsControllerCompat(window, window.decorView)
+
+        when (style) {
+            "dark" -> {
+                controller.isAppearanceLightStatusBars = true
+                controller.isAppearanceLightNavigationBars = true
+            }
+            "light" -> {
+                controller.isAppearanceLightStatusBars = false
+                controller.isAppearanceLightNavigationBars = false
+            }
+        }
+
+        invoke.resolve()
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -66,55 +66,6 @@ pub fn set_interface_style(style: String) -> Result<(), String> {
     Ok(())
 }
 
-// === Android bar color & insets ===============================================================
-
-/// Set the Android status bar and navigation bar icon appearance.
-/// style: "dark" (dark icons on light bg) | "light" (light icons on dark bg)
-/// No-op on non-Android platforms.
-#[command]
-pub fn set_bar_color(style: String) -> Result<(), String> {
-    #[cfg(target_os = "android")]
-    {
-        // Android implementation is handled via the Kotlin plugin bridge.
-        // For now this is a placeholder — the Kotlin side will be wired up
-        // when android-specific native code is added.
-        let _ = style;
-    }
-
-    #[cfg(not(target_os = "android"))]
-    {
-        let _ = style;
-    }
-
-    Ok(())
-}
-
-/// Returns the Android edge-to-edge display insets (safe area padding).
-/// Returns null on non-Android platforms.
-#[derive(Serialize)]
-pub struct AndroidInsets {
-    #[serde(rename = "adjustedInsetTop")]
-    pub adjusted_inset_top: f64,
-    #[serde(rename = "adjustedInsetBottom")]
-    pub adjusted_inset_bottom: f64,
-}
-
-#[command]
-pub fn get_android_insets() -> Option<AndroidInsets> {
-    #[cfg(target_os = "android")]
-    {
-        // Android implementation is handled via the Kotlin plugin bridge.
-        // For now this is a placeholder — the Kotlin side will be wired up
-        // when android-specific native code is added.
-        None
-    }
-
-    #[cfg(not(target_os = "android"))]
-    {
-        None
-    }
-}
-
 // === Capabilities ============================================================================
 
 /// List of runtime capabilities that the renderer can query once and cache.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -66,6 +66,55 @@ pub fn set_interface_style(style: String) -> Result<(), String> {
     Ok(())
 }
 
+// === Android bar color & insets ===============================================================
+
+/// Set the Android status bar and navigation bar icon appearance.
+/// style: "dark" (dark icons on light bg) | "light" (light icons on dark bg)
+/// No-op on non-Android platforms.
+#[command]
+pub fn set_bar_color(style: String) -> Result<(), String> {
+    #[cfg(target_os = "android")]
+    {
+        // Android implementation is handled via the Kotlin plugin bridge.
+        // For now this is a placeholder — the Kotlin side will be wired up
+        // when android-specific native code is added.
+        let _ = style;
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = style;
+    }
+
+    Ok(())
+}
+
+/// Returns the Android edge-to-edge display insets (safe area padding).
+/// Returns null on non-Android platforms.
+#[derive(Serialize)]
+pub struct AndroidInsets {
+    #[serde(rename = "adjustedInsetTop")]
+    pub adjusted_inset_top: f64,
+    #[serde(rename = "adjustedInsetBottom")]
+    pub adjusted_inset_bottom: f64,
+}
+
+#[command]
+pub fn get_android_insets() -> Option<AndroidInsets> {
+    #[cfg(target_os = "android")]
+    {
+        // Android implementation is handled via the Kotlin plugin bridge.
+        // For now this is a placeholder — the Kotlin side will be wired up
+        // when android-specific native code is added.
+        None
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        None
+    }
+}
+
 // === Capabilities ============================================================================
 
 /// List of runtime capabilities that the renderer can query once and cache.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,7 +33,6 @@ pub fn create_app() -> tauri::Builder<tauri::Wry> {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
-        .plugin(tauri_plugin_m3::init())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_haptics::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -42,6 +41,8 @@ pub fn create_app() -> tauri::Builder<tauri::Wry> {
             commands::toggle_dock_icon,
             commands::capabilities,
             commands::set_interface_style,
+            commands::set_bar_color,
+            commands::get_android_insets,
             commands::start_oauth_server,
         ]);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 #[allow(dead_code)]
 pub mod commands;
 pub mod oauth_server;
+pub mod platform_utils;
 
 use tauri::Manager;
 
@@ -37,12 +38,11 @@ pub fn create_app() -> tauri::Builder<tauri::Wry> {
         .plugin(tauri_plugin_haptics::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::default().build())
+        .plugin(platform_utils::init())
         .invoke_handler(tauri::generate_handler![
             commands::toggle_dock_icon,
             commands::capabilities,
             commands::set_interface_style,
-            commands::set_bar_color,
-            commands::get_android_insets,
             commands::start_oauth_server,
         ]);
 

--- a/src-tauri/src/platform_utils.rs
+++ b/src-tauri/src/platform_utils.rs
@@ -1,0 +1,40 @@
+use serde::Serialize;
+use tauri::{command, plugin::Builder, plugin::TauriPlugin, Runtime};
+
+#[derive(Serialize)]
+pub struct AndroidInsets {
+    #[serde(rename = "adjustedInsetTop")]
+    pub adjusted_inset_top: f64,
+    #[serde(rename = "adjustedInsetBottom")]
+    pub adjusted_inset_bottom: f64,
+}
+
+/// Returns Android edge-to-edge display insets. On Android this is overridden by
+/// the Kotlin PlatformUtilsPlugin which reads real WindowInsetsCompat values.
+/// On desktop/iOS this Rust fallback returns None.
+#[command]
+fn get_android_insets() -> Option<AndroidInsets> {
+    None
+}
+
+/// Sets Android status/navigation bar icon appearance. On Android this is
+/// overridden by the Kotlin PlatformUtilsPlugin which calls
+/// WindowInsetsControllerCompat. On desktop/iOS this Rust fallback is a no-op.
+#[command]
+fn set_bar_color(style: String) -> Result<(), String> {
+    let _ = style;
+    Ok(())
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    let builder = Builder::new("platform-utils")
+        .invoke_handler(tauri::generate_handler![get_android_insets, set_bar_color]);
+
+    #[cfg(target_os = "android")]
+    let builder = builder.setup(|_app, api| {
+        api.register_android_plugin("net.thunderbird.thunderbolt", "PlatformUtilsPlugin")?;
+        Ok(())
+    });
+
+    builder.build()
+}

--- a/src/hooks/use-safe-area-inset.test.ts
+++ b/src/hooks/use-safe-area-inset.test.ts
@@ -63,6 +63,31 @@ describe('useSafeAreaInset', () => {
     document.documentElement.style.removeProperty('--safe-area-bottom-padding')
   })
 
+  it('sets CSS var defaults synchronously before async insets resolve', () => {
+    let resolve: (v: { adjustedInsetTop: number; adjustedInsetBottom: number }) => void
+    const pending = new Promise<{ adjustedInsetTop: number; adjustedInsetBottom: number }>((r) => {
+      resolve = r
+    })
+
+    renderHook(() =>
+      useSafeAreaInset({
+        isTauri: () => true,
+        getInsets: () => pending,
+      }),
+    )
+
+    // Before the promise resolves, CSS vars should already have defaults (not be empty)
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe(
+      'env(safe-area-inset-top, 24px)',
+    )
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe(
+      'env(safe-area-inset-bottom, 24px)',
+    )
+
+    // Clean up the pending promise
+    resolve!({ adjustedInsetTop: 0, adjustedInsetBottom: 0 })
+  })
+
   it('sets CSS vars from insets when running in Tauri', async () => {
     renderHook(() =>
       useSafeAreaInset({

--- a/src/hooks/use-safe-area-inset.test.ts
+++ b/src/hooks/use-safe-area-inset.test.ts
@@ -1,0 +1,141 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { createCSSVars, useSafeAreaInset } from './use-safe-area-inset'
+import { getClock } from '@/testing-library'
+
+describe('createCSSVars', () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--safe-area-top-padding')
+    document.documentElement.style.removeProperty('--safe-area-bottom-padding')
+  })
+
+  it('sets CSS vars to pixel values when insets are positive', () => {
+    createCSSVars({ top: 48, bottom: 24 })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe('48px')
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe('24px')
+  })
+
+  it('falls back to env(safe-area-inset-*) when insets are zero', () => {
+    createCSSVars({ top: 0, bottom: 0 })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe(
+      'env(safe-area-inset-top, 24px)',
+    )
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe(
+      'env(safe-area-inset-bottom, 24px)',
+    )
+  })
+
+  it('falls back to env() when only top is zero', () => {
+    createCSSVars({ top: 0, bottom: 16 })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe(
+      'env(safe-area-inset-top, 24px)',
+    )
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe('16px')
+  })
+
+  it('falls back to env() when only bottom is zero', () => {
+    createCSSVars({ top: 32, bottom: 0 })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe('32px')
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe(
+      'env(safe-area-inset-bottom, 24px)',
+    )
+  })
+
+  it('falls back to env() when insets are negative', () => {
+    createCSSVars({ top: -1, bottom: -5 })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe(
+      'env(safe-area-inset-top, 24px)',
+    )
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe(
+      'env(safe-area-inset-bottom, 24px)',
+    )
+  })
+})
+
+describe('useSafeAreaInset', () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--safe-area-top-padding')
+    document.documentElement.style.removeProperty('--safe-area-bottom-padding')
+  })
+
+  it('sets CSS vars from insets when running in Tauri', async () => {
+    renderHook(() =>
+      useSafeAreaInset({
+        isTauri: () => true,
+        getInsets: () => Promise.resolve({ adjustedInsetTop: 44, adjustedInsetBottom: 20 }),
+      }),
+    )
+
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe('44px')
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe('20px')
+  })
+
+  it('falls back to env() when getInsets returns null', async () => {
+    renderHook(() =>
+      useSafeAreaInset({
+        isTauri: () => true,
+        getInsets: () => Promise.resolve(null),
+      }),
+    )
+
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe(
+      'env(safe-area-inset-top, 24px)',
+    )
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe(
+      'env(safe-area-inset-bottom, 24px)',
+    )
+  })
+
+  it('falls back to env() when getInsets rejects', async () => {
+    renderHook(() =>
+      useSafeAreaInset({
+        isTauri: () => true,
+        getInsets: () => Promise.reject(new Error('not android')),
+      }),
+    )
+
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe(
+      'env(safe-area-inset-top, 24px)',
+    )
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe(
+      'env(safe-area-inset-bottom, 24px)',
+    )
+  })
+
+  it('sets CSS vars to env() fallback when not running in Tauri', async () => {
+    renderHook(() =>
+      useSafeAreaInset({
+        isTauri: () => false,
+        getInsets: () => Promise.reject(new Error('should not be called')),
+      }),
+    )
+
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    expect(document.documentElement.style.getPropertyValue('--safe-area-top-padding')).toBe(
+      'env(safe-area-inset-top, 24px)',
+    )
+    expect(document.documentElement.style.getPropertyValue('--safe-area-bottom-padding')).toBe(
+      'env(safe-area-inset-bottom, 24px)',
+    )
+  })
+})

--- a/src/hooks/use-safe-area-inset.ts
+++ b/src/hooks/use-safe-area-inset.ts
@@ -37,7 +37,12 @@ export const useSafeAreaInset = (deps: SafeAreaInsetDeps = defaultDeps) => {
    * So in your CSS instead of using env(safe-area-inset-*) use can/should use var(--safe-area-top-padding) and var(--safe-area-bottom-padding).
    */
   useEffect(() => {
+    // Set defaults synchronously so CSS vars are never unset — components
+    // reference them without a CSS fallback (e.g. bare var(--safe-area-top-padding)).
+    createCSSVars({ bottom: 0, top: 0 })
+
     if (deps.isTauri()) {
+      // On Android, overwrite with real insets once the native call resolves.
       deps
         .getInsets()
         .then((insets) => {
@@ -47,15 +52,8 @@ export const useSafeAreaInset = (deps: SafeAreaInsetDeps = defaultDeps) => {
           })
         })
         .catch(() => {
-          createCSSVars({ bottom: 0, top: 0 })
+          // Already set to defaults above; nothing to do.
         })
-
-      return
     }
-
-    createCSSVars({
-      bottom: 0,
-      top: 0,
-    })
   }, [])
 }

--- a/src/hooks/use-safe-area-inset.ts
+++ b/src/hooks/use-safe-area-inset.ts
@@ -43,17 +43,17 @@ export const useSafeAreaInset = (deps: SafeAreaInsetDeps = defaultDeps) => {
 
     if (deps.isTauri()) {
       // On Android, overwrite with real insets once the native call resolves.
-      deps
-        .getInsets()
-        .then((insets) => {
+      ;(async () => {
+        try {
+          const insets = await deps.getInsets()
           createCSSVars({
             bottom: insets?.adjustedInsetBottom ?? 0,
             top: insets?.adjustedInsetTop ?? 0,
           })
-        })
-        .catch(() => {
+        } catch {
           // Already set to defaults above; nothing to do.
-        })
+        }
+      })()
     }
   }, [])
 }

--- a/src/hooks/use-safe-area-inset.ts
+++ b/src/hooks/use-safe-area-inset.ts
@@ -1,8 +1,23 @@
-import { isTauri } from '@/lib/platform'
+import { invoke } from '@tauri-apps/api/core'
 import { useEffect } from 'react'
-import { M3 } from 'tauri-plugin-m3'
+import { isTauri } from '@/lib/platform'
 
-const createCSSVars = (insets: { bottom: number; top: number }) => {
+type AndroidInsets = {
+  adjustedInsetTop: number
+  adjustedInsetBottom: number
+}
+
+type SafeAreaInsetDeps = {
+  isTauri: () => boolean
+  getInsets: () => Promise<AndroidInsets | null>
+}
+
+const defaultDeps: SafeAreaInsetDeps = {
+  isTauri,
+  getInsets: () => invoke<AndroidInsets | null>('get_android_insets'),
+}
+
+export const createCSSVars = (insets: { bottom: number; top: number }) => {
   document.documentElement.style.setProperty(
     '--safe-area-top-padding',
     insets?.top > 0 ? `${insets.top}px` : 'env(safe-area-inset-top, 24px)',
@@ -14,7 +29,7 @@ const createCSSVars = (insets: { bottom: number; top: number }) => {
   )
 }
 
-export const useSafeAreaInset = () => {
+export const useSafeAreaInset = (deps: SafeAreaInsetDeps = defaultDeps) => {
   /**
    * This hook sets the `--safe-area-top-padding` and `--safe-area-bottom-padding` CSS custom properties on the root `<html>` element.
    * On iOS env(safe-area-inset-*) works fine, but on Android it can fail due the edge-to-edge display.
@@ -22,15 +37,18 @@ export const useSafeAreaInset = () => {
    * So in your CSS instead of using env(safe-area-inset-*) use can/should use var(--safe-area-top-padding) and var(--safe-area-bottom-padding).
    */
   useEffect(() => {
-    if (isTauri()) {
-      M3.getInsets().then((insetsScheme) => {
-        const insets = insetsScheme || null
-
-        createCSSVars({
-          bottom: insets?.adjustedInsetBottom ?? 0,
-          top: insets?.adjustedInsetTop ?? 0,
+    if (deps.isTauri()) {
+      deps
+        .getInsets()
+        .then((insets) => {
+          createCSSVars({
+            bottom: insets?.adjustedInsetBottom ?? 0,
+            top: insets?.adjustedInsetTop ?? 0,
+          })
         })
-      })
+        .catch(() => {
+          createCSSVars({ bottom: 0, top: 0 })
+        })
 
       return
     }

--- a/src/hooks/use-safe-area-inset.ts
+++ b/src/hooks/use-safe-area-inset.ts
@@ -50,8 +50,8 @@ export const useSafeAreaInset = (deps: SafeAreaInsetDeps = defaultDeps) => {
             bottom: insets?.adjustedInsetBottom ?? 0,
             top: insets?.adjustedInsetTop ?? 0,
           })
-        } catch {
-          // Already set to defaults above; nothing to do.
+        } catch (e) {
+          console.info('Failed to get Android insets, using CSS env() defaults:', e)
         }
       })()
     }

--- a/src/hooks/use-safe-area-inset.ts
+++ b/src/hooks/use-safe-area-inset.ts
@@ -14,7 +14,7 @@ type SafeAreaInsetDeps = {
 
 const defaultDeps: SafeAreaInsetDeps = {
   isTauri,
-  getInsets: () => invoke<AndroidInsets | null>('get_android_insets'),
+  getInsets: () => invoke<AndroidInsets | null>('plugin:platform-utils|get_android_insets'),
 }
 
 export const createCSSVars = (insets: { bottom: number; top: number }) => {

--- a/src/lib/set-android-bar-color.test.ts
+++ b/src/lib/set-android-bar-color.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test'
+import { setAndroidBarColor } from './set-android-bar-color'
+
+describe('setAndroidBarColor', () => {
+  it('calls invoke with "set_bar_color" and style "dark" when Tauri', async () => {
+    let invokedWith: { command: string; args: Record<string, string> } | null = null
+
+    await setAndroidBarColor('dark', {
+      isTauri: () => true,
+      invoke: (cmd, args) => {
+        invokedWith = { command: cmd, args: args as Record<string, string> }
+        return Promise.resolve()
+      },
+    })
+
+    expect(invokedWith!).toEqual({ command: 'set_bar_color', args: { style: 'dark' } })
+  })
+
+  it('calls invoke with "set_bar_color" and style "light" when Tauri', async () => {
+    let invokedWith: { command: string; args: Record<string, string> } | null = null
+
+    await setAndroidBarColor('light', {
+      isTauri: () => true,
+      invoke: (cmd, args) => {
+        invokedWith = { command: cmd, args: args as Record<string, string> }
+        return Promise.resolve()
+      },
+    })
+
+    expect(invokedWith!).toEqual({ command: 'set_bar_color', args: { style: 'light' } })
+  })
+
+  it('does not call invoke when not running in Tauri', async () => {
+    let invokeCalled = false
+
+    await setAndroidBarColor('dark', {
+      isTauri: () => false,
+      invoke: () => {
+        invokeCalled = true
+        return Promise.resolve()
+      },
+    })
+
+    expect(invokeCalled).toBe(false)
+  })
+
+  it('does not throw when invoke rejects', async () => {
+    await setAndroidBarColor('dark', {
+      isTauri: () => true,
+      invoke: () => Promise.reject(new Error('not android')),
+    })
+
+    // Should not throw - errors are caught silently
+    expect(true).toBe(true)
+  })
+})

--- a/src/lib/set-android-bar-color.test.ts
+++ b/src/lib/set-android-bar-color.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { setAndroidBarColor } from './set-android-bar-color'
 
 describe('setAndroidBarColor', () => {
-  it('calls invoke with "set_bar_color" and style "dark" when Tauri', async () => {
+  it('calls invoke with plugin command and style "dark" when Tauri', async () => {
     let invokedWith: { command: string; args: Record<string, string> } | null = null
 
     await setAndroidBarColor('dark', {
@@ -13,10 +13,10 @@ describe('setAndroidBarColor', () => {
       },
     })
 
-    expect(invokedWith!).toEqual({ command: 'set_bar_color', args: { style: 'dark' } })
+    expect(invokedWith!).toEqual({ command: 'plugin:platform-utils|set_bar_color', args: { style: 'dark' } })
   })
 
-  it('calls invoke with "set_bar_color" and style "light" when Tauri', async () => {
+  it('calls invoke with plugin command and style "light" when Tauri', async () => {
     let invokedWith: { command: string; args: Record<string, string> } | null = null
 
     await setAndroidBarColor('light', {
@@ -27,7 +27,7 @@ describe('setAndroidBarColor', () => {
       },
     })
 
-    expect(invokedWith!).toEqual({ command: 'set_bar_color', args: { style: 'light' } })
+    expect(invokedWith!).toEqual({ command: 'plugin:platform-utils|set_bar_color', args: { style: 'light' } })
   })
 
   it('does not call invoke when not running in Tauri', async () => {
@@ -44,13 +44,14 @@ describe('setAndroidBarColor', () => {
     expect(invokeCalled).toBe(false)
   })
 
-  it('does not throw when invoke rejects', async () => {
-    await setAndroidBarColor('dark', {
+  it('propagates invoke errors (no silent catch)', async () => {
+    const error = new Error('command failed')
+
+    const promise = setAndroidBarColor('dark', {
       isTauri: () => true,
-      invoke: () => Promise.reject(new Error('not android')),
+      invoke: () => Promise.reject(error),
     })
 
-    // Should not throw - errors are caught silently
-    expect(true).toBe(true)
+    expect(promise).rejects.toThrow('command failed')
   })
 })

--- a/src/lib/set-android-bar-color.test.ts
+++ b/src/lib/set-android-bar-color.test.ts
@@ -52,6 +52,6 @@ describe('setAndroidBarColor', () => {
       invoke: () => Promise.reject(error),
     })
 
-    expect(promise).rejects.toThrow('command failed')
+    await expect(promise).rejects.toThrow('command failed')
   })
 })

--- a/src/lib/set-android-bar-color.ts
+++ b/src/lib/set-android-bar-color.ts
@@ -1,0 +1,27 @@
+import { invoke } from '@tauri-apps/api/core'
+import { isTauri } from './platform'
+
+type SetAndroidBarColorDeps = {
+  isTauri: () => boolean
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>
+}
+
+const defaultDeps: SetAndroidBarColorDeps = { isTauri, invoke }
+
+/**
+ * Sets the Android status bar and navigation bar icon appearance.
+ * @param style - "dark" for dark icons (use on light backgrounds), "light" for light icons (use on dark backgrounds)
+ */
+export const setAndroidBarColor = async (
+  style: 'dark' | 'light',
+  deps: SetAndroidBarColorDeps = defaultDeps,
+): Promise<void> => {
+  if (!deps.isTauri()) {
+    return
+  }
+  try {
+    await deps.invoke('set_bar_color', { style })
+  } catch {
+    // No-op on platforms that don't support this (desktop, iOS)
+  }
+}

--- a/src/lib/set-android-bar-color.ts
+++ b/src/lib/set-android-bar-color.ts
@@ -19,9 +19,5 @@ export const setAndroidBarColor = async (
   if (!deps.isTauri()) {
     return
   }
-  try {
-    await deps.invoke('set_bar_color', { style })
-  } catch {
-    // No-op on platforms that don't support this (desktop, iOS)
-  }
+  await deps.invoke('plugin:platform-utils|set_bar_color', { style })
 }

--- a/src/lib/theme-provider.tsx
+++ b/src/lib/theme-provider.tsx
@@ -1,7 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
-import { M3 } from 'tauri-plugin-m3'
 import { isTauri } from './platform'
+import { setAndroidBarColor } from './set-android-bar-color'
 
 /** Sync native UI (keyboard, system controls) with the resolved theme on iOS. */
 const syncNativeInterfaceStyle = (resolvedTheme: 'dark' | 'light') => {
@@ -80,9 +80,7 @@ export const ThemeProvider = ({
       root.style.backgroundColor = bgColor
       metaThemeColor?.setAttribute('content', bgColor)
 
-      if (isTauri()) {
-        M3.setBarColor(systemTheme === 'dark' ? 'light' : 'dark')
-      }
+      setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark')
       syncNativeInterfaceStyle(systemTheme)
 
       return
@@ -94,9 +92,7 @@ export const ThemeProvider = ({
     root.style.backgroundColor = bgColor
     metaThemeColor?.setAttribute('content', bgColor)
 
-    if (isTauri()) {
-      M3.setBarColor(theme === 'dark' ? 'light' : 'dark')
-    }
+    setAndroidBarColor(theme === 'dark' ? 'light' : 'dark')
     syncNativeInterfaceStyle(theme)
   }, [theme])
 
@@ -116,9 +112,7 @@ export const ThemeProvider = ({
         root.style.backgroundColor = bgColor
         metaThemeColor?.setAttribute('content', bgColor)
 
-        if (isTauri()) {
-          M3.setBarColor(systemTheme === 'dark' ? 'light' : 'dark')
-        }
+        setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark')
         syncNativeInterfaceStyle(systemTheme)
       }
     }

--- a/src/lib/theme-provider.tsx
+++ b/src/lib/theme-provider.tsx
@@ -112,7 +112,7 @@ export const ThemeProvider = ({
         root.style.backgroundColor = bgColor
         metaThemeColor?.setAttribute('content', bgColor)
 
-        setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark')
+        setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark').catch(console.error)
         syncNativeInterfaceStyle(systemTheme)
       }
     }

--- a/src/lib/theme-provider.tsx
+++ b/src/lib/theme-provider.tsx
@@ -80,7 +80,7 @@ export const ThemeProvider = ({
       root.style.backgroundColor = bgColor
       metaThemeColor?.setAttribute('content', bgColor)
 
-      setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark')
+      setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark').catch(console.error)
       syncNativeInterfaceStyle(systemTheme)
 
       return
@@ -92,7 +92,7 @@ export const ThemeProvider = ({
     root.style.backgroundColor = bgColor
     metaThemeColor?.setAttribute('content', bgColor)
 
-    setAndroidBarColor(theme === 'dark' ? 'light' : 'dark')
+    setAndroidBarColor(theme === 'dark' ? 'light' : 'dark').catch(console.error)
     syncNativeInterfaceStyle(theme)
   }, [theme])
 

--- a/src/lib/theme-provider.tsx
+++ b/src/lib/theme-provider.tsx
@@ -80,7 +80,7 @@ export const ThemeProvider = ({
       root.style.backgroundColor = bgColor
       metaThemeColor?.setAttribute('content', bgColor)
 
-      setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark').catch(console.error)
+      void setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark')
       syncNativeInterfaceStyle(systemTheme)
 
       return
@@ -92,7 +92,7 @@ export const ThemeProvider = ({
     root.style.backgroundColor = bgColor
     metaThemeColor?.setAttribute('content', bgColor)
 
-    setAndroidBarColor(theme === 'dark' ? 'light' : 'dark').catch(console.error)
+    void setAndroidBarColor(theme === 'dark' ? 'light' : 'dark')
     syncNativeInterfaceStyle(theme)
   }, [theme])
 
@@ -112,7 +112,7 @@ export const ThemeProvider = ({
         root.style.backgroundColor = bgColor
         metaThemeColor?.setAttribute('content', bgColor)
 
-        setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark').catch(console.error)
+        void setAndroidBarColor(systemTheme === 'dark' ? 'light' : 'dark')
         syncNativeInterfaceStyle(systemTheme)
       }
     }


### PR DESCRIPTION
## Summary

- **Removes `tauri-plugin-m3`** (GPL-3.0-only), which is incompatible with our MPL-2.0 license
- We only used 2 of its 4 APIs (`getInsets` for Android safe area padding, `setBarColor` for status/nav bar theming) — neither of which requires a third-party plugin
- Replaces them with native Tauri `invoke()` commands backed by lightweight Rust stubs that no-op on non-Android platforms
- Extracts `setAndroidBarColor` utility and refactors `useSafeAreaInset` with dependency injection for testability
- Adds 13 tests covering all code paths (createCSSVars, hook behavior, bar color utility)

## What changed

| File | Change |
|------|--------|
| `package.json` | Remove `tauri-plugin-m3` dependency |
| `src-tauri/Cargo.toml` | Remove `tauri-plugin-m3` crate |
| `src-tauri/src/lib.rs` | Remove plugin init, register new commands |
| `src-tauri/src/commands.rs` | Add `set_bar_color` and `get_android_insets` commands |
| `src-tauri/capabilities/default.json` | Remove `m3:default` permission |
| `src/hooks/use-safe-area-inset.ts` | Use `invoke()` instead of `M3.getInsets()`, export `createCSSVars`, accept DI deps |
| `src/lib/theme-provider.tsx` | Use `setAndroidBarColor()` instead of `M3.setBarColor()` |
| `src/lib/set-android-bar-color.ts` | New utility with DI support |

## Follow-up

The Rust commands are no-op placeholders on Android. When we build the Android release, we'll add ~50 lines of Kotlin calling `WindowInsetsCompat` and `WindowInsetsControllerCompat` to wire them up.

## Test plan

- [x] 13 new unit tests pass (createCSSVars, useSafeAreaInset hook, setAndroidBarColor)
- [x] Full test suite passes (2088 tests, 0 failures)
- [x] TypeScript type-check passes
- [x] Rust `cargo check` passes
- [ ] Verify web app still works (theme switching, no console errors)
- [ ] Verify desktop Tauri app still works (theme switching is a no-op for bar color, which is correct)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces a core mobile UI integration (safe-area insets and status/nav bar theming) with new Tauri plugin commands and Android-native implementation, which could regress Android layout/theme behavior if command wiring or permissions are misconfigured.
> 
> **Overview**
> Removes the GPL `tauri-plugin-m3` dependency from JS/Rust and replaces its used APIs with a new first-party Tauri plugin, `platform-utils`, exposing `get_android_insets` and `set_bar_color`.
> 
> Adds a Rust plugin module with desktop/iOS no-op fallbacks, wires it into the Tauri builder/build script and capabilities, and provides an Android Kotlin plugin implementation to read real window insets and toggle system bar icon appearance.
> 
> Refactors `useSafeAreaInset` to use `invoke()` (with synchronous CSS-var defaults and DI for testability) and introduces `setAndroidBarColor`, updating theme syncing to call it; includes new unit tests covering these paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df53276763b3c63c1e2f2bad102d265991b7e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->