### PR TITLE
THU-431: Remove OTP value from subject line

### DIFF
--- a/backend/src/auth/utils.tsx
+++ b/backend/src/auth/utils.tsx
@@ -92,7 +92,7 @@ export const sendSignInEmail = async ({ email, otp, verifyUrl }: SendSignInEmail
 
   const data = await sendEmail({
     to: email,
-    subject: `Thunderbolt Verification Code: ${otp}`,
+    subject: 'Your Thunderbolt verification code',
     react: <MagicLinkEmail code={otp} magicLinkUrl={verifyUrl} />,
   })
 

--- a/backend/src/emails/magic-link.tsx
+++ b/backend/src/emails/magic-link.tsx
@@ -11,7 +11,7 @@ type MagicLinkEmailProps = {
 }
 
 export const MagicLinkEmail = ({ code, magicLinkUrl }: MagicLinkEmailProps) => (
-  <EmailLayout preview={`Thunderbolt Verification Code: ${code}`}>
+  <EmailLayout preview="Sign in to Thunderbolt">
     <Section className="bg-white border border-solid border-tb-border rounded-2xl text-center px-8 py-8">
       <Text className="text-sm text-tb-text m-0 mb-6">Use the code below to sign in, or click the button.</Text>
       <Text className="text-2xl font-semibold text-tb-text m-0 mb-6">{code}</Text>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: copy-only changes to email subject/preview to avoid exposing OTPs; no changes to OTP generation, delivery, or verification logic.
> 
> **Overview**
> Updates the sign-in email to stop including the OTP in email metadata by changing `sendSignInEmail`’s subject and the `MagicLinkEmail` preview text to generic copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9274a49ceb78156af3541c2f1b0402eb2164c76f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->