### PR TITLE
Add sccache to development.md prerequisites

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,9 @@
 
 ## Quick Start
 
-You must have Bun, Rust, and Docker installed first. Then:
+You must have Bun, Rust, sccache, and Docker installed first. Then:
+
+> **Note**: The Rust build uses `sccache` (configured in `src-tauri/.cargo/config.toml`) to speed up rebuilds. Install it with: `cargo install sccache`
 
 ```sh
 # Install dependencies


### PR DESCRIPTION
## Problem

src-tauri/.cargo/config.toml uses rustc-wrapper = "sccache" to speed up Rust builds, but development.md's Quick Start does not mention installing sccache. Contributors following the docs will hit a silent failure on first clone.

## Solution

- Add sccache to the list of required tools in the Quick Start section
- Add a note explaining what sccache is and how to install it

## Use case

First-time contributors cloning the repo will get a working Rust toolchain without trial-and-error debugging.

Closes #715

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or runtime behavior is modified.
> 
> **Overview**
> Updates `docs/development.md` Quick Start prerequisites to include `sccache` and adds a note with install instructions, aligning the setup docs with the Rust build’s `rustc-wrapper = "sccache"` configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a4802c9c0e8549f8ad738e0d83095c244c1d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->