### PR TITLE
ci: use environment secrets and rename RELEASE_APP_ID to RELEASE_APP_CLIENT_ID

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -71,10 +71,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          app-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: thunderbird
-          repositories: thunderbolt
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the GitHub Actions release workflow token generation; a misconfigured secret name/value could block automated version bumps and releases.
> 
> **Overview**
> Updates `.github/workflows/version-bump.yml` to generate the GitHub App token using `secrets.RELEASE_APP_CLIENT_ID` (renamed from `RELEASE_APP_ID`) and drops the explicit `owner`/`repositories` inputs for `actions/create-github-app-token`.
> 
> This changes how the release workflow authenticates for checkout and release creation, so reviewers should verify the new environment secret is set correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc925d2085689d6ec65a60978f6b1af370ffc632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->