### PR TITLE
docs: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Thunderbolt [![CI](https://github.com/thunderbird/thunderbolt/actions/workflows/ci.yml/badge.svg)](https://github.com/thunderbird/thunderbolt/actions/workflows/ci.yml)
 
+> [!IMPORTANT]
+> ⚠️ **We are excited about the amount of interest Thunderbolt has been getting and want to clarify that it is still early and under active development**. Currently, we are targeting enterprise customers that want to deploy it on-prem. We encourage you to self-host it and try it out, but there are a few caveats we are still working on:
+>
+> - While we eventually plan to make Thunderbolt fully offline-first, it currently depends on authentication and search functionality (though you can disable search on the integrations screen in the app). You can [deploy your own backend with Docker](./deploy/README.md) and sign up in order to test it locally.
+> - You’ll need to add your own model providers - we don’t yet have a public inference endpoint. We recommend using Thunderbolt with [Ollama](https://ollama.com) or [llama.cpp](https://github.com/ggml-org/llama.cpp) if you want free local inference, or you can add API keys for any OpenAI-compatible model provider in the settings.
+
 **AI You Control: Choose your models. Own your data. Eliminate vendor lock-in.**
 
 ![Thunderbolt Main Dashboard](./docs/screenshots/main.png)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Thunderbolt [![CI](https://github.com/thunderbird/thunderbolt/actions/workflows/ci.yml/badge.svg)](https://github.com/thunderbird/thunderbolt/actions/workflows/ci.yml)
 
+**AI You Control: Choose your models. Own your data. Eliminate vendor lock-in.**
+
+![Thunderbolt Main Dashboard](./docs/screenshots/main.png)
+
 > [!IMPORTANT]
 > ⚠️ **We are excited about the amount of interest Thunderbolt has been getting and want to clarify that it is still early and under active development**. Currently, we are targeting enterprise customers that want to deploy it on-prem. We encourage you to self-host it and try it out, but there are a few caveats we are still working on:
 >
 > - While we eventually plan to make Thunderbolt fully offline-first, it currently depends on authentication and search functionality (though you can disable search on the integrations screen in the app). You can [deploy your own backend with Docker](./deploy/README.md) and sign up in order to test it locally.
 > - You’ll need to add your own model providers - we don’t yet have a public inference endpoint. We recommend using Thunderbolt with [Ollama](https://ollama.com) or [llama.cpp](https://github.com/ggml-org/llama.cpp) if you want free local inference, or you can add API keys for any OpenAI-compatible model provider in the settings.
-
-**AI You Control: Choose your models. Own your data. Eliminate vendor lock-in.**
-
-![Thunderbolt Main Dashboard](./docs/screenshots/main.png)
 
 Thunderbolt is an open-source, cross-platform AI client that can be deployed on-prem anywhere.
 

--- a/marketing/src/components/sections/announcing-thunderbolt-page.tsx
+++ b/marketing/src/components/sections/announcing-thunderbolt-page.tsx
@@ -260,17 +260,15 @@ export const AnnouncingThunderboltPage = () => (
     <BackgroundGrid />
     <Header
       action={
-        <div className="flex items-center gap-6">
-          <a href="https://github.com/thunderbird/thunderbolt" target="_blank" rel="noopener noreferrer" className="flex items-center">
-            <img src="/enterprise/github.svg" alt="GitHub" className="h-7 w-auto" />
-          </a>
-          <a
-            href="/contact"
-            className="inline-flex h-[46px] w-[131px] items-center justify-center bg-[#344054] font-mono text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#344054]/90"
-          >
-            Get Started
-          </a>
-        </div>
+        <a
+          href="https://github.com/thunderbird/thunderbolt"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex h-[46px] items-center justify-center gap-2 bg-[#344054] px-5 font-mono text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#344054]/90"
+        >
+          <img src="/enterprise/github.svg" alt="" className="size-[18px] invert" />
+          Get Started
+        </a>
       }
     />
 

--- a/marketing/src/components/sections/contact-page.tsx
+++ b/marketing/src/components/sections/contact-page.tsx
@@ -129,7 +129,7 @@ export const ContactPage = () => {
           &larr; Back
         </a>
         <h1 className="text-[32px] font-medium leading-[1.2] tracking-[-0.96px] text-[#101828] md:text-[40px]">
-          Get Started
+          Get in Touch
         </h1>
         <p className="mt-2 text-base leading-6 text-[#667085]">
           Tell us about your organization and how we can help.

--- a/marketing/src/components/sections/enterprise-page.tsx
+++ b/marketing/src/components/sections/enterprise-page.tsx
@@ -5,10 +5,36 @@ import { Header } from '../header'
 
 const GetStartedButton = () => (
   <a
-    href="/contact"
-    className="inline-flex h-[46px] w-[131px] items-center justify-center bg-[#344054] font-mono text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#344054]/90"
+    href="https://github.com/thunderbird/thunderbolt"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex h-[46px] items-center justify-center gap-2 bg-[#344054] px-5 font-mono text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#344054]/90"
   >
+    <img src="/enterprise/github.svg" alt="" className="size-[18px] invert" />
     Get Started
+  </a>
+)
+
+const EnterpriseInquiriesButton = () => (
+  <a
+    href="/contact"
+    className="group inline-flex h-[46px] items-center justify-center gap-2 border border-[#344054] px-5 font-mono text-sm font-bold uppercase tracking-wider text-[#344054] transition-colors hover:bg-[#344054] hover:text-white"
+  >
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M22 2L11 13" />
+      <path d="M22 2l-7 20-4-9-9-4 20-7z" />
+    </svg>
+    Get in Touch
   </a>
 )
 
@@ -192,7 +218,10 @@ const Hero = () => (
       <p className="max-w-[718px] text-lg leading-[1.2] text-[#667085] md:text-2xl">
         The Open-Source, Cross-Platform, Extensible AI Client
       </p>
-      <GetStartedButton />
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <GetStartedButton />
+        <EnterpriseInquiriesButton />
+      </div>
     </div>
     {/* Device mockups — composed from separate SVG frames + PNG screenshots */}
     <div className="mx-auto mt-10 max-w-[1120px] px-6 lg:px-0">
@@ -404,8 +433,9 @@ const CTASection = () => (
       <p className="mx-auto mt-2 max-w-[567px] text-base leading-6 text-[#667085]">
         Start with a pilot deployment or talk to our enterprise team about Forward-Deployed Engineering and sovereign infrastructure.
       </p>
-      <div className="mt-6">
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
         <GetStartedButton />
+        <EnterpriseInquiriesButton />
       </div>
     </div>
   </section>
@@ -416,9 +446,12 @@ const CTASection = () => (
 const MobileFooterCTA = () => (
   <div className="fixed inset-x-0 bottom-0 z-50 bg-white/20 backdrop-blur-[32px] px-6 py-4 md:hidden">
     <a
-      href="/contact"
-      className="flex h-[46px] w-full items-center justify-center bg-[#344054] font-mono text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#344054]/90"
+      href="https://github.com/thunderbird/thunderbolt"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex h-[46px] w-full items-center justify-center gap-2 bg-[#344054] font-mono text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#344054]/90"
     >
+      <img src="/enterprise/github.svg" alt="" className="size-[18px] invert" />
       Get Started
     </a>
   </div>
@@ -441,14 +474,7 @@ export const EnterprisePage = () => (
           <span className="text-white/80 transition-transform group-hover:translate-x-0.5">&rarr;</span>
         </a>
       }
-      action={
-        <div className="flex items-center gap-6">
-          <a href="https://github.com/thunderbird/thunderbolt" target="_blank" rel="noopener noreferrer" className="flex items-center">
-            <img src="/enterprise/github.svg" alt="GitHub" className="h-7 w-auto" />
-          </a>
-          <GetStartedButton />
-        </div>
-      }
+      action={<GetStartedButton />}
     />
     <main className="relative pt-[144px]">
       <Hero />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs/marketing-only copy and link/CTA updates; low risk beyond potentially changing where users are directed (GitHub vs contact form).
> 
> **Overview**
> Adds an **IMPORTANT** notice to `README.md` clarifying Thunderbolt is early/actively developed, currently enterprise/on-prem focused, and documenting current caveats (backend dependency and bring-your-own model providers).
> 
> Updates marketing CTAs to better separate self-serve vs enterprise: “Get Started” buttons in `enterprise-page.tsx` and `announcing-thunderbolt-page.tsx` now link to the GitHub repo with a unified button style/icon, while the enterprise page adds a new “Get in Touch” button that continues to route to `/contact` (and updates the contact page heading to match).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00224a165641b346398f868c0f38a3d085b9313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->