### PR TITLE
THU-430: Missing canary proof-of-CK-possession on device revocation enables E2EE state reset

### DIFF
--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -716,6 +716,73 @@ describe('Account API', () => {
       expect(envelopes).toHaveLength(0)
     })
 
+    it('prevents full attack chain: stolen session cannot revoke devices to reset E2EE state', async () => {
+      // Setup: user with 2 trusted devices, both with envelopes, E2EE fully active
+      const userId = p('attack-chain-user')
+      const token = p('attack-chain-token')
+      const attackerDeviceId = p('attacker-device')
+      const victimDevice1 = p('victim-device-1')
+      const victimDevice2 = p('victim-device-2')
+      const now = await createUserSessionAndDevice(userId, token, victimDevice1)
+      await insertCanaryWithSecret(userId)
+
+      await db.insert(devicesTable).values({
+        id: victimDevice2,
+        userId,
+        name: 'Victim Device 2',
+        trusted: true,
+        lastSeen: now,
+        createdAt: now,
+      })
+
+      await db.insert(envelopesTable).values([
+        { deviceId: victimDevice1, userId, wrappedCk: 'victim-ck-1', updatedAt: now },
+        { deviceId: victimDevice2, userId, wrappedCk: 'victim-ck-2', updatedAt: now },
+      ])
+
+      // Attack step 1: Try to revoke device 1 without canary proof
+      const attack1 = await app.handle(revokeRequest(victimDevice1, token, { callerDeviceId: victimDevice1 }))
+      expect(attack1.status).toBe(403)
+
+      // Attack step 2: Try to revoke device 2 with a guessed canary
+      const attack2 = await app.handle(
+        revokeRequest(victimDevice2, token, {
+          callerDeviceId: victimDevice1,
+          canarySecret: 'attacker-guess',
+        }),
+      )
+      expect(attack2.status).toBe(403)
+
+      // Attack step 3: Try from an untrusted attacker device
+      await db.insert(devicesTable).values({
+        id: attackerDeviceId,
+        userId,
+        name: 'Attacker Device',
+        trusted: false,
+        lastSeen: now,
+        createdAt: now,
+      })
+      const attack3 = await app.handle(
+        revokeRequest(victimDevice1, token, {
+          callerDeviceId: attackerDeviceId,
+          canarySecret: testCanarySecret,
+        }),
+      )
+      expect(attack3.status).toBe(403)
+
+      // Verify: both envelopes still intact, both devices still trusted
+      const envelopes = await db.select().from(envelopesTable).where(eq(envelopesTable.userId, userId))
+      expect(envelopes).toHaveLength(2)
+
+      const [d1] = await db.select().from(devicesTable).where(eq(devicesTable.id, victimDevice1))
+      expect(d1.trusted).toBe(true)
+      expect(d1.revokedAt).toBeNull()
+
+      const [d2] = await db.select().from(devicesTable).where(eq(devicesTable.id, victimDevice2))
+      expect(d2.trusted).toBe(true)
+      expect(d2.revokedAt).toBeNull()
+    })
+
     it('returns 204 without canarySecret for pre-encryption user (no E2EE metadata)', async () => {
       const userId = p('pre-enc-user')
       const token = p('pre-enc-token')

--- a/backend/src/api/account.test.ts
+++ b/backend/src/api/account.test.ts
@@ -1,7 +1,8 @@
 import { createAuth } from '@/auth/auth'
 import { session as sessionTable, user } from '@/db/auth-schema'
-import { envelopesTable } from '@/db/encryption-schema'
+import { encryptionMetadataTable, envelopesTable } from '@/db/encryption-schema'
 import { chatThreadsTable, devicesTable, settingsTable, tasksTable } from '@/db/schema'
+import { hashCanarySecret } from '@/lib/canary'
 import { createTestDb } from '@/test-utils/db'
 import { createHmac } from 'crypto'
 import { eq } from 'drizzle-orm'
@@ -30,6 +31,9 @@ const signToken = (token: string): string => {
 const counterKey = Symbol.for('account-test-runId')
 ;(globalThis as Record<symbol, number>)[counterKey] ??= 0
 
+/** Known canary secret for tests that require proof-of-CK-possession. */
+const testCanarySecret = 'test-canary-secret-for-revoke-proof'
+
 describe('Account API', () => {
   let app: ReturnType<typeof createAccountRoutes>
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
@@ -53,7 +57,77 @@ describe('Account API', () => {
     await cleanup()
   })
 
-  describe('POST /v1/account/devices/:id/revoke', () => {
+  /** Create a user, session, and trusted caller device. Returns { now, callerDeviceId }. */
+  const createUserSessionAndDevice = async (userId: string, token: string, callerDeviceId: string) => {
+    const now = new Date()
+    const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+    await db.insert(user).values({
+      id: userId,
+      name: 'Test User',
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    await db.insert(sessionTable).values({
+      id: `session-${userId}`,
+      expiresAt,
+      token,
+      createdAt: now,
+      updatedAt: now,
+      userId,
+      deviceId: callerDeviceId,
+    })
+
+    await db.insert(devicesTable).values({
+      id: callerDeviceId,
+      userId,
+      name: 'Caller Device',
+      lastSeen: now,
+      createdAt: now,
+      trusted: true,
+    })
+
+    return now
+  }
+
+  /** Insert encryption metadata with a known canary secret hash. */
+  const insertCanaryWithSecret = async (userId: string) => {
+    const hash = await hashCanarySecret(testCanarySecret)
+    const now = new Date()
+    await db.insert(encryptionMetadataTable).values({
+      userId,
+      canaryIv: 'iv-test',
+      canaryCtext: 'ctext-test',
+      canarySecretHash: hash,
+      createdAt: now,
+    })
+  }
+
+  /** Build a revoke request with proper headers and body. */
+  const revokeRequest = (
+    deviceId: string,
+    token: string,
+    opts?: { callerDeviceId?: string; canarySecret?: string; omitDeviceHeader?: boolean },
+  ) => {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${signToken(token)}`,
+      'Content-Type': 'application/json',
+    }
+    if (!opts?.omitDeviceHeader && opts?.callerDeviceId) {
+      headers['X-Device-ID'] = opts.callerDeviceId
+    }
+    const body = opts?.canarySecret ? JSON.stringify({ canarySecret: opts.canarySecret }) : '{}'
+    return new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
+      method: 'POST',
+      headers,
+      body,
+    })
+  }
+
+  describe('POST /v1/account/devices/:id/revoke (session behavior)', () => {
     it('revokes only sessions linked to the revoked device', async () => {
       const userId = p('session-revoke-user')
       const token = p('session-revoke-token')
@@ -101,6 +175,7 @@ describe('Account API', () => {
           id: myDeviceId,
           userId,
           name: 'My Device',
+          trusted: true,
           lastSeen: now,
           createdAt: now,
         },
@@ -113,13 +188,8 @@ describe('Account API', () => {
         },
       ])
 
-      // Revoke the compromised device
-      const response = await app.handle(
-        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(token)}` },
-        }),
-      )
+      // No encryption metadata — pre-encryption user path (no canary needed)
+      const response = await app.handle(revokeRequest(deviceId, token, { callerDeviceId: myDeviceId }))
       expect(response.status).toBe(204)
 
       // My session (linked to my device) should still exist
@@ -159,20 +229,25 @@ describe('Account API', () => {
         deviceId: myDeviceId,
       })
 
-      await db.insert(devicesTable).values({
-        id: deviceId,
-        userId,
-        name: 'Device',
-        lastSeen: now,
-        createdAt: now,
-      })
+      await db.insert(devicesTable).values([
+        {
+          id: myDeviceId,
+          userId,
+          name: 'My Device',
+          trusted: true,
+          lastSeen: now,
+          createdAt: now,
+        },
+        {
+          id: deviceId,
+          userId,
+          name: 'Device',
+          lastSeen: now,
+          createdAt: now,
+        },
+      ])
 
-      const response = await app.handle(
-        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(token)}` },
-        }),
-      )
+      const response = await app.handle(revokeRequest(deviceId, token, { callerDeviceId: myDeviceId }))
       expect(response.status).toBe(204)
 
       // Session should still exist (linked to a different device)
@@ -186,6 +261,7 @@ describe('Account API', () => {
       const otherToken = p('nonexistent-revoke-other-token')
       const sessionId = p('session-revoker')
       const otherSessionId = p('session-other')
+      const callerDeviceId = p('caller-device-nonexist')
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
 
@@ -198,6 +274,15 @@ describe('Account API', () => {
         updatedAt: now,
       })
 
+      await db.insert(devicesTable).values({
+        id: callerDeviceId,
+        userId,
+        name: 'Caller Device',
+        trusted: true,
+        lastSeen: now,
+        createdAt: now,
+      })
+
       await db.insert(sessionTable).values([
         {
           id: sessionId,
@@ -206,6 +291,7 @@ describe('Account API', () => {
           createdAt: now,
           updatedAt: now,
           userId,
+          deviceId: callerDeviceId,
         },
         {
           id: otherSessionId,
@@ -217,13 +303,8 @@ describe('Account API', () => {
         },
       ])
 
-      // Revoke a device that doesn't exist
-      const response = await app.handle(
-        new Request('http://localhost/v1/account/devices/nonexistent-device/revoke', {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(token)}` },
-        }),
-      )
+      // Revoke a device that doesn't exist — pre-encryption user (no canary needed)
+      const response = await app.handle(revokeRequest('nonexistent-device', token, { callerDeviceId }))
       expect(response.status).toBe(204)
 
       // Both sessions should still exist — no device was actually revoked
@@ -373,36 +454,13 @@ describe('Account API', () => {
     })
   })
 
-  describe('POST /v1/account/devices/:id/revoke', () => {
-    const createUserAndSession = async (userId: string, token: string) => {
-      const now = new Date()
-      const expiresAt = new Date(now.getTime() + 3600 * 1000)
-
-      await db.insert(user).values({
-        id: userId,
-        name: 'Test User',
-        email: `${userId}@example.com`,
-        emailVerified: true,
-        createdAt: now,
-        updatedAt: now,
-      })
-
-      await db.insert(sessionTable).values({
-        id: `session-${userId}`,
-        expiresAt,
-        token,
-        createdAt: now,
-        updatedAt: now,
-        userId,
-      })
-
-      return now
-    }
-
+  describe('POST /v1/account/devices/:id/revoke (canary proof)', () => {
     it('returns 401 without auth', async () => {
       const response = await app.handle(
         new Request('http://localhost/v1/account/devices/some-device/revoke', {
           method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
         }),
       )
       expect(response.status).toBe(401)
@@ -412,17 +470,94 @@ describe('Account API', () => {
       const response = await app.handle(
         new Request('http://localhost/v1/account/devices/some-device/revoke', {
           method: 'POST',
-          headers: { Authorization: 'Bearer bogus-token' },
+          headers: { Authorization: 'Bearer bogus-token', 'Content-Type': 'application/json' },
+          body: '{}',
         }),
       )
       expect(response.status).toBe(401)
     })
 
-    it('returns 204 and revokes device + deletes envelope', async () => {
+    it('returns 400 when X-Device-ID header is missing', async () => {
+      const userId = p('no-header-user')
+      const token = p('no-header-token')
+      await createUserSessionAndDevice(userId, token, p('caller-no-header'))
+      await insertCanaryWithSecret(userId)
+
+      const response = await app.handle(revokeRequest(p('some-device'), token, { omitDeviceHeader: true }))
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.error).toContain('X-Device-ID')
+    })
+
+    it('returns 403 when canarySecret is missing (E2EE active)', async () => {
+      const userId = p('no-canary-user')
+      const token = p('no-canary-token')
+      const callerDeviceId = p('caller-no-canary')
+      await createUserSessionAndDevice(userId, token, callerDeviceId)
+      await insertCanaryWithSecret(userId)
+
+      const response = await app.handle(revokeRequest(p('target-device'), token, { callerDeviceId }))
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toContain('Canary secret required')
+    })
+
+    it('returns 403 when canarySecret is invalid', async () => {
+      const userId = p('bad-canary-user')
+      const token = p('bad-canary-token')
+      const callerDeviceId = p('caller-bad-canary')
+      await createUserSessionAndDevice(userId, token, callerDeviceId)
+      await insertCanaryWithSecret(userId)
+
+      const response = await app.handle(
+        revokeRequest(p('target-device'), token, {
+          callerDeviceId,
+          canarySecret: 'wrong-secret',
+        }),
+      )
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toContain('Invalid canary secret')
+    })
+
+    it('returns 403 when caller device is not trusted', async () => {
+      const userId = p('untrusted-caller-user')
+      const token = p('untrusted-caller-token')
+      const callerDeviceId = p('caller-untrusted')
+      const now = await createUserSessionAndDevice(userId, token, callerDeviceId)
+      await insertCanaryWithSecret(userId)
+
+      // Mark the caller device as untrusted
+      await db.update(devicesTable).set({ trusted: false }).where(eq(devicesTable.id, callerDeviceId))
+
+      const targetDeviceId = p('target-untrusted-test')
+      await db.insert(devicesTable).values({
+        id: targetDeviceId,
+        userId,
+        name: 'Target Device',
+        trusted: true,
+        lastSeen: now,
+        createdAt: now,
+      })
+
+      const response = await app.handle(
+        revokeRequest(targetDeviceId, token, {
+          callerDeviceId,
+          canarySecret: testCanarySecret,
+        }),
+      )
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toContain('Only trusted devices')
+    })
+
+    it('returns 204 and revokes device + deletes envelope (with canary proof)', async () => {
       const userId = p('revoke-user')
       const token = p('revoke-token')
+      const callerDeviceId = p('caller-revoke')
       const deviceId = p('device-to-revoke')
-      const now = await createUserAndSession(userId, token)
+      const now = await createUserSessionAndDevice(userId, token, callerDeviceId)
+      await insertCanaryWithSecret(userId)
 
       await db.insert(devicesTable).values({
         id: deviceId,
@@ -441,9 +576,9 @@ describe('Account API', () => {
       })
 
       const response = await app.handle(
-        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(token)}` },
+        revokeRequest(deviceId, token, {
+          callerDeviceId,
+          canarySecret: testCanarySecret,
         }),
       )
 
@@ -460,10 +595,13 @@ describe('Account API', () => {
       const userAId = p('user-a-revoke')
       const userBId = p('user-b-revoke')
       const tokenA = p('token-user-a')
+      const callerDeviceA = p('caller-device-a')
       const deviceId = p('device-user-b')
 
-      await createUserAndSession(userAId, tokenA)
-      const now = await createUserAndSession(userBId, p('token-user-b'))
+      await createUserSessionAndDevice(userAId, tokenA, callerDeviceA)
+      // User A has no encryption metadata — pre-encryption path
+
+      const now = await createUserSessionAndDevice(userBId, p('token-user-b'), p('caller-device-b'))
 
       await db.insert(devicesTable).values({
         id: deviceId,
@@ -474,12 +612,7 @@ describe('Account API', () => {
         trusted: true,
       })
 
-      const response = await app.handle(
-        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(tokenA)}` },
-        }),
-      )
+      const response = await app.handle(revokeRequest(deviceId, tokenA, { callerDeviceId: callerDeviceA }))
 
       // Returns 204 (idempotent) but device is NOT actually revoked
       expect(response.status).toBe(204)
@@ -492,12 +625,14 @@ describe('Account API', () => {
     it('returns 204 for non-existent device (idempotent)', async () => {
       const userId = p('revoke-nonexistent-user')
       const token = p('revoke-nonexistent-token')
-      await createUserAndSession(userId, token)
+      const callerDeviceId = p('caller-nonexist')
+      await createUserSessionAndDevice(userId, token, callerDeviceId)
+      await insertCanaryWithSecret(userId)
 
       const response = await app.handle(
-        new Request(`http://localhost/v1/account/devices/${p('does-not-exist')}/revoke`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(token)}` },
+        revokeRequest(p('does-not-exist'), token, {
+          callerDeviceId,
+          canarySecret: testCanarySecret,
         }),
       )
 
@@ -507,8 +642,10 @@ describe('Account API', () => {
     it('returns 204 when revoking already-revoked device (preserves original revokedAt)', async () => {
       const userId = p('revoke-idempotent-user')
       const token = p('revoke-idempotent-token')
+      const callerDeviceId = p('caller-idempotent')
       const deviceId = p('device-already-revoked')
-      const now = await createUserAndSession(userId, token)
+      const now = await createUserSessionAndDevice(userId, token, callerDeviceId)
+      await insertCanaryWithSecret(userId)
 
       await db.insert(devicesTable).values({
         id: deviceId,
@@ -521,9 +658,9 @@ describe('Account API', () => {
 
       // First revoke
       const firstResponse = await app.handle(
-        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(token)}` },
+        revokeRequest(deviceId, token, {
+          callerDeviceId,
+          canarySecret: testCanarySecret,
         }),
       )
       expect(firstResponse.status).toBe(204)
@@ -533,9 +670,9 @@ describe('Account API', () => {
 
       // Second revoke — no-op because isNull(revokedAt) guard skips already-revoked devices
       const response = await app.handle(
-        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(token)}` },
+        revokeRequest(deviceId, token, {
+          callerDeviceId,
+          canarySecret: testCanarySecret,
         }),
       )
 
@@ -549,8 +686,10 @@ describe('Account API', () => {
     it('handles device with no envelope gracefully', async () => {
       const userId = p('revoke-no-envelope-user')
       const token = p('revoke-no-envelope-token')
+      const callerDeviceId = p('caller-no-envelope')
       const deviceId = p('device-no-envelope')
-      const now = await createUserAndSession(userId, token)
+      const now = await createUserSessionAndDevice(userId, token, callerDeviceId)
+      await insertCanaryWithSecret(userId)
 
       await db.insert(devicesTable).values({
         id: deviceId,
@@ -562,9 +701,9 @@ describe('Account API', () => {
       })
 
       const response = await app.handle(
-        new Request(`http://localhost/v1/account/devices/${deviceId}/revoke`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${signToken(token)}` },
+        revokeRequest(deviceId, token, {
+          callerDeviceId,
+          canarySecret: testCanarySecret,
         }),
       )
 
@@ -575,6 +714,32 @@ describe('Account API', () => {
 
       const envelopes = await db.select().from(envelopesTable).where(eq(envelopesTable.deviceId, deviceId))
       expect(envelopes).toHaveLength(0)
+    })
+
+    it('returns 204 without canarySecret for pre-encryption user (no E2EE metadata)', async () => {
+      const userId = p('pre-enc-user')
+      const token = p('pre-enc-token')
+      const callerDeviceId = p('caller-pre-enc')
+      const deviceId = p('device-pre-enc')
+      const now = await createUserSessionAndDevice(userId, token, callerDeviceId)
+
+      // No encryption metadata inserted — pre-encryption user
+
+      await db.insert(devicesTable).values({
+        id: deviceId,
+        userId,
+        name: 'Pre-encryption Device',
+        lastSeen: now,
+        createdAt: now,
+        trusted: false,
+      })
+
+      const response = await app.handle(revokeRequest(deviceId, token, { callerDeviceId }))
+
+      expect(response.status).toBe(204)
+
+      const [device] = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+      expect(device.revokedAt).not.toBeNull()
     })
   })
 })

--- a/backend/src/api/account.ts
+++ b/backend/src/api/account.ts
@@ -1,9 +1,17 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { createAuthMacro } from '@/auth/elysia-plugin'
-import { deleteUser, revokeDevice, deleteEnvelope, revokeDeviceSessions } from '@/dal'
+import {
+  deleteUser,
+  revokeDevice,
+  deleteEnvelope,
+  revokeDeviceSessions,
+  getDeviceById,
+  getEncryptionMetadata,
+} from '@/dal'
 import type { db as DbType } from '@/db/client'
+import { verifyCanaryProofWithMetadata } from '@/lib/canary'
 import { safeErrorHandler } from '@/middleware/error-handling'
-import { Elysia } from 'elysia'
+import { Elysia, t } from 'elysia'
 
 /** Account API routes. All routes require authentication. */
 export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
@@ -12,8 +20,37 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
     .use(createAuthMacro(auth))
     .post(
       '/devices/:id/revoke',
-      async ({ params, set, user: sessionUser }) => {
+      async ({ params, body, request, set, user: sessionUser }) => {
         const userId = sessionUser!.id
+
+        const callerDeviceId = request.headers.get('x-device-id')?.trim()
+        if (!callerDeviceId) {
+          set.status = 400
+          return { error: 'X-Device-ID header is required' }
+        }
+
+        // If E2EE is active (encryption metadata exists), require canary proof-of-CK-possession.
+        // Checks `metadata` (not `metadata?.canarySecretHash`) for fail-closed behavior:
+        // if metadata exists with a null hash, we still block rather than silently skip.
+        const metadata = await getEncryptionMetadata(database, userId)
+        if (metadata) {
+          if (!body.canarySecret) {
+            set.status = 403
+            return { error: 'Canary secret required for device revocation' }
+          }
+          if (!(await verifyCanaryProofWithMetadata(body.canarySecret, metadata.canarySecretHash))) {
+            set.status = 403
+            return { error: 'Invalid canary secret' }
+          }
+
+          // Caller must be a trusted device (defense-in-depth)
+          const callerDevice = await getDeviceById(database, callerDeviceId)
+          if (!callerDevice || callerDevice.userId !== userId || !callerDevice.trusted) {
+            set.status = 403
+            return { error: 'Only trusted devices can revoke devices' }
+          }
+        }
+
         await database.transaction(async (tx) => {
           const txDb = tx as unknown as typeof database
           await deleteEnvelope(txDb, params.id, userId)
@@ -25,7 +62,12 @@ export const createAccountRoutes = (auth: Auth, database: typeof DbType) => {
         })
         set.status = 204
       },
-      { auth: true },
+      {
+        auth: true,
+        body: t.Object({
+          canarySecret: t.Optional(t.String({ maxLength: 500 })),
+        }),
+      },
     )
     .delete(
       '/',

--- a/backend/src/api/encryption.test.ts
+++ b/backend/src/api/encryption.test.ts
@@ -913,6 +913,79 @@ describe('Encryption API', () => {
       expect(metadata.canarySecretHash).toBe(await hashSecret('my-secret'))
     })
 
+    it('blocks re-bootstrap with wrong canary when encryption metadata already exists (defense-in-depth)', async () => {
+      await createUserAndSession(p('u-reboot'), p('tok-reboot'))
+      await insertDevice(p('d-reboot'), p('u-reboot'))
+      // Simulate existing encryption metadata from a previous first-device setup
+      await insertCanaryWithSecret(p('u-reboot'))
+      // No envelopes exist — simulates state after all devices revoked/envelopes deleted
+
+      // Attacker tries first-device bootstrap with a fake canary secret
+      const response = await app.handle(
+        new Request(`${BASE}/devices/${p('d-reboot')}/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${signToken(p('tok-reboot'))}`,
+            'X-Device-ID': p('d-reboot'),
+          },
+          body: JSON.stringify({
+            wrappedCK: 'attacker-controlled-key',
+            canaryIv: 'attacker-iv',
+            canaryCtext: 'attacker-ctext',
+            canarySecret: 'wrong-secret',
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toContain('Invalid canary secret')
+
+      // No envelope should have been stored
+      const envelopes = await db
+        .select()
+        .from(envelopesTable)
+        .where(eq(envelopesTable.deviceId, p('d-reboot')))
+      expect(envelopes).toHaveLength(0)
+    })
+
+    it('allows re-bootstrap with correct canary when encryption metadata already exists', async () => {
+      await createUserAndSession(p('u-recover'), p('tok-recover'))
+      await insertDevice(p('d-recover'), p('u-recover'))
+      await insertCanaryWithSecret(p('u-recover'))
+      // No envelopes — simulates recovery after all devices revoked
+
+      // Legitimate user re-bootstraps with the correct canary secret (e.g. from recovery key)
+      const response = await app.handle(
+        new Request(`${BASE}/devices/${p('d-recover')}/envelope`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${signToken(p('tok-recover'))}`,
+            'X-Device-ID': p('d-recover'),
+          },
+          body: JSON.stringify({
+            wrappedCK: 'recovered-wrapped-key',
+            canaryIv: 'recover-iv',
+            canaryCtext: 'recover-ctext',
+            canarySecret: testCanarySecret,
+          }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.trusted).toBe(true)
+
+      // Device should be trusted
+      const [device] = await db
+        .select()
+        .from(devicesTable)
+        .where(eq(devicesTable.id, p('d-recover')))
+      expect(device.trusted).toBe(true)
+    })
+
     it('does not overwrite existing canary on subsequent envelope submissions', async () => {
       await createUserAndSession(p('u-noow'), p('tok-noow'))
       await insertDevice(p('d-noow-caller'), p('u-noow'), { trusted: true })

--- a/backend/src/api/encryption.ts
+++ b/backend/src/api/encryption.ts
@@ -15,32 +15,10 @@ import {
 } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import { BadRequestError, ForbiddenError } from '@/errors/http-errors'
-import { timingSafeEqual } from 'crypto'
+import { hashCanarySecret, verifyCanaryProof, verifyCanaryProofWithMetadata } from '@/lib/canary'
 import { Elysia, t } from 'elysia'
 
 const MAX_DEVICES_PER_USER = 10
-
-/** Hash a canary secret using SHA-256. Returns hex-encoded hash. */
-const hashCanarySecret = async (secret: string): Promise<string> => {
-  const encoded = new TextEncoder().encode(secret)
-  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded)
-  return Array.from(new Uint8Array(hashBuffer), (b) => b.toString(16).padStart(2, '0')).join('')
-}
-
-/**
- * Verify proof-of-CK-possession by comparing SHA-256(canarySecret) against stored hash.
- * Used to gate trust-sensitive operations (device approval, deny) — prevents X-Device-ID spoofing
- * because only a device that possesses the Content Key can decrypt the canary and extract the secret.
- */
-const verifyCanaryProof = async (db: typeof DbType, userId: string, canarySecret: string): Promise<boolean> => {
-  const metadata = await getEncryptionMetadata(db, userId)
-  if (!metadata?.canarySecretHash) return false
-  const hash = await hashCanarySecret(canarySecret)
-  const hashBuf = Buffer.from(hash)
-  const storedBuf = Buffer.from(metadata.canarySecretHash)
-  if (hashBuf.length !== storedBuf.length) return false
-  return timingSafeEqual(hashBuf, storedBuf)
-}
 
 /**
  * Check if the caller is performing a self-recovery.
@@ -198,6 +176,21 @@ export const createEncryptionRoutes = (auth: Auth, database: typeof DbType) =>
             // First device bootstrap requires canary data for recovery to work
             if (isFirstDeviceBootstrap && (!canaryIv || !canaryCtext || !canarySecret)) {
               throw new BadRequestError('First device bootstrap requires canaryIv, canaryCtext, and canarySecret')
+            }
+
+            // Defense-in-depth: if encryption metadata already exists, verify canary proof
+            // to prevent E2EE state reset even if device revocation protections are bypassed.
+            // Checks `existingMetadata` (not `existingMetadata?.canarySecretHash`) for fail-closed
+            // behavior: if metadata exists with a null hash, we block rather than silently skip.
+            if (isFirstDeviceBootstrap) {
+              const existingMetadata = await getEncryptionMetadata(txDb, userId)
+              if (existingMetadata) {
+                if (!(await verifyCanaryProofWithMetadata(canarySecret!, existingMetadata.canarySecretHash))) {
+                  throw new ForbiddenError(
+                    'Invalid canary secret — cannot re-bootstrap with existing encryption metadata',
+                  )
+                }
+              }
             }
 
             // Recovery: device is self-storing and provided canary that matches stored metadata.

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -1570,6 +1570,59 @@ describe('PowerSync API', () => {
       expect(rows[0]?.userId).toBe(userA)
     })
 
+    it('blocks DELETE on devices table (must use dedicated revoke API)', async () => {
+      const userId = 'user-delete-device-blocked'
+      const deviceId = 'device-to-delete-blocked'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(userTable).values({
+        id: userId,
+        name: 'Delete Device Blocked User',
+        email: 'delete-device-blocked@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await db.insert(sessionTable).values({
+        id: 'session-delete-device-blocked',
+        expiresAt,
+        token: 'bearer-delete-device-blocked',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+      await insertTrustedDevice('test-device-id', userId)
+
+      // Insert a second device that the attacker will try to delete via PowerSync
+      await db.insert(devicesTable).values({
+        id: deviceId,
+        userId,
+        name: 'Target Device',
+        trusted: true,
+        lastSeen: now,
+        createdAt: now,
+      })
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders('bearer-delete-device-blocked'),
+          body: JSON.stringify({
+            operations: [{ op: 'DELETE' as const, type: 'devices', id: deviceId }],
+          }),
+        }),
+      )
+      expect(response.status).toBe(400)
+      const body = (await response.json()) as { code: string }
+      expect(body.code).toBe('UPLOAD_OPERATION_FAILED')
+
+      // Device must still exist
+      const devices = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
+      expect(devices).toHaveLength(1)
+      expect(devices[0]?.trusted).toBe(true)
+    })
+
     it('ignores unknown and injection-like column names in PUT data', async () => {
       const userId = 'user-upload-safe'
       const now = new Date()

--- a/backend/src/dal/powersync.ts
+++ b/backend/src/dal/powersync.ts
@@ -16,6 +16,9 @@ const uploadDenyColumns: Partial<Record<PowerSyncTableName, string[]>> = {
   devices: ['revoked_at', 'trusted', 'public_key', 'mlkem_public_key', 'approval_pending'],
 }
 
+/** Tables that cannot be deleted via PowerSync upload — must use dedicated API endpoints. */
+const uploadDenyDelete = new Set<PowerSyncTableName>(['devices'])
+
 type PowerSyncOperation = {
   op: 'PUT' | 'PATCH' | 'DELETE'
   type: string
@@ -121,6 +124,8 @@ export const applyOperation = async (
       return patched.length > 0
     }
     case 'DELETE': {
+      if (uploadDenyDelete.has(tableName)) return false
+
       const deleted = await database
         .delete(table)
         .where(and(eq(pkColumn, op.id), eq(tableWithUserId.userId, userId)))

--- a/backend/src/lib/canary.ts
+++ b/backend/src/lib/canary.ts
@@ -1,0 +1,42 @@
+import { getEncryptionMetadata } from '@/dal'
+import type { db as DbType } from '@/db/client'
+import { timingSafeEqual } from 'crypto'
+
+/** Hash a canary secret using SHA-256. Returns hex-encoded hash. */
+export const hashCanarySecret = async (secret: string): Promise<string> => {
+  const encoded = new TextEncoder().encode(secret)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded)
+  return Array.from(new Uint8Array(hashBuffer), (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/** Compare a canary secret against a stored hash using timing-safe comparison. */
+const verifyAgainstHash = async (canarySecret: string, storedHash: string): Promise<boolean> => {
+  const hash = await hashCanarySecret(canarySecret)
+  const hashBuf = Buffer.from(hash)
+  const storedBuf = Buffer.from(storedHash)
+  if (hashBuf.length !== storedBuf.length) return false
+  return timingSafeEqual(hashBuf, storedBuf)
+}
+
+/**
+ * Verify proof-of-CK-possession by comparing SHA-256(canarySecret) against stored hash.
+ * Used to gate trust-sensitive operations (device approval, deny, revoke) — prevents X-Device-ID spoofing
+ * because only a device that possesses the Content Key can decrypt the canary and extract the secret.
+ */
+export const verifyCanaryProof = async (db: typeof DbType, userId: string, canarySecret: string): Promise<boolean> => {
+  const metadata = await getEncryptionMetadata(db, userId)
+  if (!metadata?.canarySecretHash) return false
+  return verifyAgainstHash(canarySecret, metadata.canarySecretHash)
+}
+
+/**
+ * Verify canary proof against pre-fetched metadata. Avoids a redundant getEncryptionMetadata call
+ * when the caller already has the metadata (e.g., to decide whether E2EE is active).
+ */
+export const verifyCanaryProofWithMetadata = async (
+  canarySecret: string,
+  storedHash: string | null | undefined,
+): Promise<boolean> => {
+  if (!storedHash) return false
+  return verifyAgainstHash(canarySecret, storedHash)
+}

--- a/src/api/encryption.ts
+++ b/src/api/encryption.ts
@@ -89,6 +89,15 @@ export const denyDevice = async (httpClient: HttpClient, deviceId: string, canar
   })
 }
 
+/** Revoke a device (called by a trusted device). Requires canary proof-of-CK-possession. */
+export const revokeDevice = async (httpClient: HttpClient, deviceId: string, canarySecret: string): Promise<void> => {
+  await httpClient.post(`account/devices/${encodeURIComponent(deviceId)}/revoke`, {
+    json: { canarySecret },
+    headers: authHeaders(),
+    credentials: 'omit',
+  })
+}
+
 /** Cancel this device's pending approval state (called by the pending device itself). */
 export const cancelPending = async (httpClient: HttpClient): Promise<void> => {
   await httpClient.post('devices/me/cancel-pending', {

--- a/src/api/encryption.ts
+++ b/src/api/encryption.ts
@@ -89,10 +89,10 @@ export const denyDevice = async (httpClient: HttpClient, deviceId: string, canar
   })
 }
 
-/** Revoke a device (called by a trusted device). Requires canary proof-of-CK-possession. */
-export const revokeDevice = async (httpClient: HttpClient, deviceId: string, canarySecret: string): Promise<void> => {
+/** Revoke a device. Includes canary proof-of-CK-possession when E2EE is active. */
+export const revokeDevice = async (httpClient: HttpClient, deviceId: string, canarySecret?: string): Promise<void> => {
   await httpClient.post(`account/devices/${encodeURIComponent(deviceId)}/revoke`, {
-    json: { canarySecret },
+    json: canarySecret ? { canarySecret } : {},
     headers: authHeaders(),
     credentials: 'omit',
   })

--- a/src/hooks/use-revoke-device.ts
+++ b/src/hooks/use-revoke-device.ts
@@ -1,21 +1,16 @@
 import { useHttpClient } from '@/contexts'
-import { authHeaders } from '@/api/encryption'
+import { revokeDeviceWithProof } from '@/services/encryption'
 import { useMutation } from '@tanstack/react-query'
 
 /**
- * Shared mutation for revoking a device (trusted or pending).
+ * Mutation for revoking a device (trusted or pending).
  * Used by both the pending device modal and the devices settings page.
+ * Requires proof-of-CK-possession (canary secret) to prevent session-theft attacks.
  */
 export const useRevokeDevice = () => {
   const httpClient = useHttpClient()
 
   return useMutation({
-    mutationFn: (deviceId: string) =>
-      httpClient
-        .post(`account/devices/${encodeURIComponent(deviceId)}/revoke`, {
-          headers: authHeaders(),
-          credentials: 'omit',
-        })
-        .then(() => {}),
+    mutationFn: (deviceId: string) => revokeDeviceWithProof(httpClient, deviceId),
   })
 }

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -195,10 +195,16 @@ export const denyDeviceWithProof = async (httpClient: HttpClient, deviceId: stri
 
 /**
  * Revoke a device with proof-of-CK-possession.
- * Extracts canary secret and sends it to prove the caller has the Content Key.
+ * Extracts canary secret when E2EE is active. Falls back to no proof for pre-E2EE users
+ * (the backend skips canary verification when no encryption metadata exists).
  */
 export const revokeDeviceWithProof = async (httpClient: HttpClient, deviceId: string): Promise<void> => {
-  const canarySecret = await extractCanarySecret(httpClient)
+  let canarySecret: string | undefined
+  try {
+    canarySecret = await extractCanarySecret(httpClient)
+  } catch {
+    // E2EE not set up (fetchCanary 404) or CK unavailable — proceed without proof
+  }
   await revokeDeviceApi(httpClient, deviceId, canarySecret)
 }
 

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -32,6 +32,7 @@ import {
   fetchMyEnvelope,
   fetchCanary,
   denyDevice as denyDeviceApi,
+  revokeDevice as revokeDeviceApi,
   type RegisterDeviceResponse,
 } from '@/api/encryption'
 import { invalidateCKCache, resetCodecState } from '@/db/encryption'
@@ -130,7 +131,7 @@ export const completeFirstDeviceSetup = async (httpClient: HttpClient): Promise<
 
 /**
  * Extract the canary secret by decrypting the server-stored canary with the local CK.
- * Used as proof-of-CK-possession for trust-sensitive operations (approve, deny).
+ * Used as proof-of-CK-possession for trust-sensitive operations (approve, deny, revoke).
  */
 export const extractCanarySecret = async (httpClient: HttpClient): Promise<string> => {
   const { canaryIv, canaryCtext } = await fetchCanary(httpClient)
@@ -190,6 +191,15 @@ export const approveDevice = async (
 export const denyDeviceWithProof = async (httpClient: HttpClient, deviceId: string): Promise<void> => {
   const canarySecret = await extractCanarySecret(httpClient)
   await denyDeviceApi(httpClient, deviceId, canarySecret)
+}
+
+/**
+ * Revoke a device with proof-of-CK-possession.
+ * Extracts canary secret and sends it to prove the caller has the Content Key.
+ */
+export const revokeDeviceWithProof = async (httpClient: HttpClient, deviceId: string): Promise<void> => {
+  const canarySecret = await extractCanarySecret(httpClient)
+  await revokeDeviceApi(httpClient, deviceId, canarySecret)
 }
 
 // =============================================================================

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -1,5 +1,7 @@
 import { type HttpClient } from '@/contexts'
+import { createHandleError } from '@/lib/error-utils'
 import { HttpError } from '@/lib/http'
+import { trackError } from '@/lib/posthog'
 import {
   generateKeyPair,
   generateMlKemKeyPair,
@@ -199,12 +201,15 @@ export const denyDeviceWithProof = async (httpClient: HttpClient, deviceId: stri
  * (the backend skips canary verification when no encryption metadata exists).
  */
 export const revokeDeviceWithProof = async (httpClient: HttpClient, deviceId: string): Promise<void> => {
-  let canarySecret: string | undefined
-  try {
-    canarySecret = await extractCanarySecret(httpClient)
-  } catch {
-    // E2EE not set up (fetchCanary 404) or CK unavailable — proceed without proof
-  }
+  const canarySecret = await extractCanarySecret(httpClient).catch((err: unknown) => {
+    if (err instanceof HttpError && err.response.status === 404) {
+      return undefined
+    }
+    trackError(
+      createHandleError('CANARY_EXTRACTION_FAILED', 'Failed to extract canary secret during device revocation', err),
+    )
+    throw err
+  })
   await revokeDeviceApi(httpClient, deviceId, canarySecret)
 }
 

--- a/src/types/handle-errors.ts
+++ b/src/types/handle-errors.ts
@@ -7,6 +7,7 @@ export type HandleErrorCode =
   | 'APP_DIR_CREATION_FAILED'
   | 'DATABASE_PATH_FAILED'
   | 'HTTP_CLIENT_INIT_FAILED'
+  | 'CANARY_EXTRACTION_FAILED'
   | 'UNKNOWN_ERROR'
 
 export type HandleError = {


### PR DESCRIPTION
## Summary

- **Security fix**: Device revocation (`POST /account/devices/:id/revoke`) now requires canary proof-of-CK-possession when E2EE is active, closing an attack vector where a stolen session could reset all encryption state
- **Defense-in-depth**: First-device bootstrap path now verifies canary against existing metadata, preventing E2EE state reset even if revocation protections are bypassed
- **PowerSync hardening**: Blocked `DELETE` operations on the `devices` table via PowerSync upload — devices can only be revoked through the dedicated API endpoint

### Root cause

The revoke endpoint deleted envelopes without requiring canary proof, unlike approve/deny which both require it. An attacker with a stolen session could revoke all devices (deleting all envelopes), then re-bootstrap as first device with attacker-controlled keys — fully resetting E2EE state without ever possessing the Content Key.

### Changes

**Backend**
- Extracted `hashCanarySecret`, `verifyCanaryProof`, `verifyCanaryProofWithMetadata` into shared `backend/src/lib/canary.ts`
- Revoke endpoint now requires `X-Device-ID` header + `canarySecret` body (when encryption metadata exists)
- Added caller trusted-device check (defense-in-depth, consistent with deny endpoint)
- Pre-encryption users can still revoke without canary (backward compatible)
- Added `uploadDenyDelete` set in PowerSync upload handler blocking device hard-deletes
- Added canary verification in first-device bootstrap when metadata already exists

**Frontend**
- Added `revokeDevice` API function (`src/api/encryption.ts`)
- Added `revokeDeviceWithProof` service function (mirrors `denyDeviceWithProof` pattern)
- Rewired `useRevokeDevice` hook to extract canary proof before calling API

## Test plan

- [x] 650 backend tests pass (0 failures)
- [x] TypeScript compiles cleanly on both backend and frontend
- [x] New test cases cover: missing X-Device-ID (400), missing canary (403), invalid canary (403), untrusted caller (403), pre-encryption backward compatibility (204), revoke with valid proof (204), idempotent re-revoke, cross-user isolation
- [ ] Manual: revoke a device from Settings > Devices — should work seamlessly with canary proof sent automatically
- [ ] Manual: verify recovery flow still works after all devices revoked (recovery key holder can re-bootstrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-critical device/E2EE flows and adds new request requirements (`X-Device-ID`, `canarySecret`) that could break clients or block legitimate revocations if metadata/proof handling is wrong, but changes are localized and well-covered by new tests.
> 
> **Overview**
> Closes an E2EE state-reset attack by **requiring canary proof-of-CK-possession for device revocation when encryption is active**: `POST /account/devices/:id/revoke` now enforces `X-Device-ID`, validates optional `canarySecret` against stored encryption metadata, and (when E2EE is active) requires the caller device to be *trusted* before revoking/deleting envelopes.
> 
> Adds defense-in-depth by **blocking “first-device bootstrap” re-initialization when encryption metadata already exists unless the canary secret matches**, and centralizes canary hashing/verification into a new shared `backend/src/lib/canary.ts` used by both account and encryption routes.
> 
> Hardens sync ingestion by **disallowing PowerSync `DELETE` operations on the `devices` table**, and updates frontend revoke flow to automatically extract/send canary proof via new `revokeDevice` API + `revokeDeviceWithProof` service (hook rewired accordingly). Tests are expanded to cover the new security gates and idempotent/backwards-compatible behavior for pre-encryption users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e64617dadb33538f6d68fb3010ff6b10f0953a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->