### PR TITLE
feat(THU-455): cut over deep links to app.thunderbolt.io

### DIFF
--- a/backend/src/auth/utils.test.ts
+++ b/backend/src/auth/utils.test.ts
@@ -122,7 +122,7 @@ describe('buildVerifyUrl', () => {
       headers: { 'x-client-platform': 'ios' },
     })
     const result = buildVerifyUrl('https://app.example.com', 'user@example.com', '123456', request)
-    expect(result).toBe('https://thunderbolt.io/auth/verify?email=user%40example.com&otp=123456')
+    expect(result).toBe('https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=123456')
   })
 
   it('uses deep link URL for Android platform', () => {
@@ -130,7 +130,7 @@ describe('buildVerifyUrl', () => {
       headers: { 'x-client-platform': 'android' },
     })
     const result = buildVerifyUrl('https://app.example.com', 'user@example.com', '123456', request)
-    expect(result).toBe('https://thunderbolt.io/auth/verify?email=user%40example.com&otp=123456')
+    expect(result).toBe('https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=123456')
   })
 
   it('uses origin URL for web platform', () => {

--- a/backend/src/auth/utils.tsx
+++ b/backend/src/auth/utils.tsx
@@ -2,7 +2,7 @@ import { sendEmail, shouldSkipEmail } from '@/lib/resend'
 import { MagicLinkEmail } from '@/emails/magic-link'
 
 /** Deep link base URL for mobile apps (iOS/Android) */
-const deepLinkHost = 'https://thunderbolt.io'
+const deepLinkHost = 'https://app.thunderbolt.io'
 
 /** Platforms that support deep linking */
 const deepLinkPlatforms = ['ios', 'android']

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -490,7 +490,7 @@ describe('Config Settings', () => {
     })
 
     it('allows mobile App Link callback', () => {
-      expect(isOAuthRedirectUriAllowed('https://thunderbolt.io/oauth/callback', settings)).toBe(true)
+      expect(isOAuthRedirectUriAllowed('https://app.thunderbolt.io/oauth/callback', settings)).toBe(true)
     })
 
     it('allows production origin from corsOrigins', () => {

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -177,7 +177,7 @@ export const isOAuthRedirectUriAllowed = (uri: string, settings: Pick<Settings, 
     const url = new URL(uri)
     // Construct origin manually — url.origin returns 'null' for non-standard protocols like tauri://
     const origin = `${url.protocol}//${url.host}`
-    const allowedOrigins = [...getCorsOriginsList(settings), 'https://thunderbolt.io']
+    const allowedOrigins = [...getCorsOriginsList(settings), 'https://app.thunderbolt.io']
     if (allowedOrigins.includes(origin)) {
       return true
     }

--- a/backend/src/emails/magic-link.tsx
+++ b/backend/src/emails/magic-link.tsx
@@ -23,7 +23,7 @@ export const MagicLinkEmail = ({ code, magicLinkUrl }: MagicLinkEmailProps) => (
 
 MagicLinkEmail.PreviewProps = {
   code: '882999',
-  magicLinkUrl: 'https://thunderbolt.io/auth/verify?email=user@example.com&otp=882999',
+  magicLinkUrl: 'https://app.thunderbolt.io/auth/verify?email=user@example.com&otp=882999',
 } satisfies MagicLinkEmailProps
 
 export default MagicLinkEmail

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
-                <data android:host="thunderbolt.io" />
+                <data android:host="app.thunderbolt.io" />
                 
                 
                 <data android:pathPrefix="/oauth/callback" />

--- a/src-tauri/gen/apple/thunderbolt_iOS/thunderbolt_iOS.entitlements
+++ b/src-tauri/gen/apple/thunderbolt_iOS/thunderbolt_iOS.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:thunderbolt.io</string>
+		<string>applinks:app.thunderbolt.io</string>
 	</array>
 </dict>
 </plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -62,7 +62,7 @@
           "scheme": [
             "https"
           ],
-          "host": "thunderbolt.io",
+          "host": "app.thunderbolt.io",
           "pathPrefix": [
             "/oauth/callback",
             "/auth/verify"

--- a/src/hooks/use-deep-link-listener.test.ts
+++ b/src/hooks/use-deep-link-listener.test.ts
@@ -28,7 +28,7 @@ const wrapper = ({ children }: { children: ReactNode }) => {
 
 describe('parseOAuthCallback', () => {
   it('parses valid OAuth callback URL with code and state', () => {
-    const url = new URL('https://thunderbolt.io/oauth/callback?code=abc123&state=xyz789')
+    const url = new URL('https://app.thunderbolt.io/oauth/callback?code=abc123&state=xyz789')
     const result = parseOAuthCallback(url)
 
     expect(result).toEqual({
@@ -39,7 +39,7 @@ describe('parseOAuthCallback', () => {
   })
 
   it('parses OAuth callback URL with error parameter', () => {
-    const url = new URL('https://thunderbolt.io/oauth/callback?error=access_denied')
+    const url = new URL('https://app.thunderbolt.io/oauth/callback?error=access_denied')
     const result = parseOAuthCallback(url)
 
     expect(result).toEqual({
@@ -50,7 +50,9 @@ describe('parseOAuthCallback', () => {
   })
 
   it('prioritizes error_description over error parameter', () => {
-    const url = new URL('https://thunderbolt.io/oauth/callback?error=access_denied&error_description=User%20cancelled')
+    const url = new URL(
+      'https://app.thunderbolt.io/oauth/callback?error=access_denied&error_description=User%20cancelled',
+    )
     const result = parseOAuthCallback(url)
 
     expect(result).toEqual({
@@ -61,7 +63,7 @@ describe('parseOAuthCallback', () => {
   })
 
   it('handles OAuth callback URL with missing parameters', () => {
-    const url = new URL('https://thunderbolt.io/oauth/callback')
+    const url = new URL('https://app.thunderbolt.io/oauth/callback')
     const result = parseOAuthCallback(url)
 
     expect(result).toEqual({
@@ -72,7 +74,7 @@ describe('parseOAuthCallback', () => {
   })
 
   it('handles OAuth callback URL with nested path', () => {
-    const url = new URL('https://thunderbolt.io/oauth/callback/extra?code=abc123&state=xyz789')
+    const url = new URL('https://app.thunderbolt.io/oauth/callback/extra?code=abc123&state=xyz789')
     const result = parseOAuthCallback(url)
 
     expect(result).toEqual({
@@ -90,14 +92,14 @@ describe('parseOAuthCallback', () => {
   })
 
   it('returns null for wrong path', () => {
-    const url = new URL('https://thunderbolt.io/different/path?code=abc123&state=xyz789')
+    const url = new URL('https://app.thunderbolt.io/different/path?code=abc123&state=xyz789')
     const result = parseOAuthCallback(url)
 
     expect(result).toBeNull()
   })
 
   it('returns null for non-OAuth URL', () => {
-    const url = new URL('https://thunderbolt.io/')
+    const url = new URL('https://app.thunderbolt.io/')
     const result = parseOAuthCallback(url)
 
     expect(result).toBeNull()
@@ -106,7 +108,7 @@ describe('parseOAuthCallback', () => {
 
 describe('parseVerifyLinkCallback', () => {
   it('parses valid verify link callback URL with email and otp', () => {
-    const url = new URL('https://thunderbolt.io/auth/verify?email=user%40example.com&otp=123456')
+    const url = new URL('https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=123456')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toEqual({
@@ -117,7 +119,7 @@ describe('parseVerifyLinkCallback', () => {
   })
 
   it('handles verify link URL with nested path', () => {
-    const url = new URL('https://thunderbolt.io/auth/verify/extra?email=user%40example.com&otp=123456')
+    const url = new URL('https://app.thunderbolt.io/auth/verify/extra?email=user%40example.com&otp=123456')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toEqual({
@@ -128,21 +130,21 @@ describe('parseVerifyLinkCallback', () => {
   })
 
   it('returns null when email is missing', () => {
-    const url = new URL('https://thunderbolt.io/auth/verify?otp=123456')
+    const url = new URL('https://app.thunderbolt.io/auth/verify?otp=123456')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toBeNull()
   })
 
   it('returns null when otp is missing', () => {
-    const url = new URL('https://thunderbolt.io/auth/verify?email=user%40example.com')
+    const url = new URL('https://app.thunderbolt.io/auth/verify?email=user%40example.com')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toBeNull()
   })
 
   it('returns null when both params are missing', () => {
-    const url = new URL('https://thunderbolt.io/auth/verify')
+    const url = new URL('https://app.thunderbolt.io/auth/verify')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toBeNull()
@@ -156,21 +158,21 @@ describe('parseVerifyLinkCallback', () => {
   })
 
   it('returns null for wrong path', () => {
-    const url = new URL('https://thunderbolt.io/different/path?email=user%40example.com&otp=123456')
+    const url = new URL('https://app.thunderbolt.io/different/path?email=user%40example.com&otp=123456')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toBeNull()
   })
 
   it('returns null for OAuth callback URL', () => {
-    const url = new URL('https://thunderbolt.io/oauth/callback?code=abc&state=xyz')
+    const url = new URL('https://app.thunderbolt.io/oauth/callback?code=abc&state=xyz')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toBeNull()
   })
 
   it('handles email with special characters', () => {
-    const url = new URL('https://thunderbolt.io/auth/verify?email=user%2Btag%40example.com&otp=123456')
+    const url = new URL('https://app.thunderbolt.io/auth/verify?email=user%2Btag%40example.com&otp=123456')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toEqual({
@@ -182,7 +184,7 @@ describe('parseVerifyLinkCallback', () => {
 
   it('parses challengeToken when present', () => {
     const url = new URL(
-      'https://thunderbolt.io/auth/verify?email=user%40example.com&otp=12345678&challengeToken=abc-123-def',
+      'https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=12345678&challengeToken=abc-123-def',
     )
     const result = parseVerifyLinkCallback(url)
 
@@ -194,7 +196,7 @@ describe('parseVerifyLinkCallback', () => {
   })
 
   it('returns undefined challengeToken when not present', () => {
-    const url = new URL('https://thunderbolt.io/auth/verify?email=user%40example.com&otp=12345678')
+    const url = new URL('https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=12345678')
     const result = parseVerifyLinkCallback(url)
 
     expect(result).toEqual({
@@ -320,7 +322,7 @@ describe('determineNavigationTarget', () => {
 
 describe('parseOAuthCallback + determineNavigationTarget integration', () => {
   it('handles complete OAuth success flow', () => {
-    const url = new URL('https://thunderbolt.io/oauth/callback?code=abc123&state=xyz789')
+    const url = new URL('https://app.thunderbolt.io/oauth/callback?code=abc123&state=xyz789')
     const oauthData = parseOAuthCallback(url)
 
     expect(oauthData).not.toBeNull()
@@ -339,7 +341,7 @@ describe('parseOAuthCallback + determineNavigationTarget integration', () => {
 
   it('handles complete OAuth error flow', () => {
     const url = new URL(
-      'https://thunderbolt.io/oauth/callback?error=access_denied&error_description=User%20cancelled%20authorization',
+      'https://app.thunderbolt.io/oauth/callback?error=access_denied&error_description=User%20cancelled%20authorization',
     )
     const oauthData = parseOAuthCallback(url)
 
@@ -380,7 +382,7 @@ describe('useDeepLinkListener hook', () => {
   })
 
   it('handles custom handler for non-OAuth deep links', async () => {
-    const mockUrls = ['https://thunderbolt.io/some/other/path']
+    const mockUrls = ['https://app.thunderbolt.io/some/other/path']
     let customHandlerCalled = false
     let customHandlerUrls: string[] = []
     let callback: ((urls: string[]) => void) | null = null
@@ -424,7 +426,7 @@ describe('useDeepLinkListener hook', () => {
   })
 
   it('does NOT call custom handler for OAuth callback URLs', async () => {
-    const mockUrls = ['https://thunderbolt.io/oauth/callback?code=abc123&state=xyz789']
+    const mockUrls = ['https://app.thunderbolt.io/oauth/callback?code=abc123&state=xyz789']
     let customHandlerCalled = false
     let callback: ((urls: string[]) => void) | null = null
 
@@ -466,7 +468,7 @@ describe('useDeepLinkListener hook', () => {
   })
 
   it('does NOT call custom handler for verify link callback URLs', async () => {
-    const mockUrls = ['https://thunderbolt.io/auth/verify?email=user%40example.com&otp=123456']
+    const mockUrls = ['https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=123456']
     let customHandlerCalled = false
     let callback: ((urls: string[]) => void) | null = null
 
@@ -508,7 +510,11 @@ describe('useDeepLinkListener hook', () => {
   })
 
   it('calls custom handler only once with multiple non-OAuth URLs', async () => {
-    const mockUrls = ['https://thunderbolt.io/path1', 'https://thunderbolt.io/path2', 'https://thunderbolt.io/path3']
+    const mockUrls = [
+      'https://app.thunderbolt.io/path1',
+      'https://app.thunderbolt.io/path2',
+      'https://app.thunderbolt.io/path3',
+    ]
     let customHandlerCallCount = 0
     let receivedUrls: string[] = []
     let callback: ((urls: string[]) => void) | null = null
@@ -554,10 +560,10 @@ describe('useDeepLinkListener hook', () => {
 
   it('filters out OAuth and verify link URLs and only passes unhandled URLs to handler', async () => {
     const mockUrls = [
-      'https://thunderbolt.io/path1',
-      'https://thunderbolt.io/oauth/callback?code=abc123&state=xyz',
-      'https://thunderbolt.io/auth/verify?email=user%40example.com&otp=123456',
-      'https://thunderbolt.io/path2',
+      'https://app.thunderbolt.io/path1',
+      'https://app.thunderbolt.io/oauth/callback?code=abc123&state=xyz',
+      'https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=123456',
+      'https://app.thunderbolt.io/path2',
     ]
     let receivedUrls: string[] = []
     let callback: ((urls: string[]) => void) | null = null
@@ -596,7 +602,7 @@ describe('useDeepLinkListener hook', () => {
     })
 
     // Handler should only receive unhandled URLs (not OAuth or verify link)
-    expect(receivedUrls).toEqual(['https://thunderbolt.io/path1', 'https://thunderbolt.io/path2'])
+    expect(receivedUrls).toEqual(['https://app.thunderbolt.io/path1', 'https://app.thunderbolt.io/path2'])
   })
 
   it('handles invalid URLs gracefully', async () => {
@@ -658,7 +664,7 @@ describe('useDeepLinkListener hook', () => {
     // Simulate a deep link event
     expect(storedCallback).not.toBeNull()
     await act(async () => {
-      storedCallback!(['https://thunderbolt.io/oauth/callback?code=test&state=test'])
+      storedCallback!(['https://app.thunderbolt.io/oauth/callback?code=test&state=test'])
     })
     // If no error thrown, the listener worked
     expect(true).toBe(true)

--- a/src/hooks/use-deep-link-listener.ts
+++ b/src/hooks/use-deep-link-listener.ts
@@ -55,7 +55,7 @@ export const determineNavigationTarget = (
  * Exported for testing
  */
 export const parseOAuthCallback = (url: URL): OAuthCallbackData | null => {
-  if (url.hostname !== 'thunderbolt.io' || !url.pathname.startsWith('/oauth/callback')) {
+  if (url.hostname !== 'app.thunderbolt.io' || !url.pathname.startsWith('/oauth/callback')) {
     return null
   }
 
@@ -77,7 +77,7 @@ export const parseOAuthCallback = (url: URL): OAuthCallbackData | null => {
  * Exported for testing
  */
 export const parseVerifyLinkCallback = (url: URL): VerifyLinkData | null => {
-  if (url.hostname !== 'thunderbolt.io' || !url.pathname.startsWith('/auth/verify')) {
+  if (url.hostname !== 'app.thunderbolt.io' || !url.pathname.startsWith('/auth/verify')) {
     return null
   }
 
@@ -100,7 +100,7 @@ type DeepLinkDependencies = {
 
 /**
  * Hook to listen for deep links (App Links / Universal Links)
- * Handles OAuth callbacks when the app is opened via https://thunderbolt.io/oauth/callback
+ * Handles OAuth callbacks when the app is opened via https://app.thunderbolt.io/oauth/callback
  *
  * @param handler Optional custom handler for deep links
  * @param dependencies Optional dependencies for testing (uses real implementations by default)


### PR DESCRIPTION
Moves the app off `thunderbolt.io` onto `app.thunderbolt.io`. Well-known files are already deployed on the new domain.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates deep-link and OAuth redirect allowlists from `thunderbolt.io` to `app.thunderbolt.io`, which can break mobile sign-in/OAuth flows if any clients or provider consoles still use the old domain.
> 
> **Overview**
> Switches the mobile deep-link base domain from `https://thunderbolt.io` to `https://app.thunderbolt.io` for magic-link verification URLs and in-app deep-link parsing.
> 
> Updates OAuth redirect URI validation to trust `https://app.thunderbolt.io` (and adjusts related tests), and aligns Tauri mobile deep-link configuration/entitlements (Android manifest, iOS associated domains, `tauri.conf.json`) to the new host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc991a3de8c01e625872b63eeaad9009887ca3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->