### PR TITLE
fix: release pipeline version bump failing due to branch protection

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -61,6 +61,7 @@ permissions:
 jobs:
   version_bump:
     runs-on: ubuntu-latest
+    environment: thunderbolt_release
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
       tag_name: ${{ steps.tag.outputs.tag_name }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -66,11 +66,18 @@ jobs:
       tag_name: ${{ steps.tag.outputs.tag_name }}
 
     steps:
+      - name: Generate release token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
         run: |

--- a/scripts/create-release.ts
+++ b/scripts/create-release.ts
@@ -67,7 +67,7 @@ const parseArgs = (): Args => {
     if (arg === '--help' || arg === '-h') {
       args.help = true
     } else if (arg === '--version' || arg === '-v') {
-      args.version = process.argv[++i]
+      args.version = process.argv[++i]?.replace(/^v/, '')
     } else if (arg === '--type' || arg === '-t') {
       args.type = process.argv[++i] as VersionType
     } else if (arg === '--platform') {


### PR DESCRIPTION
## Summary

- Use a GitHub App token (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) instead of `GITHUB_TOKEN` so the version-bump workflow can push directly to `main` — the default token cannot bypass repository ruleset branch protection.
- Strip leading `v` from `--version` CLI argument in `create-release.ts` to prevent double-prefixed tags (`vv0.1.89`).

## Requires setup before merging

1. Create a GitHub App with **Contents: Read & Write** permission
2. Install it on the repo and add it to the `main` branch ruleset bypass list
3. Add `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` as repo secrets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI release credentials and push behavior, which can break automated releases if secrets/app permissions are misconfigured. The CLI tweak is low risk but affects tag/version naming.
> 
> **Overview**
> Fixes the release version-bump pipeline failing under branch protection by having `version-bump.yml` generate a GitHub App token (via `actions/create-github-app-token`) and use it for `actions/checkout`, with the job now scoped to the `thunderbolt_release` environment.
> 
> Prevents malformed tags when an explicit version is provided by updating `scripts/create-release.ts` to strip a leading `v` from the `--version` argument (avoiding `vvX.Y.Z`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7178ef5fd5c83e0a5ef4f5ce713a975395137975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->