### PR TITLE
THU-485: Warn if using default credentials, disable warnings via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,10 @@ VITE_THUNDERBOLT_CLOUD_URL="http://localhost:8000/v1"
 # Show app download links/banners in the web UI (set to "true" for internal testing deployments)
 # When enabled, desktop users see a sidebar section + bottom-right banner; mobile users see a top banner
 # VITE_SHOW_APP_DOWNLOADS="true"
+
+# Suppress the loud "INSECURE DEFAULT CREDENTIALS" warning emitted by the
+# vite dev server, the backend, and the browser DevTools console. Use ONLY
+# for short-lived eval / local-dev runs where defaults are accepted on
+# purpose. See deploy/README.md#default-credentials for the canonical list
+# of defaults and how to rotate them properly.
+# DANGEROUSLY_ALLOW_DEFAULT_CREDS=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -102,3 +102,12 @@ RATE_LIMIT_ENABLED=true
 # Set to 'cloudflare' to trust CF-Connecting-IP, 'akamai' for True-Client-IP.
 # Leave empty to use the direct socket IP only (all proxy headers are ignored).
 TRUSTED_PROXY=
+
+# Suppress the red "INSECURE DEFAULT CREDENTIALS" banner the backend prints
+# at startup when any of BETTER_AUTH_SECRET, OIDC_CLIENT_SECRET,
+# POWERSYNC_JWT_SECRET, POSTGRES_PASSWORD, POWERSYNC_DB_PASSWORD, or
+# KC_BOOTSTRAP_ADMIN_PASSWORD matches its public default from deploy/.
+# Use ONLY for short-lived eval / local-dev runs. See
+# deploy/README.md#default-credentials for the canonical list and rotation
+# commands.
+# DANGEROUSLY_ALLOW_DEFAULT_CREDS=true

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,1 +1,4 @@
 EXA_API_KEY=""
+# Tests should never print the insecure-default banner regardless of
+# what fixture values they set.
+DANGEROUSLY_ALLOW_DEFAULT_CREDS=true

--- a/backend/src/api/config.test.ts
+++ b/backend/src/api/config.test.ts
@@ -15,7 +15,7 @@ describe('Config Routes', () => {
       const response = await app.handle(new Request('http://localhost/config'))
 
       expect(response.status).toBe(200)
-      expect(await response.json()).toEqual({ e2eeEnabled: false })
+      expect(await response.json()).toMatchObject({ e2eeEnabled: false, securityWarnings: expect.any(Array) })
     })
 
     it('returns e2eeEnabled: true when enabled', async () => {
@@ -24,7 +24,7 @@ describe('Config Routes', () => {
       const response = await app.handle(new Request('http://localhost/config'))
 
       expect(response.status).toBe(200)
-      expect(await response.json()).toEqual({ e2eeEnabled: true })
+      expect(await response.json()).toMatchObject({ e2eeEnabled: true, securityWarnings: expect.any(Array) })
     })
 
     it('does not require authentication', async () => {

--- a/backend/src/api/config.ts
+++ b/backend/src/api/config.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { detectInsecureDefaultsForBackend } from '@/config/insecure-defaults-warning'
 import type { Settings } from '@/config/settings'
 import { safeErrorHandler } from '@/middleware/error-handling'
 import { Elysia } from 'elysia'
@@ -9,4 +10,9 @@ import { Elysia } from 'elysia'
 export const createConfigRoutes = (settings: Settings) =>
   new Elysia({ prefix: '/config' }).onError(safeErrorHandler).get('/', () => ({
     e2eeEnabled: settings.e2eeEnabled,
+    // Names of well-known default credentials currently in use. Empty array
+    // when secure (or when DANGEROUSLY_ALLOW_DEFAULT_CREDS=true). The frontend
+    // surfaces this in the browser DevTools console — never the values, just
+    // the env-var names — so anyone who opens DevTools sees a security alert.
+    securityWarnings: detectInsecureDefaultsForBackend().map((m) => m.envKey),
   }))

--- a/backend/src/config/insecure-defaults-warning.ts
+++ b/backend/src/config/insecure-defaults-warning.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { type InsecureDefault, detectInsecureDefaults, renderTerminalBanner } from '@shared/insecure-defaults'
+
+/**
+ * Returns the subset of well-known default credentials currently in use by
+ * this backend, based on its env vars. Empty when DANGEROUSLY_ALLOW_DEFAULT_CREDS
+ * is set.
+ */
+export const detectInsecureDefaultsForBackend = (
+  env: Record<string, string | undefined> = process.env,
+): InsecureDefault[] => {
+  return detectInsecureDefaults((entry) => env[entry.envKey], env)
+}
+
+/**
+ * Render the multi-line ANSI banner. Color is auto-disabled when stderr
+ * isn't a TTY (CI logs, files, redirected pipes) so the box drawing stays
+ * readable but doesn't pollute log aggregators with escape sequences.
+ */
+export const renderInsecureDefaultsBanner = (matches: InsecureDefault[]): string => {
+  const useColor = Boolean(process.stderr.isTTY)
+  return renderTerminalBanner(matches, useColor)
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import { createUniversalProxyRoutes } from '@/proxy/routes'
 import { createPostHogRoutes } from '@/posthog/routes'
 import { createProToolsRoutes } from '@/pro/routes'
 import { createWaitlistRoutes } from '@/waitlist/routes'
+import { detectInsecureDefaultsForBackend, renderInsecureDefaultsBanner } from '@/config/insecure-defaults-warning'
 import { createAccountRoutes } from '@/api/account'
 import { createConfigRoutes } from '@/api/config'
 import { createEncryptionRoutes } from '@/api/encryption'
@@ -137,6 +138,19 @@ const startServer = async () => {
     },
     'Server configuration',
   )
+
+  // Loud, hard-to-miss banner if any well-known default credentials are
+  // active. Suppressed by DANGEROUSLY_ALLOW_DEFAULT_CREDS=true.
+  const insecureMatches = detectInsecureDefaultsForBackend()
+  if (insecureMatches.length > 0) {
+    process.stderr.write(renderInsecureDefaultsBanner(insecureMatches))
+    for (const m of insecureMatches) {
+      log.warn(
+        { event: 'INSECURE_DEFAULT_CREDENTIAL', key: m.envKey, description: m.description },
+        `Insecure default credential in use: ${m.envKey}`,
+      )
+    }
+  }
 
   try {
     // Run PGLite migrations before creating the app (no-op for Postgres)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -56,3 +56,10 @@ POWERSYNC_TOKEN_EXPIRY_SECONDS=3600
 
 # Resend (email — optional)
 RESEND_API_KEY=
+
+# Suppress the loud "INSECURE DEFAULT CREDENTIALS" warnings emitted across
+# the stack (backend stderr, frontend container, browser DevTools console)
+# when the public default values from this directory are in use. Use ONLY
+# for short-lived eval / local-dev runs. See README.md#default-credentials
+# for the list of defaults and the override recipe.
+# DANGEROUSLY_ALLOW_DEFAULT_CREDS=true

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,10 +2,13 @@
 
 > ⚠️ **Under active development — not production ready.** Thunderbolt is currently undergoing a security audit and preparing for enterprise production readiness. These deployment paths are provided for evaluation and early testing. Do not use in production environments.
 
+> 🚨 **STOP — read [Default Credentials](#default-credentials) first.** Every deployment path in this directory ships with public, well-known default values for database passwords, OIDC client secrets, JWT signing keys, and the Keycloak admin password. If you `docker compose up` / `helm install` / `pulumi up` without overriding them, your stack runs with credentials anyone can read in the source tree. Pulumi, the backend, the browser DevTools console, and the frontend container will all warn loudly when defaults are detected — but the only fix is to rotate them.
+
 Self-hosted Thunderbolt with OIDC or SAML authentication via Keycloak. Three deployment paths: Docker Compose for local development, Helm chart for Kubernetes, and Pulumi for AWS (Fargate or EKS).
 
 ## Table of Contents
 
+- [Default Credentials](#default-credentials)
 - [Architecture](#architecture)
 - [Services](#services)
 - [Directory Structure](#directory-structure)
@@ -15,6 +18,92 @@ Self-hosted Thunderbolt with OIDC or SAML authentication via Keycloak. Three dep
 - [4. GitHub Actions CI/CD](#4-github-actions-cicd)
 - [Configuration Reference](#configuration-reference)
 - [Troubleshooting](#troubleshooting)
+
+---
+
+## Default Credentials
+
+> 🚨 **All defaults below are public** — they live in this repository. Every fresh deployment uses them unless you override. Every layer of the stack (Pulumi at deploy time, backend at startup, browser DevTools, frontend container) will print a loud warning until you rotate them.
+
+| Credential | Default value | Defined in | Used by |
+|---|---|---|---|
+| `BETTER_AUTH_SECRET` | `enterprise-thunderbolt-better-auth-default-secret` | `deploy/pulumi/index.ts`, `deploy/k8s/values.yaml`, `deploy/docker-compose.yml` | Backend session signing |
+| `OIDC_CLIENT_SECRET` | `thunderbolt-enterprise-secret` | same + `deploy/config/keycloak-realm.json` | OIDC client auth |
+| `POWERSYNC_JWT_SECRET` | `enterprise-thunderbolt-powersync-jwt-default-secret` | same | PowerSync JWT signing |
+| `POSTGRES_PASSWORD` | `postgres` | same | Postgres admin |
+| `POWERSYNC_DB_PASSWORD` | `myhighlyrandompassword` | same | PowerSync DB role |
+| `KC_BOOTSTRAP_ADMIN_PASSWORD` | `admin` | same | Keycloak admin console |
+| Keycloak demo user | `demo@thunderbolt.io` / `demo` | `deploy/config/keycloak-realm.json` | Demo login |
+
+The canonical machine-readable list lives at [`shared/insecure-defaults.ts`](../shared/insecure-defaults.ts) — every warning surface reads from it.
+
+### How to override
+
+**Docker Compose** — generate values and put them in `deploy/.env`:
+
+```bash
+cd deploy
+cat >> .env <<EOF
+BETTER_AUTH_SECRET=$(openssl rand -base64 32)
+OIDC_CLIENT_SECRET=$(openssl rand -base64 32)
+POWERSYNC_JWT_SECRET=$(openssl rand -base64 32)
+POSTGRES_PASSWORD=$(openssl rand -base64 24)
+POWERSYNC_DB_PASSWORD=$(openssl rand -base64 24)
+KC_BOOTSTRAP_ADMIN_PASSWORD=$(openssl rand -base64 16)
+EOF
+docker compose up
+```
+
+Then update `deploy/config/keycloak-realm.json` line 16 to match the new `OIDC_CLIENT_SECRET`, and rebuild the Keycloak image — the realm value is baked in at image build time.
+
+**Helm** — base64-encode each value and override in your `values.yaml` (or `helm install --set ...`):
+
+```bash
+helm install thunderbolt deploy/k8s \
+  --set backend.betterAuthSecretBase64=$(echo -n "$(openssl rand -base64 32)" | base64) \
+  --set powersync.jwt.secretBase64=$(echo -n "$(openssl rand -base64 32)" | base64) \
+  --set powersync.db.passwordBase64=$(echo -n "$(openssl rand -base64 24)" | base64) \
+  --set postgres.credentials.passwordBase64=$(echo -n "$(openssl rand -base64 24)" | base64) \
+  --set keycloak.admin.password=$(openssl rand -base64 16) \
+  --set keycloak.oidc.clientSecretBase64=$(echo -n "$(openssl rand -base64 32)" | base64)
+```
+
+**Pulumi (AWS)** — use `pulumi config set --secret` so values are encrypted in stack state:
+
+```bash
+cd deploy/pulumi
+pulumi config set --secret betterAuthSecret "$(openssl rand -base64 32)"
+pulumi config set --secret oidcClientSecret "$(openssl rand -base64 32)"
+pulumi config set --secret powersyncJwtSecret "$(openssl rand -base64 32)"
+pulumi config set --secret postgresPassword "$(openssl rand -base64 24)"
+pulumi config set --secret powersyncDbPassword "$(openssl rand -base64 24)"
+pulumi config set --secret keycloakAdminPassword "$(openssl rand -base64 16)"
+pulumi up
+```
+
+After `pulumi up`, confirm no warnings in the stack output: `pulumi stack output securityWarnings` should be `[]`.
+
+### Suppressing the warnings
+
+For short-lived evaluation environments where you accept defaults on purpose, suppress every warning with:
+
+```bash
+DANGEROUSLY_ALLOW_DEFAULT_CREDS=true   # backend, frontend container, vite dev server
+pulumi config set dangerouslyAllowDefaultCreds true   # Pulumi
+```
+
+> 🚨 **Do not set this in production.** It silences the only signal you have that the stack is insecure. The flag exists so CI environments and short eval stacks aren't drowned in warnings — not as an answer to "how do I deploy with defaults safely" (you don't).
+
+### Where the warnings show up
+
+| Surface | What you'll see |
+|---|---|
+| `pulumi up` console | Yellow `warn` log lines listing each Pulumi-config key still using a default; box-drawing banner at the top |
+| Backend startup logs (`docker compose logs backend`, `kubectl logs backend`, CloudWatch) | Red ANSI banner on stderr + structured `WARN` log entries with `event: 'INSECURE_DEFAULT_CREDENTIAL'` so prod alerting can grep |
+| Browser DevTools console | Red banner-styled `console.error` listing the env-var names (never values) — counts toward the DevTools error badge |
+| Frontend container logs | Yellow ANSI reminder banner from the nginx entrypoint |
+| `bun run dev` terminal | Yellow ANSI reminder banner from a vite plugin |
+| `pulumi stack output securityWarnings` | Array of Pulumi-config keys still using defaults — useful for CI assertions |
 
 ---
 

--- a/deploy/config/keycloak-realm.json
+++ b/deploy/config/keycloak-realm.json
@@ -14,7 +14,7 @@
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
       "secret": "thunderbolt-enterprise-secret",
-      "redirectUris": ["${OIDC_REDIRECT_URI:http://localhost:3000/v1/api/auth/oauth2/callback/oidc}"],
+      "redirectUris": ["${OIDC_REDIRECT_URI:http://localhost:3000/v1/api/auth/sso/callback/sso}"],
       "webOrigins": ["${OIDC_WEB_ORIGIN:http://localhost:3000}"],
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -9,6 +9,7 @@ server {
     # here (not user-controlled), so SSRF-style host injection is not possible.
     # The `internal` directive is intentionally omitted: this is a public API
     # endpoint that the SPA calls directly from the browser.
+    # nosemgrep: generic.nginx.security.missing-internal.missing-internal
     location ^~ /v1/ {
         include /etc/nginx/snippets/security-headers.conf;
 

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -13,14 +13,19 @@ server {
         include /etc/nginx/snippets/security-headers.conf;
 
         resolver 127.0.0.11 valid=10s;
+        # `set` + variable in proxy_pass forces runtime DNS resolution via the
+        # `resolver` above so nginx doesn't crash on boot if the backend isn't
+        # up yet. Value is a hardcoded literal — no user-input path — so the
+        # "dynamic proxy host" Semgrep finding is a false positive.
+        #
+        # No URI part on proxy_pass — when variables are used in the host, nginx
+        # can't reliably do the location-prefix substitution, so the URI part
+        # of proxy_pass gets misapplied and the backend receives the wrong path
+        # (e.g. /config instead of /v1/config). With no URI part nginx forwards
+        # the original request URI verbatim.
         set $backend "backend";
         # nosemgrep: generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host
         # nosemgrep: generic.nginx.security.missing-internal.missing-internal
-        # No URI part on proxy_pass — when variables are used in the host, nginx
-        # cannot reliably do the location-prefix substitution, so the URI part
-        # of proxy_pass gets misapplied and the backend receives the wrong path
-        # (e.g. /config instead of /v1/config). With no URI part nginx forwards
-        # the original request URI verbatim, which is what we want here.
         proxy_pass http://$backend:8000;
         proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -16,7 +16,12 @@ server {
         set $backend "backend";
         # nosemgrep: generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host
         # nosemgrep: generic.nginx.security.missing-internal.missing-internal
-        proxy_pass http://$backend:8000/v1/;
+        # No URI part on proxy_pass — when variables are used in the host, nginx
+        # cannot reliably do the location-prefix substitution, so the URI part
+        # of proxy_pass gets misapplied and the backend receives the wrong path
+        # (e.g. /config instead of /v1/config). With no URI part nginx forwards
+        # the original request URI verbatim, which is what we want here.
+        proxy_pass http://$backend:8000;
         proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
       # Discovery URL uses the internal Docker hostname — backchannel-dynamic lets this work
       # while Keycloak's metadata returns localhost:8180 URLs for the browser
-      OIDC_ISSUER: http://keycloak:8080/realms/thunderbolt
+      OIDC_ISSUER: http://localhost:8180/realms/thunderbolt
       OIDC_CLIENT_ID: thunderbolt-app
       OIDC_CLIENT_SECRET: thunderbolt-enterprise-secret
       BETTER_AUTH_URL: http://localhost:${FRONTEND_PORT:-3000}
@@ -46,7 +46,7 @@ services:
       keycloak:
         condition: service_healthy
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - "localhost:host-gateway"
 
   postgres:
     image: postgres:17-alpine

--- a/deploy/docker/frontend-security-banner.sh
+++ b/deploy/docker/frontend-security-banner.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Frontend startup banner — printed once at container start to remind the
+# operator that this is a deployment and they need to verify they have
+# rotated the default credentials. Constant (not detection-driven) — the
+# backend is the layer that knows what's actually in use; this banner is
+# belt-and-suspenders for surfaces where the backend logs aren't visible
+# (e.g. someone scrolling docker-compose output past the backend startup).
+#
+# Suppress with DANGEROUSLY_ALLOW_DEFAULT_CREDS=true.
+#
+# This script runs as part of the official nginx image's
+# /docker-entrypoint.d/ chain (executed in alphanumeric order before nginx
+# starts).
+
+set -e
+
+case "${DANGEROUSLY_ALLOW_DEFAULT_CREDS:-}" in
+  true|TRUE|True) exit 0 ;;
+esac
+
+DOCS_URL='https://github.com/thunderbird/thunderbolt/blob/main/deploy/README.md#default-credentials'
+
+# Yellow background, black bold text. Echo to stderr so it doesn't get
+# swallowed if anything pipes stdout.
+{
+  printf '\n\033[43;1;30m╔══════════════════════════════════════════════════════════════════════════════╗\033[0m\n'
+  printf '\033[43;1;30m║                                                                              ║\033[0m\n'
+  printf '\033[43;1;30m║   ⚠   Thunderbolt frontend — security reminder                               ║\033[0m\n'
+  printf '\033[43;1;30m║                                                                              ║\033[0m\n'
+  printf '\033[43;1;30m║   If this is a fresh deployment, verify you have rotated the default         ║\033[0m\n'
+  printf '\033[43;1;30m║   credentials. The backend logs and the browser DevTools console will        ║\033[0m\n'
+  printf '\033[43;1;30m║   list any defaults still in use.                                            ║\033[0m\n'
+  printf '\033[43;1;30m║                                                                              ║\033[0m\n'
+  printf '\033[43;1;30m║   Docs:                                                                      ║\033[0m\n'
+  printf '\033[43;1;30m║   %-75s║\033[0m\n' "$DOCS_URL"
+  printf '\033[43;1;30m║                                                                              ║\033[0m\n'
+  printf '\033[43;1;30m║   Suppress: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true                             ║\033[0m\n'
+  printf '\033[43;1;30m║                                                                              ║\033[0m\n'
+  printf '\033[43;1;30m╚══════════════════════════════════════════════════════════════════════════════╝\033[0m\n\n'
+} >&2

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -32,6 +32,15 @@ COPY deploy/config/nginx.conf /etc/nginx/conf.d/default.conf
 COPY deploy/config/security-headers.conf /etc/nginx/snippets/security-headers.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
+# Insecure-defaults reminder banner. The official nginx image runs every
+# executable file in /docker-entrypoint.d/ (in alphanumeric order) before
+# starting nginx, so this prints once at container start and shows up in
+# `docker compose logs` / `kubectl logs frontend`. Suppressible via
+# DANGEROUSLY_ALLOW_DEFAULT_CREDS=true. Prefixed `00-` so it runs before
+# the built-in template-substitution and config-reload scripts.
+COPY deploy/docker/frontend-security-banner.sh /docker-entrypoint.d/00-security-banner.sh
+RUN chmod +x /docker-entrypoint.d/00-security-banner.sh
+
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/deploy/k8s/values.yaml
+++ b/deploy/k8s/values.yaml
@@ -71,7 +71,8 @@ postgres:
   credentials:
     user: postgres
     database: postgres
-    # -- Base64-encoded password (default: "postgres")
+    # 🚨 INSECURE DEFAULT — base64("postgres"). REGENERATE BEFORE PRODUCTION:
+    #    echo -n "$(openssl rand -base64 24)" | base64
     passwordBase64: cG9zdGdyZXM=
 
 # =============================================================================
@@ -86,12 +87,13 @@ powersync:
     port: 8080
   jwt:
     kid: enterprise-powersync
-    # -- Base64-encoded JWT secret. Minimum 32 chars when decoded (backend validation).
-    # Default: "enterprise-thunderbolt-powersync-jwt-default-secret" (51 chars).
-    # Override for production: echo -n "<your-secret>" | base64
+    # 🚨 INSECURE DEFAULT — base64("enterprise-thunderbolt-powersync-jwt-default-secret").
+    # REGENERATE BEFORE PRODUCTION (minimum 32 chars when decoded — backend validates):
+    #    echo -n "$(openssl rand -base64 32)" | base64
     secretBase64: ZW50ZXJwcmlzZS10aHVuZGVyYm9sdC1wb3dlcnN5bmMtand0LWRlZmF1bHQtc2VjcmV0
   db:
-    # -- Base64-encoded powersync_role database password (default: "myhighlyrandompassword")
+    # 🚨 INSECURE DEFAULT — base64("myhighlyrandompassword"). REGENERATE BEFORE PRODUCTION:
+    #    echo -n "$(openssl rand -base64 24)" | base64
     passwordBase64: bXloaWdobHlyYW5kb21wYXNzd29yZA==
 
 # =============================================================================
@@ -105,11 +107,16 @@ keycloak:
   service:
     port: 8080
   admin:
+    # 🚨 INSECURE DEFAULTS — Keycloak admin console login. CHANGE BEFORE PRODUCTION.
     username: admin
     password: admin
   oidc:
     clientId: thunderbolt-app
-    # -- Base64-encoded client secret (default: "thunderbolt-enterprise-secret")
+    # 🚨 INSECURE DEFAULT — base64("thunderbolt-enterprise-secret"). REGENERATE BEFORE PRODUCTION:
+    #    echo -n "$(openssl rand -base64 32)" | base64
+    # NOTE: this value is also baked into deploy/config/keycloak-realm.json, which the
+    # Keycloak image imports at build time — you must rebuild the keycloak image for the
+    # realm-side value to match.
     clientSecretBase64: dGh1bmRlcmJvbHQtZW50ZXJwcmlzZS1zZWNyZXQ=
 
 # =============================================================================

--- a/deploy/pulumi/index.ts
+++ b/deploy/pulumi/index.ts
@@ -3,6 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as pulumi from '@pulumi/pulumi'
+import {
+  INSECURE_DEFAULTS,
+  INSECURE_DEFAULTS_DOCS_URL,
+  isInsecureDefaultsHushed,
+} from '../../shared/insecure-defaults'
 import { createVpc } from './src/vpc'
 import { createEksCluster } from './src/eks'
 import { createStorage } from './src/storage'
@@ -96,6 +101,74 @@ const secrets = {
 
 // Thunderbolt inference gateway URL (not a secret; set per-stack)
 const thunderboltInferenceUrl = config.get('thunderboltInferenceUrl') ?? ''
+
+// --- Insecure-default credentials warning ---------------------------------
+//
+// Detect any credentials still set to their public, well-known sentinel
+// values and emit a *very* loud warning at deploy time. Resources are still
+// created — the goal is awareness, not blocking — but the warning prints in
+// yellow during `pulumi preview` and `pulumi up`, and surfaces as a stack
+// output (`securityWarnings`) for post-deploy auditing / CI assertions.
+//
+// Suppress (e.g. for short-lived eval stacks) with:
+//   pulumi config set dangerouslyAllowDefaultCreds true
+const dangerouslyAllowDefaultCreds = (config.get('dangerouslyAllowDefaultCreds') ?? '').toLowerCase() === 'true'
+const insecureDefaultsHushedViaEnv = isInsecureDefaultsHushed(process.env as Record<string, string | undefined>)
+const insecureDefaultsHushed = dangerouslyAllowDefaultCreds || insecureDefaultsHushedViaEnv
+
+const insecureDefaultMatches = insecureDefaultsHushed
+  ? []
+  : INSECURE_DEFAULTS.filter((entry) => {
+      const configured = config.getSecret(entry.pulumiKey)
+      // No config value → fallback in `secrets` above is the sentinel → match.
+      // A config value exists but equals the sentinel → also a match.
+      // We can't synchronously read a Pulumi.Output here, so fall back to the
+      // simpler check: if `config.getSecret` returned undefined, the fallback
+      // (the sentinel) is in use.
+      return configured === undefined
+    })
+
+if (insecureDefaultMatches.length > 0) {
+  pulumi.log.warn(
+    `\n` +
+      `╔════════════════════════════════════════════════════════════════════════════╗\n` +
+      `║  🚨🚨🚨   INSECURE DEFAULT CREDENTIALS IN USE   🚨🚨🚨                      ║\n` +
+      `╠════════════════════════════════════════════════════════════════════════════╣\n` +
+      `║                                                                            ║\n` +
+      `║  This stack has not overridden the following secrets, so the public        ║\n` +
+      `║  default values from deploy/ will be deployed into your AWS account:       ║\n` +
+      `║                                                                            ║\n` +
+      insecureDefaultMatches
+        .map((m) => {
+          const line = `║    • ${m.pulumiKey}  —  ${m.description}`
+          return line + ' '.repeat(Math.max(0, 78 - line.length)) + '║'
+        })
+        .join('\n') +
+      `\n║                                                                            ║\n` +
+      `║  These values are PUBLIC. Anyone who finds this deploy can read them.      ║\n` +
+      `║                                                                            ║\n` +
+      `║  Override each with:                                                       ║\n` +
+      `║    pulumi config set --secret <key> <value> -s ${stackName}` +
+      ' '.repeat(Math.max(0, 78 - (`    pulumi config set --secret <key> <value> -s ${stackName}`.length + 4))) +
+      `    ║\n` +
+      `║                                                                            ║\n` +
+      `║  Docs:                                                                     ║\n` +
+      `║    ${INSECURE_DEFAULTS_DOCS_URL}` +
+      ' '.repeat(Math.max(0, 78 - (`    ${INSECURE_DEFAULTS_DOCS_URL}`.length + 4))) +
+      `    ║\n` +
+      `║                                                                            ║\n` +
+      `║  Suppress this warning (DO NOT do this in production):                     ║\n` +
+      `║    pulumi config set dangerouslyAllowDefaultCreds true                     ║\n` +
+      `║                                                                            ║\n` +
+      `╚════════════════════════════════════════════════════════════════════════════╝\n`,
+  )
+  for (const m of insecureDefaultMatches) {
+    pulumi.log.warn(`Insecure default in use: ${m.pulumiKey} (${m.description})`)
+  }
+}
+
+// Surface as stack output for post-deploy audit / CI assertion.
+export const securityWarnings = insecureDefaultMatches.map((m) => m.pulumiKey)
 
 // Shared: VPC (both platforms need this)
 const { vpc, publicSubnets, privateSubnets, albSg, servicesSg } = createVpc(name)

--- a/deploy/pulumi/index.ts
+++ b/deploy/pulumi/index.ts
@@ -3,11 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as pulumi from '@pulumi/pulumi'
-import {
-  INSECURE_DEFAULTS,
-  INSECURE_DEFAULTS_DOCS_URL,
-  isInsecureDefaultsHushed,
-} from '../../shared/insecure-defaults'
 import { createVpc } from './src/vpc'
 import { createEksCluster } from './src/eks'
 import { createStorage } from './src/storage'
@@ -112,9 +107,27 @@ const thunderboltInferenceUrl = config.get('thunderboltInferenceUrl') ?? ''
 //
 // Suppress (e.g. for short-lived eval stacks) with:
 //   pulumi config set dangerouslyAllowDefaultCreds true
+//
+// Inline list rather than imported from shared/insecure-defaults.ts because
+// pulling files from outside this directory pushes TypeScript's common
+// source root above the project (TS5011) when ts-node compiles index.ts
+// during `pulumi up`. Keep this in sync with shared/insecure-defaults.ts —
+// the shared module is the canonical source for backend + frontend, this
+// is the deploy-time mirror.
+const INSECURE_DEFAULTS_DOCS_URL =
+  'https://github.com/thunderbird/thunderbolt/blob/main/deploy/README.md#default-credentials'
+const INSECURE_DEFAULTS = [
+  { pulumiKey: 'postgresPassword', description: 'PostgreSQL admin password' },
+  { pulumiKey: 'keycloakAdminPassword', description: 'Keycloak admin console password' },
+  { pulumiKey: 'oidcClientSecret', description: 'OIDC client secret' },
+  { pulumiKey: 'powersyncJwtSecret', description: 'PowerSync JWT signing secret' },
+  { pulumiKey: 'betterAuthSecret', description: 'Better Auth session signing secret' },
+  { pulumiKey: 'powersyncDbPassword', description: 'PowerSync database role password' },
+] as const
+
 const dangerouslyAllowDefaultCreds = (config.get('dangerouslyAllowDefaultCreds') ?? '').toLowerCase() === 'true'
-const insecureDefaultsHushedViaEnv = isInsecureDefaultsHushed(process.env as Record<string, string | undefined>)
-const insecureDefaultsHushed = dangerouslyAllowDefaultCreds || insecureDefaultsHushedViaEnv
+const dangerouslyAllowDefaultCredsViaEnv = process.env.DANGEROUSLY_ALLOW_DEFAULT_CREDS?.toLowerCase() === 'true'
+const insecureDefaultsHushed = dangerouslyAllowDefaultCreds || dangerouslyAllowDefaultCredsViaEnv
 
 const insecureDefaultMatches = insecureDefaultsHushed
   ? []

--- a/deploy/pulumi/index.ts
+++ b/deploy/pulumi/index.ts
@@ -142,39 +142,35 @@ const insecureDefaultMatches = insecureDefaultsHushed
     })
 
 if (insecureDefaultMatches.length > 0) {
-  pulumi.log.warn(
-    `\n` +
-      `╔════════════════════════════════════════════════════════════════════════════╗\n` +
-      `║  🚨🚨🚨   INSECURE DEFAULT CREDENTIALS IN USE   🚨🚨🚨                      ║\n` +
-      `╠════════════════════════════════════════════════════════════════════════════╣\n` +
-      `║                                                                            ║\n` +
-      `║  This stack has not overridden the following secrets, so the public        ║\n` +
-      `║  default values from deploy/ will be deployed into your AWS account:       ║\n` +
-      `║                                                                            ║\n` +
-      insecureDefaultMatches
-        .map((m) => {
-          const line = `║    • ${m.pulumiKey}  —  ${m.description}`
-          return line + ' '.repeat(Math.max(0, 78 - line.length)) + '║'
-        })
-        .join('\n') +
-      `\n║                                                                            ║\n` +
-      `║  These values are PUBLIC. Anyone who finds this deploy can read them.      ║\n` +
-      `║                                                                            ║\n` +
-      `║  Override each with:                                                       ║\n` +
-      `║    pulumi config set --secret <key> <value> -s ${stackName}` +
-      ' '.repeat(Math.max(0, 78 - (`    pulumi config set --secret <key> <value> -s ${stackName}`.length + 4))) +
-      `    ║\n` +
-      `║                                                                            ║\n` +
-      `║  Docs:                                                                     ║\n` +
-      `║    ${INSECURE_DEFAULTS_DOCS_URL}` +
-      ' '.repeat(Math.max(0, 78 - (`    ${INSECURE_DEFAULTS_DOCS_URL}`.length + 4))) +
-      `    ║\n` +
-      `║                                                                            ║\n` +
-      `║  Suppress this warning (DO NOT do this in production):                     ║\n` +
-      `║    pulumi config set dangerouslyAllowDefaultCreds true                     ║\n` +
-      `║                                                                            ║\n` +
-      `╚════════════════════════════════════════════════════════════════════════════╝\n`,
-  )
+  // Build the box once with a single pad-to-width formula so geometry stays
+  // consistent across every line, and grow the width to fit the longest line
+  // (the docs URL is ~89 chars and would otherwise overflow the right border).
+  const innerLines: string[] = [
+    '  🚨🚨🚨   INSECURE DEFAULT CREDENTIALS IN USE   🚨🚨🚨',
+    '',
+    '  This stack has not overridden the following secrets, so the public',
+    '  default values from deploy/ will be deployed into your AWS account:',
+    '',
+    ...insecureDefaultMatches.map((m) => `    • ${m.pulumiKey}  —  ${m.description}`),
+    '',
+    '  These values are PUBLIC. Anyone who finds this deploy can read them.',
+    '',
+    '  Override each with:',
+    `    pulumi config set --secret <key> <value> -s ${stackName}`,
+    '',
+    '  Docs:',
+    `    ${INSECURE_DEFAULTS_DOCS_URL}`,
+    '',
+    '  Suppress this warning (DO NOT do this in production):',
+    '    pulumi config set dangerouslyAllowDefaultCreds true',
+  ]
+  const W = Math.max(78, ...innerLines.map((s) => s.length))
+  const pad = (s: string): string => s + ' '.repeat(Math.max(0, W - s.length))
+  const fmt = (s: string): string => `║ ${pad(s)} ║`
+  const top = `╔${'═'.repeat(W + 2)}╗`
+  const bot = `╚${'═'.repeat(W + 2)}╝`
+
+  pulumi.log.warn(['', top, ...innerLines.map(fmt), bot, ''].join('\n'))
   for (const m of insecureDefaultMatches) {
     pulumi.log.warn(`Insecure default in use: ${m.pulumiKey} (${m.description})`)
   }

--- a/deploy/pulumi/tsconfig.json
+++ b/deploy/pulumi/tsconfig.json
@@ -10,5 +10,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["index.ts", "src/**/*.ts", "../../shared/**/*.ts"]
+  "include": ["index.ts", "src/**/*.ts"]
 }

--- a/deploy/pulumi/tsconfig.json
+++ b/deploy/pulumi/tsconfig.json
@@ -10,5 +10,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["index.ts", "src/**/*.ts"]
+  "include": ["index.ts", "src/**/*.ts", "../../shared/**/*.ts"]
 }

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -2,6 +2,8 @@
 
 > ⚠️ Thunderbolt is currently undergoing a security audit and preparing for enterprise production readiness. The paths below are provided for evaluation and early testing — **not for production use yet**.
 
+> 🚨 **Read [Default Credentials](../../deploy/README.md#default-credentials) before deploying.** Every path here ships with public, well-known default values for database passwords, OIDC client secrets, JWT signing keys, and the Keycloak admin password. The stack will deploy and run with them — and warn loudly across multiple surfaces (Pulumi log, backend stderr, browser DevTools, frontend container logs) — but the only fix is to rotate them. The override commands per platform are in that section.
+
 Every self-hosted target uses the same stack: Elysia backend, Vite frontend, PostgreSQL, PowerSync, Keycloak (OIDC/SAML), and MongoDB (PowerSync's operational store). What changes is the orchestration layer.
 
 ## Which Option Should I Pick?
@@ -27,7 +29,7 @@ All three paths deploy the same opinionated enterprise configuration:
 | Frontend build args           | `VITE_AUTH_MODE=sso`, `VITE_THUNDERBOLT_CLOUD_URL=/v1`    |
 | Waitlist                      | Disabled                                                  |
 
-You're expected to replace the demo user, reconfigure the Keycloak client, and rotate all default credentials before anyone touches it.
+You're expected to replace the demo user, reconfigure the Keycloak client, and rotate all default credentials before anyone touches it. The full table of public-default values + per-platform override commands is in [`deploy/README.md`](../../deploy/README.md#default-credentials), and is the canonical source — every warning surface (Pulumi, backend, DevTools, container entrypoint) reads from the same machine-readable list at [`shared/insecure-defaults.ts`](../../shared/insecure-defaults.ts).
 
 ## What You'll Need
 

--- a/docs/self-hosting/configuration.md
+++ b/docs/self-hosting/configuration.md
@@ -10,6 +10,8 @@ cp backend/.env.example backend/.env
 
 Variables marked **required** must be set before the backend will start.
 
+> 🚨 If any of `BETTER_AUTH_SECRET`, `OIDC_CLIENT_SECRET`, `POWERSYNC_JWT_SECRET`, `POSTGRES_PASSWORD`, `POWERSYNC_DB_PASSWORD`, or `KC_BOOTSTRAP_ADMIN_PASSWORD` matches its public default from `deploy/`, the backend logs a red banner on stderr at startup and the public `/v1/api/config` endpoint returns the affected env-var names — which the frontend surfaces in the browser DevTools console. The full table of defaults and rotation commands is in [`deploy/README.md`](../../deploy/README.md#default-credentials). Suppress all of these with `DANGEROUSLY_ALLOW_DEFAULT_CREDS=true` for short eval runs only.
+
 ## Authentication
 
 | Variable                  | Default                    | Required | Description                                                                                 |

--- a/docs/self-hosting/docker-compose.md
+++ b/docs/self-hosting/docker-compose.md
@@ -2,6 +2,8 @@
 
 The Docker Compose stack is the fastest path to a working Thunderbolt install. It's well suited to demos, evaluations, and single-host internal tools.
 
+> 🚨 The compose file ships with **public default values** for `BETTER_AUTH_SECRET`, `OIDC_CLIENT_SECRET`, `POWERSYNC_JWT_SECRET`, the Postgres and PowerSync DB passwords, and the Keycloak admin password. `docker compose up` works without overriding them, but the backend, the browser DevTools console, and the frontend container will all warn until you do. See [Default Credentials](../../deploy/README.md#default-credentials) for the override recipe (a one-liner that puts random values into `deploy/.env`).
+
 ## Prerequisites
 
 - Docker 24+ with the Compose plugin (`docker compose version` must succeed)

--- a/docs/self-hosting/kubernetes.md
+++ b/docs/self-hosting/kubernetes.md
@@ -2,6 +2,8 @@
 
 The Kubernetes manifests at `deploy/k8s/` deploy the full Thunderbolt stack — frontend, backend, PostgreSQL, MongoDB, Keycloak, and PowerSync — onto any conformant cluster.
 
+> 🚨 The Helm chart's `values.yaml` ships with **public default values** for every secret (Postgres password, PowerSync JWT, OIDC client secret, Keycloak admin password). The chart will install with them, but they're known and listed in this repository. See [Default Credentials](../../deploy/README.md#default-credentials) for the override commands (`helm install --set ...`) and the canonical list at [`shared/insecure-defaults.ts`](../../shared/insecure-defaults.ts).
+
 ## Local Clusters
 
 Any local Kubernetes works. Pick one:

--- a/docs/self-hosting/pulumi.md
+++ b/docs/self-hosting/pulumi.md
@@ -2,6 +2,8 @@
 
 The Pulumi project at `deploy/pulumi/` provisions the full Thunderbolt stack on AWS. One config key (`platform`) chooses between ECS Fargate and EKS; both paths share the same VPC, ECR repositories, and secrets.
 
+> 🚨 If you `pulumi up` without overriding the secret config keys, the stack deploys with **public default values** baked into AWS Secrets Manager. The deploy still succeeds (with a yellow warning per default detected), but anyone who finds the deployment can read the same credentials in this repository. See [Default Credentials](../../deploy/README.md#default-credentials) for the full list of `pulumi config set --secret` commands you should run before your first `pulumi up`. After the deploy, `pulumi stack output securityWarnings` should be `[]` — anything else means a credential is still on its default.
+
 ## Platforms
 
 | `platform` value | What it creates                                                | Best for                                          |

--- a/shared/insecure-defaults.ts
+++ b/shared/insecure-defaults.ts
@@ -1,0 +1,191 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Canonical list of well-known default credentials baked into the Thunderbolt
+ * deployment scaffolding (Pulumi, Helm, docker-compose, Keycloak realm).
+ *
+ * If any of these match a deployed value, the deployer almost certainly forgot
+ * to override the default. Every layer that has access to live values
+ * (Pulumi at deploy time, backend at startup, the /v1/api/config endpoint,
+ * frontend on init, container entrypoints) consults this list and emits a
+ * loud warning.
+ *
+ * Override behavior is suppressible via the `DANGEROUSLY_ALLOW_DEFAULT_CREDS`
+ * env var (or `dangerouslyAllowDefaultCreds` Pulumi config) — intended only
+ * for short-lived evaluation environments where defaults are accepted on
+ * purpose.
+ */
+
+export type InsecureDefault = {
+  /** Backend env var name. */
+  envKey: string
+  /** Pulumi config key (camelCase) used in deploy/pulumi/index.ts. */
+  pulumiKey: string
+  /** The literal sentinel value baked into deploy/ scaffolding. */
+  defaultValue: string
+  /** Human-readable description of what this credential protects. */
+  description: string
+}
+
+export const INSECURE_DEFAULTS: readonly InsecureDefault[] = [
+  {
+    envKey: 'POSTGRES_PASSWORD',
+    pulumiKey: 'postgresPassword',
+    defaultValue: 'postgres',
+    description: 'PostgreSQL admin password',
+  },
+  {
+    envKey: 'KC_BOOTSTRAP_ADMIN_PASSWORD',
+    pulumiKey: 'keycloakAdminPassword',
+    defaultValue: 'admin',
+    description: 'Keycloak admin console password',
+  },
+  {
+    envKey: 'OIDC_CLIENT_SECRET',
+    pulumiKey: 'oidcClientSecret',
+    defaultValue: 'thunderbolt-enterprise-secret',
+    description: 'OIDC client secret (also baked into deploy/config/keycloak-realm.json)',
+  },
+  {
+    envKey: 'POWERSYNC_JWT_SECRET',
+    pulumiKey: 'powersyncJwtSecret',
+    defaultValue: 'enterprise-thunderbolt-powersync-jwt-default-secret',
+    description: 'PowerSync JWT signing secret',
+  },
+  {
+    envKey: 'BETTER_AUTH_SECRET',
+    pulumiKey: 'betterAuthSecret',
+    defaultValue: 'enterprise-thunderbolt-better-auth-default-secret',
+    description: 'Better Auth session signing secret',
+  },
+  {
+    envKey: 'POWERSYNC_DB_PASSWORD',
+    pulumiKey: 'powersyncDbPassword',
+    defaultValue: 'myhighlyrandompassword',
+    description: 'PowerSync database role password',
+  },
+] as const
+
+/** Public docs anchor that warning surfaces should link to. */
+export const INSECURE_DEFAULTS_DOCS_URL =
+  'https://github.com/thunderbird/thunderbolt/blob/main/deploy/README.md#default-credentials'
+
+/**
+ * Returns true if the deployer has explicitly opted into running with
+ * default credentials via `DANGEROUSLY_ALLOW_DEFAULT_CREDS=true`. Any other
+ * spelling (including the typo-prone `DANGEROUS_*`) is intentionally NOT
+ * accepted — silently honoring a misspelled override means an operator
+ * thinks they suppressed warnings when they haven't.
+ */
+export const isInsecureDefaultsHushed = (env: Record<string, string | undefined>): boolean => {
+  const v = env.DANGEROUSLY_ALLOW_DEFAULT_CREDS
+  return !!v && v.toLowerCase() === 'true'
+}
+
+/**
+ * Detect which entries in INSECURE_DEFAULTS are currently live, given a
+ * resolver (e.g. an env-var lookup, or a Pulumi-config lookup). Returns an
+ * empty array when the deployer has hushed warnings via the env var.
+ *
+ * The resolver receives both the envKey and pulumiKey so callers can choose
+ * which one to consult based on their context.
+ */
+export const detectInsecureDefaults = (
+  resolve: (entry: InsecureDefault) => string | undefined,
+  env: Record<string, string | undefined> = {},
+): InsecureDefault[] => {
+  if (isInsecureDefaultsHushed(env)) {
+    return []
+  }
+  return INSECURE_DEFAULTS.filter((entry) => {
+    const value = resolve(entry)
+    return value !== undefined && value === entry.defaultValue
+  })
+}
+
+/**
+ * Render a multi-line ANSI-colored terminal banner. Used by backend startup
+ * logs and the frontend container entrypoint.
+ *
+ * Pass `useColor: false` for environments that don't support ANSI escapes
+ * (CI logs, files redirected from a TTY).
+ */
+export const renderTerminalBanner = (matches: InsecureDefault[], useColor = true): string => {
+  const RED_BG = useColor ? '\x1b[41m' : ''
+  const WHITE_BOLD = useColor ? '\x1b[1;37m' : ''
+  const YELLOW = useColor ? '\x1b[1;33m' : ''
+  const DIM = useColor ? '\x1b[2m' : ''
+  const RESET = useColor ? '\x1b[0m' : ''
+
+  const width = 78
+  const pad = (s: string): string => s + ' '.repeat(Math.max(0, width - s.length))
+  const line = (s: string): string => `${RED_BG}${WHITE_BOLD}║ ${pad(s)} ║${RESET}`
+  const top = `${RED_BG}${WHITE_BOLD}╔${'═'.repeat(width + 2)}╗${RESET}`
+  const bot = `${RED_BG}${WHITE_BOLD}╚${'═'.repeat(width + 2)}╝${RESET}`
+  const blank = line('')
+
+  const rows: string[] = [
+    '',
+    top,
+    blank,
+    line('  🚨🚨🚨   INSECURE DEFAULT CREDENTIALS DETECTED   🚨🚨🚨'),
+    blank,
+    line('  This Thunderbolt deployment is using well-known default values for:'),
+    blank,
+    ...matches.map((m) => line(`    • ${m.envKey}  —  ${m.description}`)),
+    blank,
+    line('  These values are public in the source tree. Anyone who knows the'),
+    line('  deployment exists can read them. Rotate before exposing this'),
+    line('  instance to the internet.'),
+    blank,
+    line('  Docs (override per platform):'),
+    line(`  ${INSECURE_DEFAULTS_DOCS_URL}`),
+    blank,
+    line(`  ${YELLOW}Suppress with: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true${RESET}${RED_BG}${WHITE_BOLD}`),
+    blank,
+    bot,
+    '',
+  ]
+
+  return rows.join('\n') + DIM + '' + RESET
+}
+
+/**
+ * A constant reminder banner (not detection-driven) for the frontend nginx
+ * container, where polling the backend at boot is fragile. Visible in
+ * `docker compose up` and `kubectl logs` regardless of whether defaults are
+ * actually in use. Suppressed by DANGEROUSLY_ALLOW_DEFAULT_CREDS.
+ */
+export const renderFrontendReminderBanner = (useColor = true): string => {
+  const YELLOW_BG = useColor ? '\x1b[43m' : ''
+  const BLACK_BOLD = useColor ? '\x1b[1;30m' : ''
+  const RESET = useColor ? '\x1b[0m' : ''
+
+  const width = 78
+  const pad = (s: string): string => s + ' '.repeat(Math.max(0, width - s.length))
+  const line = (s: string): string => `${YELLOW_BG}${BLACK_BOLD}║ ${pad(s)} ║${RESET}`
+  const top = `${YELLOW_BG}${BLACK_BOLD}╔${'═'.repeat(width + 2)}╗${RESET}`
+  const bot = `${YELLOW_BG}${BLACK_BOLD}╚${'═'.repeat(width + 2)}╝${RESET}`
+  const blank = line('')
+
+  return [
+    '',
+    top,
+    blank,
+    line('  ⚠   Thunderbolt frontend started — security reminder'),
+    blank,
+    line('  If this is a fresh deployment, verify you have rotated all'),
+    line('  default credentials. The backend logs (and the browser DevTools'),
+    line('  console) will list any defaults still in use.'),
+    blank,
+    line('  Docs:'),
+    line(`  ${INSECURE_DEFAULTS_DOCS_URL}`),
+    blank,
+    line('  Suppress with: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true'),
+    blank,
+    bot,
+    '',
+  ].join('\n')
+}

--- a/shared/insecure-defaults.ts
+++ b/shared/insecure-defaults.ts
@@ -120,8 +120,12 @@ export const renderTerminalBanner = (matches: InsecureDefault[], useColor = true
   const RESET = useColor ? '\x1b[0m' : ''
 
   const width = 78
+  // Pad the plain visible text first, then wrap with color codes — ANSI escapes
+  // are zero-width visually but would otherwise inflate `s.length`, throwing
+  // off the right-hand `║` border alignment.
   const pad = (s: string): string => s + ' '.repeat(Math.max(0, width - s.length))
-  const line = (s: string): string => `${RED_BG}${WHITE_BOLD}║ ${pad(s)} ║${RESET}`
+  const line = (s: string, inner = `${RED_BG}${WHITE_BOLD}`): string =>
+    `${RED_BG}${WHITE_BOLD}║ ${inner}${pad(s)}${RESET}${RED_BG}${WHITE_BOLD} ║${RESET}`
   const top = `${RED_BG}${WHITE_BOLD}╔${'═'.repeat(width + 2)}╗${RESET}`
   const bot = `${RED_BG}${WHITE_BOLD}╚${'═'.repeat(width + 2)}╝${RESET}`
   const blank = line('')
@@ -143,49 +147,11 @@ export const renderTerminalBanner = (matches: InsecureDefault[], useColor = true
     line('  Docs (override per platform):'),
     line(`  ${INSECURE_DEFAULTS_DOCS_URL}`),
     blank,
-    line(`  ${YELLOW}Suppress with: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true${RESET}${RED_BG}${WHITE_BOLD}`),
+    line('  Suppress with: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true', `${YELLOW}`),
     blank,
     bot,
     '',
   ]
 
   return rows.join('\n') + DIM + '' + RESET
-}
-
-/**
- * A constant reminder banner (not detection-driven) for the frontend nginx
- * container, where polling the backend at boot is fragile. Visible in
- * `docker compose up` and `kubectl logs` regardless of whether defaults are
- * actually in use. Suppressed by DANGEROUSLY_ALLOW_DEFAULT_CREDS.
- */
-export const renderFrontendReminderBanner = (useColor = true): string => {
-  const YELLOW_BG = useColor ? '\x1b[43m' : ''
-  const BLACK_BOLD = useColor ? '\x1b[1;30m' : ''
-  const RESET = useColor ? '\x1b[0m' : ''
-
-  const width = 78
-  const pad = (s: string): string => s + ' '.repeat(Math.max(0, width - s.length))
-  const line = (s: string): string => `${YELLOW_BG}${BLACK_BOLD}║ ${pad(s)} ║${RESET}`
-  const top = `${YELLOW_BG}${BLACK_BOLD}╔${'═'.repeat(width + 2)}╗${RESET}`
-  const bot = `${YELLOW_BG}${BLACK_BOLD}╚${'═'.repeat(width + 2)}╝${RESET}`
-  const blank = line('')
-
-  return [
-    '',
-    top,
-    blank,
-    line('  ⚠   Thunderbolt frontend started — security reminder'),
-    blank,
-    line('  If this is a fresh deployment, verify you have rotated all'),
-    line('  default credentials. The backend logs (and the browser DevTools'),
-    line('  console) will list any defaults still in use.'),
-    blank,
-    line('  Docs:'),
-    line(`  ${INSECURE_DEFAULTS_DOCS_URL}`),
-    blank,
-    line('  Suppress with: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true'),
-    blank,
-    bot,
-    '',
-  ].join('\n')
 }

--- a/shared/insecure-defaults.ts
+++ b/shared/insecure-defaults.ts
@@ -116,42 +116,42 @@ export const renderTerminalBanner = (matches: InsecureDefault[], useColor = true
   const RED_BG = useColor ? '\x1b[41m' : ''
   const WHITE_BOLD = useColor ? '\x1b[1;37m' : ''
   const YELLOW = useColor ? '\x1b[1;33m' : ''
-  const DIM = useColor ? '\x1b[2m' : ''
   const RESET = useColor ? '\x1b[0m' : ''
 
-  const width = 78
+  // Inner content lines (no padding, no borders, no color). Build the list
+  // first so we can size the box to the longest line — the docs URL is ~89
+  // chars and would otherwise overflow the right-hand `║` border.
+  const innerLines: string[] = [
+    '',
+    '  🚨🚨🚨   INSECURE DEFAULT CREDENTIALS DETECTED   🚨🚨🚨',
+    '',
+    '  This Thunderbolt deployment is using well-known default values for:',
+    '',
+    ...matches.map((m) => `    • ${m.envKey}  —  ${m.description}`),
+    '',
+    '  These values are public in the source tree. Anyone who knows the',
+    '  deployment exists can read them. Rotate before exposing this',
+    '  instance to the internet.',
+    '',
+    '  Docs (override per platform):',
+    `  ${INSECURE_DEFAULTS_DOCS_URL}`,
+    '',
+    '  Suppress with: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true',
+    '',
+  ]
+  const width = Math.max(78, ...innerLines.map((s) => s.length))
+
   // Pad the plain visible text first, then wrap with color codes — ANSI escapes
   // are zero-width visually but would otherwise inflate `s.length`, throwing
   // off the right-hand `║` border alignment.
   const pad = (s: string): string => s + ' '.repeat(Math.max(0, width - s.length))
-  const line = (s: string, inner = `${RED_BG}${WHITE_BOLD}`): string =>
-    `${RED_BG}${WHITE_BOLD}║ ${inner}${pad(s)}${RESET}${RED_BG}${WHITE_BOLD} ║${RESET}`
+  const isHushHint = (s: string): boolean => s.startsWith('  Suppress with:')
+  const line = (s: string): string => {
+    const inner = isHushHint(s) ? YELLOW : `${RED_BG}${WHITE_BOLD}`
+    return `${RED_BG}${WHITE_BOLD}║ ${inner}${pad(s)}${RESET}${RED_BG}${WHITE_BOLD} ║${RESET}`
+  }
   const top = `${RED_BG}${WHITE_BOLD}╔${'═'.repeat(width + 2)}╗${RESET}`
   const bot = `${RED_BG}${WHITE_BOLD}╚${'═'.repeat(width + 2)}╝${RESET}`
-  const blank = line('')
 
-  const rows: string[] = [
-    '',
-    top,
-    blank,
-    line('  🚨🚨🚨   INSECURE DEFAULT CREDENTIALS DETECTED   🚨🚨🚨'),
-    blank,
-    line('  This Thunderbolt deployment is using well-known default values for:'),
-    blank,
-    ...matches.map((m) => line(`    • ${m.envKey}  —  ${m.description}`)),
-    blank,
-    line('  These values are public in the source tree. Anyone who knows the'),
-    line('  deployment exists can read them. Rotate before exposing this'),
-    line('  instance to the internet.'),
-    blank,
-    line('  Docs (override per platform):'),
-    line(`  ${INSECURE_DEFAULTS_DOCS_URL}`),
-    blank,
-    line('  Suppress with: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true', `${YELLOW}`),
-    blank,
-    bot,
-    '',
-  ]
-
-  return rows.join('\n') + DIM + '' + RESET
+  return ['', top, ...innerLines.map(line), bot, ''].join('\n')
 }

--- a/src/api/config-store.ts
+++ b/src/api/config-store.ts
@@ -7,6 +7,12 @@ import { persist } from 'zustand/middleware'
 
 export type AppConfig = {
   e2eeEnabled?: boolean
+  /**
+   * Env-var names of well-known default credentials currently in use on
+   * the backend. Empty/absent when secure. Surfaced in DevTools as a loud
+   * `console.error` — values are never sent over the wire, only names.
+   */
+  securityWarnings?: string[]
 }
 
 type ConfigStore = {

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { INSECURE_DEFAULTS_DOCS_URL } from '@shared/insecure-defaults'
 import { createClient, type HttpClient } from '@/lib/http'
 import { useConfigStore, type AppConfig } from './config-store'
 
@@ -15,9 +16,48 @@ export const fetchConfig = async (cloudUrl: string, httpClient?: HttpClient): Pr
     const client = httpClient ?? createClient({ prefixUrl: cloudUrl })
     const config = await client.get('config', { timeout: 5_000 }).json<AppConfig>()
     useConfigStore.getState().updateConfig(config)
+    logSecurityWarningsToConsole(config.securityWarnings)
     return config
   } catch {
     console.warn('Failed to fetch app config, using cached value')
     return null
   }
+}
+
+/**
+ * Surface backend-detected default credentials in the browser DevTools
+ * console as a loud, banner-styled `console.error`. Anyone who opens
+ * DevTools — security auditors, QA, customer engineers, curious users —
+ * will see it on the first load and the error counts toward the DevTools
+ * error badge in the toolbar.
+ *
+ * Never logs the credential *values* — just the env-var names the backend
+ * reported. Suppressed when the backend has been told to hush warnings via
+ * `DANGEROUSLY_ALLOW_DEFAULT_CREDS=true` (the backend will return an empty
+ * `securityWarnings` array in that case, so this is a no-op).
+ */
+const logSecurityWarningsToConsole = (warnings: string[] | undefined): void => {
+  if (!warnings || warnings.length === 0) {
+    return
+  }
+  const list = warnings.map((k) => `  • ${k}`).join('\n')
+  console.error(
+    `%c⚠  INSECURE DEFAULT CREDENTIALS DETECTED  ⚠%c\n\n` +
+      `%cThis Thunderbolt deployment is using well-known default values for:%c\n` +
+      `${list}\n\n` +
+      `%cThese values are public in the source tree. Anyone can read them.\n` +
+      `Rotate before exposing this instance to the internet.%c\n\n` +
+      `%cDocs:%c ${INSECURE_DEFAULTS_DOCS_URL}\n\n` +
+      `%cSuppress this warning (do not do this in production):%c DANGEROUSLY_ALLOW_DEFAULT_CREDS=true`,
+    'background:#b00020;color:#fff;font-size:18px;font-weight:bold;padding:12px 16px;letter-spacing:1px;',
+    '',
+    'color:#b00020;font-size:14px;font-weight:bold;',
+    '',
+    'color:#b00020;font-size:13px;',
+    '',
+    'color:#444;font-weight:bold;',
+    'color:#444;',
+    'color:#888;font-size:12px;',
+    'color:#888;font-size:12px;font-family:monospace;',
+  )
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,9 +9,67 @@ import react from '@vitejs/plugin-react'
 import { execSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import { analyzer } from 'vite-bundle-analyzer'
 const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Print a yellow security-reminder banner once when the dev server starts.
+ * Constant (not detection-driven) — the actual detection happens in the
+ * browser DevTools console once the SPA fetches /v1/api/config from the
+ * backend. This banner just makes sure the dev who ran `bun run dev` is
+ * aware before they get to that point. Suppressed with
+ * DANGEROUSLY_ALLOW_DEFAULT_CREDS=true.
+ *
+ * The canonical list of defaults + override commands lives at
+ * deploy/README.md#default-credentials and shared/insecure-defaults.ts.
+ * The banner here is intentionally self-contained (no cross-project
+ * import) so vite.config.ts stays in the Node tsconfig project without
+ * pulling shared/ across the project-reference boundary.
+ */
+const DOCS_URL = 'https://github.com/thunderbird/thunderbolt/blob/main/deploy/README.md#default-credentials'
+const insecureDefaultsReminderPlugin = (): Plugin => ({
+  name: 'thunderbolt-insecure-defaults-reminder',
+  apply: 'serve',
+  configureServer(server) {
+    if (process.env.DANGEROUSLY_ALLOW_DEFAULT_CREDS?.toLowerCase() === 'true') return
+    server.httpServer?.once('listening', () => {
+      const useColor = Boolean(process.stdout.isTTY)
+      const Y = useColor ? '\x1b[43;1;30m' : ''
+      const R = useColor ? '\x1b[0m' : ''
+      const W = 78
+      const pad = (s: string): string => s + ' '.repeat(Math.max(0, W - s.length))
+      const line = (s: string): string => `${Y}║ ${pad(s)} ║${R}`
+      const out =
+        '\n' +
+        `${Y}╔${'═'.repeat(W + 2)}╗${R}\n` +
+        line('') +
+        '\n' +
+        line('  ⚠   Thunderbolt frontend dev server — security reminder') +
+        '\n' +
+        line('') +
+        '\n' +
+        line('  If your backend is using default credentials, the browser') +
+        '\n' +
+        line('  DevTools console will print a red banner naming each one.') +
+        '\n' +
+        line('  Rotate them before pointing this at a real deployment.') +
+        '\n' +
+        line('') +
+        '\n' +
+        line(`  ${DOCS_URL}`) +
+        '\n' +
+        line('') +
+        '\n' +
+        line('  Suppress: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true') +
+        '\n' +
+        line('') +
+        '\n' +
+        `${Y}╚${'═'.repeat(W + 2)}╝${R}\n\n`
+      process.stdout.write(out)
+    })
+  },
+})
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 const host = process.env.TAURI_DEV_HOST
@@ -44,6 +102,7 @@ export default defineConfig({
     },
     tailwindcss(),
     react(),
+    insecureDefaultsReminderPlugin(),
     // Include the bundle analyzer plugin only when explicitly requested.
     ...(shouldAnalyze
       ? [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,36 +37,27 @@ const insecureDefaultsReminderPlugin = (): Plugin => ({
       const useColor = Boolean(process.stdout.isTTY)
       const Y = useColor ? '\x1b[43;1;30m' : ''
       const R = useColor ? '\x1b[0m' : ''
-      const W = 78
+      // Build inner content first so width can grow to fit the longest line
+      // (the docs URL is ~89 chars and would otherwise overflow the right border).
+      const innerLines: string[] = [
+        '',
+        '  ⚠   Thunderbolt frontend dev server — security reminder',
+        '',
+        '  If your backend is using default credentials, the browser',
+        '  DevTools console will print a red banner naming each one.',
+        '  Rotate them before pointing this at a real deployment.',
+        '',
+        `  ${DOCS_URL}`,
+        '',
+        '  Suppress: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true',
+        '',
+      ]
+      const W = Math.max(78, ...innerLines.map((s) => s.length))
       const pad = (s: string): string => s + ' '.repeat(Math.max(0, W - s.length))
-      const line = (s: string): string => `${Y}║ ${pad(s)} ║${R}`
-      const out =
-        '\n' +
-        `${Y}╔${'═'.repeat(W + 2)}╗${R}\n` +
-        line('') +
-        '\n' +
-        line('  ⚠   Thunderbolt frontend dev server — security reminder') +
-        '\n' +
-        line('') +
-        '\n' +
-        line('  If your backend is using default credentials, the browser') +
-        '\n' +
-        line('  DevTools console will print a red banner naming each one.') +
-        '\n' +
-        line('  Rotate them before pointing this at a real deployment.') +
-        '\n' +
-        line('') +
-        '\n' +
-        line(`  ${DOCS_URL}`) +
-        '\n' +
-        line('') +
-        '\n' +
-        line('  Suppress: DANGEROUSLY_ALLOW_DEFAULT_CREDS=true') +
-        '\n' +
-        line('') +
-        '\n' +
-        `${Y}╚${'═'.repeat(W + 2)}╝${R}\n\n`
-      process.stdout.write(out)
+      const fmt = (s: string): string => `${Y}║ ${pad(s)} ║${R}`
+      const top = `${Y}╔${'═'.repeat(W + 2)}╗${R}`
+      const bot = `${Y}╚${'═'.repeat(W + 2)}╝${R}`
+      process.stdout.write(['', top, ...innerLines.map(fmt), bot, '', ''].join('\n'))
     })
   },
 })


### PR DESCRIPTION
… to acknowledge and skip warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new detection/reporting surfaces and changes the public `/config` response shape, which may affect clients and deployment tooling if assumptions or paths differ. Also tweaks nginx proxying and OIDC issuer settings, so misconfiguration could break routing/login in self-hosted setups.
> 
> **Overview**
> Adds **cross-stack warnings for insecure default credentials** backed by a new canonical list in `shared/insecure-defaults.ts`, with an opt-out via `DANGEROUSLY_ALLOW_DEFAULT_CREDS` (and Pulumi `dangerouslyAllowDefaultCreds`).
> 
> The backend now detects default secrets at startup (printing an ANSI banner + structured `WARN` logs) and exposes `securityWarnings` (env var names only) on `GET /config`, which the frontend logs as a prominent DevTools `console.error`; the Vite dev server and the frontend nginx container also print reminder banners.
> 
> Deployment scaffolding is updated to document/flag defaults and suppression (env examples + expanded `deploy/README.md`), Pulumi emits deploy-time warnings and exports `securityWarnings`, and self-hosting docs are updated accordingly; additionally adjusts nginx `proxy_pass` behavior and updates Keycloak redirect URI plus docker-compose OIDC issuer/host mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5565b1e4827c777948c26e55d3994aafbd186bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->