### PR TITLE
test: use exact hostname matching in mock fetch handlers

### DIFF
--- a/backend/src/api/routes.test.ts
+++ b/backend/src/api/routes.test.ts
@@ -10,7 +10,8 @@ describe('Main Routes', () => {
 
   const mockFetch = mock((input: RequestInfo | URL, _init?: RequestInit) => {
     const url = input instanceof Request ? input.url : input.toString()
-    if (url.startsWith('https://geocoding-api.open-meteo.com')) {
+    const { hostname } = new URL(url)
+    if (hostname === 'geocoding-api.open-meteo.com') {
       return Promise.resolve(
         new Response(
           JSON.stringify({
@@ -87,7 +88,8 @@ describe('Main Routes', () => {
   it('should filter out country-level results without admin1', async () => {
     const mockFetchWithCountry = mock((input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : input.toString()
-      if (url.startsWith('https://geocoding-api.open-meteo.com')) {
+      const { hostname } = new URL(url)
+      if (hostname === 'geocoding-api.open-meteo.com') {
         return Promise.resolve(
           new Response(
             JSON.stringify({

--- a/backend/src/inference/posthog-privacy.test.ts
+++ b/backend/src/inference/posthog-privacy.test.ts
@@ -5,6 +5,15 @@ import { OpenAI as PostHogOpenAI } from '@posthog/ai'
 import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test'
 import { clearInferenceClientCache, getInferenceClient } from './client'
 
+const isPosthogRequest = (url: string): boolean => {
+  try {
+    const { hostname } = new URL(url)
+    return hostname === 'posthog.com' || hostname.endsWith('.posthog.com')
+  } catch {
+    return false
+  }
+}
+
 type PostHogEvent = {
   event?: string
   properties?: Record<string, unknown>
@@ -60,7 +69,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       })
 
       // Return appropriate mock responses based on URL
-      if (url.includes('posthog.com') || url.includes('/batch') || url.includes('/capture')) {
+      if (isPosthogRequest(url)) {
         return new Response(JSON.stringify({ status: 1 }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -216,13 +225,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       expect(completion).toBeDefined()
 
       // Find PostHog requests
-      const posthogRequests = capturedFetches.filter(
-        (call) =>
-          call.url.includes('posthog.com') ||
-          call.url.includes('/batch') ||
-          call.url.includes('/capture') ||
-          call.url.includes('/e'),
-      )
+      const posthogRequests = capturedFetches.filter((call) => isPosthogRequest(call.url))
 
       // If PostHog sent events, verify they don't contain conversation content
       for (const request of posthogRequests) {
@@ -277,13 +280,7 @@ describe('Inference Routes - PostHog Privacy Integration', () => {
       }
 
       // Check ALL captured PostHog requests
-      const posthogRequests = capturedFetches.filter(
-        (call) =>
-          call.url.includes('posthog.com') ||
-          call.url.includes('/batch') ||
-          call.url.includes('/capture') ||
-          call.url.includes('/e'),
-      )
+      const posthogRequests = capturedFetches.filter((call) => isPosthogRequest(call.url))
 
       // Verify NONE of the secret messages appear in any request
       for (const request of posthogRequests) {

--- a/backend/src/inference/posthog-privacy.test.ts
+++ b/backend/src/inference/posthog-privacy.test.ts
@@ -1,18 +1,10 @@
 import { clearSettingsCache } from '@/config/settings'
 import { clearPostHogClient, isPostHogConfigured, shutdownPostHog } from '@/posthog/client'
+import { isPosthogRequest } from '@/test-utils/posthog'
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { OpenAI as PostHogOpenAI } from '@posthog/ai'
 import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test'
 import { clearInferenceClientCache, getInferenceClient } from './client'
-
-const isPosthogRequest = (url: string): boolean => {
-  try {
-    const { hostname } = new URL(url)
-    return hostname === 'posthog.com' || hostname.endsWith('.posthog.com')
-  } catch {
-    return false
-  }
-}
 
 type PostHogEvent = {
   event?: string

--- a/backend/src/posthog/client.test.ts
+++ b/backend/src/posthog/client.test.ts
@@ -8,6 +8,15 @@ type FetchCall = {
   body: any
 }
 
+const isPosthogRequest = (url: string): boolean => {
+  try {
+    const { hostname } = new URL(url)
+    return hostname === 'posthog.com' || hostname.endsWith('.posthog.com')
+  } catch {
+    return false
+  }
+}
+
 /**
  * Tests to verify that PostHog privacy mode correctly prevents
  * conversation content from being sent to PostHog servers
@@ -132,13 +141,7 @@ describe('PostHog Privacy Mode', () => {
       await phClient.flush()
 
       // Find PostHog capture requests (check various URL patterns)
-      const posthogRequests = capturedFetches.filter(
-        (call) =>
-          call.url.includes('posthog.com') ||
-          call.url.includes('/batch') ||
-          call.url.includes('/capture') ||
-          call.url.includes('/e'),
-      )
+      const posthogRequests = capturedFetches.filter((call) => isPosthogRequest(call.url))
 
       // If no requests were captured, this might mean the AI library didn't send any
       // In that case, we pass the test since no conversation data was sent
@@ -220,9 +223,7 @@ describe('PostHog Privacy Mode', () => {
       await phClient.flush()
 
       // Check PostHog requests
-      const posthogRequests = capturedFetches.filter(
-        (call) => call.url.includes('posthog.com') || call.url.includes('/batch'),
-      )
+      const posthogRequests = capturedFetches.filter((call) => isPosthogRequest(call.url))
 
       for (const request of posthogRequests) {
         const batch = request.body?.batch || [request.body]
@@ -287,9 +288,7 @@ describe('PostHog Privacy Mode', () => {
 
       await phClient.flush()
 
-      const posthogRequests = capturedFetches.filter(
-        (call) => call.url.includes('posthog.com') || call.url.includes('/batch'),
-      )
+      const posthogRequests = capturedFetches.filter((call) => isPosthogRequest(call.url))
 
       for (const request of posthogRequests) {
         const batch = request.body?.batch || [request.body]

--- a/backend/src/posthog/client.test.ts
+++ b/backend/src/posthog/client.test.ts
@@ -1,3 +1,4 @@
+import { isPosthogRequest } from '@/test-utils/posthog'
 import { OpenAI as PostHogOpenAI } from '@posthog/ai'
 import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test'
 import { PostHog } from 'posthog-node'
@@ -6,15 +7,6 @@ type FetchCall = {
   url: string
   options: RequestInit
   body: any
-}
-
-const isPosthogRequest = (url: string): boolean => {
-  try {
-    const { hostname } = new URL(url)
-    return hostname === 'posthog.com' || hostname.endsWith('.posthog.com')
-  } catch {
-    return false
-  }
 }
 
 /**

--- a/backend/src/pro/routes.test.ts
+++ b/backend/src/pro/routes.test.ts
@@ -21,7 +21,8 @@ describe('Pro Tools Routes', () => {
     // Create mock fetch for weather API calls
     mockFetch = mock((input: RequestInfo | URL, _init?: RequestInit) => {
       const url = input instanceof Request ? input.url : input.toString()
-      if (url.includes('geocoding-api.open-meteo.com')) {
+      const { hostname } = new URL(url)
+      if (hostname === 'geocoding-api.open-meteo.com') {
         return Promise.resolve(
           createMockWeatherResponse({
             results: [
@@ -37,7 +38,7 @@ describe('Pro Tools Routes', () => {
           }),
         )
       }
-      if (url.includes('api.open-meteo.com')) {
+      if (hostname === 'api.open-meteo.com') {
         return Promise.resolve(
           createMockWeatherResponse({
             current: {

--- a/backend/src/test-utils/posthog.ts
+++ b/backend/src/test-utils/posthog.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns true when the given URL is hosted on posthog.com or a subdomain
+ * (e.g. us.i.posthog.com). Used by mock fetch handlers in tests to filter
+ * PostHog analytics requests from other captured fetches.
+ */
+export const isPosthogRequest = (url: string): boolean => {
+  try {
+    const { hostname } = new URL(url)
+    return hostname === 'posthog.com' || hostname.endsWith('.posthog.com')
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Replace loose `url.includes(...)` / `url.startsWith(...)` in backend test mock fetch handlers with proper hostname parsing via `new URL(url).hostname`. Fixes 10 CodeQL `js/incomplete-url-substring-sanitization` alerts (#21–#30).

## Test plan

- [x] `bun tsc --noEmit` (backend) clean
- [x] `bun test --rerun-each 5` on modified files: 170/170 pass
- [x] prettier + eslint clean on modified files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are isolated to test code and a new test helper; behavior changes are limited to how mocked fetch calls classify external URLs.
> 
> **Overview**
> Tightens backend test `fetch` mocks to **match by parsed URL hostname** instead of `includes`/`startsWith` substring checks, reducing false positives and addressing incomplete URL substring sanitization findings.
> 
> Adds a small shared helper, `isPosthogRequest`, and updates PostHog privacy/integration tests to use it when identifying analytics requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7868bcac3135a99c501a24db823a1d352c0d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->