### PR TITLE
fix: typo in docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ Thunderbolt is funded through a grant from Mozilla.
 
 ### What is Thunderbolt's relationship to Thunderbird?
 
-Thunderbolt is a separate product developed under the same entity, MLZA Technologies. It is not part of Thunderbird's existing products.
+Thunderbolt is a separate product developed under the same entity, MZLA Technologies. It is not part of Thunderbird's existing products.
 
 ### Is there going to be a hosted version if I don't want to deploy it myself?
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no effect on runtime behavior or data flow.
> 
> **Overview**
> Fixes a typo in `docs/faq.md` by correcting the company name from `MLZA Technologies` to `MZLA Technologies` in the Thunderbird relationship FAQ entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a086d03a0ee560e829b5c10f1552abc979ac90fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->