### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Detect file changes to optimize CI performance (THU-28)
   # Skip Rust build step when no Rust-related files have changed

--- a/.github/workflows/enterprise-deploy.yml
+++ b/.github/workflows/enterprise-deploy.yml
@@ -58,9 +58,11 @@ jobs:
 
       - name: Set platform config
         working-directory: deploy/pulumi
-        run: pulumi config set platform ${{ inputs.platform }} -s ${{ inputs.stack_name }} --non-interactive
+        run: pulumi config set platform "$PLATFORM" -s "$STACK_NAME" --non-interactive
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          PLATFORM: ${{ inputs.platform }}
+          STACK_NAME: ${{ inputs.stack_name }}
 
       - name: Deploy
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6
@@ -74,7 +76,9 @@ jobs:
 
       - name: Print outputs
         working-directory: deploy/pulumi
-        run: pulumi stack output --json -s ${{ inputs.stack_name }}
+        run: pulumi stack output --json -s "$STACK_NAME"
+        env:
+          STACK_NAME: ${{ inputs.stack_name }}
 
   destroy:
     if: inputs.action == 'destroy'

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -53,6 +53,9 @@ concurrency:
   group: ios-release-${{ inputs.version }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_and_deploy_ios:
     if: ${{ !inputs.skip_build }}


### PR DESCRIPTION
Two hardening changes to close 6 CodeQL alerts on Actions workflows.

- **`ci.yml` / `ios-release.yml`** — add top-level `permissions: contents: read` as least-privilege default. Pre-existing per-job permissions blocks (e.g. the `typescript` job) are preserved and continue to override. Closes #17, #18, #19, #20.
- **`enterprise-deploy.yml`** — move `${{ inputs.platform }}` and `${{ inputs.stack_name }}` out of `run:` steps into `env:` vars (`PLATFORM`, `STACK_NAME`), referenced as `"\$VAR"` in the shell. `inputs.stack_name` is a free-form string, so this is a genuine shell-injection fix; `inputs.platform` is a fixed `choice`, patched too for CodeQL completeness. Closes #1, #2.

## Test plan

- [x] YAML syntax valid on all 3 files (`python3 -c 'import yaml; yaml.safe_load(open(f))'`)
- [x] Workflow schema validated on push (GitHub)
- [ ] CI green on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow permission tightening and changes to how user-provided inputs are passed into `run:` steps could break CI/deploy execution if any job relied on implicit permissions or on unquoted input expansion. However, changes are scoped to workflow YAML and primarily reduce security risk (least privilege and shell-injection mitigation).
> 
> **Overview**
> **Hardens GitHub Actions workflows** by adding a top-level `permissions: contents: read` default to `ci.yml` and `ios-release.yml`, relying on existing per-job overrides where broader access is needed.
> 
> **Mitigates shell-injection risk** in `enterprise-deploy.yml` by moving `${{ inputs.platform }}` and `${{ inputs.stack_name }}` out of inline `run:` commands into `env` (`PLATFORM`, `STACK_NAME`) and referencing them as quoted shell variables in Pulumi commands (including `pulumi stack output`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de577b7e10fb2bc2b18f3f199f0a2e74902ab405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->