### PR TITLE
fix(android): use draft status for Play Store uploads

### DIFF
--- a/scripts/upload-to-play.cjs
+++ b/scripts/upload-to-play.cjs
@@ -74,7 +74,10 @@ async function uploadToPlayStore() {
             releases: [
               {
                 versionCodes: [uploadResponse.data.versionCode],
-                status: track === 'internal' ? 'completed' : 'draft',
+                // To auto-rollout to testers, the app setup must be fully completed in Google Play Console
+                // (store listing, content rating, target audience, etc.). Until then, only 'draft' is accepted.
+                // Once the setup is done, switch back to: status: track === 'internal' ? 'completed' : 'draft',
+                status: 'draft',
               },
             ],
           },


### PR DESCRIPTION
## Summary

Nightly Android builds were failing at the Google Play upload step with: `Only releases with status draft may be created on draft app`.

The upload script was using `status: 'completed'` for internal track releases, but Google Play rejects non-draft releases until the app's Console setup is fully complete (store listing, content rating, target audience, etc.).

This reverts the release status to `'draft'` to unblock CI. Once the Play Console setup is finalized, the commented-out line can be restored to auto-rollout to testers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change in the Play upload script that only affects CI/release automation behavior. It may delay internal tester rollout until the status is reverted, but does not impact runtime app code or data handling.
> 
> **Overview**
> Fixes Google Play upload failures by forcing non-production track releases created by `scripts/upload-to-play.cjs` to use `status: 'draft'` instead of auto-marking internal releases as `completed`.
> 
> Adds an in-file note explaining that auto-rollout requires completing Play Console app setup, and that the previous conditional status can be restored once setup is finished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b897c8ca0a39a69ef61fa6fc9663c27441afffe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->