### PR TITLE
Update GitHub Actions versions and rustls-webpki security patch

### DIFF
--- a/.github/actions/upload-to-play/action.yml
+++ b/.github/actions/upload-to-play/action.yml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Bun
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         bun-version: latest
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns: ["*"]

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -66,18 +66,18 @@ jobs:
           df -h
 
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: v${{ inputs.version }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # using commit hash for security reasons
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Display version information
         env:
@@ -160,7 +160,7 @@ jobs:
           cat "$PROPS_FILE"
 
       - name: Setup Java
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -193,7 +193,7 @@ jobs:
           rustflags: ''
 
       - name: Cache Cargo registry and build
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.0.2
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -308,7 +308,7 @@ jobs:
 
       - name: Upload build artifacts (if build fails)
         if: failure()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-build-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 
@@ -63,7 +63,7 @@ jobs:
           bun-version: ~1.3.13
 
       - name: Cache Bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.bun/install/cache
@@ -118,7 +118,7 @@ jobs:
 
       - name: Cache metrics baseline
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .metrics-baseline
           key: pr-metrics-main-${{ github.sha }}
@@ -137,7 +137,7 @@ jobs:
           cache: false
 
       - name: Cache cargo registry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -148,7 +148,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: src-tauri/target/
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('src-tauri/Cargo.lock') }}-${{ hashFiles('src-tauri/src/**/*.rs') }}
@@ -191,7 +191,7 @@ jobs:
           bun-version: ~1.3.13
 
       - name: Cache Bun dependencies (backend)
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -38,7 +38,7 @@ jobs:
           git config --local user.name "GitHub Action"
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           ref: v${{ inputs.version }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -139,7 +139,7 @@ jobs:
           rustflags: ''
 
       - name: Cache cargo dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
           bun-version: ~1.3.13
 
       - name: Cache Bun dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.bun/install/cache
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload blob report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: blob-report-${{ strategy.job-index }}
           path: blob-report/
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload test screenshots
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-screenshots-${{ strategy.job-index }}
           path: test-results/
@@ -85,7 +85,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download blob reports
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: blob-report-*
           path: all-blob-reports
@@ -95,7 +95,7 @@ jobs:
         run: bunx playwright merge-reports --reporter html ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-report
           path: playwright-report/

--- a/.github/workflows/enterprise-deploy.yml
+++ b/.github/workflows/enterprise-deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ inputs.region }}
@@ -91,7 +91,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ inputs.region }}

--- a/.github/workflows/enterprise-publish.yml
+++ b/.github/workflows/enterprise-publish.yml
@@ -33,7 +33,7 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -66,18 +66,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: v${{ inputs.version }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # using commit hash for security reasons
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Display version information
         env:
@@ -162,7 +162,7 @@ jobs:
           rustflags: ''
 
       - name: Cache Cargo registry and build
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.0.2
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -196,7 +196,7 @@ jobs:
           echo "✅ Metal Toolchain removed"
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@cf7216d52fba1017929b4d7162fabe2b30af5b49 # v1.262.0
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1
         with:
           ruby-version: '3.0'
           bundler-cache: true
@@ -408,7 +408,7 @@ jobs:
 
       - name: Upload build artifacts (if build fails)
         if: failure()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-build-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           bun-version: ~1.3.13
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.bun/install/cache
@@ -78,7 +78,7 @@ jobs:
 
       # --- Restore main baseline for deltas ---
       - name: Restore main baseline
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .metrics-baseline
           key: pr-metrics-main-${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -83,7 +83,7 @@ jobs:
           CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER: ${{ inputs.platform == 'macos-intel' && 'clang' || '' }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.platform }}-build
           path: |

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4073,9 +4073,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Consolidates 7 Dependabot PRs into a single update, normalizes version inconsistencies across workflows, and bumps `upload-artifact` to v7 (no Dependabot PR existed for it).

**GitHub Actions updated:**
- `actions/checkout` v4.1.7 → v6 (normalized in release workflows)
- `actions/setup-node` v4 → v6.4.0
- `actions/cache` v4 → v5.0.5 (including cache/save and cache/restore)
- `actions/download-artifact` v4 → v8.0.1
- `actions/upload-artifact` v4 → v7.0.1 (unified from two different v4 SHAs)
- `docker/login-action` v3 → v4.1.0
- `aws-actions/configure-aws-credentials` v4 → v6.1.0
- `oven-sh/setup-bun` normalized to latest v2 SHA
- `actions/setup-java` v5 SHA refreshed
- `ruby/setup-ruby` v1.262.0 → v1 (latest)

**Security patch:**
- `rustls-webpki` 0.103.12 → 0.103.13 — fixes High severity DoS (GHSA-82j2-j2ch-gfr8)

All updates have been researched and confirmed as drop-in compatible — no workflow config changes needed beyond SHA + version comment updates.

## Dependabot PRs addressed

- #737 — bump the actions group (setup-bun, setup-java, setup-ruby)
- #738 — bump actions/download-artifact from 4.3.0 to 8.0.1
- #739 — bump aws-actions/configure-aws-credentials from 4.3.1 to 6.1.0
- #740 — bump docker/login-action from 3.7.0 to 4.1.0
- #742 — bump actions/cache from 4.2.2 to 5.0.5
- #744 — bump actions/setup-node from 4.0.3 to 6.4.0
- #762 — bump rustls-webpki from 0.103.12 to 0.103.13

## Additional fixes (no Dependabot PR)

- `actions/checkout` normalized from v4.1.7 to v6 in `android-release.yml` and `ios-release.yml`
- `actions/upload-artifact` unified and bumped from v4/v4.4.3 to v7.0.1 across all workflows
- `oven-sh/setup-bun` normalized in `upload-to-play` composite action
- Stale version comments fixed across all files

## Test plan

- [ ] CI passes (exercises: setup-node, setup-bun, cache, cache/save)
- [ ] E2E passes (exercises: cache, upload-artifact, download-artifact)
- [ ] Security scan passes
- [ ] PR metrics passes (exercises: cache, cache/restore)
- [ ] Release/deploy workflows validated via changelog review (not testable via PR)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily infrastructure/dependency bumps, but they touch multiple CI and release workflows, so misconfigured action version changes could break builds or deployments.
> 
> **Overview**
> Updates CI/release GitHub workflows and the `upload-to-play` composite action to newer pinned versions of key actions (notably `actions/checkout`, `actions/setup-node`, `actions/cache`, `actions/*-artifact`, AWS credentials, and Docker login), largely normalizing versions/SHAs across pipelines.
> 
> Adds a 7-day Dependabot `cooldown` for GitHub Actions updates to reduce churn, and bumps the Rust dependency `rustls-webpki` to `0.103.13` in `Cargo.lock` to pick up the latest security fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745e019dde4f4e4b7bb282ff41b6645a34d431fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->