### PR TITLE
fix(landing): restore thunderbird logo to footer

### DIFF
--- a/marketing/src/components/footer-section.tsx
+++ b/marketing/src/components/footer-section.tsx
@@ -11,8 +11,9 @@ export const FooterSection = ({ className = '' }: FooterSectionProps) => (
       </div>
       <div className="mx-auto mt-6 h-px max-w-[1118px] bg-[#eaecf0]" />
       <div className="mt-6 flex flex-col items-center justify-center gap-4 text-center lg:flex-row lg:gap-6">
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-3">
           <img src="/enterprise/mozilla-logo.svg" alt="Mozilla" className="h-6 w-auto" />
+          <img src="/enterprise/thunderbird.svg" alt="Thunderbird" className="h-6 w-auto" />
         </div>
         <p className="max-w-[638px] text-center text-xs leading-4 text-[#667085] lg:text-left">
           Thunderbolt is a product of{' '}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, presentation-only change confined to the marketing footer; minimal risk beyond potential asset/path or minor layout regressions.
> 
> **Overview**
> Restores the Thunderbird logo in `FooterSection` by adding a `/enterprise/thunderbird.svg` image alongside the existing Mozilla logo.
> 
> Updates the logo container styles from a single-row flex layout to a wrapping, centered layout (`flex-wrap` with x/y gaps) to prevent spacing issues when multiple logos are shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8f323aa90a5badb4dcfe599b8c95686ac76248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->