### PR TITLE
fix: remove invalid "//" entry from package.json overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",
@@ -135,7 +136,6 @@
     },
   },
   "overrides": {
-    "//": "Force semver >= 7 at top-level so storybook can resolve semver/functions/sort.js. Without this, bun hoists semver@6 (pulled by babel/eslint-plugin-react) and storybook breaks at vite config load.",
     "semver": "^7.7.3",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "vitest": "^4.1.4"
   },
   "overrides": {
-    "//": "Force semver >= 7 at top-level so storybook can resolve semver/functions/sort.js. Without this, bun hoists semver@6 (pulled by babel/eslint-plugin-react) and storybook breaks at vite config load.",
     "semver": "^7.7.3"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: dependency override behavior is unchanged (still pins `semver`), with only JSON/lockfile cleanup that may slightly affect install determinism.
> 
> **Overview**
> Cleans up dependency overrides by removing the invalid `"//"` key from `package.json` `overrides` while keeping the `semver` pin.
> 
> Updates `bun.lock` to match, including dropping the same entry and recording the current lockfile metadata (`configVersion`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d3a8547853ca097655df36c95bbd0fe3f9333e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->