### PR TITLE
Local network serve and beta bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
-# Thunderbolt Cloud URL (optional, defaults to http://localhost:8000)
-VITE_THUNDERBOLT_CLOUD_URL="http://localhost:8000/v1"
+# Thunderbolt Cloud URL.
+# Leave unset to target the current browser hostname on port 8000
+# (works for localhost, LAN IPs, and Tailscale hostnames by default).
+# VITE_THUNDERBOLT_CLOUD_URL="http://localhost:8000/v1"
 
-# Bypass waitlist routes for UI development (set to "true" to skip waitlist)
-# Note: This only bypasses frontend routing, not backend auth
+# Backend port used when auto-deriving the Cloud URL from the current hostname.
+VITE_THUNDERBOLT_BACKEND_PORT="8000"
+
+# Waitlist routing (disabled by default for local/self-hosted installs)
+VITE_WAITLIST_ENABLED="false"
+
+# Override: bypass waitlist routes even when VITE_WAITLIST_ENABLED is "true"
 # VITE_BYPASS_WAITLIST="true"
 
 # Show app download links/banners in the web UI (set to "true" for internal testing deployments)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BLUE := \033[0;34m
 GREEN := \033[0;32m
 YELLOW := \033[0;33m
 NC := \033[0m # No Color
+BUN := $(shell if command -v bun >/dev/null 2>&1; then command -v bun; elif [ -x "$$HOME/.bun/bin/bun" ]; then printf '%s' "$$HOME/.bun/bin/bun"; else printf '%s' bun; fi)
 
 # Default target
 help:
@@ -41,43 +42,43 @@ setup-symlinks:
 # Setup project - install frontend and backend dependencies
 setup: setup-symlinks
 	@echo "$(BLUE)→ Installing frontend dependencies...$(NC)"
-	bun install
+	$(BUN) install
 	@echo "$(BLUE)→ Installing backend dependencies...$(NC)"
-	cd backend && bun install
+	cd backend && $(BUN) install
 	@echo "$(GREEN)✓ Setup complete!$(NC)"
 
 # Install dependencies
 install:
-	bun install
+	$(BUN) install
 
 # Build frontend
 build:
-	bun run build
+	$(BUN) run build
 
 # Build desktop app
 build-desktop:
-	bun install
-	bun tauri build
+	$(BUN) install
+	$(BUN) tauri build
 
 # Build desktop app with specific target
 build-desktop-target:
-	bun install
-	bun tauri build --target $(TARGET)
+	$(BUN) install
+	$(BUN) tauri build --target $(TARGET)
 
 # Build desktop app with bundles and target
 build-desktop-full:
-	bun install
-	bun tauri build --bundles $(BUNDLES) --target $(TARGET)
+	$(BUN) install
+	$(BUN) tauri build --bundles $(BUNDLES) --target $(TARGET)
 
 # Build Android app
 build-android:
-	bun install
-	bun tauri android build
+	$(BUN) install
+	$(BUN) tauri android build
 
 # Build iOS app
 build-ios:
-	bun install
-	bun tauri ios build --export-method app-store-connect
+	$(BUN) install
+	$(BUN) tauri ios build --export-method app-store-connect
 
 # Clean build artifacts
 clean:
@@ -86,44 +87,44 @@ clean:
 
 # Linting
 lint:
-	bun run lint
+	$(BUN) run lint
 
 lint-fix:
-	bun run lint:fix
+	$(BUN) run lint:fix
 
 # Formatting
 format:
 	@echo "$(BLUE)→ Formatting frontend code...$(NC)"
-	bun run format
+	$(BUN) run format
 	@echo "$(BLUE)→ Formatting backend code...$(NC)"
-	cd backend && bun run format
+	cd backend && $(BUN) run format
 	@echo "$(BLUE)→ Formatting Rust code...$(NC)"
-	bun run format:rust
+	$(BUN) run format:rust
 	@echo "$(GREEN)✓ Formatting complete!$(NC)"
 
 format-check:
 	@echo "$(BLUE)→ Checking frontend formatting...$(NC)"
-	bun run format-check
+	$(BUN) run format-check
 	@echo "$(BLUE)→ Checking backend formatting...$(NC)"
-	cd backend && bun run format-check
+	cd backend && $(BUN) run format-check
 	@echo "$(BLUE)→ Checking Rust formatting...$(NC)"
-	bun run format:rust-check
+	$(BUN) run format:rust-check
 	@echo "$(GREEN)✓ Format check complete!$(NC)"
 
 # Type checking
 type-check:
-	bun run type-check
+	$(BUN) run type-check
 
 # Run tests
 test:
 	@echo "$(BLUE)→ Running frontend tests...$(NC)"
-	@bun test || echo "$(YELLOW)  No frontend tests found$(NC)"
+	@$(BUN) test || echo "$(YELLOW)  No frontend tests found$(NC)"
 	@echo "$(BLUE)→ Running backend tests...$(NC)"
-	@cd backend && bun test
+	@cd backend && $(BUN) test
 
 # Run all checks
 check:
-	bun run check
+	$(BUN) run check
 
 # Start development servers (backend and frontend)
 run:
@@ -136,11 +137,11 @@ run:
 	@-lsof -ti:8000 | xargs kill -9 2>/dev/null || true
 	@-lsof -ti:5173 | xargs kill -9 2>/dev/null || true
 	@# Start backend in background and frontend in foreground
-	cd backend && bun run dev & \
+	cd backend && $(BUN) run dev & \
 	BACKEND_PID=$$!; \
 	echo "$(GREEN)✓ Backend started (PID: $$BACKEND_PID)$(NC)"; \
 	sleep 2; \
-	bun run dev || (kill $$BACKEND_PID 2>/dev/null && exit 1)
+	$(BUN) run dev || (kill $$BACKEND_PID 2>/dev/null && exit 1)
 
 # Alias for run
 dev: run

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,12 +11,13 @@ MICROSOFT_CLIENT_ID=
 MICROSOFT_CLIENT_SECRET=
 
 # General settings
+HOST=0.0.0.0
 LOG_LEVEL=INFO
 PORT=8000
 APP_URL=http://localhost:1420
 
 # Waitlist settings
-# When true, inference/pro routes require authentication
+# When true, email sign-in is gated behind the waitlist flow
 WAITLIST_ENABLED=false
 # Comma-separated list of email domains that are auto-approved for waitlist access
 WAITLIST_AUTO_APPROVE_DOMAINS=mozilla.org,thunderbird.net,mozilla.ai,mozilla.com
@@ -39,7 +40,9 @@ POSTHOG_HOST=https://us.i.posthog.com
 POSTHOG_API_KEY=
 
 # Authentication
-TRUSTED_ORIGINS="http://localhost:1420"
+# Optional extra trusted web origins for auth flows.
+# LAN/Tailscale frontend origins on APP_URL's port are accepted automatically.
+# TRUSTED_ORIGINS="http://localhost:1420"
 
 # OIDC Settings (enterprise self-hosted)
 # Set AUTH_MODE=oidc to enable OIDC sign-in (works with any OIDC provider: Keycloak, Okta, Auth0, Entra ID, etc.)
@@ -53,8 +56,10 @@ BETTER_AUTH_URL=http://localhost:8000
 BETTER_AUTH_SECRET=better-auth-secret-change-in-production-12345678901234567890
 
 # CORS settings — comma-separated list of exact origins (no wildcards)
-# For preview deploys, append RENDER_EXTERNAL_URL in your start script
+# Local-network/Tailscale origins on APP_URL's port are allowed automatically.
+# For preview deploys, append RENDER_EXTERNAL_URL in your start script.
 CORS_ORIGINS=http://localhost:1420,tauri://localhost,http://tauri.localhost
+ALLOW_PRIVATE_NETWORK_ORIGINS=true
 CORS_ALLOW_CREDENTIALS=true
 CORS_ALLOW_METHODS=GET,POST,PUT,DELETE,PATCH,OPTIONS
 CORS_ALLOW_HEADERS=Content-Type,Authorization,Accept,Accept-Encoding,Accept-Language,Cache-Control,User-Agent,X-Requested-With,X-Client-Platform,X-Device-ID,X-Device-Name,X-Mcp-Target-Url,Mcp-Authorization,Mcp-Session-Id,Mcp-Protocol-Version

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -36,6 +36,7 @@ const powersyncSettings: Settings = {
   posthogHost: '',
   posthogApiKey: '',
   corsOrigins: '',
+  allowPrivateNetworkOrigins: true,
   corsAllowCredentials: true,
   corsAllowMethods: '',
   corsAllowHeaders: '',
@@ -1878,6 +1879,7 @@ describe('PowerSync cross-origin injection protection', () => {
   const corsSettings: Settings = {
     ...powersyncSettings,
     corsOrigins: 'http://localhost:1420,tauri://localhost,http://tauri.localhost',
+    allowPrivateNetworkOrigins: true,
   }
 
   let app: Elysia

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -12,7 +12,7 @@ import {
 import type { db as DbType } from '@/db/client'
 import * as schema from '@/db/schema'
 import { normalizeEmail } from '@/lib/email'
-import { getSettings } from '@/config/settings'
+import { getSettings, isOriginAllowed, type Settings } from '@/config/settings'
 import { getTrustedIpHeaders } from '@/utils/request'
 import { createAuthMiddleware } from 'better-auth/api'
 import { betterAuth } from 'better-auth'
@@ -26,10 +26,19 @@ import { buildVerifyUrl, getValidatedOrigin, parseTrustedOrigins, sendSignInEmai
 const OTP_SIGN_IN_PATH = '/sign-in/email-otp'
 
 /**
- * Trusted origins for CORS and email link validation
- * First origin is the default fallback for verify URLs
+ * Trusted origins for auth and email link validation.
+ * First origin is the default fallback for verify URLs.
  */
-const trustedOrigins = parseTrustedOrigins(process.env.TRUSTED_ORIGINS)
+const getTrustedOrigins = (settings: Settings, request?: Request): string[] => {
+  const configuredOrigins = parseTrustedOrigins(process.env.TRUSTED_ORIGINS)
+  const requestOrigin = request?.headers.get('origin')
+
+  if (!requestOrigin || !isOriginAllowed(requestOrigin, settings)) {
+    return configuredOrigins
+  }
+
+  return [...new Set([...configuredOrigins, requestOrigin])]
+}
 
 /**
  * Create a Better Auth instance with the provided database
@@ -88,7 +97,7 @@ export const createAuth = (database: typeof DbType) => {
       provider: 'pg',
       schema,
     }),
-    trustedOrigins,
+    trustedOrigins: async (request) => getTrustedOrigins(settings, request),
     // NOTE: Uses in-memory storage by default — not shared across instances in
     // horizontally-scaled deployments. Provides single-instance defence only.
     // TODO(THU-113): Replace with proof-of-work challenge (ALTCHA) for distributed protection.
@@ -148,13 +157,15 @@ export const createAuth = (database: typeof DbType) => {
           throw ctx.error('UNAUTHORIZED', { message: 'Invalid challenge token' })
         }
 
-        // Block sign-in for non-approved waitlist users (defense-in-depth).
-        // Even if a challenge token was somehow obtained, pending users cannot sign in.
-        const existingUser = await getUserByEmail(database, normalizedEmail)
-        if (!existingUser) {
-          const waitlistEntry = await getWaitlistByEmail(database, normalizedEmail)
-          if (!waitlistEntry || waitlistEntry.status !== 'approved') {
-            throw ctx.error('UNAUTHORIZED', { message: 'Sign-in not available' })
+        if (settings.waitlistEnabled) {
+          // Block sign-in for non-approved waitlist users (defense-in-depth).
+          // Even if a challenge token was somehow obtained, pending users cannot sign in.
+          const existingUser = await getUserByEmail(database, normalizedEmail)
+          if (!existingUser) {
+            const waitlistEntry = await getWaitlistByEmail(database, normalizedEmail)
+            if (!waitlistEntry || waitlistEntry.status !== 'approved') {
+              throw ctx.error('UNAUTHORIZED', { message: 'Sign-in not available' })
+            }
           }
         }
 
@@ -212,7 +223,7 @@ export const createAuth = (database: typeof DbType) => {
           // Existing users bypass waitlist entirely
           const existingUser = await getUserByEmail(database, normalizedEmail)
 
-          if (!existingUser) {
+          if (settings.waitlistEnabled && !existingUser) {
             const waitlistEntry = await getWaitlistByEmail(database, normalizedEmail)
             const autoApproved = isAutoApprovedDomain(normalizedEmail)
 
@@ -239,7 +250,7 @@ export const createAuth = (database: typeof DbType) => {
             }
           }
 
-          const origin = getValidatedOrigin(trustedOrigins, ctx?.request)
+          const origin = getValidatedOrigin(getTrustedOrigins(settings, ctx?.request), ctx?.request)
           // First-writer-wins: reuses existing challenge if /waitlist/join already
           // created one, or creates on-demand for Better Auth's native send-OTP endpoint.
           const challengeToken = await getOrCreateOtpChallenge(database, {

--- a/backend/src/auth/oidc-integration.test.ts
+++ b/backend/src/auth/oidc-integration.test.ts
@@ -45,6 +45,7 @@ const baseSettings: Settings = {
   posthogHost: '',
   posthogApiKey: '',
   corsOrigins: 'http://localhost:1420',
+  allowPrivateNetworkOrigins: true,
   corsAllowCredentials: true,
   corsAllowMethods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
   corsAllowHeaders: 'Content-Type,Authorization',

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -41,6 +41,7 @@ describe('Authentication Routes', () => {
       posthogHost: 'https://us.i.posthog.com',
       posthogApiKey: '',
       corsOrigins: 'http://localhost:1420',
+      allowPrivateNetworkOrigins: true,
       corsAllowCredentials: true,
       corsAllowMethods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
       corsAllowHeaders: 'Content-Type,Authorization',

--- a/backend/src/auth/utils.test.ts
+++ b/backend/src/auth/utils.test.ts
@@ -70,6 +70,22 @@ describe('getValidatedOrigin', () => {
     const result = getValidatedOrigin(trustedOrigins, request)
     expect(result).toBe('http://localhost:1420')
   })
+
+  it('accepts LAN origins on the app port', () => {
+    const request = new Request('https://api.example.com', {
+      headers: { origin: 'http://192.168.1.25:1420' },
+    })
+    const result = getValidatedOrigin(trustedOrigins, request)
+    expect(result).toBe('http://192.168.1.25:1420')
+  })
+
+  it('accepts Tailscale hostnames on the app port', () => {
+    const request = new Request('https://api.example.com', {
+      headers: { origin: 'http://thunderbolt.ts.net:1420' },
+    })
+    const result = getValidatedOrigin(trustedOrigins, request)
+    expect(result).toBe('http://thunderbolt.ts.net:1420')
+  })
 })
 
 describe('isDeepLinkPlatform', () => {

--- a/backend/src/auth/utils.tsx
+++ b/backend/src/auth/utils.tsx
@@ -1,3 +1,4 @@
+import { getSettings, isLocalNetworkAppUrl } from '@/config/settings'
 import { sendEmail, shouldSkipEmail } from '@/lib/resend'
 import { MagicLinkEmail } from '@/emails/magic-link'
 
@@ -46,7 +47,7 @@ export const isDeepLinkPlatform = (request?: Request): boolean => {
  */
 export const getValidatedOrigin = (trustedOrigins: string[], request?: Request): string => {
   const origin = request?.headers.get('origin')
-  if (origin && trustedOrigins.includes(origin)) {
+  if (origin && (trustedOrigins.includes(origin) || isLocalNetworkAppUrl(origin, getSettings()))) {
     return origin
   }
   return trustedOrigins[0]

--- a/backend/src/auth/waitlist-integration.test.ts
+++ b/backend/src/auth/waitlist-integration.test.ts
@@ -35,11 +35,16 @@ describe('Auth Waitlist Integration', () => {
   let auth: ReturnType<typeof createAuth>
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
   let cleanup: () => Promise<void>
+  let savedWaitlistEnabled: string | undefined
 
   beforeEach(async () => {
     mockSendSignInEmail.mockClear()
     mockSendWaitlistNotReadyEmail.mockClear()
     mockSendWaitlistJoinedEmail.mockClear()
+
+    savedWaitlistEnabled = process.env.WAITLIST_ENABLED
+    process.env.WAITLIST_ENABLED = 'true'
+    clearSettingsCache()
 
     const testEnv = await createTestDb()
     db = testEnv.db
@@ -48,6 +53,11 @@ describe('Auth Waitlist Integration', () => {
   })
 
   afterEach(async () => {
+    if (savedWaitlistEnabled !== undefined) {
+      process.env.WAITLIST_ENABLED = savedWaitlistEnabled
+    } else {
+      delete process.env.WAITLIST_ENABLED
+    }
     delete process.env.WAITLIST_AUTO_APPROVE_DOMAINS
     clearSettingsCache()
     await cleanup()
@@ -226,6 +236,37 @@ describe('Auth Waitlist Integration', () => {
       })
 
       expect(mockSendSignInEmail).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Waitlist disabled', () => {
+    it('should send OTP and allow sign-in without creating a waitlist entry', async () => {
+      process.env.WAITLIST_ENABLED = 'false'
+      clearSettingsCache()
+      auth = createAuth(db)
+
+      await auth.api.sendVerificationOTP({
+        body: { email: 'open@example.com', type: 'sign-in' },
+      })
+
+      expect(mockSendSignInEmail).toHaveBeenCalledTimes(1)
+      expect(mockSendWaitlistNotReadyEmail).toHaveBeenCalledTimes(0)
+      expect(mockSendWaitlistJoinedEmail).toHaveBeenCalledTimes(0)
+
+      const otpCall = mockSendSignInEmail.mock.calls[0] as unknown as [{ otp: string }]
+      const otp = otpCall[0].otp
+      const challengeToken = await createTestChallenge(db, 'open@example.com')
+
+      const result = (await auth.api.signInEmailOTP({
+        body: { email: 'open@example.com', otp },
+        headers: new Headers({ [challengeTokenHeader]: challengeToken }),
+      })) as unknown as { session: unknown; user: { email: string } }
+
+      expect(result.session).toBeDefined()
+      expect(result.user.email).toBe('open@example.com')
+
+      const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'open@example.com'))
+      expect(entries).toHaveLength(0)
     })
   })
 

--- a/backend/src/config/cors.test.ts
+++ b/backend/src/config/cors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { getCorsOriginsList } from '@/config/settings'
+import { isOriginAllowed } from '@/config/settings'
 import cors from '@elysiajs/cors'
 import { Elysia } from 'elysia'
 
@@ -8,11 +8,14 @@ import { Elysia } from 'elysia'
  * Verifies that the actual HTTP headers are set correctly for various origins.
  */
 describe('CORS integration', () => {
-  const createTestApp = (corsOrigins: string[]) =>
+  const createTestApp = (settings: { corsOrigins: string; appUrl?: string; allowPrivateNetworkOrigins?: boolean }) =>
     new Elysia()
       .use(
         cors({
-          origin: corsOrigins,
+          origin: (request) => {
+            const origin = request.headers.get('origin')
+            return origin ? isOriginAllowed(origin, settings) : false
+          },
           credentials: true,
           methods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
           allowedHeaders: 'Content-Type,Authorization',
@@ -22,12 +25,13 @@ describe('CORS integration', () => {
       .delete('/test', () => ({ ok: true }))
 
   describe('with Tauri and explicit origins', () => {
-    const origins = getCorsOriginsList({
+    const settings = {
       corsOrigins: 'https://app.example.com,tauri://localhost,http://tauri.localhost',
-    })
+      appUrl: 'http://localhost:1420',
+    }
 
     it('should allow the explicit origin', async () => {
-      const app = createTestApp(origins)
+      const app = createTestApp(settings)
       const res = await app.handle(
         new Request('http://localhost/test', {
           headers: { Origin: 'https://app.example.com' },
@@ -39,7 +43,7 @@ describe('CORS integration', () => {
     })
 
     it('should allow tauri://localhost', async () => {
-      const app = createTestApp(origins)
+      const app = createTestApp(settings)
       const res = await app.handle(
         new Request('http://localhost/test', {
           headers: { Origin: 'tauri://localhost' },
@@ -51,7 +55,7 @@ describe('CORS integration', () => {
     })
 
     it('should allow http://tauri.localhost', async () => {
-      const app = createTestApp(origins)
+      const app = createTestApp(settings)
       const res = await app.handle(
         new Request('http://localhost/test', {
           headers: { Origin: 'http://tauri.localhost' },
@@ -63,7 +67,7 @@ describe('CORS integration', () => {
     })
 
     it('should reject arbitrary localhost ports', async () => {
-      const app = createTestApp(origins)
+      const app = createTestApp(settings)
       const res = await app.handle(
         new Request('http://localhost/test', {
           headers: { Origin: 'http://localhost:9999' },
@@ -74,7 +78,7 @@ describe('CORS integration', () => {
     })
 
     it('should reject unknown origins', async () => {
-      const app = createTestApp(origins)
+      const app = createTestApp(settings)
       const res = await app.handle(
         new Request('http://localhost/test', {
           headers: { Origin: 'https://evil.com' },
@@ -85,7 +89,7 @@ describe('CORS integration', () => {
     })
 
     it('should reject preflight from arbitrary localhost ports', async () => {
-      const app = createTestApp(origins)
+      const app = createTestApp(settings)
       const res = await app.handle(
         new Request('http://localhost/test', {
           method: 'OPTIONS',
@@ -98,15 +102,28 @@ describe('CORS integration', () => {
 
       expect(res.headers.get('access-control-allow-origin')).toBeNull()
     })
+
+    it('should allow local-network app origins on the app port', async () => {
+      const app = createTestApp(settings)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'http://192.168.1.25:1420' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('http://192.168.1.25:1420')
+      expect(res.headers.get('access-control-allow-credentials')).toBe('true')
+    })
   })
 
   describe('with only explicit origins', () => {
-    const origins = getCorsOriginsList({
+    const settings = {
       corsOrigins: 'https://app.example.com',
-    })
+      appUrl: 'http://localhost:1420',
+    }
 
     it('should allow the explicit origin', async () => {
-      const app = createTestApp(origins)
+      const app = createTestApp(settings)
       const res = await app.handle(
         new Request('http://localhost/test', {
           headers: { Origin: 'https://app.example.com' },
@@ -117,7 +134,7 @@ describe('CORS integration', () => {
     })
 
     it('should reject other origins', async () => {
-      const app = createTestApp(origins)
+      const app = createTestApp(settings)
       const res = await app.handle(
         new Request('http://localhost/test', {
           headers: { Origin: 'http://localhost:9999' },
@@ -125,6 +142,17 @@ describe('CORS integration', () => {
       )
 
       expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    })
+
+    it('should allow Tailscale origins on the app port when private-network origins are enabled', async () => {
+      const app = createTestApp(settings)
+      const res = await app.handle(
+        new Request('http://localhost/test', {
+          headers: { Origin: 'http://thunderbolt.ts.net:1420' },
+        }),
+      )
+
+      expect(res.headers.get('access-control-allow-origin')).toBe('http://thunderbolt.ts.net:1420')
     })
   })
 })

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -95,6 +95,24 @@ describe('Config Settings', () => {
       expect(isOriginAllowed('http://localhost:1420', settings)).toBe(true)
     })
 
+    it('should allow LAN and Tailscale app origins on the app port by default', () => {
+      delete process.env.CORS_ORIGINS
+      const settings = getSettings()
+
+      expect(isOriginAllowed('http://192.168.1.25:1420', settings)).toBe(true)
+      expect(isOriginAllowed('http://100.88.12.34:1420', settings)).toBe(true)
+      expect(isOriginAllowed('http://thunderbolt.ts.net:1420', settings)).toBe(true)
+      expect(isOriginAllowed('http://thunderbolt.local:1420', settings)).toBe(true)
+    })
+
+    it('should reject local-network origins on the wrong port by default', () => {
+      delete process.env.CORS_ORIGINS
+      const settings = getSettings()
+
+      expect(isOriginAllowed('http://192.168.1.25:3000', settings)).toBe(false)
+      expect(isOriginAllowed('http://thunderbolt.ts.net:3000', settings)).toBe(false)
+    })
+
     it('should not match non-Tauri origins by default', () => {
       delete process.env.CORS_ORIGINS
       const settings = getSettings()
@@ -329,6 +347,21 @@ describe('Config Settings', () => {
       expect(isOriginAllowed('tauri://localhost', settings)).toBe(true)
       expect(isOriginAllowed('http://tauri.localhost', settings)).toBe(true)
     })
+
+    it('returns true for local-network app origins when enabled', () => {
+      const settings = { corsOrigins: 'http://localhost:1420', appUrl: 'http://localhost:1420' }
+      expect(isOriginAllowed('http://192.168.1.50:1420', settings)).toBe(true)
+      expect(isOriginAllowed('http://thunderbolt.ts.net:1420', settings)).toBe(true)
+    })
+
+    it('returns false for local-network app origins when disabled', () => {
+      const settings = {
+        corsOrigins: 'http://localhost:1420',
+        appUrl: 'http://localhost:1420',
+        allowPrivateNetworkOrigins: false,
+      }
+      expect(isOriginAllowed('http://192.168.1.50:1420', settings)).toBe(false)
+    })
   })
 
   describe('Swagger settings', () => {
@@ -491,6 +524,11 @@ describe('Config Settings', () => {
 
     it('allows mobile App Link callback', () => {
       expect(isOAuthRedirectUriAllowed('https://thunderbolt.io/oauth/callback', settings)).toBe(true)
+    })
+
+    it('allows LAN and Tailscale callbacks on the app port', () => {
+      expect(isOAuthRedirectUriAllowed('http://192.168.1.50:1420/oauth/callback', settings)).toBe(true)
+      expect(isOAuthRedirectUriAllowed('http://thunderbolt.ts.net:1420/oauth/callback', settings)).toBe(true)
     })
 
     it('allows production origin from corsOrigins', () => {

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -51,6 +51,7 @@ const settingsSchema = z
 
     // CORS settings — comma-separated list of exact origins
     corsOrigins: z.string().default('http://localhost:1420,tauri://localhost,http://tauri.localhost'),
+    allowPrivateNetworkOrigins: z.boolean().default(true),
     corsAllowCredentials: z.boolean().default(true),
     corsAllowMethods: z.string().default('GET,POST,PUT,DELETE,PATCH,OPTIONS'),
     corsAllowHeaders: z
@@ -122,6 +123,7 @@ const parseSettings = (): Settings => {
     powersyncJwtSecret: process.env.POWERSYNC_JWT_SECRET || '',
     powersyncTokenExpirySeconds: process.env.POWERSYNC_TOKEN_EXPIRY_SECONDS || '3600',
     corsOrigins: process.env.CORS_ORIGINS || 'http://localhost:1420,tauri://localhost,http://tauri.localhost',
+    allowPrivateNetworkOrigins: process.env.ALLOW_PRIVATE_NETWORK_ORIGINS !== 'false',
     corsAllowCredentials: process.env.CORS_ALLOW_CREDENTIALS !== 'false',
     corsAllowMethods: process.env.CORS_ALLOW_METHODS || 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:
@@ -166,13 +168,116 @@ export const getCorsOriginsList = (settings: Pick<Settings, 'corsOrigins'>): str
     .filter((origin) => origin.length > 0)
 }
 
-/** Check whether a given origin is allowed by the configured CORS origins (exact match). */
-export const isOriginAllowed = (origin: string, settings: Pick<Settings, 'corsOrigins'>): boolean => {
-  return getCorsOriginsList(settings).includes(origin)
+const normalizeHostname = (hostname: string): string => hostname.replace(/^\[|\]$/g, '').toLowerCase()
+
+const getUrlPort = (url: URL): string => {
+  if (url.port) {
+    return url.port
+  }
+
+  return url.protocol === 'https:' ? '443' : '80'
+}
+
+const isPrivateIpv4Hostname = (hostname: string): boolean => {
+  const octets = hostname.split('.').map((value) => Number(value))
+  if (octets.length !== 4 || octets.some((value) => Number.isNaN(value) || value < 0 || value > 255)) {
+    return false
+  }
+
+  const [first, second] = octets
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 100 && second >= 64 && second <= 127)
+  )
+}
+
+const isLoopbackHostname = (hostname: string): boolean => {
+  const normalizedHostname = normalizeHostname(hostname)
+  return (
+    normalizedHostname === 'localhost' ||
+    normalizedHostname === '0.0.0.0' ||
+    normalizedHostname === '::1' ||
+    normalizedHostname === 'tauri.localhost' ||
+    normalizedHostname.startsWith('127.')
+  )
+}
+
+const isPrivateIpv6Hostname = (hostname: string): boolean => {
+  const normalizedHostname = normalizeHostname(hostname)
+  return (
+    normalizedHostname === '::1' ||
+    normalizedHostname.startsWith('fc') ||
+    normalizedHostname.startsWith('fd') ||
+    normalizedHostname.startsWith('fe80:')
+  )
+}
+
+const localNetworkHostnameSuffixes = ['.local', '.internal', '.lan', '.home.arpa', '.ts.net'] as const
+
+const isLocalNetworkHostname = (hostname: string): boolean => {
+  const normalizedHostname = normalizeHostname(hostname)
+
+  if (isLoopbackHostname(normalizedHostname)) {
+    return true
+  }
+
+  if (isPrivateIpv4Hostname(normalizedHostname) || isPrivateIpv6Hostname(normalizedHostname)) {
+    return true
+  }
+
+  if (localNetworkHostnameSuffixes.some((suffix) => normalizedHostname.endsWith(suffix))) {
+    return true
+  }
+
+  return !normalizedHostname.includes('.') && /^[a-z0-9-]+$/.test(normalizedHostname)
+}
+
+/**
+ * Check whether a URL targets the local app port on a LAN, Tailscale, or other private-network hostname.
+ */
+export const isLocalNetworkAppUrl = (
+  urlString: string,
+  settings: Partial<Pick<Settings, 'appUrl' | 'allowPrivateNetworkOrigins'>>,
+): boolean => {
+  if (settings.allowPrivateNetworkOrigins === false) {
+    return false
+  }
+
+  try {
+    const targetUrl = new URL(urlString)
+    const appUrl = new URL(settings.appUrl || 'http://localhost:1420')
+
+    if (!['http:', 'https:'].includes(targetUrl.protocol)) {
+      return false
+    }
+
+    if (targetUrl.protocol === 'https:' && isLoopbackHostname(targetUrl.hostname)) {
+      return false
+    }
+
+    return getUrlPort(targetUrl) === getUrlPort(appUrl) && isLocalNetworkHostname(targetUrl.hostname)
+  } catch {
+    return false
+  }
+}
+
+/** Check whether a given origin is allowed by the configured CORS origins or the local-network app matcher. */
+export const isOriginAllowed = (
+  origin: string,
+  settings: Pick<Settings, 'corsOrigins'> & Partial<Pick<Settings, 'appUrl' | 'allowPrivateNetworkOrigins'>>,
+): boolean => {
+  return getCorsOriginsList(settings).includes(origin) || isLocalNetworkAppUrl(origin, settings)
 }
 
 /** Validate that an OAuth redirect_uri points to a trusted origin. */
-export const isOAuthRedirectUriAllowed = (uri: string, settings: Pick<Settings, 'corsOrigins'>): boolean => {
+export const isOAuthRedirectUriAllowed = (
+  uri: string,
+  settings: Pick<Settings, 'corsOrigins'> & Partial<Pick<Settings, 'appUrl' | 'allowPrivateNetworkOrigins'>>,
+): boolean => {
   try {
     const url = new URL(uri)
     // Construct origin manually — url.origin returns 'null' for non-standard protocols like tauri://
@@ -183,6 +288,9 @@ export const isOAuthRedirectUriAllowed = (uri: string, settings: Pick<Settings, 
     }
     // Loopback flow uses dynamic ports — allow any HTTP localhost
     if ((url.hostname === 'localhost' || url.hostname === '127.0.0.1') && url.protocol === 'http:') {
+      return true
+    }
+    if (isLocalNetworkAppUrl(uri, settings)) {
       return true
     }
     return false

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,7 +3,7 @@ import { createBetterAuthPlugin } from '@/auth/elysia-plugin'
 import { createGoogleAuthRoutes } from '@/auth/google'
 import { createMicrosoftAuthRoutes } from '@/auth/microsoft'
 import { createLoggerMiddleware, createStandaloneLogger } from '@/config/logger'
-import { getCorsOriginsList, getSettings } from '@/config/settings'
+import { getCorsOriginsList, getSettings, isOriginAllowed } from '@/config/settings'
 import { runMigrations } from '@/db/client'
 import { createInferenceRoutes } from '@/inference/routes'
 import { createErrorHandlingMiddleware } from '@/middleware/error-handling'
@@ -72,7 +72,10 @@ export const createApp = async (deps?: AppDeps) => {
     configuredApp
       .use(
         cors({
-          origin: getCorsOriginsList(settings),
+          origin: (request) => {
+            const origin = request.headers.get('origin')
+            return origin ? isOriginAllowed(origin, settings) : false
+          },
           credentials: settings.corsAllowCredentials,
           methods: settings.corsAllowMethods,
           allowedHeaders: settings.corsAllowHeaders,
@@ -132,11 +135,7 @@ const startServer = async () => {
 
     const app = await createApp()
 
-    const hostname = process.env.HOST
-      ? process.env.HOST
-      : process.env.NODE_ENV === 'production'
-        ? '0.0.0.0'
-        : 'localhost'
+    const hostname = process.env.HOST || '0.0.0.0'
 
     app.listen(
       {

--- a/backend/src/mcp-proxy/routes.test.ts
+++ b/backend/src/mcp-proxy/routes.test.ts
@@ -38,6 +38,7 @@ describe('MCP Proxy Routes', () => {
     posthogHost: 'https://us.i.posthog.com',
     posthogApiKey: '',
     corsOrigins: 'http://localhost:1420',
+    allowPrivateNetworkOrigins: true,
     corsAllowCredentials: true,
     corsAllowMethods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
     corsAllowHeaders:

--- a/backend/src/posthog/routes.test.ts
+++ b/backend/src/posthog/routes.test.ts
@@ -32,6 +32,7 @@ describe('PostHog Proxy Routes', () => {
       posthogHost: 'https://us.i.posthog.com',
       posthogApiKey: 'test-key',
       corsOrigins: 'http://localhost:1420',
+      allowPrivateNetworkOrigins: true,
       corsAllowCredentials: true,
       corsAllowMethods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
       corsAllowHeaders: 'Content-Type,Authorization',

--- a/backend/src/pro/link-preview.test.ts
+++ b/backend/src/pro/link-preview.test.ts
@@ -51,6 +51,7 @@ describe('Link Preview Routes', () => {
       posthogHost: 'https://us.i.posthog.com',
       posthogApiKey: '',
       corsOrigins: 'http://localhost:1420',
+      allowPrivateNetworkOrigins: true,
       corsAllowCredentials: true,
       corsAllowMethods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
       corsAllowHeaders: 'Content-Type,Authorization',

--- a/backend/src/pro/proxy.test.ts
+++ b/backend/src/pro/proxy.test.ts
@@ -59,6 +59,7 @@ describe('Proxy Routes', () => {
       posthogHost: 'https://us.i.posthog.com',
       posthogApiKey: '',
       corsOrigins: 'http://localhost:1420',
+      allowPrivateNetworkOrigins: true,
       corsAllowCredentials: true,
       corsAllowMethods: 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
       corsAllowHeaders: 'Content-Type,Authorization',

--- a/backend/src/waitlist/routes.test.ts
+++ b/backend/src/waitlist/routes.test.ts
@@ -1,28 +1,39 @@
+import { createAuth } from '@/auth/auth'
 import { user } from '@/db/auth-schema'
 import { waitlist } from '@/db/schema'
 import { clearSettingsCache } from '@/config/settings'
-import { createApp } from '@/index'
 import { createTestDb } from '@/test-utils/db'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
+import { Elysia } from 'elysia'
+import { createWaitlistRoutes } from './routes'
 
 describe('Waitlist API', () => {
-  let app: Awaited<ReturnType<typeof createApp>>
+  let app: Elysia
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
   let cleanup: () => Promise<void>
+  let savedWaitlistEnabled: string | undefined
   let savedWaitlistDomains: string | undefined
 
   beforeEach(async () => {
+    savedWaitlistEnabled = process.env.WAITLIST_ENABLED
+    process.env.WAITLIST_ENABLED = 'true'
     savedWaitlistDomains = process.env.WAITLIST_AUTO_APPROVE_DOMAINS
     process.env.WAITLIST_AUTO_APPROVE_DOMAINS = 'mozilla.org,thunderbird.net,mozilla.ai,mozilla.com'
     clearSettingsCache()
     const testEnv = await createTestDb()
     db = testEnv.db
     cleanup = testEnv.cleanup
-    app = await createApp({ database: db, otpCooldownMs: 0 })
+    const auth = createAuth(db)
+    app = new Elysia({ prefix: '/v1' }).use(createWaitlistRoutes({ database: db, auth, cooldownMs: 0 })) as Elysia
   })
 
   afterEach(async () => {
+    if (savedWaitlistEnabled !== undefined) {
+      process.env.WAITLIST_ENABLED = savedWaitlistEnabled
+    } else {
+      delete process.env.WAITLIST_ENABLED
+    }
     if (savedWaitlistDomains !== undefined) {
       process.env.WAITLIST_AUTO_APPROVE_DOMAINS = savedWaitlistDomains
     } else {
@@ -33,6 +44,29 @@ describe('Waitlist API', () => {
   })
 
   describe('POST /v1/waitlist/join', () => {
+    it('should send OTP immediately when waitlist is disabled', async () => {
+      process.env.WAITLIST_ENABLED = 'false'
+      clearSettingsCache()
+      const auth = createAuth(db)
+      const openApp = new Elysia({ prefix: '/v1' }).use(createWaitlistRoutes({ database: db, auth, cooldownMs: 0 }))
+
+      const response = await openApp.handle(
+        new Request('http://localhost/v1/waitlist/join', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'open@example.com' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const result = await response.json()
+      expect(result.success).toBe(true)
+      expect(result.challengeToken).toBeDefined()
+
+      const entries = await db.select().from(waitlist).where(eq(waitlist.email, 'open@example.com'))
+      expect(entries).toHaveLength(0)
+    })
+
     it('should add email to waitlist with pending status and no challenge token', async () => {
       const response = await app.handle(
         new Request('http://localhost/v1/waitlist/join', {
@@ -343,7 +377,10 @@ describe('Waitlist API', () => {
         sendJoinedEmail: () => Promise.reject(new Error('Email service error')),
         sendReminderEmail: () => Promise.resolve(),
       }
-      const appWithFailingEmail = await createApp({ database: db, waitlistEmailService: failingEmailService })
+      const auth = createAuth(db)
+      const appWithFailingEmail = new Elysia({ prefix: '/v1' }).use(
+        createWaitlistRoutes({ database: db, auth, emailService: failingEmailService, cooldownMs: 0 }),
+      )
 
       const response = await appWithFailingEmail.handle(
         new Request('http://localhost/v1/waitlist/join', {
@@ -373,7 +410,10 @@ describe('Waitlist API', () => {
         sendJoinedEmail: () => Promise.resolve(),
         sendReminderEmail: () => Promise.reject(new Error('Email service error')),
       }
-      const appWithFailingEmail = await createApp({ database: db, waitlistEmailService: failingEmailService })
+      const auth = createAuth(db)
+      const appWithFailingEmail = new Elysia({ prefix: '/v1' }).use(
+        createWaitlistRoutes({ database: db, auth, emailService: failingEmailService, cooldownMs: 0 }),
+      )
 
       const response = await appWithFailingEmail.handle(
         new Request('http://localhost/v1/waitlist/join', {

--- a/backend/src/waitlist/routes.ts
+++ b/backend/src/waitlist/routes.ts
@@ -7,6 +7,7 @@ import {
   getUserByEmail,
   getWaitlistByEmail,
 } from '@/dal'
+import { getSettings } from '@/config/settings'
 import type { db } from '@/db/client'
 import { normalizeEmail } from '@/lib/email'
 import { safeErrorHandler } from '@/middleware/error-handling'
@@ -98,6 +99,7 @@ export const createWaitlistRoutes = ({
   // Per-instance cooldown tracker. Tracks when the last OTP request was made for each email
   // to prevent rapid code cycling. In-memory is appropriate: 15s window, single-instance defense.
   const emailCooldowns = new Map<string, number>()
+  const { waitlistEnabled } = getSettings()
 
   const app = new Elysia({ prefix: '/waitlist' }).onError(safeErrorHandler)
   if (ipRateLimit) {
@@ -133,7 +135,7 @@ export const createWaitlistRoutes = ({
         emailCooldowns.set(email, Date.now())
       }
 
-      const approved = await resolveApproval(database, email, emailService)
+      const approved = waitlistEnabled ? await resolveApproval(database, email, emailService) : true
 
       if (!approved) {
         return { success: true }

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,7 +20,8 @@ make docker-up
 
 # Browser:
 bun dev
-# -> open http://localhost:1420 in your browser.
+# -> open http://localhost:1420 in your browser,
+#    or http://<your-machine-ip>:1420 / your Tailscale hostname from another device.
 
 # Desktop
 bun tauri:dev:desktop

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -9,6 +9,7 @@ import {
   shouldRetry,
 } from '@/ai/step-logic'
 import { getModel, getModelProfile, getSettings } from '@/dal'
+import { defaultCloudUrlValue } from '@/defaults/settings'
 import { getDb } from '@/db/database'
 import { getAuthToken } from '@/lib/auth-token'
 import { fetch } from '@/lib/fetch'
@@ -63,7 +64,7 @@ export const createModel = async (modelConfig: Model) => {
   switch (modelConfig.provider) {
     case 'thunderbolt': {
       const db = getDb()
-      const { cloudUrl } = await getSettings(db, { cloud_url: 'http://localhost:8000/v1' })
+      const { cloudUrl } = await getSettings(db, { cloud_url: defaultCloudUrlValue })
       const token = getAuthToken() || 'thunderbolt'
       // GPT OSS (vendor: 'openai') uses createOpenAI with .chat() to force Chat Completions API
       // (AI SDK 5 defaults createOpenAI to Responses API which our backend doesn't support)

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -87,7 +87,8 @@ const AppRoutes = ({ initData }: { initData: InitData }) => {
   })
 
   const oidcMode = isOidcMode()
-  const shouldBypassWaitlist = import.meta.env.VITE_BYPASS_WAITLIST === 'true' || isPrPreview()
+  const waitlistEnabled = import.meta.env.VITE_WAITLIST_ENABLED === 'true'
+  const shouldBypassWaitlist = !waitlistEnabled || import.meta.env.VITE_BYPASS_WAITLIST === 'true' || isPrPreview()
 
   return (
     <Routes>
@@ -107,8 +108,12 @@ const AppRoutes = ({ initData }: { initData: InitData }) => {
         />
       )}
 
-      {/* Waitlist routes - unauthenticated only (skip when bypass or OIDC mode) */}
-      {!oidcMode && !shouldBypassWaitlist && (
+      {/* Waitlist routes - mounted only when enabled; stale waitlist URLs redirect to a valid entrypoint otherwise */}
+      {oidcMode ? (
+        <Route path="waitlist/*" element={<Navigate to="/oidc-redirect" replace />} />
+      ) : shouldBypassWaitlist ? (
+        <Route path="waitlist/*" element={<Navigate to="/" replace />} />
+      ) : (
         <Route element={<AuthGate require="unauthenticated" redirectTo="/" />}>
           <Route path="waitlist" element={<WaitlistLayout />}>
             <Route index element={<WaitlistPage />} />

--- a/src/components/chat/citation-badge.tsx
+++ b/src/components/chat/citation-badge.tsx
@@ -1,5 +1,6 @@
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { defaultCloudUrlValue } from '@/defaults/settings'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useSettings } from '@/hooks/use-settings'
 import type { CitationSource } from '@/types/citation'
@@ -87,7 +88,7 @@ ManagedBadge.displayName = 'ManagedBadge'
 const StandaloneBadge = memo(({ sources }: { sources: CitationSource[] }) => {
   const [isOpen, setIsOpen] = useState(false)
   const { isMobile } = useIsMobile()
-  const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
+  const { cloudUrl } = useSettings({ cloud_url: defaultCloudUrlValue })
   const { displayName, additionalCount, ariaLabel } = getBadgeLabel(sources)
 
   const badge = (

--- a/src/components/chat/citation-popover.tsx
+++ b/src/components/chat/citation-popover.tsx
@@ -1,5 +1,6 @@
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { defaultCloudUrlValue } from '@/defaults/settings'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useSettings } from '@/hooks/use-settings'
 import type { CitationSource } from '@/types/citation'
@@ -60,7 +61,7 @@ export const CitationPopoverProvider = ({ children }: { children: ReactNode }) =
 
 const CitationOverlay = memo(({ popover, close }: { popover: PopoverData | null; close: () => void }) => {
   const { isMobile } = useIsMobile()
-  const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
+  const { cloudUrl } = useSettings({ cloud_url: defaultCloudUrlValue })
   const anchorRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {

--- a/src/components/chat/tool-icon.tsx
+++ b/src/components/chat/tool-icon.tsx
@@ -1,3 +1,4 @@
+import { defaultCloudUrlValue } from '@/defaults/settings'
 import { useSettings } from '@/hooks/use-settings'
 import { getProxiedFaviconUrl } from '@/lib/url-utils'
 import { cn } from '@/lib/utils'
@@ -40,7 +41,7 @@ export const extractFaviconUrl = (toolName: string, output: unknown): string | n
  */
 const useToolFavicon = (toolName: string, toolOutput: unknown, isLoading: boolean, isError: boolean) => {
   const [failedFavicons, setFailedFavicons] = useState<Set<string>>(new Set())
-  const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
+  const { cloudUrl } = useSettings({ cloud_url: defaultCloudUrlValue })
 
   const handleFaviconError = (url: string) => {
     setFailedFavicons((prev) => new Set(prev).add(url))

--- a/src/components/sign-in/sign-in-form.tsx
+++ b/src/components/sign-in/sign-in-form.tsx
@@ -1,4 +1,5 @@
 import { useAuth, useHttpClient } from '@/contexts'
+import { defaultCloudUrlValue } from '@/defaults/settings'
 import { useSettings } from '@/hooks/use-settings'
 import { isLocalhostUrl } from '@/lib/utils'
 import { type ReactNode, type RefObject, useCallback, useEffect } from 'react'
@@ -74,7 +75,7 @@ export const SignInForm = ({
 }: SignInFormProps) => {
   const authClient = useAuth()
   const httpClient = useHttpClient()
-  const { cloudUrl, preferredName } = useSettings({ cloud_url: 'http://localhost:8000/v1', preferred_name: '' })
+  const { cloudUrl, preferredName } = useSettings({ cloud_url: defaultCloudUrlValue, preferred_name: '' })
   const isLocalhost = isLocalhostUrl(cloudUrl.value)
   const displayName = preferredName.value as string
 

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -11,6 +11,68 @@ export const hashSetting = (setting: Setting): string => {
   return hashValues([setting.key, setting.value])
 }
 
+const defaultBackendPort = import.meta.env.VITE_THUNDERBOLT_BACKEND_PORT?.trim() || '8000'
+const fallbackCloudUrl = `http://localhost:${defaultBackendPort}/v1`
+
+const normalizeHostname = (hostname: string): string => hostname.replace(/^\[|\]$/g, '').toLowerCase()
+
+const isLoopbackHostname = (hostname: string): boolean => {
+  const normalizedHostname = normalizeHostname(hostname)
+  return (
+    normalizedHostname === 'localhost' ||
+    normalizedHostname === '127.0.0.1' ||
+    normalizedHostname === '0.0.0.0' ||
+    normalizedHostname === '::1'
+  )
+}
+
+const isLoopbackUrl = (url: string): boolean => {
+  try {
+    return isLoopbackHostname(new URL(url).hostname)
+  } catch {
+    return false
+  }
+}
+
+const deriveCloudUrlFromWindowLocation = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  if (!['http:', 'https:'].includes(window.location.protocol)) {
+    return null
+  }
+
+  const url = new URL(window.location.origin)
+  url.port = defaultBackendPort
+  url.pathname = '/v1'
+  url.search = ''
+  url.hash = ''
+  return url.toString().replace(/\/$/, '')
+}
+
+/**
+ * Resolve the default backend URL for the current runtime.
+ * When the frontend is opened from a LAN or Tailscale hostname, a loopback-configured
+ * cloud URL is treated as a local placeholder and rewritten to the current hostname.
+ */
+export const getDefaultCloudUrl = (): string => {
+  const configuredCloudUrl = import.meta.env.VITE_THUNDERBOLT_CLOUD_URL?.trim()
+  const derivedCloudUrl = deriveCloudUrlFromWindowLocation()
+
+  if (!configuredCloudUrl) {
+    return derivedCloudUrl ?? fallbackCloudUrl
+  }
+
+  if (derivedCloudUrl && isLoopbackUrl(configuredCloudUrl) && !isLoopbackHostname(window.location.hostname)) {
+    return derivedCloudUrl
+  }
+
+  return configuredCloudUrl
+}
+
+export const defaultCloudUrlValue = getDefaultCloudUrl()
+
 /**
  * Default settings shipped with the application
  * These are upserted on app start and serve as the baseline for diff comparisons
@@ -96,7 +158,7 @@ export const defaultSettingLocationLng: Setting = {
 
 export const defaultSettingCloudUrl: Setting = {
   key: 'cloud_url',
-  value: import.meta.env.VITE_THUNDERBOLT_CLOUD_URL || 'http://localhost:8000/v1',
+  value: defaultCloudUrlValue,
   updatedAt: null,
   defaultHash: null,
   userId: null,

--- a/src/lib/defaults.test.ts
+++ b/src/lib/defaults.test.ts
@@ -2,7 +2,7 @@ import type { Model } from '@/types'
 import { describe, expect, test } from 'bun:test'
 import { defaultAutomations, hashPrompt } from '../defaults/automations'
 import { defaultModels, hashModel } from '../defaults/models'
-import { defaultSettings, hashSetting } from '../defaults/settings'
+import { defaultSettings, getDefaultCloudUrl, hashSetting } from '../defaults/settings'
 
 describe('defaults', () => {
   test('defaultModels has expected structure', () => {
@@ -38,6 +38,31 @@ describe('defaults', () => {
       expect(setting.value).toBeDefined()
       expect(setting.defaultHash).toBeNull()
     }
+  })
+})
+
+describe('getDefaultCloudUrl', () => {
+  const originalLocation = window.location
+
+  test('derives the backend URL from the current browser hostname', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        origin: 'http://192.168.1.25:1420',
+        hostname: '192.168.1.25',
+        protocol: 'http:',
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    expect(getDefaultCloudUrl()).toBe('http://192.168.1.25:8000/v1')
+
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
   })
 })
 

--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -1,4 +1,5 @@
 import { type HttpClient } from '@/contexts'
+import { defaultCloudUrlValue } from '@/defaults/settings'
 import { getSettings } from '@/dal'
 import { getDb } from '@/db/database'
 import { createHandleError } from '@/lib/error-utils'
@@ -51,7 +52,7 @@ export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult
   try {
     const db = getDb()
     const { cloudUrl, dataCollection, debugPosthog } = await getSettings(db, {
-      cloud_url: 'http://localhost:8000/v1',
+      cloud_url: defaultCloudUrlValue,
       data_collection: true,
       debug_posthog: false,
     })

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -39,6 +39,7 @@ import { Switch } from '@/components/ui/switch'
 import { usePostHog } from 'posthog-js/react'
 import { usePowerSyncStatus } from '@/hooks/use-powersync-status'
 import { useSyncEnabledToggle } from '@/hooks/use-sync-enabled-toggle'
+import { defaultCloudUrlValue } from '@/defaults/settings'
 
 type PreferencesState = {
   isResetting: boolean
@@ -126,7 +127,7 @@ export default function PreferencesSettingsPage() {
     date_format: 'MM/DD/YYYY',
     time_format: '12h',
     currency: 'USD',
-    cloud_url: 'http://localhost:8000/v1',
+    cloud_url: defaultCloudUrlValue,
   })
 
   // Local state for name input (only save on blur to avoid DB writes on every keystroke)

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,8 +3,11 @@
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface ImportMetaEnv {
   readonly VITE_THUNDERBOLT_CLOUD_URL?: string
+  readonly VITE_THUNDERBOLT_BACKEND_PORT?: string
   readonly VITE_AUTH_MODE?: 'thunderbolt' | 'oidc'
   readonly VITE_E2EE_ENABLED?: string
+  readonly VITE_WAITLIST_ENABLED?: string
+  readonly VITE_BYPASS_WAITLIST?: string
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/src/widgets/link-preview/widget.tsx
+++ b/src/widgets/link-preview/widget.tsx
@@ -1,6 +1,7 @@
 import { Card, CardHeader } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useHttpClient } from '@/contexts'
+import { defaultCloudUrlValue } from '@/defaults/settings'
 import { useMessageCache } from '@/hooks/use-message-cache'
 import { useSettings } from '@/hooks/use-settings'
 import { fetchLinkPreview } from '@/integrations/thunderbolt-pro/api'
@@ -71,7 +72,7 @@ const InstantLinkPreview = ({ sourceData, cloudUrl }: { sourceData: SourceMetada
 }
 
 export const LinkPreviewWidget = ({ url, source, sources, messageId, fetchPreviewFn }: LinkPreviewWidgetProps) => {
-  const { cloudUrl } = useSettings({ cloud_url: 'http://localhost:8000/v1' })
+  const { cloudUrl } = useSettings({ cloud_url: defaultCloudUrlValue })
 
   // Instant render path: resolve from source registry (O(1) index lookup)
   if (source && sources) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,7 +89,7 @@ export default defineConfig({
   server: {
     port: 1420,
     strictPort: true,
-    host: host || false,
+    host: host || '0.0.0.0',
     hmr: host
       ? {
           protocol: 'ws',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CORS/auth origin validation and redirect URI allowance, which can impact security boundaries if the new private-network matching logic is incorrect or misconfigured. Waitlist gating behavior now depends on explicit env flags, so incorrect defaults could unintentionally open or close sign-in flows.
> 
> **Overview**
> Enables local-network (LAN/Tailscale) usage by **auto-deriving the frontend default `cloud_url` from the current browser hostname** (configurable via `VITE_THUNDERBOLT_BACKEND_PORT`) and updating multiple callers to use this shared `defaultCloudUrlValue` instead of hardcoded `http://localhost:8000/v1`.
> 
> Hardens/expands origin handling by introducing `ALLOW_PRIVATE_NETWORK_ORIGINS` and enhancing `isOriginAllowed`/`isOAuthRedirectUriAllowed` to accept private-network hostnames *only on the configured app port*; CORS middleware and Better Auth `trustedOrigins` now use this logic, and magic-link origin validation accepts these same origins.
> 
> Makes waitlist behavior explicitly configurable: frontend waitlist routes are mounted only when `VITE_WAITLIST_ENABLED` is true (otherwise redirect), and backend waitlist gating for OTP/sign-in and `/waitlist/join` is skipped when `WAITLIST_ENABLED` is false; tests/docs/env examples are updated accordingly. Also updates dev ergonomics by binding Vite/backend to `0.0.0.0` by default and making the Makefile’s `bun` invocation more robust.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4011582abb18a387a6ee67135d3b0576551273c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->