### PR TITLE
THU-462: Missing Auth headers for OpenRouter

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,10 +15,6 @@ default-run = "thunderbolt"
 name = "thunderbolt_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
-[features]
-default = []
-native_fetch = []
-
 [workspace]
 members = []
 default-members = ["."]
@@ -43,7 +39,7 @@ serde_json = "1.0.143"
 anyhow = "1.0.99"
 tokio = "1.47.1"
 tauri-plugin-devtools = "2.0.1"
-tauri-plugin-http = "2.5.4"
+tauri-plugin-http = { version = "2.5.4", features = ["unsafe-headers"] }
 tauri-plugin-process = "2.3.1"
 tauri-plugin-fs = "2.4.4"
 tauri-plugin-deep-link = "2.3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -42,6 +42,12 @@
           "url": "https://api.openai.com"
         },
         {
+          "url": "https://api.anthropic.com"
+        },
+        {
+          "url": "https://openrouter.ai"
+        },
+        {
           "url": "https://router.huggingface.co"
         },
         {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -72,22 +72,15 @@ pub fn set_interface_style(style: String) -> Result<(), String> {
 /// Extend this struct whenever we add more feature flags.
 #[derive(Serialize)]
 pub struct Capabilities {
-    /// Whether the application was compiled with the `native_fetch` feature and therefore the
-    /// `tauri-plugin-http` plugin is available for native HTTP requests.
+    /// Always true — `tauri-plugin-http` is unconditionally registered. Kept on the struct
+    /// so the renderer-side capability check has a stable shape if we add real capabilities later.
     pub native_fetch: bool,
 }
-
-#[cfg(feature = "native_fetch")]
-const NATIVE_FETCH_ENABLED: bool = true;
-#[cfg(not(feature = "native_fetch"))]
-const NATIVE_FETCH_ENABLED: bool = false;
 
 /// Returns the set of capabilities supported by the current build.
 #[command]
 pub fn capabilities() -> Capabilities {
-    Capabilities {
-        native_fetch: NATIVE_FETCH_ENABLED,
-    }
+    Capabilities { native_fetch: true }
 }
 
 // === OAuth loopback server ===================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,13 +9,7 @@ use tauri::Manager;
 
 // Shared app builder function
 pub fn create_app() -> tauri::Builder<tauri::Wry> {
-    let mut builder = tauri::Builder::default();
-
-    // Conditionally include the HTTP plugin when the `native_fetch` feature is enabled
-    #[cfg(feature = "native_fetch")]
-    {
-        builder = builder.plugin(tauri_plugin_http::init());
-    }
+    let mut builder = tauri::Builder::default().plugin(tauri_plugin_http::init());
 
     // Single-instance: focus existing window when a second instance is launched (desktop only)
     #[cfg(desktop)]

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -11,7 +11,7 @@ import {
 import { getModel, getModelProfile, getSettings } from '@/dal'
 import { getDb } from '@/db/database'
 import { getAuthToken } from '@/lib/auth-token'
-import { fetch } from '@/lib/fetch'
+import { fetch, nativeFetch } from '@/lib/fetch'
 import { createToolset, getAvailableTools } from '@/lib/tools'
 import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import type { SourceMetadata } from '@/types/source'
@@ -77,12 +77,17 @@ export const createModel = async (modelConfig: Model) => {
     case 'anthropic': {
       const anthropic = createAnthropic({
         apiKey: modelConfig.apiKey || '',
-        fetch,
+        fetch: nativeFetch,
         headers: {
-          // When a user adds their own Anthropic API key, calls go directly from the
-          // browser to Anthropic's API (not through our backend). Anthropic blocks
-          // browser-origin requests by default to prevent accidental key exposure.
-          // This header opts in, acknowledging the risk.
+          // tauri-plugin-http auto-adds an Origin header on every native request, which
+          // makes Anthropic classify the call as "CORS" and apply org-level CORS rules
+          // (some orgs disallow CORS entirely via retention settings). With the plugin's
+          // `unsafe-headers` feature, an empty Origin tells the plugin to strip it, so
+          // Anthropic treats the request as server-to-server. Browsers silently ignore
+          // JS-set Origin, so this is a no-op in the web build.
+          Origin: '',
+          // Browser direct-access opt-in for the web build. No-op in Tauri (the request
+          // is no longer browser-origin once Origin is stripped above).
           'anthropic-dangerous-direct-browser-access': 'true',
         },
       })
@@ -94,7 +99,7 @@ export const createModel = async (modelConfig: Model) => {
       }
       const openai = createOpenAI({
         apiKey: modelConfig.apiKey,
-        fetch,
+        fetch: nativeFetch,
       })
       return openai(modelConfig.model)
     }
@@ -102,6 +107,8 @@ export const createModel = async (modelConfig: Model) => {
       if (!modelConfig.url) {
         throw new Error('No URL provided for custom provider')
       }
+      // Custom URLs stay on the toggle-aware fetch — user-supplied hosts aren't in the
+      // tauri-plugin-http allowlist, so routing through the native plugin would deny them.
       const openaiCompatible = createOpenAICompatible({
         name: 'custom',
         baseURL: modelConfig.url,
@@ -120,7 +127,7 @@ export const createModel = async (modelConfig: Model) => {
         name: 'openrouter',
         baseURL: 'https://openrouter.ai/api/v1',
         apiKey: modelConfig.apiKey,
-        fetch,
+        fetch: nativeFetch,
       })
       return openrouter(modelConfig.model)
     }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -26,3 +26,22 @@ export const fetch = async (input: RequestInfo | URL, init?: RequestInit): Promi
 
 // Bun's `fetch` type expects a `preconnect` method.
 fetch.preconnect = () => Promise.resolve(false)
+
+/**
+ * Always-native fetch — routes through Tauri's HTTP plugin when running inside Tauri,
+ * regardless of the user-facing `is_native_fetch_enabled` toggle.
+ *
+ * Use this for direct calls to third-party AI providers (OpenAI/Anthropic/OpenRouter/etc.).
+ * The Tauri WebView strips the `Authorization` header from cross-origin POSTs that carry
+ * `Content-Type: application/json` + a `User-Agent` suffix (the AI SDK adds both), so those
+ * requests must go through the native HTTP plugin to reach the provider with credentials intact.
+ */
+export const nativeFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  if (!isTauri()) {
+    return globalThis.fetch(input, init)
+  }
+  const { fetch: tauriFetch } = await import('@tauri-apps/plugin-http')
+  return tauriFetch(input, init)
+}
+
+nativeFetch.preconnect = () => Promise.resolve(false)

--- a/src/settings/dev-settings.tsx
+++ b/src/settings/dev-settings.tsx
@@ -3,22 +3,14 @@ import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
 import { SectionCard } from '@/components/ui/section-card'
 import { Switch } from '@/components/ui/switch'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useSettings } from '@/hooks/use-settings'
-import { getCapabilities, isTauri } from '@/lib/platform'
-import { useQuery } from '@tanstack/react-query'
+import { isTauri } from '@/lib/platform'
 
 export default function DevSettingsPage() {
   const { cloudUrl, isNativeFetchEnabled, debugPosthog } = useSettings({
     cloud_url: '',
     is_native_fetch_enabled: false,
     debug_posthog: false,
-  })
-
-  const { data: capabilities } = useQuery({
-    queryKey: ['capabilities'],
-    queryFn: getCapabilities,
-    enabled: isTauri(),
   })
 
   return (
@@ -61,23 +53,11 @@ export default function DevSettingsPage() {
               </ModificationIndicator>
               <p className="text-sm text-muted-foreground">Proxy HTTP requests through Tauri to bypass CORS</p>
             </div>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span>
-                  <Switch
-                    checked={isNativeFetchEnabled.value}
-                    onCheckedChange={isNativeFetchEnabled.setValue}
-                    disabled={!capabilities?.native_fetch}
-                  />
-                </span>
-              </TooltipTrigger>
-              {!capabilities?.native_fetch && (
-                <TooltipContent sideOffset={4}>
-                  This feature is only available on some desktop versions of the app that were built with the
-                  native_fetch feature flag.
-                </TooltipContent>
-              )}
-            </Tooltip>
+            <Switch
+              checked={isNativeFetchEnabled.value}
+              onCheckedChange={isNativeFetchEnabled.setValue}
+              disabled={!isTauri()}
+            />
           </div>
 
           {/* Divider between settings */}

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -214,7 +214,7 @@ export default function ModelsPage() {
       await createModelDAL(db, {
         id: uuidv7(),
         ...values,
-        apiKey: values.apiKey || null,
+        apiKey: values.apiKey?.trim() || null,
         url: values.url || null,
         isSystem: 0,
         enabled: 1,
@@ -300,7 +300,7 @@ export default function ModelsPage() {
         provider: values.provider,
         model: modelId,
         url: values.url || null,
-        apiKey: values.apiKey || null,
+        apiKey: values.apiKey?.trim() || null,
         isSystem: 0,
         enabled: 1,
       }
@@ -618,7 +618,7 @@ export default function ModelsPage() {
 
   useEffect(() => {
     const provider = form.getValues('provider')
-    const apiKey = watchedApiKey
+    const apiKey = watchedApiKey?.trim()
     const url = watchedUrl
 
     if (

--- a/src/settings/models/new.tsx
+++ b/src/settings/models/new.tsx
@@ -80,9 +80,10 @@ export default function NewModelPage() {
   })
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
+    const trimmedApiKey = values.apiKey?.trim() || null
     createModelMutation.mutate({
       ...values,
-      apiKey: values.apiKey || null,
+      apiKey: trimmedApiKey,
       url: values.url || null,
       isSystem: 0,
       enabled: 1,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how OpenAI/Anthropic/OpenRouter requests are routed and enables Tauri HTTP `unsafe-headers`, which can impact outbound auth headers and request security/allowlisting behavior. Also expands the native HTTP allowlist to new domains, affecting what the desktop app can reach.
> 
> **Overview**
> Fixes missing/stripped `Authorization` headers for direct provider calls in the Tauri desktop build by **introducing an always-native `nativeFetch`** and routing OpenAI/Anthropic/OpenRouter model traffic through `@tauri-apps/plugin-http` regardless of the user toggle.
> 
> Makes Tauri HTTP support unconditional by removing the `native_fetch` compile-time feature, always registering `tauri-plugin-http` (with `unsafe-headers`), and simplifying the renderer capability/UI gating to only disable the toggle when not running in Tauri.
> 
> Extends the Tauri HTTP allowlist to include `https://api.anthropic.com` and `https://openrouter.ai`, and trims API keys on save/use in model settings to avoid whitespace-related auth failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106ce866a6e22d33b7700bcbe7dac33f95054a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->