### PR TITLE
docs(release): clarify desktop asset availability

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -395,11 +395,13 @@ jobs:
 
             ### Downloads
 
-            Download the appropriate installer for your platform below.
+            If desktop artifacts were uploaded successfully, download the appropriate installer from the assets attached to this release.
 
             - **Windows**: `.msi` or `.exe` installer
             - **macOS**: `.dmg` installer (Intel and Apple Silicon)
             - **Linux**: `.AppImage`, `.deb`, or `.rpm` package
+
+            If no desktop assets are attached yet, use the self-deploy templates in [`deploy/`](https://github.com/thunderbird/thunderbolt/tree/main/deploy) while the release pipeline is being fixed.
 
             ### Release Notes
 
@@ -424,11 +426,13 @@ jobs:
 
             ### Downloads
 
-            Download the appropriate installer for your platform below.
+            If desktop artifacts were uploaded successfully, download the appropriate installer from the assets attached to this release.
 
             - **Windows**: `.msi` or `.exe` installer
             - **macOS**: `.dmg` installer (Intel and Apple Silicon)
             - **Linux**: `.AppImage`, `.deb`, or `.rpm` package
+
+            If no desktop assets are attached yet, use the self-deploy templates in [`deploy/`](https://github.com/thunderbird/thunderbolt/tree/main/deploy) instead.
 
             ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -241,9 +241,11 @@ Once the tag exists, all platform builds run in parallel:
 
 ### Final Steps
 
-- **GitHub Release**: All artifacts uploaded to the release
+- **GitHub Release**: Desktop artifacts are attached when the desktop release workflow finishes successfully
 - **iOS TestFlight**: Testers with access are notified
 - **Android Play Store**: Available on internal track for testing
+
+If desktop assets are not attached yet, point users to the deployment templates in [`deploy/`](./deploy) instead of assuming installers are available on the GitHub release page.
 
 ## Platform-Specific Releases
 


### PR DESCRIPTION
Fixes #611.

This updates the desktop release body and release guide so they no longer imply installers are always attached. The release messaging now tells users to download attached assets when present and points them to the deploy templates otherwise.

Validation:
- reviewed the final diff for the workflow and release guide changes
- parsed `.github/workflows/desktop-release.yml` with `yaml.safe_load`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/workflow copy change only; it updates GitHub Release body text and the release guide without altering build or publishing behavior.
> 
> **Overview**
> Updates the desktop release workflow’s GitHub Release body (stable + nightly) to say installers should be downloaded from attached assets *only when the desktop upload succeeds*, and adds guidance to use `deploy/` templates when no assets are present.
> 
> Adjusts `RELEASE.md` to reflect the same expectation: desktop artifacts appear after the desktop workflow completes successfully, and release communications should redirect users to `deploy/` if installers aren’t attached yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b344dd0dcea941671ff2a788a178430f87c060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->