### PR TITLE
Revert "THU-462: Missing Auth headers for OpenRouter"

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,10 @@ default-run = "thunderbolt"
 name = "thunderbolt_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+default = []
+native_fetch = []
+
 [workspace]
 members = []
 default-members = ["."]
@@ -39,7 +43,7 @@ serde_json = "1.0.143"
 anyhow = "1.0.99"
 tokio = "1.47.1"
 tauri-plugin-devtools = "2.0.1"
-tauri-plugin-http = { version = "2.5.4", features = ["unsafe-headers"] }
+tauri-plugin-http = "2.5.4"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-fs = "2.4.4"
 tauri-plugin-deep-link = "2.3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -42,12 +42,6 @@
           "url": "https://api.openai.com"
         },
         {
-          "url": "https://api.anthropic.com"
-        },
-        {
-          "url": "https://openrouter.ai"
-        },
-        {
           "url": "https://router.huggingface.co"
         },
         {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -76,15 +76,22 @@ pub fn set_interface_style(style: String) -> Result<(), String> {
 /// Extend this struct whenever we add more feature flags.
 #[derive(Serialize)]
 pub struct Capabilities {
-    /// Always true — `tauri-plugin-http` is unconditionally registered. Kept on the struct
-    /// so the renderer-side capability check has a stable shape if we add real capabilities later.
+    /// Whether the application was compiled with the `native_fetch` feature and therefore the
+    /// `tauri-plugin-http` plugin is available for native HTTP requests.
     pub native_fetch: bool,
 }
+
+#[cfg(feature = "native_fetch")]
+const NATIVE_FETCH_ENABLED: bool = true;
+#[cfg(not(feature = "native_fetch"))]
+const NATIVE_FETCH_ENABLED: bool = false;
 
 /// Returns the set of capabilities supported by the current build.
 #[command]
 pub fn capabilities() -> Capabilities {
-    Capabilities { native_fetch: true }
+    Capabilities {
+        native_fetch: NATIVE_FETCH_ENABLED,
+    }
 }
 
 // === OAuth loopback server ===================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,13 @@ use tauri::Manager;
 
 // Shared app builder function
 pub fn create_app() -> tauri::Builder<tauri::Wry> {
-    let mut builder = tauri::Builder::default().plugin(tauri_plugin_http::init());
+    let mut builder = tauri::Builder::default();
+
+    // Conditionally include the HTTP plugin when the `native_fetch` feature is enabled
+    #[cfg(feature = "native_fetch")]
+    {
+        builder = builder.plugin(tauri_plugin_http::init());
+    }
 
     // Single-instance: focus existing window when a second instance is launched (desktop only)
     #[cfg(desktop)]

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -15,7 +15,7 @@ import {
 import { getModel, getModelProfile, getSettings } from '@/dal'
 import { getDb } from '@/db/database'
 import { getAuthToken } from '@/lib/auth-token'
-import { fetch, nativeFetch } from '@/lib/fetch'
+import { fetch } from '@/lib/fetch'
 import { createToolset, getAvailableTools } from '@/lib/tools'
 import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import type { SourceMetadata } from '@/types/source'
@@ -81,17 +81,12 @@ export const createModel = async (modelConfig: Model) => {
     case 'anthropic': {
       const anthropic = createAnthropic({
         apiKey: modelConfig.apiKey || '',
-        fetch: nativeFetch,
+        fetch,
         headers: {
-          // tauri-plugin-http auto-adds an Origin header on every native request, which
-          // makes Anthropic classify the call as "CORS" and apply org-level CORS rules
-          // (some orgs disallow CORS entirely via retention settings). With the plugin's
-          // `unsafe-headers` feature, an empty Origin tells the plugin to strip it, so
-          // Anthropic treats the request as server-to-server. Browsers silently ignore
-          // JS-set Origin, so this is a no-op in the web build.
-          Origin: '',
-          // Browser direct-access opt-in for the web build. No-op in Tauri (the request
-          // is no longer browser-origin once Origin is stripped above).
+          // When a user adds their own Anthropic API key, calls go directly from the
+          // browser to Anthropic's API (not through our backend). Anthropic blocks
+          // browser-origin requests by default to prevent accidental key exposure.
+          // This header opts in, acknowledging the risk.
           'anthropic-dangerous-direct-browser-access': 'true',
         },
       })
@@ -103,7 +98,7 @@ export const createModel = async (modelConfig: Model) => {
       }
       const openai = createOpenAI({
         apiKey: modelConfig.apiKey,
-        fetch: nativeFetch,
+        fetch,
       })
       return openai(modelConfig.model)
     }
@@ -111,8 +106,6 @@ export const createModel = async (modelConfig: Model) => {
       if (!modelConfig.url) {
         throw new Error('No URL provided for custom provider')
       }
-      // Custom URLs stay on the toggle-aware fetch — user-supplied hosts aren't in the
-      // tauri-plugin-http allowlist, so routing through the native plugin would deny them.
       const openaiCompatible = createOpenAICompatible({
         name: 'custom',
         baseURL: modelConfig.url,
@@ -131,7 +124,7 @@ export const createModel = async (modelConfig: Model) => {
         name: 'openrouter',
         baseURL: 'https://openrouter.ai/api/v1',
         apiKey: modelConfig.apiKey,
-        fetch: nativeFetch,
+        fetch,
       })
       return openrouter(modelConfig.model)
     }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -30,22 +30,3 @@ export const fetch = async (input: RequestInfo | URL, init?: RequestInit): Promi
 
 // Bun's `fetch` type expects a `preconnect` method.
 fetch.preconnect = () => Promise.resolve(false)
-
-/**
- * Always-native fetch — routes through Tauri's HTTP plugin when running inside Tauri,
- * regardless of the user-facing `is_native_fetch_enabled` toggle.
- *
- * Use this for direct calls to third-party AI providers (OpenAI/Anthropic/OpenRouter/etc.).
- * The Tauri WebView strips the `Authorization` header from cross-origin POSTs that carry
- * `Content-Type: application/json` + a `User-Agent` suffix (the AI SDK adds both), so those
- * requests must go through the native HTTP plugin to reach the provider with credentials intact.
- */
-export const nativeFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-  if (!isTauri()) {
-    return globalThis.fetch(input, init)
-  }
-  const { fetch: tauriFetch } = await import('@tauri-apps/plugin-http')
-  return tauriFetch(input, init)
-}
-
-nativeFetch.preconnect = () => Promise.resolve(false)

--- a/src/settings/dev-settings.tsx
+++ b/src/settings/dev-settings.tsx
@@ -7,14 +7,22 @@ import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
 import { SectionCard } from '@/components/ui/section-card'
 import { Switch } from '@/components/ui/switch'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useSettings } from '@/hooks/use-settings'
-import { isTauri } from '@/lib/platform'
+import { getCapabilities, isTauri } from '@/lib/platform'
+import { useQuery } from '@tanstack/react-query'
 
 export default function DevSettingsPage() {
   const { cloudUrl, isNativeFetchEnabled, debugPosthog } = useSettings({
     cloud_url: '',
     is_native_fetch_enabled: false,
     debug_posthog: false,
+  })
+
+  const { data: capabilities } = useQuery({
+    queryKey: ['capabilities'],
+    queryFn: getCapabilities,
+    enabled: isTauri(),
   })
 
   return (
@@ -57,11 +65,23 @@ export default function DevSettingsPage() {
               </ModificationIndicator>
               <p className="text-sm text-muted-foreground">Proxy HTTP requests through Tauri to bypass CORS</p>
             </div>
-            <Switch
-              checked={isNativeFetchEnabled.value}
-              onCheckedChange={isNativeFetchEnabled.setValue}
-              disabled={!isTauri()}
-            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Switch
+                    checked={isNativeFetchEnabled.value}
+                    onCheckedChange={isNativeFetchEnabled.setValue}
+                    disabled={!capabilities?.native_fetch}
+                  />
+                </span>
+              </TooltipTrigger>
+              {!capabilities?.native_fetch && (
+                <TooltipContent sideOffset={4}>
+                  This feature is only available on some desktop versions of the app that were built with the
+                  native_fetch feature flag.
+                </TooltipContent>
+              )}
+            </Tooltip>
           </div>
 
           {/* Divider between settings */}

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -218,7 +218,7 @@ export default function ModelsPage() {
       await createModelDAL(db, {
         id: uuidv7(),
         ...values,
-        apiKey: values.apiKey?.trim() || null,
+        apiKey: values.apiKey || null,
         url: values.url || null,
         isSystem: 0,
         enabled: 1,
@@ -304,7 +304,7 @@ export default function ModelsPage() {
         provider: values.provider,
         model: modelId,
         url: values.url || null,
-        apiKey: values.apiKey?.trim() || null,
+        apiKey: values.apiKey || null,
         isSystem: 0,
         enabled: 1,
       }
@@ -622,7 +622,7 @@ export default function ModelsPage() {
 
   useEffect(() => {
     const provider = form.getValues('provider')
-    const apiKey = watchedApiKey?.trim()
+    const apiKey = watchedApiKey
     const url = watchedUrl
 
     if (

--- a/src/settings/models/new.tsx
+++ b/src/settings/models/new.tsx
@@ -84,10 +84,9 @@ export default function NewModelPage() {
   })
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
-    const trimmedApiKey = values.apiKey?.trim() || null
     createModelMutation.mutate({
       ...values,
-      apiKey: trimmedApiKey,
+      apiKey: values.apiKey || null,
       url: values.url || null,
       isSystem: 0,
       enabled: 1,


### PR DESCRIPTION
Reverts thunderbird/thunderbolt#781

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing for external AI providers and makes native HTTP support conditional, which can reintroduce CORS/header-stripping failures or break certain desktop builds depending on packaging/feature flags.
> 
> **Overview**
> Reverts the prior “always native” HTTP path: removes `nativeFetch` and updates AI provider clients (Anthropic/OpenAI/OpenRouter) to use the standard toggle-aware `fetch` instead of forcing `tauri-plugin-http`.
> 
> Makes native HTTP support build-time optional by introducing a `native_fetch` Cargo feature, conditionally registering `tauri-plugin-http`, and exposing this via a `capabilities.native_fetch` flag that gates the “Use Native Fetch” dev setting (with a tooltip when unavailable).
> 
> Tightens desktop HTTP allowlist by removing `api.anthropic.com` and `openrouter.ai` from `capabilities/default.json`, and stops trimming API keys on model creation/testing so keys are stored exactly as entered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca581edda269043f40bf88b3f4b98a7e5a01969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->