### PR TITLE
Fix demo user email in README

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -40,7 +40,7 @@ docker compose up --build
 |---------|-----|-------------|
 | App | http://localhost:3000 | (via Keycloak SSO) |
 | Keycloak admin | http://localhost:8180 | admin / admin |
-| Demo user | (Keycloak login) | demo@thunderbolt.so / demo |
+| Demo user | (Keycloak login) | demo@thunderbolt.io / demo |
 
 ```bash
 docker compose down        # stop, keep data
@@ -78,7 +78,7 @@ See [.env.example](.env.example). Variables hardcoded in `docker-compose.yml` (a
 
 Realm `thunderbolt` auto-imports from `config/keycloak-realm.json` on first boot.
 - Client: `thunderbolt-app`
-- Default user: demo@thunderbolt.so / demo
+- Default user: demo@thunderbolt.io / demo
 - Admin console: `/admin` (admin / admin)
 
 ### PowerSync


### PR DESCRIPTION
Updated demo user email in README from thunderbolt.so to thunderbolt.io.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating the demo Keycloak user email; no runtime or configuration behavior is modified.
> 
> **Overview**
> Updates `deploy/README.md` to replace the demo Keycloak user email from `demo@thunderbolt.so` to `demo@thunderbolt.io` in both the Docker Compose quickstart table and the Keycloak “Default user” section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78a741a756aea57a18cf94a826f5867658287ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->