### PR TITLE
chore: podman compatibility + rename make commands

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+bunx lint-staged

--- a/.thunderbot/thunderdown.md
+++ b/.thunderbot/thunderdown.md
@@ -2,4 +2,4 @@
 description: "Stop docker containers"
 ---
 
-Run `make docker-status`, then `make docker-down`. Confirm stopped.
+Run `make status`, then `make down`. Confirm stopped.

--- a/.thunderbot/thunderup.md
+++ b/.thunderbot/thunderup.md
@@ -9,8 +9,8 @@ Bootstrap the Thunderbolt dev environment. Accepts an optional argument via $ARG
 - **Empty (default):** Run the standard bootstrap:
   1. `make doctor-q` — verify tools (only prints issues)
   2. `make setup` — install frontend + backend deps
-  3. `make docker-up` — start docker containers
-  4. `make docker-status` — confirm containers are healthy
+  3. `make up` — start containers
+  4. `make status` — confirm containers are healthy
 
 - **`all`:** Run the standard bootstrap above, then also:
   5. `make run` — start backend (:8000) and frontend (:5173) dev servers

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ YELLOW := \033[0;33m
 NC := \033[0m # No Color
 
 # Container compose tool (auto-detect podman-compose, fallback to docker compose)
-COMPOSE ?= $(shell command -v podman-compose > /dev/null 2>&1 && echo podman-compose || echo docker compose)
+COMPOSE ?= $(shell command -v podman-compose > /dev/null 2>&1 && podman info > /dev/null 2>&1 && echo podman-compose || echo docker compose)
 
 # Default target
 help:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: help setup setup-symlinks install build build-desktop build-android build-ios clean run dev doctor doctor-q docker-up docker-down docker-nuke docker-status thunderbot-pull thunderbot-push thunderbot-customize
+.PHONY: help setup setup-symlinks install build build-desktop build-android build-ios clean run dev doctor doctor-q up down nuke status thunderbot-pull thunderbot-push thunderbot-customize
 
 # Color definitions
 BLUE := \033[0;34m
 GREEN := \033[0;32m
 YELLOW := \033[0;33m
 NC := \033[0m # No Color
+
+# Container compose tool (auto-detect podman-compose, fallback to docker compose)
+COMPOSE ?= $(shell command -v podman-compose > /dev/null 2>&1 && echo podman-compose || echo docker compose)
 
 # Default target
 help:
@@ -21,10 +24,10 @@ help:
 	@echo "  make format         - Format frontend, backend (JS/TS), and Rust code"
 	@echo "  make format-check   - Check formatting for frontend, backend, and Rust code"
 	@echo "  make doctor         - Verify all dev tools and env files are configured"
-	@echo "  make docker-up      - Start docker containers (PowerSync, Mongo, etc.)"
-	@echo "  make docker-down    - Stop docker containers"
-	@echo "  make docker-nuke    - Destroy all docker data and recreate from scratch"
-	@echo "  make docker-status  - Show docker container status"
+	@echo "  make up             - Start containers (PowerSync, Mongo, etc.)"
+	@echo "  make down           - Stop containers"
+	@echo "  make nuke           - Destroy all container data and recreate from scratch"
+	@echo "  make status         - Show container status"
 	@echo "  make thunderbot-pull - Pull latest skills from thunderbot"
 	@echo "  make thunderbot-push      - Push skill changes back to thunderbot"
 	@echo "  make thunderbot-customize - Fork a thunderbot command for local edits (FILE=name.md)"
@@ -98,7 +101,7 @@ format:
 	@echo "$(BLUE)→ Formatting backend code...$(NC)"
 	cd backend && bun run format
 	@echo "$(BLUE)→ Formatting Rust code...$(NC)"
-	bun run format:rust
+	@command -v cargo > /dev/null 2>&1 && bun run format:rust || echo "$(YELLOW)⚠ cargo not found, skipping Rust formatting$(NC)"
 	@echo "$(GREEN)✓ Formatting complete!$(NC)"
 
 format-check:
@@ -152,21 +155,21 @@ doctor:
 doctor-q:
 	@bash scripts/thunderdoctor.sh --quiet
 
-# Docker management
-docker-up:
-	@echo "$(BLUE)→ Starting docker containers...$(NC)"
-	docker compose -f powersync-service/docker-compose.yml up -d
-	@echo "$(GREEN)✓ Docker containers started!$(NC)"
+# Container management
+up:
+	@echo "$(BLUE)→ Starting containers...$(NC)"
+	$(COMPOSE) -f powersync-service/docker-compose.yml up -d
+	@echo "$(GREEN)✓ Containers started!$(NC)"
 
-docker-down:
-	@echo "$(BLUE)→ Stopping docker containers...$(NC)"
-	docker compose -f powersync-service/docker-compose.yml down
-	@echo "$(GREEN)✓ Docker containers stopped!$(NC)"
+down:
+	@echo "$(BLUE)→ Stopping containers...$(NC)"
+	$(COMPOSE) -f powersync-service/docker-compose.yml down
+	@echo "$(GREEN)✓ Containers stopped!$(NC)"
 
-docker-nuke:
+nuke:
 	@bash scripts/docker-nuke.sh
 
-docker-status:
+status:
 	@bash scripts/docker-status.sh
 
 # Thunderbot skill sync

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ format-check:
 	@echo "$(BLUE)→ Checking backend formatting...$(NC)"
 	cd backend && bun run format-check
 	@echo "$(BLUE)→ Checking Rust formatting...$(NC)"
-	bun run format:rust-check
+	@command -v cargo > /dev/null 2>&1 && bun run format:rust-check || echo "$(YELLOW)⚠ cargo not found, skipping Rust format check$(NC)"
 	@echo "$(GREEN)✓ Format check complete!$(NC)"
 
 # Type checking

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ format:
 	@echo "$(BLUE)→ Formatting backend code...$(NC)"
 	cd backend && bun run format
 	@echo "$(BLUE)→ Formatting Rust code...$(NC)"
-	@command -v cargo > /dev/null 2>&1 && bun run format:rust || echo "$(YELLOW)⚠ cargo not found, skipping Rust formatting$(NC)"
+	@if command -v cargo > /dev/null 2>&1; then bun run format:rust; else echo "$(YELLOW)⚠ cargo not found, skipping Rust formatting$(NC)"; fi
 	@echo "$(GREEN)✓ Formatting complete!$(NC)"
 
 format-check:
@@ -110,7 +110,7 @@ format-check:
 	@echo "$(BLUE)→ Checking backend formatting...$(NC)"
 	cd backend && bun run format-check
 	@echo "$(BLUE)→ Checking Rust formatting...$(NC)"
-	@command -v cargo > /dev/null 2>&1 && bun run format:rust-check || echo "$(YELLOW)⚠ cargo not found, skipping Rust format check$(NC)"
+	@if command -v cargo > /dev/null 2>&1; then bun run format:rust-check; else echo "$(YELLOW)⚠ cargo not found, skipping Rust format check$(NC)"; fi
 	@echo "$(GREEN)✓ Format check complete!$(NC)"
 
 # Type checking

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -29,8 +29,8 @@ What it does:
 
 1. `make doctor-q` — verify required tools (only prints issues)
 2. `make setup` — install frontend and backend dependencies
-3. `make docker-up` — start Docker containers
-4. `make docker-status` — confirm containers are healthy
+3. `make up` — start Docker/Podman containers
+4. `make status` — confirm containers are healthy
 5. _(with `all`)_ `make run` — start backend (:8000) and frontend (:5173) dev servers
 
 When given a Linear ticket ID or branch name, it creates a git worktree first, then bootstraps inside it.

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ cd backend && cp .env.example .env
 cd ..
 
 # Run postgres + powersync
-make docker-up
+make up
 
 # Run backend
 # cd backend && bun dev

--- a/docs/powersync-account-devices.md
+++ b/docs/powersync-account-devices.md
@@ -76,7 +76,7 @@ Split the work into two PRs to avoid sync rule mismatches:
 
 See [powersync-service/README.md](../powersync-service/README.md) for full steps. Summary:
 
-- From `powersync-service/`: `docker compose up -d`
+- From the repo root: `make up` (or from `powersync-service/`: `docker compose up -d`)
 - PowerSync API: http://localhost:8080
 - Postgres: localhost:5433 (use this for the backend so PowerSync and app share one database)
 - Backend `.env`: set `DATABASE_DRIVER=postgres`, `DATABASE_URL=postgresql://postgres:postgres@localhost:5433/postgres`, and PowerSync vars (see below)

--- a/powersync-service/docker-compose.yml
+++ b/powersync-service/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    image: journeyapps/powersync-service:latest
+    image: docker.io/journeyapps/powersync-service:latest
     command: ["start", "-r", "unified"]
     volumes:
       - ./config/config.yaml:/config/config.yaml
@@ -14,7 +14,7 @@ services:
       - 8080:8080
 
   postgres:
-    image: postgres:18-alpine
+    image: docker.io/library/postgres:18-alpine
     restart: always
     environment:
       - POSTGRES_USER=postgres

--- a/scripts/docker-nuke.sh
+++ b/scripts/docker-nuke.sh
@@ -10,6 +10,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 COMPOSE_FILE="$PROJECT_ROOT/powersync-service/docker-compose.yml"
 
+# Auto-detect compose tool (podman-compose takes precedence over docker compose)
+COMPOSE=$(command -v podman-compose > /dev/null 2>&1 && echo podman-compose || echo "docker compose")
+
 if [ ! -f "$COMPOSE_FILE" ]; then
   echo -e "${RED}✗ Compose file not found: $COMPOSE_FILE${NC}"
   exit 1
@@ -34,9 +37,9 @@ if [ "$CONFIRMED" = false ]; then
 fi
 
 echo -e "${RED}→ Stopping and removing containers + volumes...${NC}"
-docker compose -f "$COMPOSE_FILE" down -v
+$COMPOSE -f "$COMPOSE_FILE" down -v
 
 echo -e "${GREEN}→ Recreating containers from scratch...${NC}"
-docker compose -f "$COMPOSE_FILE" up -d
+$COMPOSE -f "$COMPOSE_FILE" up -d
 
 echo -e "${GREEN}✓ Docker environment nuked and recreated!${NC}"

--- a/scripts/docker-nuke.sh
+++ b/scripts/docker-nuke.sh
@@ -11,7 +11,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 COMPOSE_FILE="$PROJECT_ROOT/powersync-service/docker-compose.yml"
 
 # Auto-detect compose tool (podman-compose takes precedence over docker compose)
-COMPOSE=$(command -v podman-compose > /dev/null 2>&1 && echo podman-compose || echo "docker compose")
+COMPOSE=$(command -v podman-compose > /dev/null 2>&1 && podman info > /dev/null 2>&1 && echo podman-compose || echo "docker compose")
 
 if [ ! -f "$COMPOSE_FILE" ]; then
   echo -e "${RED}✗ Compose file not found: $COMPOSE_FILE${NC}"

--- a/scripts/docker-status.sh
+++ b/scripts/docker-status.sh
@@ -10,19 +10,31 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 COMPOSE_FILE="$PROJECT_ROOT/powersync-service/docker-compose.yml"
 
-if ! command -v docker &>/dev/null; then
-  echo -e "${RED}✗ Docker is not installed.${NC}"
-  echo "  Install Docker Desktop: https://docker.com/products/docker-desktop"
-  exit 1
-fi
+# Auto-detect compose tool (podman-compose takes precedence over docker compose)
+COMPOSE=$(command -v podman-compose > /dev/null 2>&1 && echo podman-compose || echo "docker compose")
 
-if ! docker info &>/dev/null; then
-  echo -e "${RED}✗ Docker daemon is not running.${NC}"
-  echo "  Start Docker Desktop and try again."
-  exit 1
-fi
+if command -v podman-compose > /dev/null 2>&1; then
+  if ! podman info &>/dev/null; then
+    echo -e "${RED}✗ Podman daemon is not running.${NC}"
+    echo "  Start Podman and try again."
+    exit 1
+  fi
+  echo -e "${GREEN}✓ Podman is running${NC}"
+else
+  if ! command -v docker &>/dev/null; then
+    echo -e "${RED}✗ Docker is not installed.${NC}"
+    echo "  Install Docker Desktop: https://docker.com/products/docker-desktop"
+    exit 1
+  fi
 
-echo -e "${GREEN}✓ Docker is running${NC}"
+  if ! docker info &>/dev/null; then
+    echo -e "${RED}✗ Docker daemon is not running.${NC}"
+    echo "  Start Docker Desktop and try again."
+    exit 1
+  fi
+
+  echo -e "${GREEN}✓ Docker is running${NC}"
+fi
 echo ""
 
 if [ ! -f "$COMPOSE_FILE" ]; then
@@ -31,4 +43,4 @@ if [ ! -f "$COMPOSE_FILE" ]; then
 fi
 
 echo "Container status:"
-docker compose -f "$COMPOSE_FILE" ps
+$COMPOSE -f "$COMPOSE_FILE" ps

--- a/scripts/docker-status.sh
+++ b/scripts/docker-status.sh
@@ -11,14 +11,9 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 COMPOSE_FILE="$PROJECT_ROOT/powersync-service/docker-compose.yml"
 
 # Auto-detect compose tool (podman-compose takes precedence over docker compose)
-COMPOSE=$(command -v podman-compose > /dev/null 2>&1 && echo podman-compose || echo "docker compose")
+COMPOSE=$(command -v podman-compose > /dev/null 2>&1 && podman info > /dev/null 2>&1 && echo podman-compose || echo "docker compose")
 
-if command -v podman-compose > /dev/null 2>&1; then
-  if ! podman info &>/dev/null; then
-    echo -e "${RED}✗ Podman daemon is not running.${NC}"
-    echo "  Start Podman and try again."
-    exit 1
-  fi
+if command -v podman-compose > /dev/null 2>&1 && podman info &>/dev/null; then
   echo -e "${GREEN}✓ Podman is running${NC}"
 else
   if ! command -v docker &>/dev/null; then

--- a/scripts/thunderdoctor.sh
+++ b/scripts/thunderdoctor.sh
@@ -61,9 +61,9 @@ check "cmake" \
   "cmake --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'" \
   "install with: brew install cmake"
 
-check "docker" \
-  "docker info >/dev/null 2>&1 && echo \"\$(docker --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1), running\"" \
-  "install Docker Desktop: https://docker.com/products/docker-desktop — make sure daemon is running" \
+check "container runtime (docker or podman)" \
+  "if command -v podman-compose > /dev/null 2>&1 && podman info >/dev/null 2>&1; then echo \"podman \$(podman --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1), running\"; elif docker info >/dev/null 2>&1; then echo \"docker \$(docker --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1), running\"; else exit 1; fi" \
+  "install Docker Desktop (https://docker.com/products/docker-desktop) or Podman (https://podman.io) — make sure daemon is running" \
   true
 
 check "gh" \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dev-environment and documentation changes only; main risk is minor workflow breakage if contributors/scripts still rely on the old `make docker-*` target names.
> 
> **Overview**
> Updates local dev tooling to be container-runtime agnostic by **renaming `make docker-*` targets to `make up/down/status/nuke`** and auto-detecting `podman-compose` vs `docker compose` in the Makefile and helper scripts.
> 
> Improves robustness by skipping Rust format steps when `cargo` isn’t installed, fully qualifying container images in `powersync-service/docker-compose.yml`, switching Husky pre-commit to `bunx`, and updating Thunderbot/docs to match the new commands and Podman support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b55bed94ee435447757b187be9cf6b5386950e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->