### PR TITLE
ci: add owner and repositories to GitHub App token action

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -73,6 +73,8 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: thunderbird
+          repositories: thunderbolt
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to CI, but it can affect release automation if the token is scoped incorrectly and checkout/tagging no longer has the expected permissions.
> 
> **Overview**
> Updates the `version-bump.yml` workflow to pass `owner: thunderbird` and `repositories: thunderbolt` to `actions/create-github-app-token`, explicitly scoping the generated release token to the intended repository for subsequent checkout and release steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18c9596e0eb59f0eb0ccfed9256d72ec5ff8750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->