### PR TITLE
fix: increase POWERSYNC_JWT_SECRET to meet 32-char minimum

### DIFF
--- a/deploy/config/powersync-config.yaml
+++ b/deploy/config/powersync-config.yaml
@@ -35,8 +35,8 @@ client_auth:
     keys:
       - kty: oct
         # Base64 of POWERSYNC_JWT_SECRET — must match backend env var
-        # Default: base64("enterprise-powersync-secret") = ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0
-        k: ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0
+        # Default: base64("enterprise-powersync-secret-key32") = ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0LWtleTMy
+        k: ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0LWtleTMy
         alg: HS256
         kid: enterprise-powersync
   telemetry:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       TRUSTED_ORIGINS: http://localhost:${FRONTEND_PORT:-3000}
       CORS_ORIGINS: http://localhost:${FRONTEND_PORT:-3000}
       POWERSYNC_URL: http://powersync:8080
-      POWERSYNC_JWT_SECRET: enterprise-powersync-secret
+      POWERSYNC_JWT_SECRET: enterprise-powersync-secret-key32
       POWERSYNC_JWT_KID: enterprise-powersync
       RATE_LIMIT_ENABLED: "false"
     depends_on:


### PR DESCRIPTION
The hardcoded POWERSYNC_JWT_SECRET ('enterprise-powersync-secret', 27 chars) was below the backend's 32-character minimum, causing the backend to crash with a ZodError on startup and the app to hang on load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it will invalidate any existing tokens signed with the previous `POWERSYNC_JWT_SECRET` until all services pick up the new value.
> 
> **Overview**
> Updates the default `POWERSYNC_JWT_SECRET` used by local deployment to a 32+ char value and updates the matching base64-encoded `jwks.keys[].k` in `powersync-config.yaml`.
> 
> This aligns the docker-compose backend env var and PowerSync config so startup validation no longer fails due to an undersized secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1b3527177f4b89da507b13b0079098eef658ec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->