### PR TITLE
docs: add Linux desktop build prerequisites to development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -4,6 +4,18 @@
 
 You must have Bun, Rust, and Docker installed first. Then:
 
+## Desktop (Linux)
+
+> ⚠️ Linux desktop builds require system dependencies for Tauri/WebKit. On Ubuntu/Debian, install:
+> ```bash
+> sudo apt install libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
+>   build-essential curl wget file libxdo-dev libssl-dev \
+>   libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
+> ```
+> See [Tauri's Linux prerequisites](https://v2.tauri.app/start/prerequisites/#linux) for other distributions.
+>
+> **Note**: Linux desktop is supported for production builds but WebView is untested on Linux (see [webview.md](./webview.md)).
+
 ```sh
 # Install dependencies
 make setup
@@ -12,6 +24,9 @@ make setup
 cp .env.example .env
 cd backend && cp .env.example .env
 cd ..
+
+# Install sccache (required for desktop builds)
+# cargo install sccache  # or: npm install -g sccache
 
 # Run postgres + powersync
 make docker-up


### PR DESCRIPTION
## Summary

Fixes #692 — Linux desktop builds fail on fresh clone because Tauri's GTK/WebKit/libsoup system dependencies are not documented in development.md.

## Changes

- Added new "Desktop (Linux)" section with apt install command for Ubuntu/Debian
- Links to Tauri's upstream Linux prerequisites for other distributions
- Notes that Linux WebView is untested (per webview.md)
- Documents sccache as required tool (referenced by src-tauri/.cargo/config.toml)

## Testing

Verified on Ubuntu 24.04 — after installing the listed packages, cargo check and bun tauri:dev:desktop both succeed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or build logic is modified, but incorrect prerequisites could still mislead developers.
> 
> **Overview**
> Adds a new **Linux desktop** section to `docs/development.md` documenting required Tauri/WebKit system packages (with an Ubuntu/Debian `apt install` snippet) and linking to upstream distro-specific prerequisites.
> 
> Also notes that Linux WebView is currently untested and calls out `sccache` as a required tool for desktop builds in the quick-start steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a620c3543d54f7aa122b973cb1785c2f9213b88e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->