### PR TITLE
chore: rename preview cleanup opt-out label to `preview:persist`

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -7,7 +7,7 @@ name: Preview Cleanup
 #   - PRs force-closed outside the normal flow (e.g. repo transfer, API delete)
 #   - Long-forgotten open PRs whose authors went on vacation
 #
-# Add the `persist` label to a PR to opt its preview stack out of cleanup.
+# Add the `preview:persist` label to a PR to opt its preview stack out of cleanup.
 # Useful for long-lived demo/QA stacks tied to a specific PR.
 #
 # `workflow_dispatch` supports a `dry_run` input for operators to preview what
@@ -104,13 +104,13 @@ jobs:
 
             STATE=$(jq -r '.state' <<< "$PR_JSON")
             UPDATED=$(jq -r '.updated_at' <<< "$PR_JSON")
-            HAS_PERSIST=$(jq -r '.labels // [] | map(.name) | index("persist") // empty' <<< "$PR_JSON")
+            HAS_PERSIST=$(jq -r '.labels // [] | map(.name) | index("preview:persist") // empty' <<< "$PR_JSON")
 
-            # Persist label — opt-out of cleanup regardless of state/staleness.
-            # Useful for demo/QA stacks tied to a specific PR that the team
-            # wants kept alive past the normal teardown window.
+            # `preview:persist` label — opt-out of cleanup regardless of
+            # state/staleness. Useful for demo/QA stacks tied to a specific PR
+            # that the team wants kept alive past the normal teardown window.
             if [ -n "$HAS_PERSIST" ]; then
-              echo "  PR #${PR_NUM} has 'persist' label → keep"
+              echo "  PR #${PR_NUM} has 'preview:persist' label → keep"
               continue
             fi
 


### PR DESCRIPTION
- Namespaced label avoids collisions with other repo-wide uses of "persist"
- Matches the convention used by other preview-stack labels

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only renames the PR label checked by the preview cleanup workflow, which may cause unintended stack deletion if the new label isn’t applied consistently.
> 
> **Overview**
> Updates the `preview-cleanup.yml` GitHub Actions workflow to use a namespaced opt-out label, switching the cleanup exemption from `persist` to `preview:persist` (including the `jq` label lookup and log/comments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e121bd1324a4d40daad51a7ca830a6df3a546ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->