### PR TITLE
fix (deploy): PowerSync JWT secret defaults to satisfy backend 32-char validation

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -83,4 +83,4 @@ Realm `thunderbolt` auto-imports from `config/keycloak-realm.json` on first boot
 
 ### PowerSync
 
-Sync rules in `config/powersync-config.yaml`. JWT secret must match between backend and PowerSync config.
+Sync rules in `config/powersync-config.yaml`. JWT secret must match between backend and PowerSync config and must be at least 32 characters.

--- a/deploy/config/powersync-config.yaml
+++ b/deploy/config/powersync-config.yaml
@@ -35,8 +35,8 @@ client_auth:
     keys:
       - kty: oct
         # Base64 of POWERSYNC_JWT_SECRET — must match backend env var
-        # Default: base64("enterprise-powersync-secret") = ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0
-        k: ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0
+        # Default: base64("enterprise-powersync-secret-2026-key") = ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0LTIwMjYta2V5
+        k: ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0LTIwMjYta2V5
         alg: HS256
         kid: enterprise-powersync
   telemetry:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       TRUSTED_ORIGINS: http://localhost:${FRONTEND_PORT:-3000}
       CORS_ORIGINS: http://localhost:${FRONTEND_PORT:-3000}
       POWERSYNC_URL: http://powersync:8080
-      POWERSYNC_JWT_SECRET: enterprise-powersync-secret
+      POWERSYNC_JWT_SECRET: enterprise-powersync-secret-2026-key
       POWERSYNC_JWT_KID: enterprise-powersync
       RATE_LIMIT_ENABLED: "false"
     depends_on:

--- a/deploy/k8s/values.yaml
+++ b/deploy/k8s/values.yaml
@@ -69,8 +69,8 @@ powersync:
     port: 8080
   jwt:
     kid: enterprise-powersync
-    # -- Base64-encoded JWT secret (default: "enterprise-powersync-secret")
-    secretBase64: ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0
+    # -- Base64-encoded JWT secret (default: "enterprise-powersync-secret-2026-key")
+    secretBase64: ZW50ZXJwcmlzZS1wb3dlcnN5bmMtc2VjcmV0LTIwMjYta2V5
 
 # =============================================================================
 # Keycloak (OIDC Identity Provider)

--- a/deploy/pulumi/src/services.ts
+++ b/deploy/pulumi/src/services.ts
@@ -276,7 +276,7 @@ export const createServices = (args: ServiceArgs) => {
             { name: 'TRUSTED_ORIGINS', value: `http://${dns}` },
             { name: 'CORS_ORIGINS', value: `http://${dns}` },
             { name: 'POWERSYNC_URL', value: `http://${dns}/powersync` },
-            { name: 'POWERSYNC_JWT_SECRET', value: 'enterprise-powersync-secret' },
+            { name: 'POWERSYNC_JWT_SECRET', value: 'enterprise-powersync-secret-2026-key' },
             { name: 'POWERSYNC_JWT_KID', value: 'enterprise-powersync' },
             { name: 'RATE_LIMIT_ENABLED', value: 'true' },
           ],

--- a/src/integrations/google/auth.ts
+++ b/src/integrations/google/auth.ts
@@ -18,6 +18,13 @@ const fetchBackendConfig = (httpClient: HttpClient): Promise<AuthProviderBackend
 
 export const getOAuthConfig = async (httpClient: HttpClient): Promise<OAuthConfig> => {
   const { client_id: clientId } = await fetchBackendConfig(httpClient)
+
+  if (!clientId) {
+    // Reset cache so configuration can be picked up after backend env changes.
+    cachedBackendConfig = null
+    throw new Error('Google sync is not configured on this server. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.')
+  }
+
   const redirectUri = getOAuthRedirectUri()
 
   return {

--- a/src/integrations/microsoft/auth.ts
+++ b/src/integrations/microsoft/auth.ts
@@ -18,6 +18,15 @@ const fetchBackendConfig = (httpClient: HttpClient): Promise<AuthProviderBackend
 
 export const getOAuthConfig = async (httpClient: HttpClient): Promise<OAuthConfig> => {
   const { client_id: clientId } = await fetchBackendConfig(httpClient)
+
+  if (!clientId) {
+    // Reset cache so configuration can be picked up after backend env changes.
+    cachedBackendConfig = null
+    throw new Error(
+      'Microsoft sync is not configured on this server. Set MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET.',
+    )
+  }
+
   const redirectUri = getOAuthRedirectUri()
 
   return {


### PR DESCRIPTION
**Summary**
This PR fixes deployment defaults that can cause backend startup failure when PowerSync is enabled.

**Problem**
Backend validates that powersyncJwtSecret is at least 32 characters when powersyncUrl is set (see [settings.ts:76](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
Several deployment defaults used a shorter PowerSync JWT secret, which caused runtime validation failure and backend crash in default local/deploy flows.

**Changes**

- Docker Compose:
Updated backend POWERSYNC_JWT_SECRET
Updated matching PowerSync JWKS base64 key

- Kubernetes:
Updated default powersync.jwt.secretBase64

- Pulumi:
Updated backend POWERSYNC_JWT_SECRET default


**Validation**

- Ran Docker deployment flow from deploy directory
- Verified container health and service availability
- Confirmed backend starts successfully and serves health endpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration and guardrail changes; main impact is that deployments/integrations that relied on old defaults or missing OAuth env vars will now error explicitly instead of failing later.
> 
> **Overview**
> Fixes PowerSync-enabled deployments by updating the default `POWERSYNC_JWT_SECRET` (and matching JWKS/base64 values) across Docker Compose, Helm `values.yaml`, Pulumi, and docs to satisfy the backend’s **32-character minimum** validation.
> 
> Improves Google and Microsoft integration startup by making `getOAuthConfig` throw a clear error when the backend returns no `client_id`, and resetting the cached config so env changes can be picked up without a restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3079a9d2c25b1be6e3b688e356d87ff8d5f19c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->