### PR TITLE
ci: add grouped dependabot config for npm, cargo, and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-root-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      npm-root-major:
+        patterns: ["*"]
+        update-types: ["major"]
+
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-backend-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      npm-backend-major:
+        patterns: ["*"]
+        update-types: ["major"]
+
+  - package-ecosystem: "npm"
+    directory: "/marketing"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-marketing-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      npm-marketing-major:
+        patterns: ["*"]
+        update-types: ["major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-tauri-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      cargo-tauri-major:
+        patterns: ["*"]
+        update-types: ["major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
- group weekly updates by ecosystem and split minor/patch from major
- cover root, backend, and marketing npm workspaces
- cover src-tauri cargo and github-actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration-only change that affects dependency update PR generation but does not modify runtime code paths.
> 
> **Overview**
> Adds a new `.github/dependabot.yml` to enable **weekly Dependabot updates** for root, `backend`, and `marketing` npm projects, `src-tauri` Cargo, and GitHub Actions.
> 
> Updates are **grouped by ecosystem and split into minor/patch vs major** (with PR limits per ecosystem) to reduce update noise while keeping majors separate for review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1295c6092045936f9233fa2714188dcb11567f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->