### PR TITLE
Add sccache to development.md prerequisites

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,9 @@
 
 ## Quick Start
 
-You must have Bun, Rust, and Docker installed first. Then:
+You must have Bun, Rust, sccache, and Docker installed first. Then:
+
+> **Note**: The Rust build uses `sccache` (configured in `src-tauri/.cargo/config.toml`) to speed up rebuilds. Install it with: `cargo install sccache`
 
 ```sh
 # Install dependencies


### PR DESCRIPTION
Resolves merge conflict from #719 by integrating sccache prerequisite note into `docs/development/quick-start.md` (the docs were reorganized since the original PR was opened).

## Changes

- Added sccache to the Prerequisites list in `docs/development/quick-start.md`
- Added a note about the Rust build using sccache (configured in `src-tauri/.cargo/config.toml`)

Closes #719

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or build logic is modified.
> 
> **Overview**
> Adds `sccache` to `docs/development/quick-start.md` **Prerequisites**, including install guidance (`cargo install sccache`) and a pointer to its configuration in `src-tauri/.cargo/config.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7b9605454893f762eda172b3a042b95b2490b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->