### PR TITLE
chore: bump react-resizable-panels from v3 to v4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
         "react-dom": "^19.2.1",
         "react-hook-form": "^7.62.0",
         "react-markdown": "^10.1.0",
-        "react-resizable-panels": "^3.0.4",
+        "react-resizable-panels": "^4.10.0",
         "react-router": "^7.12.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.1",
@@ -1698,7 +1698,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
+    "react-resizable-panels": ["react-resizable-panels@4.10.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA=="],
 
     "react-router": ["react-router@7.14.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ=="],
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-dom": "^19.2.1",
     "react-hook-form": "^7.62.0",
     "react-markdown": "^10.1.0",
-    "react-resizable-panels": "^3.0.4",
+    "react-resizable-panels": "^4.10.0",
     "react-router": "^7.12.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -8,15 +8,12 @@ import * as ResizablePrimitive from 'react-resizable-panels'
 
 import { cn } from '@/lib/utils'
 
-// Disable global cursor styles to prevent cursor overlap issues with webviews
-// and other content. We'll manage cursor styles manually on the resize handle.
-ResizablePrimitive.disableGlobalCursorStyles()
-
-const ResizablePanelGroup = ({ className, ...props }: ComponentProps<typeof ResizablePrimitive.PanelGroup>) => {
+const ResizablePanelGroup = ({ className, ...props }: ComponentProps<typeof ResizablePrimitive.Group>) => {
   return (
-    <ResizablePrimitive.PanelGroup
+    <ResizablePrimitive.Group
       data-slot="resizable-panel-group"
-      className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
+      disableCursor
+      className={cn('flex h-full w-full', className)}
       {...props}
     />
   )
@@ -36,16 +33,15 @@ const ResizableHandle = ({
   withHandle,
   className,
   ...props
-}: ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: ComponentProps<typeof ResizablePrimitive.Separator> & {
   withHandle?: boolean
 }) => {
   return (
-    <ResizablePrimitive.PanelResizeHandle
+    <ResizablePrimitive.Separator
       data-slot="resizable-handle"
       className={cn(
-        'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-[calc(50%-2px)] after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:top-[calc(50%-2px)] data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',
-        // Manually apply cursor styles since we disabled global cursor styles
-        'cursor-ew-resize data-[panel-group-direction=vertical]:cursor-ns-resize',
+        'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-[calc(50%-2px)] after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden',
+        'cursor-ew-resize',
         className,
       )}
       {...props}
@@ -55,7 +51,7 @@ const ResizableHandle = ({
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.PanelResizeHandle>
+    </ResizablePrimitive.Separator>
   )
 }
 

--- a/src/layout/main-layout.tsx
+++ b/src/layout/main-layout.tsx
@@ -16,11 +16,11 @@ import { isTauri } from '@/lib/platform'
 import { useSettings } from '@/hooks/use-settings'
 import { animate, AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef } from 'react'
-import type { ImperativePanelHandle } from 'react-resizable-panels'
+import { usePanelRef } from 'react-resizable-panels'
 import { Outlet } from 'react-router'
 
 export default function Page() {
-  const ref = useRef<ImperativePanelHandle>(null)
+  const panelRef = usePanelRef()
   const { state, close, previewHidden } = useContentView()
   const { isMobile } = useIsMobile()
   const { contentViewWidth } = useSettings({
@@ -32,7 +32,7 @@ export default function Page() {
 
   useEffect(() => {
     // Only animate on state changes, not on mount
-    if (prevIsOpen.current !== isOpen && ref.current) {
+    if (prevIsOpen.current !== isOpen && panelRef.current) {
       if (isOpen) {
         // On mobile: always use 100% width. On desktop: use saved width if above threshold, otherwise use default
         const savedWidth = contentViewWidth.value
@@ -41,19 +41,19 @@ export default function Page() {
 
         // Opening: animate from 0 to target width
         requestAnimationFrame(() => {
-          if (ref.current) {
+          if (panelRef.current) {
             animate(0, targetWidth, {
               duration: 0.3,
               ease: [0.32, 0.72, 0, 1],
               onUpdate: (latest) => {
-                ref.current?.resize(latest)
+                panelRef.current?.resize(`${latest}%`)
               },
             })
           }
         })
       } else {
         // Closing: save current size before animating to 0 (but not on mobile)
-        const currentSize = ref.current.getSize()
+        const currentSize = panelRef.current.getSize().asPercentage
         const shouldSaveWidthOnClose = currentSize > 0 && !isMobile
         if (shouldSaveWidthOnClose) {
           lastSavedWidth.current = currentSize
@@ -64,7 +64,7 @@ export default function Page() {
           duration: 0.3,
           ease: [0.32, 0.72, 0, 1],
           onUpdate: (latest) => {
-            ref.current?.resize(latest)
+            panelRef.current?.resize(`${latest}%`)
           },
         })
       }
@@ -73,20 +73,20 @@ export default function Page() {
   }, [isOpen, isMobile, contentViewWidth])
 
   // Persist width changes as user resizes (but not on mobile)
-  const handleResize = (size: number) => {
-    const shouldPersistWidthChange = isOpen && size > 0 && !isMobile
+  const handleResize = ({ asPercentage }: { asPercentage: number }) => {
+    const shouldPersistWidthChange = isOpen && asPercentage > 0 && !isMobile
     if (shouldPersistWidthChange) {
-      const hasSignificantWidthChange = !lastSavedWidth.current || Math.abs(size - lastSavedWidth.current) > 1
+      const hasSignificantWidthChange = !lastSavedWidth.current || Math.abs(asPercentage - lastSavedWidth.current) > 1
       if (hasSignificantWidthChange) {
-        lastSavedWidth.current = size
-        contentViewWidth.setValue(size)
+        lastSavedWidth.current = asPercentage
+        contentViewWidth.setValue(asPercentage)
       }
     }
   }
 
   return (
     <SidebarInset className="h-full flex flex-col">
-      <ResizablePanelGroup direction="horizontal">
+      <ResizablePanelGroup orientation="horizontal">
         <ResizablePanel>
           <div
             className="flex flex-col h-full"
@@ -126,13 +126,17 @@ export default function Page() {
           </div>
         )}
         <ResizablePanel
-          ref={ref}
+          panelRef={panelRef}
           collapsible
-          defaultSize={0}
-          minSize={0}
-          collapsedSize={0}
-          onCollapse={() => close()}
-          onResize={handleResize}
+          defaultSize="0%"
+          minSize="0%"
+          collapsedSize="0%"
+          onResize={(panelSize, _id, prevPanelSize) => {
+            if (prevPanelSize && prevPanelSize.asPercentage > 0 && panelSize.asPercentage === 0) {
+              close()
+            }
+            handleResize(panelSize)
+          }}
           className="overflow-hidden"
         >
           <AnimatePresence initial={false}>


### PR DESCRIPTION
## Summary

Updates react-resizable-panels from v3 to v4, migrating all usage to the new API.

**Dependencies updated:**
- `react-resizable-panels` ^3.0.4 → ^4.10.0

**`src/components/ui/resizable.tsx` (wrapper):**
- Renamed imports: `PanelGroup` → `Group`, `PanelResizeHandle` → `Separator`
- Replaced `disableGlobalCursorStyles()` call with `disableCursor` prop on Group
- Removed `data-[panel-group-direction=vertical]` CSS (v4 no longer emits that attribute)

**`src/layout/main-layout.tsx` (consumer):**
- `useRef<ImperativePanelHandle>` → `usePanelRef()` hook with `panelRef` prop
- `direction` → `orientation`
- Numeric sizes → string percentages (`defaultSize={0}` → `defaultSize="0%"`)
- `getSize()` → `getSize().asPercentage` (v4 returns `{ asPercentage, inPixels }`)
- `resize(n)` → `` resize(`${n}%`) `` (v4 treats bare numbers as pixels)
- Replaced `onCollapse` with collapse detection in `onResize` using `prevPanelSize` (v4 removed `onCollapse`)

## Dependabot PRs addressed

- #795 — bump react-resizable-panels from 3.0.6 to 4.10.0

## Test plan

- [ ] `bun type-check` passes (clean)
- [ ] `bun lint` passes (0 errors)
- [ ] Content view panel opens/closes with smooth animation
- [ ] Panel width persists between open/close cycles
- [ ] Drag-to-resize works correctly
- [ ] Collapsing panel via drag triggers close
- [ ] Mobile: panel opens at 100% width
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a core layout dependency and rewires resize/collapse behavior; regressions could affect sidebar open/close animation, persisted widths, and drag-to-resize interactions.
> 
> **Overview**
> Bumps `react-resizable-panels` from v3 to v4 and migrates the app’s resizable sidebar to the new API.
> 
> Updates the `ResizablePanelGroup`/handle wrappers to use v4 components (`Group`, `Separator`) and switches cursor handling to the new `disableCursor` prop. Adjusts `main-layout` sizing/animation to use percentage-based sizes and the new `usePanelRef()`/`panelRef` API, including detecting collapses via `onResize` to trigger `close()` and persisting width based on `asPercentage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03bb3195fd2e057786e57b9ad666bda73e3540ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->