### PR TITLE
breaking: make waitlist var opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,7 @@
 # Thunderbolt Cloud URL (optional, defaults to http://localhost:8000)
 VITE_THUNDERBOLT_CLOUD_URL="http://localhost:8000/v1"
 
-# Bypass waitlist routes for UI development (set to "true" to skip waitlist)
-# Note: This only bypasses frontend routing, not backend auth
-# VITE_BYPASS_WAITLIST="true"
+VITE_BYPASS_WAITLIST="true"
 
 # Show app download links/banners in the web UI (set to "true" for internal testing deployments)
 # When enabled, desktop users see a sidebar section + bottom-right banner; mobile users see a top banner

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Thunderbolt Cloud URL (optional, defaults to http://localhost:8000)
 VITE_THUNDERBOLT_CLOUD_URL="http://localhost:8000/v1"
 
-VITE_BYPASS_WAITLIST="true"
+# Enable the waitlist gate (opt-in; leave unset to bypass the waitlist)
+# VITE_ENABLE_WAITLIST="true"
 
 # Show app download links/banners in the web UI (set to "true" for internal testing deployments)
 # When enabled, desktop users see a sidebar section + bottom-right banner; mobile users see a top banner

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -116,10 +116,10 @@ const AppRoutes = ({ initData }: { initData: InitData }) => {
         </Route>
       )}
 
-      {/* Main app routes - authenticated only (pass-through when waitlist disabled) */}
+      {/* Main app routes - authenticated only (pass-through when waitlist and OIDC both disabled) */}
       <Route
         element={
-          waitlistEnabled ? (
+          oidcMode || waitlistEnabled ? (
             <AuthGate require="authenticated" redirectTo={oidcMode ? '/oidc-redirect' : '/waitlist'} />
           ) : (
             <Outlet />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -87,7 +87,7 @@ const AppRoutes = ({ initData }: { initData: InitData }) => {
   })
 
   const oidcMode = isOidcMode()
-  const shouldBypassWaitlist = import.meta.env.VITE_BYPASS_WAITLIST === 'true' || isPrPreview()
+  const waitlistEnabled = import.meta.env.VITE_ENABLE_WAITLIST === 'true' && !isPrPreview()
 
   return (
     <Routes>
@@ -107,8 +107,8 @@ const AppRoutes = ({ initData }: { initData: InitData }) => {
         />
       )}
 
-      {/* Waitlist routes - unauthenticated only (skip when bypass or OIDC mode) */}
-      {!oidcMode && !shouldBypassWaitlist && (
+      {/* Waitlist routes - unauthenticated only (only when enabled and not OIDC mode) */}
+      {!oidcMode && waitlistEnabled && (
         <Route element={<AuthGate require="unauthenticated" redirectTo="/" />}>
           <Route path="waitlist" element={<WaitlistLayout />}>
             <Route index element={<WaitlistPage />} />
@@ -116,13 +116,13 @@ const AppRoutes = ({ initData }: { initData: InitData }) => {
         </Route>
       )}
 
-      {/* Main app routes - authenticated only (pass-through when bypass enabled) */}
+      {/* Main app routes - authenticated only (pass-through when waitlist disabled) */}
       <Route
         element={
-          shouldBypassWaitlist ? (
-            <Outlet />
-          ) : (
+          waitlistEnabled ? (
             <AuthGate require="authenticated" redirectTo={oidcMode ? '/oidc-redirect' : '/waitlist'} />
+          ) : (
+            <Outlet />
           )
         }
       >


### PR DESCRIPTION
This replaces the waitlist opt-out var (`VITE_BYPASS_WAITLIST`) with an opt-in var (`VITE_ENABLE_WAITLIST`) so that users self-deploying will not encounter the waitlist unnecessarily. The waitlist is only used by Mozilla's upcoming hosted version of Thunderbolt and is not appropriate for self-hosting users.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized routing/env-var change; main risk is misconfiguration causing unexpected waitlist gating or access behavior in deployments.
> 
> **Overview**
> The waitlist gate is flipped from an opt-out model (removed `VITE_BYPASS_WAITLIST`) to an opt-in model via `VITE_ENABLE_WAITLIST`.
> 
> Routing guards in `src/app.tsx` are updated so the `/waitlist` route only exists when `VITE_ENABLE_WAITLIST=true` (and not in PR previews), and the main app routes only require authentication/redirection to `/waitlist` when the waitlist is enabled (or to `/oidc-redirect` in OIDC mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9141bc65c4a3f5fb223820255538cba10e0f622c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->