### PR TITLE
docs: add Linux system dependencies to development.md Quick Start

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,27 @@
 
 ## Quick Start
 
-You must have Bun, Rust, and Docker installed first. Then:
+You must have Bun, Rust, and Docker installed first.
+
+### Linux system dependencies
+
+Building the desktop app on Linux requires Tauri's GTK/WebKit stack. On Ubuntu/Debian:
+
+```bash
+sudo apt install libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
+  build-essential curl wget file libxdo-dev libssl-dev \
+  libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
+```
+
+Also install `sccache` (required by the Rust build):
+
+```bash
+cargo install sccache
+```
+
+See [Tauri's Linux prerequisites](https://v2.tauri.app/start/prerequisites/#linux) for other distributions.
+
+Then:
 
 ```sh
 # Install dependencies


### PR DESCRIPTION
## Summary

Fixes #692 — Linux desktop build fails on fresh clone because Tauri system dependencies are missing from development.md.

## Changes

Adds a **Linux system dependencies** section to the Quick Start in :
- Tauri GTK/WebKit/libsoup prerequisites for Ubuntu/Debian
-  installation (required by )
- Link to Tauri's upstream Linux prerequisites for other distributions

## Testing

The fix was verified locally on Ubuntu 24.04:
-  completes successfully after installing the listed packages
-  compiles and launches the desktop window

## Related

- Issue #692 (open) — same root cause, fix aligns with the suggested resolution
- Issue #64 (closed) — prior Linux Metal compilation issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds Linux package prerequisites and `sccache` install steps; no runtime or behavior changes.
> 
> **Overview**
> Updates `docs/development.md` Quick Start to include a new **Linux system dependencies** section for building the Tauri desktop app, listing required Ubuntu/Debian packages, adding `sccache` installation, and linking to Tauri’s upstream Linux prerequisites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93db2d672e6c9e93a45fd9fc52a198d2eee93c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->