### PR TITLE
chore: replace MongoDB with PostgreSQL for PowerSync bucket storage

### DIFF
--- a/powersync-service/config/config.yaml
+++ b/powersync-service/config/config.yaml
@@ -5,8 +5,9 @@ replication:
       sslmode: disable
 
 storage:
-  type: mongodb
-  uri: mongodb://mongo:27017/powersync_demo
+  type: postgresql
+  uri: postgresql://postgres:postgres@postgres:5432/powersync_storage
+  sslmode: disable
 
 port: 8080
 

--- a/powersync-service/docker-compose.yml
+++ b/powersync-service/docker-compose.yml
@@ -2,8 +2,6 @@ services:
   powersync:
     restart: unless-stopped
     depends_on:
-      mongo-rs-init:
-        condition: service_completed_successfully
       postgres:
         condition: service_healthy
     image: journeyapps/powersync-service:latest
@@ -35,25 +33,5 @@ services:
       timeout: 5s
       retries: 5
 
-  mongo:
-    image: mongo:7.0
-    command: --replSet rs0 --bind_ip_all --quiet
-    restart: unless-stopped
-    ports:
-      - 27017:27017
-    volumes:
-      - mongo_storage:/data/db
-
-  mongo-rs-init:
-    image: mongo:7.0
-    depends_on:
-      - mongo
-    restart: on-failure
-    entrypoint:
-      - bash
-      - -c
-      - 'mongosh --host mongo:27017 --eval ''try{rs.status().ok && quit(0)} catch {} rs.initiate({_id: "rs0", version: 1, members: [{ _id: 0, host : "mongo:27017" }]})'''
-
 volumes:
-  mongo_storage:
   pg_data:

--- a/powersync-service/init-db/01-powersync.sql
+++ b/powersync-service/init-db/01-powersync.sql
@@ -10,3 +10,7 @@ GRANT USAGE ON SCHEMA powersync TO powersync_role;
 GRANT SELECT ON ALL TABLES IN SCHEMA powersync TO powersync_role;
 ALTER DEFAULT PRIVILEGES IN SCHEMA powersync GRANT SELECT ON TABLES TO powersync_role;
 CREATE PUBLICATION powersync FOR ALL TABLES;
+
+-- Separate database for PowerSync bucket storage (avoids schema conflicts with app data).
+-- See https://docs.powersync.com/configuration/powersync-service/self-hosted-instances
+CREATE DATABASE powersync_storage OWNER postgres;


### PR DESCRIPTION
## Summary

- Replace MongoDB with PostgreSQL as the PowerSync Service bucket storage backend
- Remove the `mongo` and `mongo-rs-init` services from `docker-compose.yml`, along with the `mongo_storage` volume
- Create a dedicated `powersync_storage` database in the existing PostgreSQL instance via the init script
- Update `config.yaml` to use the `postgresql` storage type

This simplifies the self-hosted stack by eliminating the MongoDB dependency entirely — PowerSync Service now uses the same PostgreSQL instance as the app (in a separate database).

## Test plan

- [ ] Run `docker compose up` in `powersync-service/` and verify the service starts without errors
- [ ] Confirm PowerSync sync operations work end-to-end with the new PostgreSQL storage backend
- [ ] Verify no references to MongoDB remain in the running containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PowerSync bucket storage backend from MongoDB to PostgreSQL and modifies local stack initialization; misconfiguration or data-migration/compatibility issues could prevent sync/startup.
> 
> **Overview**
> PowerSync Service bucket storage is switched from MongoDB to PostgreSQL by updating `config.yaml` to use `storage.type: postgresql` pointing at a new `powersync_storage` database.
> 
> The local `docker-compose.yml` stack is simplified by removing the `mongo`/`mongo-rs-init` services and the `mongo_storage` volume, leaving only PowerSync and Postgres.
> 
> Postgres initialization now creates the dedicated `powersync_storage` database via `init-db/01-powersync.sql`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77afb6c348d36d398191dca76a199a02fbe685fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->