### PR TITLE
docs(development): add missing `cd ..` in Quick Start before `make docker-up`

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -11,6 +11,7 @@ make setup
 # Set up .env files
 cp .env.example .env
 cd backend && cp .env.example .env
+cd ..
 
 # Run postgres + powersync
 make docker-up


### PR DESCRIPTION
Closes #620

## What
Adds `cd ..` in the `development.md` Quick Start block after `cd backend && cp .env.example .env`, so that the subsequent `make docker-up` runs from the repo root as intended.

## Why
Following the Quick Start as a continuous sequence of commands leaves the user in `backend/` when they reach `make docker-up`, which fails:

``` 
make: *** No rule to make target 'docker-up'.  Stop.
```

The commented-out `# cd backend && bun dev` line that appears shortly after `make docker-up` in the same block implies the author expected the reader to be at the repo root at that point — confirming this is an unintentional omission rather than a design choice.

## How I tested
- Fresh clone of `main` (commit `edd5e15`) on Ubuntu 24.04
- Ran the updated Quick Start block end-to-end
- Confirmed `make docker-up` now succeeds from the correct directory
- Unrelated: hit a port 5433 conflict from a pre-existing local Postgres service; resolved locally by stopping it. Not relevant to this change.

## Scope
Minimal fix - only one line added. I considered restructuring the block into numbered steps with explicit working directories per step, but opted for the smallest change that resolves the reported issue. Happy to expand scope if preferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts a single shell command sequence and does not affect runtime behavior.
> 
> **Overview**
> Updates `docs/development.md` Quick Start to add an explicit `cd ..` after copying `backend/.env`, ensuring subsequent commands (notably `make docker-up`) run from the repository root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12388080584f1e89a5c5385f3e40d16b9aa69cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->