### PR TITLE
docs: add Linux system prerequisites to development.md (#704)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,19 @@
 
 ## Quick Start
 
-You must have Bun, Rust, and Docker installed first. Then:
+You must have Bun, Rust, and Docker installed first.
+
+### Linux System Prerequisites
+
+If you're on Linux (e.g. Ubuntu 24.04), install the following system dependencies before running `make setup`, or `cargo check` will fail with missing library errors:
+
+```bash
+sudo apt install libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev   build-essential curl wget file libxdo-dev libssl-dev   libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
+```
+
+Alternatively, see [Tauri's Linux prerequisites guide](https://v2.tauri.app/start/prerequisites/#linux).
+
+Then:
 
 ```sh
 # Install dependencies


### PR DESCRIPTION
## Summary

Added Linux system prerequisites to the Quick Start section in `docs/development.md`.

On a fresh Ubuntu 24.04 clone, `cargo check` fails with missing library errors for `javascriptcoregtk-4.1` and `libsoup-3.0`. This PR adds the required `apt install` command and links to Tauri's upstream Linux prerequisites guide.

## Changes

- Added `### Linux System Prerequisites` subsection to Quick Start
- Listed all required `apt` packages
- Added link to [Tauri's Linux prerequisites](https://v2.tauri.app/start/prerequisites/#linux)

Fixes #704

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or build logic is modified.
> 
> **Overview**
> Updates `docs/development.md` Quick Start to include a new **Linux System Prerequisites** section with an `apt install` command for required system libraries (notably `webkit2gtk`, `javascriptcoregtk`, and `libsoup`) and a link to Tauri’s upstream Linux prerequisites guide before proceeding with `make setup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c083fae4a96acc479c7c2b4bd78d3da086f6ec77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->