### PR TITLE
fix(auth): surface OAuth config errors before external redirect (#626)

### DIFF
--- a/backend/src/auth/google.ts
+++ b/backend/src/auth/google.ts
@@ -22,6 +22,7 @@ export const createGoogleAuthRoutes = (auth: Auth, fetchFn: typeof fetch = globa
 
         return {
           client_id: settings.googleClientId,
+          configured: Boolean(settings.googleClientId && settings.googleClientSecret),
         }
       },
       { auth: true },

--- a/backend/src/auth/routes.test.ts
+++ b/backend/src/auth/routes.test.ts
@@ -119,9 +119,30 @@ describe('Authentication Routes', () => {
   })
 
   describe('Google OAuth', () => {
-    it('should return Google OAuth config', async () => {
+    it('should return configured=true for Google OAuth config when credentials are set', async () => {
       const response = await app.handle(new Request('http://localhost/auth/google/config'))
       expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body).toEqual({
+        client_id: 'test-google-client-id',
+        configured: true,
+      })
+    })
+
+    it('should return configured=false for Google OAuth config when credentials are empty', async () => {
+      const settings = settingsModule.getSettings()
+      getSettingsSpy.mockReturnValueOnce({
+        ...settings,
+        googleClientId: '',
+        googleClientSecret: '',
+      })
+      const response = await app.handle(new Request('http://localhost/auth/google/config'))
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body).toEqual({
+        client_id: '',
+        configured: false,
+      })
     })
 
     it('should require valid body for token exchange', async () => {
@@ -148,9 +169,30 @@ describe('Authentication Routes', () => {
   })
 
   describe('Microsoft OAuth', () => {
-    it('should return Microsoft OAuth config', async () => {
+    it('should return configured=true for Microsoft OAuth config when credentials are set', async () => {
       const response = await app.handle(new Request('http://localhost/auth/microsoft/config'))
       expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body).toEqual({
+        client_id: 'test-microsoft-client-id',
+        configured: true,
+      })
+    })
+
+    it('should return configured=false for Microsoft OAuth config when credentials are empty', async () => {
+      const settings = settingsModule.getSettings()
+      getSettingsSpy.mockReturnValueOnce({
+        ...settings,
+        microsoftClientId: '',
+        microsoftClientSecret: '',
+      })
+      const response = await app.handle(new Request('http://localhost/auth/microsoft/config'))
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body).toEqual({
+        client_id: '',
+        configured: false,
+      })
     })
 
     it('should require valid body for token exchange', async () => {

--- a/src/integrations/google/auth.test.ts
+++ b/src/integrations/google/auth.test.ts
@@ -1,0 +1,38 @@
+import { createClient, type HttpClient } from '@/lib/http'
+import { describe, expect, it } from 'bun:test'
+import { buildAuthUrl } from './auth'
+
+const createMockHttpClient = (responses: unknown[]): HttpClient => {
+  let callCount = 0
+  const mockFetch = async (): Promise<Response> => {
+    const response = responses[callCount] ?? responses[responses.length - 1]
+    callCount++
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  return createClient({ prefixUrl: 'http://localhost/', fetch: mockFetch })
+}
+
+describe('buildAuthUrl', () => {
+  // The configured=false test runs first and invalidates the module cache so the
+  // configured=true test gets a fresh fetch. Ordering matters here.
+
+  it('throws a clear error when Google OAuth is not configured', async () => {
+    const httpClient = createMockHttpClient([{ client_id: '', configured: false }])
+    const promise = buildAuthUrl(httpClient, 'state-abc', 'challenge-xyz')
+    await expect(promise).rejects.toThrow(
+      'Google OAuth is not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET on the backend before enabling Google integration.',
+    )
+  })
+
+  it('builds the auth URL when configured', async () => {
+    const httpClient = createMockHttpClient([{ client_id: 'test-google-client-id', configured: true }])
+    const url = await buildAuthUrl(httpClient, 'state-abc', 'challenge-xyz')
+    expect(url).toContain('https://accounts.google.com/o/oauth2/v2/auth')
+    expect(url).toContain('client_id=test-google-client-id')
+    expect(url).toContain('state=state-abc')
+    expect(url).toContain('code_challenge=challenge-xyz')
+  })
+})

--- a/src/integrations/google/auth.ts
+++ b/src/integrations/google/auth.ts
@@ -17,11 +17,12 @@ const fetchBackendConfig = (httpClient: HttpClient): Promise<AuthProviderBackend
 }
 
 export const getOAuthConfig = async (httpClient: HttpClient): Promise<OAuthConfig> => {
-  const { client_id: clientId } = await fetchBackendConfig(httpClient)
+  const { client_id: clientId, configured } = await fetchBackendConfig(httpClient)
   const redirectUri = getOAuthRedirectUri()
 
   return {
     clientId,
+    configured,
     redirectUri,
     scope: [
       'email',
@@ -42,6 +43,11 @@ export const buildAuthUrl = async (
   redirectUri?: string,
 ): Promise<string> => {
   const config = await getOAuthConfig(httpClient)
+  if (!config.configured) {
+    throw new Error(
+      'Google OAuth is not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET on the backend before enabling Google integration.',
+    )
+  }
   const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
   authUrl.searchParams.set('client_id', config.clientId)
   authUrl.searchParams.set('redirect_uri', redirectUri ?? config.redirectUri)

--- a/src/integrations/google/auth.ts
+++ b/src/integrations/google/auth.ts
@@ -8,10 +8,20 @@ let cachedBackendConfig: Promise<AuthProviderBackendConfig> | null = null
 
 const fetchBackendConfig = (httpClient: HttpClient): Promise<AuthProviderBackendConfig> => {
   if (!cachedBackendConfig) {
-    cachedBackendConfig = httpClient.get('auth/google/config').json<AuthProviderBackendConfig>()
-    cachedBackendConfig.catch(() => {
-      cachedBackendConfig = null
-    })
+    const pending = httpClient.get('auth/google/config').json<AuthProviderBackendConfig>()
+    cachedBackendConfig = pending
+    pending.then(
+      (config) => {
+        // Don't cache "not configured" — let the next call retry so the UI recovers
+        // after the backend is fixed without needing an app reload.
+        if (!config.configured) {
+          cachedBackendConfig = null
+        }
+      },
+      () => {
+        cachedBackendConfig = null
+      },
+    )
   }
   return cachedBackendConfig
 }
@@ -22,7 +32,9 @@ export const getOAuthConfig = async (httpClient: HttpClient): Promise<OAuthConfi
 
   return {
     clientId,
-    configured,
+    // Pre-patch backends only return `client_id`. Treat a missing `configured`
+    // field as truthy when a client_id is present to preserve existing behavior.
+    configured: configured ?? Boolean(clientId),
     redirectUri,
     scope: [
       'email',

--- a/src/integrations/microsoft/auth.test.ts
+++ b/src/integrations/microsoft/auth.test.ts
@@ -1,0 +1,34 @@
+import { createClient, type HttpClient } from '@/lib/http'
+import { describe, expect, it } from 'bun:test'
+import { buildAuthUrl } from './auth'
+
+const createMockHttpClient = (responses: unknown[]): HttpClient => {
+  let callCount = 0
+  const mockFetch = async (): Promise<Response> => {
+    const response = responses[callCount] ?? responses[responses.length - 1]
+    callCount++
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  return createClient({ prefixUrl: 'http://localhost/', fetch: mockFetch })
+}
+
+describe('buildAuthUrl (Microsoft)', () => {
+  it('throws a clear error when Microsoft OAuth is not configured', async () => {
+    const httpClient = createMockHttpClient([{ client_id: '', configured: false }])
+    const promise = buildAuthUrl(httpClient, 'state-abc', 'challenge-xyz')
+    await expect(promise).rejects.toThrow(
+      'Microsoft OAuth is not configured. Set MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET on the backend before enabling Microsoft integration.',
+    )
+  })
+
+  it('builds the auth URL when configured', async () => {
+    const httpClient = createMockHttpClient([{ client_id: 'test-ms-client-id', configured: true }])
+    const url = await buildAuthUrl(httpClient, 'state-abc', 'challenge-xyz')
+    expect(url).toContain('https://login.microsoftonline.com/common/oauth2/v2.0/authorize')
+    expect(url).toContain('client_id=test-ms-client-id')
+    expect(url).toContain('state=state-abc')
+  })
+})

--- a/src/integrations/microsoft/auth.ts
+++ b/src/integrations/microsoft/auth.ts
@@ -8,10 +8,20 @@ let cachedBackendConfig: Promise<AuthProviderBackendConfig> | null = null
 
 const fetchBackendConfig = (httpClient: HttpClient): Promise<AuthProviderBackendConfig> => {
   if (!cachedBackendConfig) {
-    cachedBackendConfig = httpClient.get('auth/microsoft/config').json<AuthProviderBackendConfig>()
-    cachedBackendConfig.catch(() => {
-      cachedBackendConfig = null
-    })
+    const pending = httpClient.get('auth/microsoft/config').json<AuthProviderBackendConfig>()
+    cachedBackendConfig = pending
+    pending.then(
+      (config) => {
+        // Don't cache "not configured" — let the next call retry so the UI recovers
+        // after the backend is fixed without needing an app reload.
+        if (!config.configured) {
+          cachedBackendConfig = null
+        }
+      },
+      () => {
+        cachedBackendConfig = null
+      },
+    )
   }
   return cachedBackendConfig
 }
@@ -22,7 +32,9 @@ export const getOAuthConfig = async (httpClient: HttpClient): Promise<OAuthConfi
 
   return {
     clientId,
-    configured,
+    // Pre-patch backends only return `client_id`. Treat a missing `configured`
+    // field as truthy when a client_id is present to preserve existing behavior.
+    configured: configured ?? Boolean(clientId),
     redirectUri,
     scope: 'https://graph.microsoft.com/mail.read User.Read offline_access',
   }

--- a/src/integrations/microsoft/auth.ts
+++ b/src/integrations/microsoft/auth.ts
@@ -17,11 +17,12 @@ const fetchBackendConfig = (httpClient: HttpClient): Promise<AuthProviderBackend
 }
 
 export const getOAuthConfig = async (httpClient: HttpClient): Promise<OAuthConfig> => {
-  const { client_id: clientId } = await fetchBackendConfig(httpClient)
+  const { client_id: clientId, configured } = await fetchBackendConfig(httpClient)
   const redirectUri = getOAuthRedirectUri()
 
   return {
     clientId,
+    configured,
     redirectUri,
     scope: 'https://graph.microsoft.com/mail.read User.Read offline_access',
   }
@@ -34,6 +35,11 @@ export const buildAuthUrl = async (
   redirectUri?: string,
 ): Promise<string> => {
   const config = await getOAuthConfig(httpClient)
+  if (!config.configured) {
+    throw new Error(
+      'Microsoft OAuth is not configured. Set MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET on the backend before enabling Microsoft integration.',
+    )
+  }
   const authUrl = new URL('https://login.microsoftonline.com/common/oauth2/v2.0/authorize')
   authUrl.searchParams.set('client_id', config.clientId)
   authUrl.searchParams.set('redirect_uri', redirectUri ?? config.redirectUri)

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,7 @@ export type OAuthProvider = 'google' | 'microsoft'
 
 export type OAuthConfig = {
   clientId: string
+  configured: boolean
   redirectUri: string
   scope: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,9 @@ export type ToolConfig = {
 
 export type AuthProviderBackendConfig = {
   client_id: string
-  configured: boolean
+  // Optional for backward-compat with pre-patch backends that only return client_id.
+  // Callers should treat `undefined` as configured when a client_id is present.
+  configured?: boolean
 }
 
 // Re-export types from schemas to maintain backward compatibility

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,7 @@ export type ToolConfig = {
 
 export type AuthProviderBackendConfig = {
   client_id: string
+  configured: boolean
 }
 
 // Re-export types from schemas to maintain backward compatibility


### PR DESCRIPTION
## Summary

Surface OAuth configuration errors inside Thunderbolt instead of letting users land on external Google/Microsoft error pages when `GOOGLE_CLIENT_ID` / `MICROSOFT_CLIENT_ID` are empty on the backend.

## Why this matters

Quoting the issue:
> Google and Microsoft integration needs Client IDs in configuration files, this isn't provided or enforced by default during deployment with Docker and K8s etc. It leads to an error on external authentication service page instead of thunderbolt itself.

Before: Connect -> empty `client_id` in the URL -> redirected to `accounts.google.com` / `login.microsoftonline.com` error page. No way for the user (or maintainer) to tell this is a self-hosting config issue.

After: Connect -> the frontend throws a specific message naming the env vars to set, before any external redirect.

## What changed

- `backend/src/auth/google.ts` — `/auth/google/config` now returns `configured: Boolean(client_id && client_secret)`, matching the shape `/auth/microsoft/config` already had.
- `src/types.ts` — `AuthProviderBackendConfig.configured` added as optional so pre-patch backends that only return `client_id` still work (treated as configured when `client_id` is present).
- `src/lib/auth.ts` — `OAuthConfig` carries the `configured` flag.
- `src/integrations/google/auth.ts` and `src/integrations/microsoft/auth.ts`:
  - `getOAuthConfig` reads `configured` (with the backward-compat fallback).
  - `buildAuthUrl` throws a clear, user-facing error before building any external URL when `configured === false`.
  - The module-level cache now invalidates when a `configured: false` response comes back, so a temporary backend misconfiguration can recover without a reload.

## Testing

Backend (`backend/src/auth/routes.test.ts`): added `configured: true` / `configured: false` assertions for both providers.

Frontend (`src/integrations/{google,microsoft}/auth.test.ts`): new files covering the guard — `buildAuthUrl` throws the exact error message when unconfigured, and still produces the valid auth URL when configured.

```
$ bun test src/integrations/google/auth.test.ts src/integrations/microsoft/auth.test.ts
 4 pass, 0 fail

$ cd backend && bun test src/auth/routes.test.ts
 16 pass, 0 fail
```

`bun run format-check` passes. `bun run type-check` flags only a pre-existing `ky` import error in `src/api/encryption.test.ts` that also fails on `upstream/main` and is unrelated to this change.

## Test Evidence

![Test output](https://files.catbox.moe/tri5of.gif)

Fixes #626

This contribution was developed with AI assistance (Codex).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth configuration/URL-building paths for Google and Microsoft and changes the contract of the `/config` endpoints, so mis-handling could block sign-in or integrations; coverage was added via new backend and frontend tests.
> 
> **Overview**
> Prevents external Google/Microsoft redirects when OAuth is misconfigured by adding an explicit `configured` flag to provider config and checking it before building auth URLs.
> 
> Backend `GET /auth/google/config` now returns `{ client_id, configured }` (matching Microsoft) and backend route tests assert both `configured: true` and `false` cases. Frontend OAuth config types were extended (`OAuthConfig.configured`, `AuthProviderBackendConfig.configured?` for backward compat), provider config caching now avoids caching `configured: false`, and `buildAuthUrl` throws a clear, user-facing error when the backend reports OAuth is not configured; new unit tests cover these behaviors for both providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4dc0f43ec2ebc0c28b31f43eee12e4d0e94c77f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->