### PR TITLE
refactor: harden nginx config with per-location security headers

### DIFF
--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -3,28 +3,25 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Required by PowerSync WASM workers
-    add_header Cross-Origin-Embedder-Policy "require-corp" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-
     # Reverse proxy backend API
     location ^~ /v1/ {
+        include /etc/nginx/snippets/security-headers.conf;
+
         proxy_pass http://backend:8000/v1/;
-        proxy_set_header Host $host;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        # Upgrade/Connection headers intentionally omitted — backend uses SSE, not WebSocket.
+        # If WebSocket is added later, scope proxy_set_header Upgrade tightly to expected protocols.
     }
 
     # Cache static assets aggressively
     location /assets/ {
+        include /etc/nginx/snippets/security-headers.conf;
         expires 1y;
         add_header Cache-Control "public, immutable";
-        add_header Cross-Origin-Embedder-Policy "require-corp" always;
-        add_header Cross-Origin-Opener-Policy "same-origin" always;
     }
 
     # Block source maps (they are uploaded to PostHog for error tracking, not served publicly)
@@ -34,6 +31,7 @@ server {
 
     # SPA fallback — serve index.html for all non-file routes
     location / {
+        include /etc/nginx/snippets/security-headers.conf;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -13,8 +13,11 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_http_version 1.1;
-        # Upgrade/Connection headers intentionally omitted — backend uses SSE, not WebSocket.
-        # If WebSocket is added later, scope proxy_set_header Upgrade tightly to expected protocols.
+        proxy_set_header Connection "";
+        # Connection set to empty (not nginx's default "close") for HTTP/1.1 keep-alive — pools
+        # upstream TCP connections, helps SSE streams. Upgrade header intentionally omitted —
+        # backend uses SSE, not WebSocket. If WebSocket is added later, scope proxy_set_header
+        # Upgrade tightly to expected protocols.
     }
 
     # Cache static assets aggressively

--- a/deploy/config/security-headers.conf
+++ b/deploy/config/security-headers.conf
@@ -1,0 +1,6 @@
+# Security headers for HTML + asset responses.
+# Included from every location block to avoid nginx's add_header inheritance quirk:
+# a child location with any add_header silently drops all parent add_headers.
+# Do NOT add add_header directives at the server {} level.
+add_header Cross-Origin-Embedder-Policy "require-corp" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;

--- a/deploy/config/security-headers.conf
+++ b/deploy/config/security-headers.conf
@@ -4,3 +4,6 @@
 # Do NOT add add_header directives at the server {} level.
 add_header Cross-Origin-Embedder-Policy "require-corp" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header X-Frame-Options "DENY" always;
+add_header Content-Security-Policy "frame-ancestors 'none'" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -29,6 +29,7 @@ RUN bunx vite build && \
 FROM nginx:alpine
 
 COPY deploy/config/nginx.conf /etc/nginx/conf.d/default.conf
+COPY deploy/config/security-headers.conf /etc/nginx/snippets/security-headers.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
 EXPOSE 80


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches production `nginx` reverse-proxy behavior (headers, `Host`, and connection handling), which could affect API routing and SSE/keep-alive semantics if misconfigured.
> 
> **Overview**
> Centralizes response hardening by adding `deploy/config/security-headers.conf` and including it in each `location` block, ensuring security headers are consistently applied despite nginx `add_header` inheritance quirks.
> 
> Adjusts the `/v1/` reverse proxy configuration by changing the forwarded `Host` to `$proxy_host` and disabling explicit upgrade behavior while forcing an empty `Connection` header to favor HTTP/1.1 keep-alive (for pooled upstream connections / SSE). Updates the frontend nginx image build to ship the new headers snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc74a603a3f8bca47047ad0d26c8d1761e080ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->