### PR TITLE
THU-330: Keep header fixed to top on mobile

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/net/thunderbird/thunderbolt/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/net/thunderbird/thunderbolt/MainActivity.kt
@@ -1,3 +1,19 @@
 package net.thunderbird.thunderbolt
 
-class MainActivity : TauriActivity()
+import android.webkit.WebView
+
+class MainActivity : TauriActivity() {
+    // Prevent the WebView from scrolling when the keyboard appears.
+    // With adjustResize, the viewport shrinks but the WebView may also scroll
+    // to show the focused input, pushing the header off-screen.
+    // Our JS-based approach (useKeyboardInset + --kb CSS variable) handles
+    // keyboard layout instead.
+    override fun onWebViewCreate(webView: WebView) {
+        super.onWebViewCreate(webView)
+        webView.overScrollMode = WebView.OVER_SCROLL_NEVER
+        webView.isVerticalScrollBarEnabled = false
+        webView.setOnScrollChangeListener { v, _, _, _, _ ->
+            v.scrollTo(0, 0)
+        }
+    }
+}

--- a/src-tauri/gen/apple/Sources/thunderbolt/main.mm
+++ b/src-tauri/gen/apple/Sources/thunderbolt/main.mm
@@ -6,22 +6,88 @@
 static void removeKeyboardAccessoryBar() {
     Class WKContentViewClass = NSClassFromString(@"WKContentView");
     if (!WKContentViewClass) return;
-    
+
     SEL originalSelector = @selector(inputAccessoryView);
-    
-    // Create a new implementation that returns nil
+
     IMP newImplementation = imp_implementationWithBlock(^UIView*(id self) {
         return nil;
     });
-    
+
     Method originalMethod = class_getInstanceMethod(WKContentViewClass, originalSelector);
     if (originalMethod) {
         method_setImplementation(originalMethod, newImplementation);
     }
 }
 
+// Prevent WKWebView's scroll view from scrolling when the keyboard appears.
+//
+// When the iOS keyboard opens, WKWebView's internal WKScrollView adjusts its
+// content offset and insets to scroll the focused input into view. This moves
+// the entire web content (including fixed headers) off-screen.
+//
+// Our JS-based approach (useKeyboardInset) handles keyboard layout via the --kb
+// CSS variable instead. This native lock prevents the two from conflicting.
+//
+// IMPORTANT: uses class_replaceMethod to add/replace methods ONLY on WKScrollView,
+// NOT on UIScrollView (the superclass). This preserves normal scrolling in all
+// inner CSS scroll containers (overflow: auto/scroll), which are rendered using
+// regular UIScrollView instances.
+static void lockWebViewScrollPosition() {
+    Class WKScrollViewClass = NSClassFromString(@"WKScrollView");
+    if (!WKScrollViewClass) return;
+
+    // Lock setContentOffset: to (0, 0)
+    {
+        SEL sel = @selector(setContentOffset:);
+        Method method = class_getInstanceMethod(WKScrollViewClass, sel);
+        if (!method) return;
+
+        IMP superIMP = method_getImplementation(method);
+        const char *types = method_getTypeEncoding(method);
+
+        IMP newIMP = imp_implementationWithBlock(^(UIScrollView *self, CGPoint offset) {
+            ((void(*)(id, SEL, CGPoint))superIMP)(self, sel, CGPointZero);
+        });
+
+        class_replaceMethod(WKScrollViewClass, sel, newIMP, types);
+    }
+
+    // Lock setContentOffset:animated: to (0, 0)
+    {
+        SEL sel = @selector(setContentOffset:animated:);
+        Method method = class_getInstanceMethod(WKScrollViewClass, sel);
+        if (!method) return;
+
+        IMP superIMP = method_getImplementation(method);
+        const char *types = method_getTypeEncoding(method);
+
+        IMP newIMP = imp_implementationWithBlock(^(UIScrollView *self, CGPoint offset, BOOL animated) {
+            ((void(*)(id, SEL, CGPoint, BOOL))superIMP)(self, sel, CGPointZero, NO);
+        });
+
+        class_replaceMethod(WKScrollViewClass, sel, newIMP, types);
+    }
+
+    // Zero out content inset (iOS sets bottom inset for keyboard)
+    {
+        SEL sel = @selector(setContentInset:);
+        Method method = class_getInstanceMethod(WKScrollViewClass, sel);
+        if (!method) return;
+
+        IMP superIMP = method_getImplementation(method);
+        const char *types = method_getTypeEncoding(method);
+
+        IMP newIMP = imp_implementationWithBlock(^(UIScrollView *self, UIEdgeInsets insets) {
+            ((void(*)(id, SEL, UIEdgeInsets))superIMP)(self, sel, UIEdgeInsetsZero);
+        });
+
+        class_replaceMethod(WKScrollViewClass, sel, newIMP, types);
+    }
+}
+
 int main(int argc, char * argv[]) {
 	removeKeyboardAccessoryBar();
+	lockWebViewScrollPosition();
 	ffi::start_app();
 	return 0;
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -18,6 +18,7 @@ import { AuthProvider, DatabaseProvider, HttpClientProvider, SignInModalProvider
 import { usePageTracking } from '@/hooks/use-analytics'
 import { useDeepLinkListener } from '@/hooks/use-deep-link-listener'
 import { useKeyboardInset } from '@/hooks/use-keyboard-inset'
+import { useViewportLock } from '@/hooks/use-viewport-lock'
 import { useMcpSync } from '@/hooks/use-mcp-sync'
 import ChatLayout from '@/layout/main-layout'
 import { PostHogProvider } from '@/lib/posthog'
@@ -71,6 +72,7 @@ const AppContent = ({ initData }: { initData: InitData }) => {
   useMcpSync()
   useTriggerScheduler()
   useKeyboardInset()
+  useViewportLock()
   useSafeAreaInset()
 
   return (

--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -44,7 +44,7 @@ export default function ChatUI() {
   }, [hasMessages, scrollToBottom])
 
   return (
-    <div className="h-full w-full">
+    <div className="h-full w-full" style={{ paddingBottom: 'var(--kb, 0px)' }}>
       <div
         className={cn(
           'flex flex-col h-full overflow-hidden w-full max-w-[728px] mx-auto min-w-[300px]',

--- a/src/components/onboarding/onboarding-dialog.tsx
+++ b/src/components/onboarding/onboarding-dialog.tsx
@@ -92,9 +92,6 @@ export const OnboardingDialog = () => {
     <Dialog open={isOpen}>
       <DialogContent
         className={cn('p-0 overflow-hidden', !isMobile && 'h-[650px]')}
-        style={{
-          bottom: 'var(--kb, 0px)',
-        }}
         showCloseButton={false}
         useTransparentOverlay={!isMobile}
         fullScreen={isMobile}

--- a/src/hooks/use-viewport-lock.ts
+++ b/src/hooks/use-viewport-lock.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect } from 'react'
+import { isTauri } from '@/lib/platform'
+
+/**
+ * Locks the layout viewport at scroll position 0, preventing iOS Safari from
+ * scrolling fixed-position elements off-screen when the software keyboard opens.
+ *
+ * On iOS, `position: fixed` anchors to the layout viewport, which Safari scrolls
+ * independently of the visual viewport when the keyboard appears. This causes
+ * fixed headers/toolbars to jump or disappear. This hook prevents that with a
+ * three-layer defense:
+ *
+ * 1. `position: fixed` on `<html>` — blocks most iOS viewport scrolling
+ * 2. Touch interception on inputs — `focus({ preventScroll: true })` prevents
+ *    iOS's automatic scroll-into-view when the keyboard opens
+ * 3. rAF scroll-reset loop on focus/blur — catches programmatic focus and any
+ *    residual scroll during the ~300ms keyboard animation
+ *
+ * Web only — skipped on Tauri iOS/Android where the native WKWebView handles
+ * keyboard layout via its own scroll view insets. Running both would cause
+ * double compensation (blank gap at the bottom).
+ *
+ * Pair with `paddingBottom: var(--kb)` on content containers so inputs remain
+ * visible above the keyboard (see `useKeyboardInset` for the `--kb` variable).
+ */
+export const useViewportLock = (): void => {
+  useEffect(() => {
+    // Tauri iOS/Android: setting position:fixed + height:100% on <html>
+    // causes a blank gap in the WKWebView. The native lockWebViewScrollPosition()
+    // (main.mm) handles the scroll lock instead. We only need to scroll the
+    // focused input into view after the keyboard appears and --kb reflows layout.
+    if (isTauri()) {
+      const vv = window.visualViewport
+      if (!vv) {
+        return
+      }
+
+      const isFocusable = (el: Element | null): el is HTMLElement =>
+        el instanceof HTMLInputElement ||
+        el instanceof HTMLTextAreaElement ||
+        (el instanceof HTMLElement && el.isContentEditable)
+
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const onResize = () => {
+        clearTimeout(timer)
+        const active = document.activeElement
+        if (isFocusable(active)) {
+          timer = setTimeout(() => {
+            active.scrollIntoView({ block: 'center', behavior: 'smooth' })
+          }, 350)
+        }
+      }
+
+      vv.addEventListener('resize', onResize)
+      return () => {
+        clearTimeout(timer)
+        vv.removeEventListener('resize', onResize)
+      }
+    }
+
+    const html = document.documentElement
+    html.style.position = 'fixed'
+    html.style.width = '100%'
+    html.style.height = '100%'
+
+    const forceScrollTop = () => {
+      if (window.scrollY !== 0 || window.scrollX !== 0) {
+        window.scrollTo(0, 0)
+      }
+    }
+
+    const isFocusable = (el: EventTarget | null): el is HTMLElement =>
+      el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      (el instanceof HTMLElement && el.isContentEditable)
+
+    // Intercept touch on focusable elements — prevent iOS's automatic
+    // scroll-into-view by manually focusing with preventScroll.
+    const onTouchEnd = (e: TouchEvent) => {
+      const target = e.target
+      if (isFocusable(target)) {
+        e.preventDefault()
+        target.focus({ preventScroll: true })
+      }
+    }
+
+    // Since preventScroll suppresses all scrolling (including inner scroll
+    // containers), we manually scroll the focused element into view once the
+    // keyboard has appeared and the layout has reflowed via --kb.
+    let scrollIntoViewTimer: ReturnType<typeof setTimeout> | undefined
+    const scrollFocusedElementIntoView = () => {
+      clearTimeout(scrollIntoViewTimer)
+      const active = document.activeElement
+      if (isFocusable(active)) {
+        scrollIntoViewTimer = setTimeout(() => {
+          active.scrollIntoView({ block: 'center', behavior: 'smooth' })
+        }, 350) // Wait for keyboard animation + --kb layout reflow
+      }
+    }
+
+    // During keyboard open/close (~300ms), run scrollTo(0,0) every frame
+    // to fight any residual iOS viewport scrolling.
+    let rafId: number | undefined
+    let rafTimeout: ReturnType<typeof setTimeout> | undefined
+
+    const startScrollResetLoop = () => {
+      cancelAnimationFrame(rafId!)
+      clearTimeout(rafTimeout)
+      const loop = () => {
+        forceScrollTop()
+        rafId = requestAnimationFrame(loop)
+      }
+      rafId = requestAnimationFrame(loop)
+      rafTimeout = setTimeout(() => cancelAnimationFrame(rafId!), 500)
+    }
+
+    document.addEventListener('touchend', onTouchEnd, { passive: false })
+    document.addEventListener('focusin', startScrollResetLoop)
+    document.addEventListener('focusout', startScrollResetLoop)
+    window.addEventListener('scroll', forceScrollTop, { passive: false })
+
+    const vv = window.visualViewport
+    if (vv) {
+      vv.addEventListener('scroll', forceScrollTop)
+      vv.addEventListener('resize', forceScrollTop)
+      vv.addEventListener('resize', scrollFocusedElementIntoView)
+    }
+
+    return () => {
+      html.style.position = ''
+      html.style.width = ''
+      html.style.height = ''
+      cancelAnimationFrame(rafId!)
+      clearTimeout(rafTimeout)
+      clearTimeout(scrollIntoViewTimer)
+      document.removeEventListener('touchend', onTouchEnd)
+      document.removeEventListener('focusin', startScrollResetLoop)
+      document.removeEventListener('focusout', startScrollResetLoop)
+      window.removeEventListener('scroll', forceScrollTop)
+      if (vv) {
+        vv.removeEventListener('scroll', forceScrollTop)
+        vv.removeEventListener('resize', forceScrollTop)
+        vv.removeEventListener('resize', scrollFocusedElementIntoView)
+      }
+    }
+  }, [])
+}

--- a/src/hooks/use-viewport-lock.ts
+++ b/src/hooks/use-viewport-lock.ts
@@ -91,9 +91,15 @@ export const useViewportLock = (): void => {
     // Intercept touch on focusable elements — prevent iOS's automatic
     // scroll-into-view by manually focusing with preventScroll.
     // Skip if the element is already focused to preserve cursor repositioning.
+    // Skip native picker inputs (date, time, file, etc.) — preventDefault suppresses
+    // the synthetic click that iOS uses to open the picker UI.
+    const pickerTypes = new Set(['date', 'time', 'datetime-local', 'month', 'week', 'file', 'color'])
     const onTouchEnd = (e: TouchEvent) => {
       const target = e.target
       if (isFocusable(target) && target !== document.activeElement) {
+        if (target instanceof HTMLInputElement && pickerTypes.has(target.type)) {
+          return
+        }
         e.preventDefault()
         target.focus({ preventScroll: true })
       }

--- a/src/hooks/use-viewport-lock.ts
+++ b/src/hooks/use-viewport-lock.ts
@@ -80,9 +80,10 @@ export const useViewportLock = (): void => {
 
     // Intercept touch on focusable elements — prevent iOS's automatic
     // scroll-into-view by manually focusing with preventScroll.
+    // Skip if the element is already focused to preserve cursor repositioning.
     const onTouchEnd = (e: TouchEvent) => {
       const target = e.target
-      if (isFocusable(target)) {
+      if (isFocusable(target) && target !== document.activeElement) {
         e.preventDefault()
         target.focus({ preventScroll: true })
       }

--- a/src/hooks/use-viewport-lock.ts
+++ b/src/hooks/use-viewport-lock.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useEffect } from 'react'
-import { isTauri } from '@/lib/platform'
+import { getPlatform, isTauri } from '@/lib/platform'
 
 /**
  * Locks the layout viewport at scroll position 0, preventing iOS Safari from
@@ -20,20 +20,30 @@ import { isTauri } from '@/lib/platform'
  * 3. rAF scroll-reset loop on focus/blur — catches programmatic focus and any
  *    residual scroll during the ~300ms keyboard animation
  *
- * Web only — skipped on Tauri iOS/Android where the native WKWebView handles
- * keyboard layout via its own scroll view insets. Running both would cause
- * double compensation (blank gap at the bottom).
+ * Skipped on Tauri iOS where the native lockWebViewScrollPosition() (main.mm)
+ * handles the WKWebView scroll lock instead — running both causes a blank gap.
+ * Runs normally on Tauri Android (no native scroll lock available).
  *
  * Pair with `paddingBottom: var(--kb)` on content containers so inputs remain
  * visible above the keyboard (see `useKeyboardInset` for the `--kb` variable).
  */
 export const useViewportLock = (): void => {
   useEffect(() => {
-    // Tauri iOS/Android: setting position:fixed + height:100% on <html>
-    // causes a blank gap in the WKWebView. The native lockWebViewScrollPosition()
-    // (main.mm) handles the scroll lock instead. We only need to scroll the
-    // focused input into view after the keyboard appears and --kb reflows layout.
+    // Tauri iOS: setting position:fixed + height:100% on <html> causes a blank
+    // gap in the WKWebView. The native lockWebViewScrollPosition() (main.mm)
+    // handles the scroll lock instead. We only need to scroll the focused input
+    // into view after the keyboard appears and --kb reflows layout.
+    // Tauri iOS/Android: the native WebView handles scroll locking
+    // (iOS: lockWebViewScrollPosition in main.mm, Android: MainActivity.kt).
+    // We only scroll the focused input into view after --kb reflows layout.
     if (isTauri()) {
+      // On Android with adjustNothing, --kb padding already repositions the input.
+      // scrollIntoView during the keyboard animation causes visible flickering.
+      // Only run on iOS where the native scroll lock needs this assist.
+      if (getPlatform() !== 'ios') {
+        return
+      }
+
       const vv = window.visualViewport
       if (!vv) {
         return

--- a/src/hooks/use-viewport-lock.ts
+++ b/src/hooks/use-viewport-lock.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useEffect } from 'react'
-import { getPlatform, isTauri } from '@/lib/platform'
+import { getPlatform, isTauri, isWebMobilePlatform } from '@/lib/platform'
 
 /**
  * Locks the layout viewport at scroll position 0, preventing iOS Safari from
@@ -70,6 +70,13 @@ export const useViewportLock = (): void => {
         clearTimeout(timer)
         vv.removeEventListener('resize', onResize)
       }
+    }
+
+    // Web path: these workarounds target mobile Safari/Chrome — skip on desktop
+    // browsers where they cause unexpected scrollIntoView on window resize and
+    // break first-tap cursor placement on touch-screen laptops.
+    if (!isWebMobilePlatform()) {
+      return
     }
 
     const html = document.documentElement

--- a/src/settings/layout.tsx
+++ b/src/settings/layout.tsx
@@ -14,6 +14,7 @@ export default function SettingsLayout() {
           className="flex flex-col h-full"
           style={{
             paddingTop: 'var(--safe-area-top-padding)',
+            paddingBottom: 'var(--kb, 0px)',
           }}
         >
           <Header />

--- a/src/waitlist/layout.tsx
+++ b/src/waitlist/layout.tsx
@@ -11,10 +11,10 @@ import { Outlet } from 'react-router'
 export const WaitlistLayout = () => {
   return (
     <div
-      className="flex min-h-dvh w-full flex-col items-center justify-center bg-background"
+      className="flex h-dvh w-full flex-col items-center justify-center overflow-hidden bg-background"
       style={{
         paddingTop: 'var(--safe-area-top-padding)',
-        paddingBottom: 'var(--safe-area-bottom-padding)',
+        paddingBottom: 'calc(var(--safe-area-bottom-padding) + var(--kb, 0px))',
       }}
     >
       <Outlet />

--- a/src/waitlist/waitlist-card.tsx
+++ b/src/waitlist/waitlist-card.tsx
@@ -20,7 +20,7 @@ export const WaitlistCard = ({ children }: WaitlistCardProps) => {
       className={cn(
         'relative flex flex-col items-center backdrop-blur-[5px]',
         // Mobile styles (default)
-        'inset-0 w-full min-h-dvh border-0 rounded-none px-4 py-8 justify-start overflow-y-auto',
+        'inset-0 w-full h-full border-0 rounded-none px-4 py-8 justify-start overflow-y-auto',
         // Desktop styles (md breakpoint = 768px)
         'md:h-[600px] md:w-[430px] md:min-h-0 md:rounded-[16px] md:border md:border-border md:p-8 md:justify-center md:overflow-clip',
       )}


### PR DESCRIPTION
## Summary

- Add `useViewportLock` hook that prevents iOS Safari from scrolling fixed elements off-screen when the keyboard opens (via `position: fixed` on `<html>`, `preventScroll` focus interception, and rAF scroll reset loop)
- On Tauri iOS, lock `WKScrollView` scroll position via native `class_replaceMethod` in `main.mm` — targets only the WKWebView's scroll view without affecting inner `UIScrollView` instances used by CSS overflow containers
- On Tauri Android, skip `scrollIntoView` during keyboard animation to prevent input flickering — `--kb` padding handles repositioning
- Exclude native picker inputs (date, time, file, etc.) from touch interception to preserve native picker UI on first tap
- Use the existing `--kb` CSS variable (`useKeyboardInset`) to shrink content containers above the keyboard across chat, settings, and waitlist screens
- Add subtle bottom border to mobile header
- Fix onboarding dialog pushing content behind status bar by removing double `--kb` compensation

## Test plan

- [x] **Safari mobile**: focus chat prompt input — header stays fixed, input appears above keyboard
- [x] **Safari mobile**: focus input on preferences/settings — content scrolls to show input above keyboard
- [x] **Safari mobile**: focus input on waitlist screen — logo stays fixed, input visible above keyboard
- [x] **iOS app (Tauri)**: same three scenarios as Safari — header fixed, inputs above keyboard
- [x] **iOS app (Tauri)**: verify chat messages, settings page, and other content still scroll normally
- [x] **Android app (Tauri)**: focus chat prompt input — no flickering, input stays above keyboard
- [x] **Android app (Tauri)**: onboarding name/location steps — content doesn't shift behind status bar
- [x] **Android app (Tauri)**: native picker inputs (date/time) open on first tap
- [x] **Desktop**: no visual changes, everything works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile keyboard/scroll behavior across web and native Tauri (iOS/Android), including Objective-C runtime method replacement in `WKScrollView`, which could cause regressions in scrolling and input focus behavior on mobile.
> 
> **Overview**
> Keeps headers/toolbars fixed on mobile when the software keyboard opens by introducing `useViewportLock` (enabled app-wide) to lock the layout viewport on mobile web and manage focus/scroll behavior.
> 
> Adds native WebView scroll locking for Tauri iOS (`WKScrollView` method replacement) and Tauri Android (disable/override `WebView` scrolling) so the keyboard doesn’t shift the entire page, while relying on `--kb` padding to keep inputs visible.
> 
> Updates key layouts (`ChatUI`, `SettingsLayout`, waitlist pages) to apply `paddingBottom: var(--kb)` and removes onboarding dialog’s extra keyboard offset to avoid double-compensation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77d75d2b9497b595a0aef8966db6af377d490d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->