### PR TITLE
Use --chmod flag instead of separate RUN chmod command in backend Dockerfile

### DIFF
--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -15,8 +15,7 @@ COPY backend/drizzle.config.ts ./
 COPY shared /app/shared
 
 # Entrypoint: run migrations then start server
-COPY deploy/docker/backend-entrypoint.sh ./entrypoint.sh
-RUN chmod +x ./entrypoint.sh
+COPY --chmod=755 deploy/docker/backend-entrypoint.sh ./entrypoint.sh
 
 ENV NODE_ENV=production
 ENV PORT=8000


### PR DESCRIPTION
It is good practise to do the chmod in the COPY, not in a separate command as this creates an extra layer and is known to not work in every build environment, for example in my setup which is kaniko.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build change that only affects Docker image layering and file permissions for the entrypoint script. Potential impact is limited to environments/builders that differ in support for `COPY --chmod`.
> 
> **Overview**
> Updates `deploy/docker/backend.Dockerfile` to apply executable permissions to `backend-entrypoint.sh` during `COPY` via `--chmod=755`, removing the separate `RUN chmod +x` layer.
> 
> This reduces image layers and improves compatibility with builders where post-copy `chmod` can be unreliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ab6bfe2d3a7e1e802caf61255ba09c3aae9cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->