### PR TITLE
docs: fix powersync doc links + update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ We welcome contributions from everyone.
 ## Documentation
 
 - [FAQ](./docs/faq.md) - Frequently asked questions
+- [Deployment](./deploy/README.md) - Self-host with Docker Compose or Kubernetes
 - [Development](./docs/development.md) - Quick start, setup, and testing
 - [Architecture](./docs/architecture.md) - System architecture and diagrams
 - [Features and Roadmap](./docs/roadmap.md) - Platform and feature status

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,7 @@
 # Thunderbolt Deployment
 
+> ⚠️ **Under active development — not production ready.** Thunderbolt is currently undergoing a security audit and preparing for enterprise production readiness. These deployment paths are provided for evaluation and early testing. Do not use in production environments.
+
 Self-hosted Thunderbolt with OIDC authentication via Keycloak. Two deployment paths: Docker Compose for simplicity, Kubernetes for enterprise environments.
 
 ## Structure

--- a/docs/powersync-account-devices.md
+++ b/docs/powersync-account-devices.md
@@ -22,13 +22,13 @@ For the sync data transformation middleware and custom SharedWorker (E2E encrypt
 
 - Every synced table must have a **`user_id`** column (sync rules and backend scope by `user_id`).
 - Define the table in **both**:
-  - Frontend: [src/db/tables.ts](src/db/tables.ts) (SQLite)
-  - Backend: [backend/src/db/powersync-schema.ts](backend/src/db/powersync-schema.ts) (PostgreSQL)
+  - Frontend: [src/db/tables.ts](../src/db/tables.ts) (SQLite)
+  - Backend: [backend/src/db/powersync-schema.ts](../backend/src/db/powersync-schema.ts) (PostgreSQL)
 - **Backend schema uses minimal indexes**: Only primary keys and `user_id` indexes (see [Indexes and Foreign Keys](#indexes-and-foreign-keys) below).
 
 ### Current tables
 
-Defined in [shared/powersync-tables.ts](shared/powersync-tables.ts):
+Defined in [shared/powersync-tables.ts](../shared/powersync-tables.ts):
 
 `settings`, `chat_threads`, `chat_messages`, `tasks`, `models`, `mcp_servers`, `prompts`, `triggers`, `modes`, `model_profiles`, `devices`.
 
@@ -52,9 +52,9 @@ See [docs/composite-primary-keys-and-default-data.md](composite-primary-keys-and
 
 1. Create the table in both `src/db/tables.ts` and `backend/src/db/powersync-schema.ts` (include `user_id`).
 2. **Backend schema**: Add only a `user_id` index: `index('idx_[table]_user_id').on(table.userId)`. Do not add composite foreign keys or other indexes (see above).
-3. Register in [src/db/powersync/schema.ts](src/db/powersync/schema.ts) (`drizzleSchema`).
-4. Add the table name and query keys in [shared/powersync-tables.ts](shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` and `powersyncTableToQueryKeys`).
-5. Update [powersync-service/config/config.yaml](powersync-service/config/config.yaml): add a line under `sync_rules.content` → `bucket_definitions.user_data.data` (e.g. `- SELECT * FROM my_table WHERE my_table.user_id = bucket.user_id`).
+3. Register in [src/db/powersync/schema.ts](../src/db/powersync/schema.ts) (`drizzleSchema`).
+4. Add the table name and query keys in [shared/powersync-tables.ts](../shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` and `powersyncTableToQueryKeys`).
+5. Update [powersync-service/config/config.yaml](../powersync-service/config/config.yaml): add a line under `sync_rules.content` → `bucket_definitions.user_data.data` (e.g. `- SELECT * FROM my_table WHERE my_table.user_id = bucket.user_id`).
 6. Run migrations for frontend and backend as needed.
 
 ### PR flow for adding tables


### PR DESCRIPTION
- Paths were missing the `../` prefix needed to resolve from docs/
- Links now correctly point to repo-root files from within docs/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (links and warnings) with no impact on runtime behavior.
> 
> **Overview**
> Improves documentation navigation by adding a `Deployment` link to the main `README.md` docs list.
> 
> Updates `deploy/README.md` with a prominent *not production ready* warning for self-hosting paths.
> 
> Fixes broken relative links in `docs/powersync-account-devices.md` by adjusting repo-root references to use `../` so they resolve correctly from within `docs/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac101eac1efba3734eece2466217588a78fbde52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->