### PR TITLE
THU-481: Make k8s backend address configurable via env var

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,7 +78,7 @@ deploy/
     backend-entrypoint.sh   # Waits for Postgres, runs migrations, starts server
     postgres-init/          # SQL to create PowerSync replication role
   config/                   # Shared config files
-    nginx.conf              # Frontend nginx with COEP/COOP headers
+    nginx.conf.template     # Frontend nginx with COEP/COOP headers; ${BACKEND_HOST}/${BACKEND_PORT} substituted at container start
     powersync-config.yaml   # Sync rules + replication config
     keycloak-realm.json     # Thunderbolt realm + demo user
   k8s/                      # Helm chart

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,7 +78,7 @@ deploy/
     backend-entrypoint.sh   # Waits for Postgres, runs migrations, starts server
     postgres-init/          # SQL to create PowerSync replication role
   config/                   # Shared config files
-    nginx.conf.template     # Frontend nginx with COEP/COOP headers; ${BACKEND_HOST}/${BACKEND_PORT} substituted at container start
+    nginx.conf.template     # Frontend nginx with COEP/COOP headers; ${THUNDERBOLT_BACKEND_HOST}/${THUNDERBOLT_BACKEND_PORT} substituted at container start
     powersync-config.yaml   # Sync rules + replication config
     keycloak-realm.json     # Thunderbolt realm + demo user
   k8s/                      # Helm chart

--- a/deploy/config/keycloak-realm.json
+++ b/deploy/config/keycloak-realm.json
@@ -14,7 +14,7 @@
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
       "secret": "thunderbolt-enterprise-secret",
-      "redirectUris": ["${OIDC_REDIRECT_URI:http://localhost:3000/v1/api/auth/oauth2/callback/oidc}"],
+      "redirectUris": ["${OIDC_REDIRECT_URI:http://localhost:3000/v1/api/auth/sso/callback/sso}"],
       "webOrigins": ["${OIDC_WEB_ORIGIN:http://localhost:3000}"],
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,

--- a/deploy/config/nginx.conf.template
+++ b/deploy/config/nginx.conf.template
@@ -4,10 +4,20 @@ server {
     index index.html;
 
     # Reverse proxy backend API. The upstream host/port are resolved from
-    # ${BACKEND_HOST} and ${BACKEND_PORT} at container start (envsubst on the
-    # nginx template), with defaults set in frontend.Dockerfile so docker-compose
-    # works out of the box. Operators can override for k8s, where the backend
-    # Service name typically differs (e.g. thunderbolt-backend.default.svc).
+    # ${THUNDERBOLT_BACKEND_HOST} and ${THUNDERBOLT_BACKEND_PORT} at container
+    # start (envsubst on the nginx template), with defaults set in
+    # frontend.Dockerfile so docker-compose works out of the box. Operators
+    # can override for k8s, where the backend Service name typically differs
+    # (e.g. thunderbolt-backend.default.svc).
+    #
+    # The names are namespaced with `THUNDERBOLT_` because Kubernetes
+    # auto-injects `<SERVICE>_PORT` env vars (docker-link compatibility) for
+    # every Service in the namespace. A Service named `backend` injects
+    # `BACKEND_PORT=tcp://10.x.y.z:8000` into every pod, which would clobber
+    # this image's `BACKEND_PORT=8000` default and produce an invalid
+    # `proxy_pass` directive. The `THUNDERBOLT_` prefix sidesteps the
+    # collision.
+    #
     # Assigning the host to a variable forces runtime DNS resolution via the
     # `resolver` directive, so nginx doesn't crash on boot if the backend
     # isn't up yet. Values are operator-controlled (not request-controlled),
@@ -18,10 +28,10 @@ server {
         include /etc/nginx/snippets/security-headers.conf;
 
         resolver 127.0.0.11 valid=10s;
-        set $backend "${BACKEND_HOST}";
+        set $backend "${THUNDERBOLT_BACKEND_HOST}";
         # nosemgrep: generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host
         # nosemgrep: generic.nginx.security.missing-internal.missing-internal
-        proxy_pass http://$backend:${BACKEND_PORT}/v1/;
+        proxy_pass http://$backend:${THUNDERBOLT_BACKEND_PORT}/v1/;
         proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/deploy/config/nginx.conf.template
+++ b/deploy/config/nginx.conf.template
@@ -3,20 +3,25 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Reverse proxy backend API — assign the upstream host via a hardcoded
-    # variable so nginx performs runtime DNS resolution (via `resolver`) and
-    # doesn't crash on boot if the backend isn't up yet. The value is fixed
-    # here (not user-controlled), so SSRF-style host injection is not possible.
+    # Reverse proxy backend API. The upstream host/port are resolved from
+    # ${BACKEND_HOST} and ${BACKEND_PORT} at container start (envsubst on the
+    # nginx template), with defaults set in frontend.Dockerfile so docker-compose
+    # works out of the box. Operators can override for k8s, where the backend
+    # Service name typically differs (e.g. thunderbolt-backend.default.svc).
+    # Assigning the host to a variable forces runtime DNS resolution via the
+    # `resolver` directive, so nginx doesn't crash on boot if the backend
+    # isn't up yet. Values are operator-controlled (not request-controlled),
+    # so SSRF-style host injection from clients is not possible.
     # The `internal` directive is intentionally omitted: this is a public API
     # endpoint that the SPA calls directly from the browser.
     location ^~ /v1/ {
         include /etc/nginx/snippets/security-headers.conf;
 
         resolver 127.0.0.11 valid=10s;
-        set $backend "backend";
+        set $backend "${BACKEND_HOST}";
         # nosemgrep: generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host
         # nosemgrep: generic.nginx.security.missing-internal.missing-internal
-        proxy_pass http://$backend:8000/v1/;
+        proxy_pass http://$backend:${BACKEND_PORT}/v1/;
         proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -30,9 +30,15 @@ FROM nginx:alpine
 
 # Backend upstream — resolved at container start via the official nginx
 # image's `envsubst` entrypoint over /etc/nginx/templates/*.template.
-# Override at runtime (e.g. k8s) by setting BACKEND_HOST / BACKEND_PORT.
-ENV BACKEND_HOST=backend
-ENV BACKEND_PORT=8000
+# Override at runtime (e.g. k8s) by setting THUNDERBOLT_BACKEND_HOST /
+# THUNDERBOLT_BACKEND_PORT.
+#
+# Namespaced with `THUNDERBOLT_` to dodge Kubernetes' auto-injected
+# `<SERVICE>_PORT` env vars: a Service named `backend` injects
+# `BACKEND_PORT=tcp://10.x.y.z:8000` into every pod, which would override
+# any `BACKEND_PORT=8000` default we set here and break envsubst.
+ENV THUNDERBOLT_BACKEND_HOST=backend
+ENV THUNDERBOLT_BACKEND_PORT=8000
 
 COPY deploy/config/nginx.conf.template /etc/nginx/templates/default.conf.template
 COPY deploy/config/security-headers.conf /etc/nginx/snippets/security-headers.conf

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -28,7 +28,13 @@ RUN bunx vite build && \
 # Stage 2: Serve with nginx
 FROM nginx:alpine
 
-COPY deploy/config/nginx.conf /etc/nginx/conf.d/default.conf
+# Backend upstream — resolved at container start via the official nginx
+# image's `envsubst` entrypoint over /etc/nginx/templates/*.template.
+# Override at runtime (e.g. k8s) by setting BACKEND_HOST / BACKEND_PORT.
+ENV BACKEND_HOST=backend
+ENV BACKEND_PORT=8000
+
+COPY deploy/config/nginx.conf.template /etc/nginx/templates/default.conf.template
 COPY deploy/config/security-headers.conf /etc/nginx/snippets/security-headers.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 

--- a/deploy/k8s/templates/configmaps.yaml
+++ b/deploy/k8s/templates/configmaps.yaml
@@ -73,7 +73,7 @@ data:
           "enabled": true,
           "clientAuthenticatorType": "client-secret",
           "secret": "{{ .Values.keycloak.oidc.clientSecretBase64 | b64dec }}",
-          "redirectUris": ["{{ .Values.appUrl }}/v1/api/auth/oauth2/callback/oidc"],
+          "redirectUris": ["{{ .Values.appUrl }}/v1/api/auth/sso/callback/sso"],
           "webOrigins": ["{{ .Values.appUrl }}"],
           "standardFlowEnabled": true,
           "directAccessGrantsEnabled": false,

--- a/deploy/pulumi/src/services.ts
+++ b/deploy/pulumi/src/services.ts
@@ -428,7 +428,11 @@ export const createServices = (args: ServiceArgs) => {
           // frontend's nginx proxy (which requires different DNS config).
           { name: 'BETTER_AUTH_URL', value: args.publicUrls.api },
           { name: 'APP_URL', value: args.publicUrls.app },
-          { name: 'TRUSTED_ORIGINS', value: pulumi.interpolate`${args.publicUrls.app},${args.publicUrls.marketing}` },
+          // The auth subdomain must be in TRUSTED_ORIGINS — Better Auth's SSO plugin
+          // (post-THU-461) validates that the OIDC discovery URL's origin is trusted
+          // before fetching the .well-known doc, so missing the auth host produces a
+          // 400 on /v1/auth/sso/config and the SPA can't render the sign-in page.
+          { name: 'TRUSTED_ORIGINS', value: pulumi.interpolate`${args.publicUrls.app},${args.publicUrls.marketing},${args.publicUrls.auth}` },
           { name: 'CORS_ORIGINS', value: pulumi.interpolate`${args.publicUrls.app},${args.publicUrls.marketing}` },
           { name: 'CORS_ORIGIN_REGEX', value: '' },
           { name: 'POWERSYNC_URL', value: args.publicUrls.powersync },

--- a/deploy/pulumi/src/services.ts
+++ b/deploy/pulumi/src/services.ts
@@ -280,7 +280,11 @@ export const createServices = (args: ServiceArgs) => {
           // Realm import substitutes ${OIDC_REDIRECT_URI} / ${OIDC_WEB_ORIGIN} so the
           // baked-in realm JSON works for both local dev (defaults) and Fargate (real URLs).
           // Redirect URI = backend OAuth callback (BETTER_AUTH_URL = publicUrls.api).
-          { name: 'OIDC_REDIRECT_URI', value: pulumi.interpolate`${args.publicUrls.api}/v1/api/auth/oauth2/callback/oidc` },
+          // Callback path is the @better-auth/sso plugin's standard
+          // `/sso/callback/<providerId>` (post-THU-461 SSO migration). The
+          // legacy genericOAuth path was `/oauth2/callback/oidc`; both are
+          // documented here in case anything still references it.
+          { name: 'OIDC_REDIRECT_URI', value: pulumi.interpolate`${args.publicUrls.api}/v1/api/auth/sso/callback/sso` },
           { name: 'OIDC_WEB_ORIGIN', value: args.publicUrls.app },
         ],
         portMappings: [{ containerPort: 8080 }],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes nginx proxy routing via env-substituted host/port and updates Keycloak redirect URIs/trusted origins, which could break API reachability or SSO login if misconfigured.
> 
> **Overview**
> **Frontend nginx now proxies `/v1/*` to an env-configurable backend host/port** by switching to `nginx.conf.template` + nginx `envsubst` and adding `THUNDERBOLT_BACKEND_HOST`/`THUNDERBOLT_BACKEND_PORT` defaults in the frontend image (avoiding Kubernetes `*_PORT` env collisions).
> 
> **OIDC/SSO deployment config is updated** to use the `/v1/api/auth/sso/callback/sso` redirect URI (Keycloak realm JSON, Helm ConfigMap, and Pulumi’s `OIDC_REDIRECT_URI`), and Pulumi now includes the auth URL in `TRUSTED_ORIGINS` to satisfy the Better Auth SSO plugin’s origin checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3daaa7510bd1d09f2dab34672fccfa8758a00182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->