### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/src/ai/fetch.test.ts
+++ b/src/ai/fetch.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'bun:test'
+import { z } from 'zod'
+
+/**
+ * Tests for MiniMax provider support in the model creation form schemas.
+ *
+ * These tests verify the provider-level validation rules:
+ * - MiniMax requires an API key (like openai / openrouter)
+ * - MiniMax does not require a URL (unlike custom)
+ */
+
+// Mirror the form schema from src/settings/models/new.tsx
+const newModelFormSchema = z
+  .object({
+    provider: z.enum(['thunderbolt', 'openai', 'custom', 'openrouter', 'minimax']),
+    name: z.string().min(1),
+    model: z.string().min(1),
+    url: z.string().optional(),
+    apiKey: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.provider === 'custom') return data.url !== undefined && data.url.length > 0
+      return true
+    },
+    { message: 'URL is required for Custom providers', path: ['url'] },
+  )
+  .refine(
+    (data) => {
+      if (data.provider === 'custom' || data.provider === 'thunderbolt') return true
+      return data.apiKey !== undefined && data.apiKey.length > 0
+    },
+    { message: 'API Key is required for this provider', path: ['apiKey'] },
+  )
+
+// Mirror the form schema from src/settings/models/detail.tsx
+const detailModelFormSchema = z
+  .object({
+    provider: z.enum(['thunderbolt', 'anthropic', 'openai', 'custom', 'openrouter', 'minimax']),
+    name: z.string().min(1),
+    model: z.string().min(1),
+    url: z.string().optional(),
+    apiKey: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.provider === 'custom') return data.url !== undefined && data.url.length > 0
+      return true
+    },
+    { message: 'URL is required for Custom providers', path: ['url'] },
+  )
+  .refine(
+    (data) => {
+      if (data.provider === 'custom' || data.provider === 'thunderbolt') return true
+      return data.apiKey !== undefined && data.apiKey.length > 0
+    },
+    { message: 'API Key is required for this provider', path: ['apiKey'] },
+  )
+
+const validBase = { name: 'MiniMax M2.7', model: 'MiniMax-M2.7', url: '', apiKey: '' }
+
+describe('MiniMax provider - new model form schema', () => {
+  it('accepts minimax as a valid provider', () => {
+    const result = newModelFormSchema.safeParse({
+      ...validBase,
+      provider: 'minimax',
+      apiKey: 'mm-test-key',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects minimax without an API key', () => {
+    const result = newModelFormSchema.safeParse({
+      ...validBase,
+      provider: 'minimax',
+      apiKey: '',
+    })
+    expect(result.success).toBe(false)
+    const errors = result.error?.flatten().fieldErrors
+    expect(errors?.apiKey).toBeDefined()
+  })
+
+  it('does not require a URL for minimax', () => {
+    const result = newModelFormSchema.safeParse({
+      ...validBase,
+      provider: 'minimax',
+      apiKey: 'mm-test-key',
+      url: '',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('includes minimax in the provider enum', () => {
+    const result = newModelFormSchema.safeParse({
+      ...validBase,
+      provider: 'unknown-provider',
+      apiKey: 'key',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts MiniMax-M2.7 as model name', () => {
+    const result = newModelFormSchema.safeParse({
+      provider: 'minimax',
+      name: 'MiniMax M2.7',
+      model: 'MiniMax-M2.7',
+      apiKey: 'mm-key',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts MiniMax-M2.7-highspeed as model name', () => {
+    const result = newModelFormSchema.safeParse({
+      provider: 'minimax',
+      name: 'MiniMax M2.7 Highspeed',
+      model: 'MiniMax-M2.7-highspeed',
+      apiKey: 'mm-key',
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('MiniMax provider - model detail form schema', () => {
+  it('accepts minimax provider for editing', () => {
+    const result = detailModelFormSchema.safeParse({
+      ...validBase,
+      provider: 'minimax',
+      apiKey: 'mm-test-key',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects minimax without API key on detail form', () => {
+    const result = detailModelFormSchema.safeParse({
+      ...validBase,
+      provider: 'minimax',
+      apiKey: '',
+    })
+    expect(result.success).toBe(false)
+    const errors = result.error?.flatten().fieldErrors
+    expect(errors?.apiKey).toBeDefined()
+  })
+
+  it('includes anthropic in detail form provider enum (for direct Anthropic models)', () => {
+    const result = detailModelFormSchema.safeParse({
+      ...validBase,
+      provider: 'anthropic',
+      apiKey: 'sk-ant-test',
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -124,6 +124,18 @@ export const createModel = async (modelConfig: Model) => {
       })
       return openrouter(modelConfig.model)
     }
+    case 'minimax': {
+      if (!modelConfig.apiKey) {
+        throw new Error('No API key provided')
+      }
+      const minimax = createOpenAICompatible({
+        name: 'minimax',
+        baseURL: 'https://api.minimax.io/v1',
+        apiKey: modelConfig.apiKey,
+        fetch,
+      })
+      return minimax(modelConfig.model)
+    }
     default:
       throw new Error(`Unsupported provider: ${modelConfig.provider}`)
   }

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -78,7 +78,7 @@ export const modelsTable = sqliteTable(
   {
     id: text('id').primaryKey(),
     provider: text('provider', {
-      enum: ['openai', 'custom', 'openrouter', 'thunderbolt', 'anthropic'],
+      enum: ['openai', 'custom', 'openrouter', 'thunderbolt', 'anthropic', 'minimax'],
     }),
     name: text('name'),
     model: text('model'),

--- a/src/settings/models/detail.tsx
+++ b/src/settings/models/detail.tsx
@@ -28,7 +28,7 @@ import { Trash2 } from 'lucide-react'
 
 const formSchema = z
   .object({
-    provider: z.enum(['thunderbolt', 'anthropic', 'openai', 'custom', 'openrouter']),
+    provider: z.enum(['thunderbolt', 'anthropic', 'openai', 'custom', 'openrouter', 'minimax']),
     name: z.string().min(1, { message: 'Name is required.' }),
     model: z.string().min(1, { message: 'Model name is required.' }),
     url: z.string().optional(),

--- a/src/settings/models/new.tsx
+++ b/src/settings/models/new.tsx
@@ -16,7 +16,7 @@ import type { Model } from '@/types'
 
 const formSchema = z
   .object({
-    provider: z.enum(['thunderbolt', 'openai', 'custom', 'openrouter']),
+    provider: z.enum(['thunderbolt', 'openai', 'custom', 'openrouter', 'minimax']),
     name: z.string().min(1, { message: 'Name is required.' }),
     model: z.string().min(1, { message: 'Model name is required.' }),
     url: z.string().optional(),
@@ -119,6 +119,7 @@ export default function NewModelPage() {
                         <SelectItem value="thunderbolt">Thunderbolt</SelectItem>
                         <SelectItem value="openai">OpenAI</SelectItem>
                         <SelectItem value="openrouter">OpenRouter</SelectItem>
+                        <SelectItem value="minimax">MiniMax</SelectItem>
                         <SelectItem value="custom">Custom</SelectItem>
                       </SelectContent>
                     </Select>


### PR DESCRIPTION
## Summary

- Add MiniMax as a selectable AI provider using the OpenAI-compatible API interface
- Register `'minimax'` in the provider enum in `src/db/tables.ts`
- Add `createModel` case for MiniMax in `src/ai/fetch.ts` with base URL `https://api.minimax.io/v1`
- Add MiniMax to the provider dropdown in the new model form (`src/settings/models/new.tsx`)
- Add MiniMax to the provider enum in the model detail edit form (`src/settings/models/detail.tsx`)

## Usage

1. Go to **Settings → Models → Add Model**
2. Select **MiniMax** as the provider
3. Enter model name: `MiniMax-M2.7` or `MiniMax-M2.7-highspeed`
4. Enter your MiniMax API key (from https://platform.minimax.io)
5. Click **Add Model**

## Supported Models

| Model | Description |
|-------|-------------|
| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex |
| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan

- [x] Unit tests for form schema validation (MiniMax requires API key, does not require URL)
- [x] Full test suite passes (2036 pass, 1 pre-existing skip unrelated to this PR)
- [x] TypeScript type check passes (only pre-existing error in encryption.test.ts unrelated to this PR)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new external LLM provider path and persists a new `provider` enum value, which could break model creation/selection or cause runtime errors if misconfigured. Changes are localized and reuse the existing OpenAI-compatible integration pattern.
> 
> **Overview**
> Adds **MiniMax** as a first-class model provider across the stack: the models DB `provider` enum now includes `minimax`, the Settings → Models UI allows selecting it (new + detail forms), and the backend model factory (`createModel`) can instantiate it via `createOpenAICompatible` targeting `https://api.minimax.io/v1` (API key required).
> 
> Also adds a focused Bun test (`src/ai/fetch.test.ts`) covering form-schema validation expectations for MiniMax (requires API key, does not require URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da72a1933e524c0a3e1e50a6ecc0d7df20464e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->