### PR TITLE
THU-459: Add github stars badge to marketing site and update contact form

### DIFF
--- a/web/src/components/marketing/header.tsx
+++ b/web/src/components/marketing/header.tsx
@@ -24,9 +24,9 @@ export const Header = ({ action, banner }: HeaderProps) => (
         <img src="/enterprise/thunderbolt-logo.png" alt="Thunderbolt" className="size-[23px]" />
         <span className="text-xl font-medium leading-7 tracking-[-0.4px] text-[#101828]">Thunderbolt</span>
       </a>
-      <div className="hidden items-center gap-8 md:flex">
+      <div className="flex items-center gap-4 md:gap-8">
         <NavLinks />
-        {action}
+        <div className="hidden md:block">{action}</div>
       </div>
     </div>
   </header>

--- a/web/src/components/marketing/sections/contact-page.tsx
+++ b/web/src/components/marketing/sections/contact-page.tsx
@@ -12,11 +12,12 @@ type FormState = {
   email: string
   help: string
   org: string
+  companySize: string
   status: 'idle' | 'submitting' | 'success' | 'error'
   errorMessage: string
 }
 
-type FormField = 'firstName' | 'lastName' | 'title' | 'email' | 'help' | 'org'
+type FormField = 'firstName' | 'lastName' | 'title' | 'email' | 'help' | 'org' | 'companySize'
 
 type FormAction =
   | { type: 'SET_FIELD'; field: FormField; value: string }
@@ -31,6 +32,7 @@ const initialState: FormState = {
   email: '',
   help: '',
   org: '',
+  companySize: '',
   status: 'idle',
   errorMessage: '',
 }
@@ -48,8 +50,9 @@ const useContactFormState = () => {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const formRef = useRef<HTMLFormElement>(null)
 
-  const set = (field: FormField) => (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-    dispatch({ type: 'SET_FIELD', field, value: e.target.value })
+  const set =
+    (field: FormField) => (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+      dispatch({ type: 'SET_FIELD', field, value: e.target.value })
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
@@ -170,6 +173,23 @@ export const ContactPage = () => {
           <div>
             <label htmlFor="mce-ORG" className={labelClass}>Company / Organization</label>
             <input type="text" name="ORG" id="mce-ORG" value={state.org} onChange={set('org')} className={inputClass} />
+          </div>
+
+          <div>
+            <label htmlFor="mce-MMERGE8" className={labelClass}>Company Size</label>
+            <select
+              name="MMERGE8"
+              id="mce-MMERGE8"
+              value={state.companySize}
+              onChange={set('companySize')}
+              className={inputClass}
+            >
+              <option value=""></option>
+              <option value="1 to 50">1 to 50</option>
+              <option value="51 to 200">51 to 200</option>
+              <option value="201 to 1,000">201 to 1,000</option>
+              <option value="1,001+">1,001+</option>
+            </select>
           </div>
 
           <div>

--- a/web/src/components/marketing/sections/enterprise-page.tsx
+++ b/web/src/components/marketing/sections/enterprise-page.tsx
@@ -21,6 +21,51 @@ const GetStartedButton = () => (
   </a>
 )
 
+const StarIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="16"
+    height="16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    style={{ flexShrink: 0 }}
+  >
+    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+  </svg>
+)
+
+const REPO_URL = 'https://github.com/thunderbird/thunderbolt'
+
+const StarOnGitHubButton = () => (
+  <span className="inline-flex h-[46px] items-stretch border border-[#d0d5dd] bg-white text-sm font-medium text-[#344054]">
+    <a
+      href={REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-2 px-4 transition-colors hover:bg-[#f2f4f7]"
+    >
+      <GitHubIcon />
+      Star on GitHub
+    </a>
+    {/* Count half — hidden until the inline <script> in index.astro fetches the
+        count and populates it. If the fetch fails, it stays hidden. */}
+    <a
+      id="github-star-count-link"
+      href={`${REPO_URL}/stargazers`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="hidden items-center gap-1.5 border-l border-[#d0d5dd] px-4 transition-colors hover:bg-[#f2f4f7]"
+    >
+      <StarIcon />
+      <span id="github-star-count-value" />
+    </a>
+  </span>
+)
+
 const EnterpriseInquiriesButton = () => (
   <a
     href="/contact"
@@ -217,7 +262,10 @@ const DesktopMockup = () => (
 
 const Hero = () => (
   <section className="relative pb-16 pt-[80px]">
-    <div className="mx-auto flex max-w-[730px] flex-col items-center gap-8 px-6 text-center">
+    <div className="mx-auto flex max-w-[730px] flex-col items-center gap-6 px-6 text-center">
+      <div className="mb-4 md:mb-8">
+        <StarOnGitHubButton />
+      </div>
       <h1 className="text-[40px] font-medium leading-[1.1] tracking-[-0.96px] text-[#101828] md:text-[48px]">
         AI You Control
       </h1>
@@ -594,7 +642,8 @@ const MobileFooterCTA = () => (
 
 /* ─── Page ────────────────────────────────────────────── */
 
-export const EnterprisePage = () => (
+export const EnterprisePage = () => {
+  return (
   <div className="relative min-h-screen overflow-x-hidden bg-[#f9fafb]">
     <BackgroundGrid />
     <Header
@@ -623,4 +672,5 @@ export const EnterprisePage = () => (
     <FooterSection className="relative z-10 bg-[#f9fafb] pb-24 md:pb-16" />
     <MobileFooterCTA />
   </div>
-)
+  )
+}

--- a/web/src/components/marketing/sections/enterprise-page.tsx
+++ b/web/src/components/marketing/sections/enterprise-page.tsx
@@ -9,9 +9,11 @@ const GitHubIcon = () => (
   </svg>
 )
 
+const REPO_URL = 'https://github.com/thunderbird/thunderbolt'
+
 const GetStartedButton = () => (
   <a
-    href="https://github.com/thunderbird/thunderbolt"
+    href={REPO_URL}
     target="_blank"
     rel="noopener noreferrer"
     className="inline-flex h-[46px] items-center justify-center gap-2 bg-[#344054] px-5 font-mono text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#344054]/90"
@@ -37,8 +39,6 @@ const StarIcon = () => (
     <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
   </svg>
 )
-
-const REPO_URL = 'https://github.com/thunderbird/thunderbolt'
 
 const StarOnGitHubButton = () => (
   <span className="inline-flex h-[46px] items-stretch border border-[#d0d5dd] bg-white text-sm font-medium text-[#344054]">
@@ -629,7 +629,7 @@ const CTASection = () => (
 const MobileFooterCTA = () => (
   <div className="fixed inset-x-0 bottom-0 z-50 bg-white/20 backdrop-blur-[32px] px-6 py-4 md:hidden">
     <a
-      href="https://github.com/thunderbird/thunderbolt"
+      href={REPO_URL}
       target="_blank"
       rel="noopener noreferrer"
       className="flex h-[46px] w-full items-center justify-center gap-2 bg-[#344054] font-mono text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#344054]/90"

--- a/web/src/components/marketing/sections/enterprise-page.tsx
+++ b/web/src/components/marketing/sections/enterprise-page.tsx
@@ -55,7 +55,7 @@ const StarOnGitHubButton = () => (
         count and populates it. If the fetch fails, it stays hidden. */}
     <a
       id="github-star-count-link"
-      href={`${REPO_URL}/stargazers`}
+      href={REPO_URL}
       target="_blank"
       rel="noopener noreferrer"
       className="hidden items-center gap-1.5 border-l border-[#d0d5dd] px-4 transition-colors hover:bg-[#f2f4f7]"

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -6,3 +6,30 @@ import { EnterprisePage } from '../components/marketing/sections/enterprise-page
 <MarketingLayout canonical="https://thunderbolt.io/">
 	<EnterprisePage client:load />
 </MarketingLayout>
+
+<script>
+	// Populates the GitHub star count in the hero. Runs in the browser after DOM
+	// parse. If the fetch fails (offline, rate-limited, GitHub down), the count
+	// half stays hidden and the button just reads "Star on GitHub".
+	const formatStars = (n: number): string =>
+		n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k` : String(n);
+
+	try {
+		const res = await fetch('https://api.github.com/repos/thunderbird/thunderbolt');
+		if (res.ok) {
+			const data = await res.json();
+			if (typeof data.stargazers_count === 'number') {
+				const link = document.getElementById('github-star-count-link');
+				const value = document.getElementById('github-star-count-value');
+				if (link && value) {
+					value.textContent = formatStars(data.stargazers_count);
+					link.setAttribute('aria-label', `${data.stargazers_count} stars on GitHub`);
+					link.classList.remove('hidden');
+					link.classList.add('inline-flex');
+				}
+			}
+		}
+	} catch {
+		// Leave the count half hidden.
+	}
+</script>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk marketing-only UI changes; the only behavioral addition is a client-side fetch to the public GitHub API, which is non-critical and fails gracefully if blocked or rate-limited.
> 
> **Overview**
> Adds a **GitHub “Star on GitHub” badge with live star count** to the enterprise landing page hero, and wires `index.astro` to fetch `stargazers_count` from the GitHub repo API and reveal/populate the count when available.
> 
> Updates the contact form to capture **Company Size** (new `select` field posted to Mailchimp) and tweaks the marketing header layout so nav links remain visible while the `action` CTA is hidden on small screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1e051f3a0c0107e6a943b71b134fded969528c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->