### PR TITLE
THU-477: Reflect telemetry configuration in UI

### DIFF
--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -10,7 +10,7 @@ import { createClient } from '@/lib/http'
 import type { HandleError, HandleResult } from '@/types/handle-errors'
 import posthog, { type PostHog } from 'posthog-js'
 import { PostHogProvider as PostHogReactProvider } from 'posthog-js/react'
-import type { ReactNode } from 'react'
+import { createContext, useContext, type ReactNode } from 'react'
 
 let posthogClient: PostHog | null = null
 
@@ -120,11 +120,21 @@ export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult
   }
 }
 
+const TelemetryAvailableContext = createContext(false)
+
+/**
+ * Whether telemetry is actually wired up (i.e. a PostHog client was successfully initialized
+ * because the backend supplied a public API key). Self-hosted deployments without a configured
+ * key return false here regardless of the user's `data_collection` consent setting.
+ */
+export const useTelemetryAvailable = () => useContext(TelemetryAvailableContext)
+
 /**
  * PostHog Provider component for React
  */
 export const PostHogProvider = ({ children, client }: { children: ReactNode; client: PostHog | null }) => {
-  return client ? <PostHogReactProvider client={client}>{children}</PostHogReactProvider> : children
+  const inner = client ? <PostHogReactProvider client={client}>{children}</PostHogReactProvider> : children
+  return <TelemetryAvailableContext.Provider value={!!client}>{inner}</TelemetryAvailableContext.Provider>
 }
 
 export type EventType =

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -11,7 +11,7 @@ import { useUnitsOptions } from '@/hooks/use-units-options'
 import { privacyPolicyUrl } from '@/lib/constants'
 import { extractCountryFromLocation } from '@/lib/country-utils'
 import { clearLocalData } from '@/lib/cleanup'
-import { trackEvent } from '@/lib/posthog'
+import { trackEvent, useTelemetryAvailable } from '@/lib/posthog'
 import type { CountryUnitsData } from '@/types'
 import { useHttpClient } from '@/contexts'
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
@@ -96,6 +96,7 @@ export default function PreferencesSettingsPage() {
   const telemetryWarningModalRef = useRef<TelemetryWarningModalRef>(null)
 
   const postHog = usePostHog()
+  const telemetryAvailable = useTelemetryAvailable()
 
   const httpClient = useHttpClient()
   const { syncEnabled, syncSetupOpen, setSyncSetupOpen, handleSyncToggle, handleSyncSetupComplete } =
@@ -198,7 +199,9 @@ export default function PreferencesSettingsPage() {
   }
 
   const handleExperimentalFeaturesToggle = async (value: boolean) => {
-    if (value && !dataCollection.value) {
+    // Only require telemetry consent when telemetry is actually wired up.
+    // On self-hosted deployments without a PostHog key, this gate would be impossible to satisfy.
+    if (value && telemetryAvailable && !dataCollection.value) {
       telemetryRequiredModalRef.current?.open('experimentalFeatureTasks')
       return
     }
@@ -616,7 +619,7 @@ export default function PreferencesSettingsPage() {
           <div className="h-px bg-border -mx-6" />
 
           <div className="flex-row flex items-center gap-4">
-            <div>
+            <div className="flex-1">
               <div className="mb-2">
                 <ModificationIndicator
                   as="label"
@@ -627,16 +630,30 @@ export default function PreferencesSettingsPage() {
                   Anonymous Usage Data
                 </ModificationIndicator>
               </div>
-              <p className="text-sm text-muted-foreground">
-                Help us improve the app by sending anonymous usage info such as crashes, performance, and usage. Read
-                more about our{' '}
-                <a className="text-primary underline-offset-4 hover:underline" href={privacyPolicyUrl} target="_blank">
-                  privacy policy
-                </a>
-                .
-              </p>
+              {telemetryAvailable ? (
+                <p className="text-sm text-muted-foreground">
+                  Help us improve the app by sending anonymous usage info such as crashes, performance, and usage. Read
+                  more about our{' '}
+                  <a
+                    className="text-primary underline-offset-4 hover:underline"
+                    href={privacyPolicyUrl}
+                    target="_blank"
+                  >
+                    privacy policy
+                  </a>
+                  .
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Telemetry isn't configured for this organization, so no usage data is being collected.
+                </p>
+              )}
             </div>
-            <Switch checked={dataCollection.value} onCheckedChange={handleDataCollectionToggle} />
+            <Switch
+              checked={telemetryAvailable && dataCollection.value}
+              onCheckedChange={handleDataCollectionToggle}
+              disabled={!telemetryAvailable}
+            />
           </div>
         </div>
       </SectionCard>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that gates telemetry-related toggles on whether a PostHog client is actually configured; minor behavior changes could affect users on self-hosted deployments.
> 
> **Overview**
> Adds a `TelemetryAvailableContext` (via `useTelemetryAvailable`) to indicate whether a PostHog client was successfully initialized, and wires it through `PostHogProvider`.
> 
> Updates the Preferences telemetry section to **reflect actual telemetry availability**: disables the “Anonymous Usage Data” switch and shows a message when telemetry isn’t configured, and only requires telemetry consent for enabling preview features when telemetry is available (avoiding an unsatisfiable gate on self-hosted installs without a PostHog key).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01d9907157407110157738523c7b4b43ad043ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->