### PR TITLE
Fix wrong postgres mount path

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql
       - ./docker/postgres-init:/docker-entrypoint-initdb.d
     command: ["postgres", "-c", "wal_level=logical"]
     ports:

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -15,8 +15,7 @@ COPY backend/drizzle.config.ts ./
 COPY shared /app/shared
 
 # Entrypoint: run migrations then start server
-COPY deploy/docker/backend-entrypoint.sh ./entrypoint.sh
-RUN chmod +x ./entrypoint.sh
+COPY --chmod=755 deploy/docker/backend-entrypoint.sh ./entrypoint.sh
 
 ENV NODE_ENV=production
 ENV PORT=8000

--- a/deploy/k8s/templates/postgres.yaml
+++ b/deploy/k8s/templates/postgres.yaml
@@ -47,7 +47,7 @@ spec:
                   key: postgres-password
           volumeMounts:
             - name: pg-data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
             - name: init-scripts
               mountPath: /docker-entrypoint-initdb.d
           readinessProbe:


### PR DESCRIPTION
closes #763

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk deployment-config change, but it can affect where Postgres stores data and may require attention when upgrading existing persisted volumes.
> 
> **Overview**
> Updates Postgres persistence to mount the volume at `/var/lib/postgresql` (instead of `/var/lib/postgresql/data`) in both `deploy/docker-compose.yml` and the Helm `postgres.yaml` StatefulSet template.
> 
> Also simplifies the backend Docker build by using `COPY --chmod=755` for `backend-entrypoint.sh`, removing the separate `chmod` layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3b687e2bc9ed21647edf8e78adaf7c83a22141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->