### PR TITLE
feat: add lighthouse plugin to PRs

### DIFF
--- a/.github/scripts/post-pr-metrics.cjs
+++ b/.github/scripts/post-pr-metrics.cjs
@@ -13,7 +13,8 @@ module.exports = async ({ github, context }) => {
   // All metric values are passed in as environment variables by the workflow.
   // The workflow captures them from individual step outputs.
   const { LINES_ADDED, LINES_REMOVED, BUNDLE_GZIP, COVERAGE, BUILD_OUTCOME,
-          PREVIEW_URL, PREVIEW_READY, LH_PERF, LH_FCP, LH_LCP, LH_TBT } = process.env
+          PREVIEW_URL, PREVIEW_READY, LH_PERF, LH_A11Y, LH_BP, LH_SEO,
+          LH_FCP, LH_LCP, LH_TBT, LH_CLS, LH_REPORT_URL, LH_WARNINGS } = process.env
 
   // BUNDLE_GZIP is the gzipped JS bundle size in bytes — what users actually download.
   // Measured by size-limit, which is more accurate than summing raw file sizes.
@@ -79,26 +80,30 @@ module.exports = async ({ github, context }) => {
     return `${COVERAGE}% _(no baseline yet — merge to main first)_`
   })()
 
-  // Builds the load time cell using Lighthouse metrics from the Render PR preview.
-  // Shows performance score + the three key timing metrics:
-  // - FCP: when something first appears on screen
-  // - LCP: when the main content appears (best proxy for "spinner gone")
-  // - TBT: total blocking time (proxy for interactivity)
+  // Builds the Lighthouse section using metrics from the Render PR preview.
+  // Shows category scores + key web vitals, with an optional link to the full report.
   // Falls back gracefully when the preview wasn't ready or Lighthouse failed.
+  const scoreIcon = (score) => score >= 90 ? ':green_circle:' : score >= 50 ? ':yellow_circle:' : ':red_circle:'
+
   const lighthouseLine = (() => {
     if (PREVIEW_READY !== 'true') return '_Preview not ready — Render deploy may have timed out_'
-    // Validate all four values before rendering — a partial failure from
-    // continue-on-error would leave some outputs empty, producing NaN or blank text.
     const perfScore = parseInt(LH_PERF)
     if (isNaN(perfScore) || !LH_FCP || !LH_LCP || !LH_TBT) return '_Lighthouse results unavailable_'
-    const icon = perfScore >= 90 ? ':green_circle:' : perfScore >= 50 ? ':yellow_circle:' : ':red_circle:'
-    return `${icon} **${perfScore}/100** · First Contentful Paint ${LH_FCP} · Largest Contentful Paint ${LH_LCP} · Total Blocking Time ${LH_TBT}`
+    const reportLink = LH_REPORT_URL ? ` · [Full report](${LH_REPORT_URL})` : ''
+    return `${scoreIcon(perfScore)} **${perfScore}/100** · FCP ${LH_FCP} · LCP ${LH_LCP} · TBT ${LH_TBT} · CLS ${LH_CLS || 'N/A'}${reportLink}`
   })()
+
+  const a11yScore = parseInt(LH_A11Y)
+  const a11yLine = isNaN(a11yScore) ? '—' : `${scoreIcon(a11yScore)} **${a11yScore}/100**`
+  const bpScore = parseInt(LH_BP)
+  const bpLine = isNaN(bpScore) ? '—' : `${scoreIcon(bpScore)} **${bpScore}/100**`
+  const seoScore = parseInt(LH_SEO)
+  const seoLine = isNaN(seoScore) ? '—' : `${scoreIcon(seoScore)} **${seoScore}/100**`
 
   const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
   const now = new Date().toUTCString()
 
-  const body = [
+  const lines = [
     '## PR Metrics',
     '',
     '| Metric | Value |',
@@ -106,10 +111,35 @@ module.exports = async ({ github, context }) => {
     `| Lines changed (prod code) | \`+${LINES_ADDED || 0} / -${LINES_REMOVED || 0}\` |`,
     `| JS bundle size (gzipped) | ${bundleLine} |`,
     `| Test coverage | ${coverageLine} |`,
-    `| Load time ([preview](${PREVIEW_URL})) | ${lighthouseLine} |`,
+    `| Performance ([preview](${PREVIEW_URL})) | ${lighthouseLine} |`,
+    `| Accessibility | ${a11yLine} |`,
+    `| Best Practices | ${bpLine} |`,
+    `| SEO | ${seoLine} |`,
+  ]
+
+  // Show LHCI assertion warnings in a collapsible section so reviewers
+  // can see what's below threshold without digging into CI logs.
+  const warnings = (LH_WARNINGS || '').trim()
+  if (warnings) {
+    lines.push(
+      '',
+      '<details>',
+      '<summary>:warning: Lighthouse warnings</summary>',
+      '',
+      '```',
+      warnings,
+      '```',
+      '',
+      '</details>',
+    )
+  }
+
+  lines.push(
     '',
     `_Updated ${now} · [run #${context.runNumber}](${runUrl})_`,
-  ].join('\n')
+  )
+
+  const body = lines.join('\n')
 
   // Look for a previous metrics comment from the Actions bot so we can
   // update it in place rather than posting a new comment on every push.

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run Lighthouse assertions
         id: lh_assert
-        if: steps.lighthouse.outcome == 'success'
+        if: steps.lighthouse.conclusion == 'success'
         run: |
           # Run assertions separately so we can capture warnings as text.
           # The action already ran collect+upload; we just need assert.
@@ -133,7 +133,7 @@ jobs:
 
       - name: Parse Lighthouse results
         id: lh
-        if: steps.lighthouse.outcome == 'success'
+        if: steps.lighthouse.conclusion == 'success'
         run: |
           # With multiple runs, pick the median report (middle file by name).
           REPORTS=($(ls .lighthouseci/*.report.json 2>/dev/null | sort))

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           # Run assertions separately so we can capture warnings as text.
           # The action already ran collect+upload; we just need assert.
-          npx @lhci/cli@0.15.x assert --config=./lighthouserc.js 2>&1 | tee /tmp/lhci-assert.txt || true
+          bunx @lhci/cli@0.15.x assert --config=./lighthouserc.js 2>&1 | tee /tmp/lhci-assert.txt || true
           # Extract only warning lines for the PR comment.
           WARNINGS=$(grep -E '^\s*warning' /tmp/lhci-assert.txt | sed 's/^\s*//' || true)
           # Store as multiline output

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run Lighthouse assertions
         id: lh_assert
-        if: steps.lighthouse.conclusion == 'success'
+        if: hashFiles('.lighthouseci/*.report.json') != ''
         run: |
           # Run assertions separately so we can capture warnings as text.
           # The action already ran collect+upload; we just need assert.
@@ -133,7 +133,7 @@ jobs:
 
       - name: Parse Lighthouse results
         id: lh
-        if: steps.lighthouse.conclusion == 'success'
+        if: hashFiles('.lighthouseci/*.report.json') != ''
         run: |
           # With multiple runs, pick the median report (middle file by name).
           REPORTS=($(ls .lighthouseci/*.report.json 2>/dev/null | sort))

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -104,26 +104,55 @@ jobs:
           echo "ready=false" >> $GITHUB_OUTPUT
         continue-on-error: true
 
-      - name: Run Lighthouse
+      - name: Run Lighthouse (collect + upload)
         id: lighthouse
         if: steps.preview.outputs.ready == 'true'
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: ${{ steps.preview.outputs.url }}
-          runs: 1
+          configPath: ./lighthouserc.js
           uploadArtifacts: false
+        continue-on-error: true
+
+      - name: Run Lighthouse assertions
+        id: lh_assert
+        if: steps.lighthouse.outcome == 'success'
+        run: |
+          # Run assertions separately so we can capture warnings as text.
+          # The action already ran collect+upload; we just need assert.
+          npx @lhci/cli@0.15.x assert --config=./lighthouserc.js 2>&1 | tee /tmp/lhci-assert.txt || true
+          # Extract only warning lines for the PR comment.
+          WARNINGS=$(grep -E '^\s*warning' /tmp/lhci-assert.txt | sed 's/^\s*//' || true)
+          # Store as multiline output
+          {
+            echo 'warnings<<LHCI_EOF'
+            echo "$WARNINGS"
+            echo 'LHCI_EOF'
+          } >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Parse Lighthouse results
         id: lh
         if: steps.lighthouse.outcome == 'success'
         run: |
-          REPORT=$(ls .lighthouseci/*.report.json 2>/dev/null | head -1)
-          if [ -z "$REPORT" ]; then exit 0; fi
+          # With multiple runs, pick the median report (middle file by name).
+          REPORTS=($(ls .lighthouseci/*.report.json 2>/dev/null | sort))
+          COUNT=${#REPORTS[@]}
+          if [ "$COUNT" -eq 0 ]; then exit 0; fi
+          MEDIAN_IDX=$(( COUNT / 2 ))
+          REPORT="${REPORTS[$MEDIAN_IDX]}"
           echo "perf=$(jq -r '.categories.performance.score * 100 | floor' "$REPORT")" >> $GITHUB_OUTPUT
+          echo "a11y=$(jq -r '.categories.accessibility.score * 100 | floor' "$REPORT")" >> $GITHUB_OUTPUT
+          echo "bp=$(jq -r '.categories["best-practices"].score * 100 | floor' "$REPORT")" >> $GITHUB_OUTPUT
+          echo "seo=$(jq -r '.categories.seo.score * 100 | floor' "$REPORT")" >> $GITHUB_OUTPUT
           echo "fcp=$(jq -r '.audits["first-contentful-paint"].displayValue' "$REPORT")" >> $GITHUB_OUTPUT
           echo "lcp=$(jq -r '.audits["largest-contentful-paint"].displayValue' "$REPORT")" >> $GITHUB_OUTPUT
           echo "tbt=$(jq -r '.audits["total-blocking-time"].displayValue' "$REPORT")" >> $GITHUB_OUTPUT
+          echo "cls=$(jq -r '.audits["cumulative-layout-shift"].displayValue' "$REPORT")" >> $GITHUB_OUTPUT
+          # Extract temporary public storage URL from LHCI output
+          LINKS=$(cat .lighthouseci/links.json 2>/dev/null || echo '{}')
+          REPORT_URL=$(echo "$LINKS" | jq -r 'to_entries[0].value // empty' 2>/dev/null)
+          echo "report_url=${REPORT_URL}" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       # --- Post or update the metrics comment ---
@@ -138,9 +167,15 @@ jobs:
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
           PREVIEW_READY: ${{ steps.preview.outputs.ready }}
           LH_PERF: ${{ steps.lh.outputs.perf }}
+          LH_A11Y: ${{ steps.lh.outputs.a11y }}
+          LH_BP: ${{ steps.lh.outputs.bp }}
+          LH_SEO: ${{ steps.lh.outputs.seo }}
           LH_FCP: ${{ steps.lh.outputs.fcp }}
           LH_LCP: ${{ steps.lh.outputs.lcp }}
           LH_TBT: ${{ steps.lh.outputs.tbt }}
+          LH_CLS: ${{ steps.lh.outputs.cls }}
+          LH_REPORT_URL: ${{ steps.lh.outputs.report_url }}
+          LH_WARNINGS: ${{ steps.lh_assert.outputs.warnings }}
         with:
           script: |
             const script = require('./.github/scripts/post-pr-metrics.cjs')

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -4,8 +4,6 @@ module.exports = {
     collect: {
       numberOfRuns: 3,
       settings: {
-        // Simulate a mid-tier mobile device on a slow 4G connection
-        preset: 'desktop',
         // Skip audits that aren't relevant for an SPA behind auth
         skipAudits: ['redirects-http', 'is-crawlable'],
       },

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,35 @@
+/** @type {import('@lhci/types').LHCI.UserConfig} */
+module.exports = {
+  ci: {
+    collect: {
+      numberOfRuns: 3,
+      settings: {
+        // Simulate a mid-tier mobile device on a slow 4G connection
+        preset: 'desktop',
+        // Skip audits that aren't relevant for an SPA behind auth
+        skipAudits: ['redirects-http', 'is-crawlable'],
+      },
+    },
+    upload: {
+      // Temporary public storage — no server needed.
+      // Results are available for ~7 days at the printed URL.
+      target: 'temporary-public-storage',
+    },
+    assert: {
+      // Informational only — log warnings but never fail CI.
+      preset: 'lighthouse:recommended',
+      assertions: {
+        // Override every category to warn-only so CI stays green.
+        'categories:performance': ['warn', { minScore: 0.8 }],
+        'categories:accessibility': ['warn', { minScore: 0.9 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:seo': ['warn', { minScore: 0.8 }],
+        // Key web vitals — warn thresholds only.
+        'first-contentful-paint': ['warn', { maxNumericValue: 2000 }],
+        'largest-contentful-paint': ['warn', { maxNumericValue: 2500 }],
+        'total-blocking-time': ['warn', { maxNumericValue: 300 }],
+        'cumulative-layout-shift': ['warn', { maxNumericValue: 0.1 }],
+      },
+    },
+  },
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the PR metrics GitHub Action workflow and comment formatting; main risk is CI flakiness/runtime changes and reliance on LHCI temporary public storage/report parsing, not application runtime behavior.
> 
> **Overview**
> Enhances the PR Metrics comment to include Lighthouse **Performance/A11y/Best Practices/SEO** scores plus CLS, and optionally links to a full Lighthouse report; it also surfaces LHCI assertion warnings in a collapsible section.
> 
> Updates the `pr-metrics` workflow to use a shared `lighthouserc.js` (3-run collection with median selection), upload results to temporary public storage, and run LHCI assertions separately to capture warning text for the PR comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a52f8fb750077fb371dedbf4ce091e398213366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->