### PR TITLE
refactor: always use appUrl for magic link verify URL

### DIFF
--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -25,7 +25,7 @@ import { bearer, emailOTP } from 'better-auth/plugins'
 import { sso } from '@better-auth/sso'
 import { isAutoApprovedDomain, sendWaitlistJoinedEmail, sendWaitlistNotReadyEmail } from '@/waitlist/utils'
 import { challengeTokenHeader, otpExpiryMs, otpExpirySeconds } from './otp-constants'
-import { buildVerifyUrl, getValidatedOrigin, parseTrustedOrigins, sendSignInEmail } from './utils'
+import { buildVerifyUrl, parseTrustedOrigins, sendSignInEmail } from './utils'
 
 const OTP_SIGN_IN_PATH = '/sign-in/email-otp'
 
@@ -292,7 +292,6 @@ export const createAuth = (database: typeof DbType) => {
             }
           }
 
-          const origin = getValidatedOrigin(trustedOrigins, ctx?.request)
           // First-writer-wins: reuses existing challenge if /waitlist/join already
           // created one, or creates on-demand for Better Auth's native send-OTP endpoint.
           const challengeToken = await getOrCreateOtpChallenge(database, {
@@ -301,7 +300,7 @@ export const createAuth = (database: typeof DbType) => {
             challengeToken: crypto.randomUUID(),
             expiresAt: new Date(Date.now() + otpExpiryMs),
           })
-          const verifyUrl = buildVerifyUrl(origin, normalizedEmail, otp, ctx?.request, challengeToken)
+          const verifyUrl = buildVerifyUrl(settings.appUrl, normalizedEmail, otp, challengeToken)
 
           await sendSignInEmail({ email: normalizedEmail, otp, verifyUrl })
         },

--- a/backend/src/auth/utils.test.ts
+++ b/backend/src/auth/utils.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'bun:test'
-import { buildVerifyUrl, getValidatedOrigin, isDeepLinkPlatform, parseTrustedOrigins } from './utils'
+import { buildVerifyUrl, parseTrustedOrigins } from './utils'
 
 describe('parseTrustedOrigins', () => {
   it('parses comma-separated origins and adds tauri origin', () => {
@@ -37,129 +37,26 @@ describe('parseTrustedOrigins', () => {
   })
 })
 
-describe('getValidatedOrigin', () => {
-  const trustedOrigins = ['http://localhost:1420', 'https://app.example.com']
-
-  it('returns origin from request if trusted', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { origin: 'https://app.example.com' },
-    })
-    const result = getValidatedOrigin(trustedOrigins, request)
-    expect(result).toBe('https://app.example.com')
-  })
-
-  it('returns first trusted origin if request origin is not trusted', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { origin: 'https://malicious.com' },
-    })
-    const result = getValidatedOrigin(trustedOrigins, request)
-    expect(result).toBe('http://localhost:1420')
-  })
-
-  it('returns first trusted origin if request has no origin header', () => {
-    const request = new Request('https://api.example.com')
-    const result = getValidatedOrigin(trustedOrigins, request)
-    expect(result).toBe('http://localhost:1420')
-  })
-
-  it('returns first trusted origin if request is undefined', () => {
-    const result = getValidatedOrigin(trustedOrigins, undefined)
-    expect(result).toBe('http://localhost:1420')
-  })
-
-  it('handles empty string origin header', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { origin: '' },
-    })
-    const result = getValidatedOrigin(trustedOrigins, request)
-    expect(result).toBe('http://localhost:1420')
-  })
-})
-
-describe('isDeepLinkPlatform', () => {
-  it('returns true for iOS platform', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { 'x-client-platform': 'ios' },
-    })
-    expect(isDeepLinkPlatform(request)).toBe(true)
-  })
-
-  it('returns true for Android platform', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { 'x-client-platform': 'android' },
-    })
-    expect(isDeepLinkPlatform(request)).toBe(true)
-  })
-
-  it('returns false for web platform', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { 'x-client-platform': 'web' },
-    })
-    expect(isDeepLinkPlatform(request)).toBe(false)
-  })
-
-  it('returns false for desktop platforms', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { 'x-client-platform': 'macos' },
-    })
-    expect(isDeepLinkPlatform(request)).toBe(false)
-  })
-
-  it('returns false when request is undefined', () => {
-    expect(isDeepLinkPlatform(undefined)).toBe(false)
-  })
-
-  it('returns false when platform header is missing', () => {
-    const request = new Request('https://api.example.com')
-    expect(isDeepLinkPlatform(request)).toBe(false)
-  })
-})
-
 describe('buildVerifyUrl', () => {
-  it('builds URL with email and otp for non-mobile platforms', () => {
-    const result = buildVerifyUrl('https://app.example.com', 'user@example.com', '123456')
-    expect(result).toBe('https://app.example.com/auth/verify?email=user%40example.com&otp=123456')
+  it('builds URL using the provided app URL', () => {
+    const result = buildVerifyUrl('https://app.thunderbolt.io', 'user@example.com', '12345678')
+    expect(result).toBe('https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=12345678')
   })
 
-  it('uses deep link URL for iOS platform', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { 'x-client-platform': 'ios' },
-    })
-    const result = buildVerifyUrl('https://app.example.com', 'user@example.com', '123456', request)
-    expect(result).toBe('https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=123456')
-  })
-
-  it('uses deep link URL for Android platform', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { 'x-client-platform': 'android' },
-    })
-    const result = buildVerifyUrl('https://app.example.com', 'user@example.com', '123456', request)
-    expect(result).toBe('https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=123456')
-  })
-
-  it('uses origin URL for web platform', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { 'x-client-platform': 'web' },
-    })
-    const result = buildVerifyUrl('https://app.example.com', 'user@example.com', '123456', request)
-    expect(result).toBe('https://app.example.com/auth/verify?email=user%40example.com&otp=123456')
-  })
-
-  it('uses origin URL for desktop platform', () => {
-    const request = new Request('https://api.example.com', {
-      headers: { 'x-client-platform': 'macos' },
-    })
-    const result = buildVerifyUrl('https://app.example.com', 'user@example.com', '123456', request)
-    expect(result).toBe('https://app.example.com/auth/verify?email=user%40example.com&otp=123456')
+  it('appends challengeToken when provided', () => {
+    const result = buildVerifyUrl('https://app.thunderbolt.io', 'user@example.com', '12345678', 'abc-123-def')
+    expect(result).toBe(
+      'https://app.thunderbolt.io/auth/verify?email=user%40example.com&otp=12345678&challengeToken=abc-123-def',
+    )
   })
 
   it('encodes special characters in email', () => {
-    const result = buildVerifyUrl('https://app.example.com', 'user+tag@example.com', '123456')
-    expect(result).toBe('https://app.example.com/auth/verify?email=user%2Btag%40example.com&otp=123456')
+    const result = buildVerifyUrl('https://app.thunderbolt.io', 'user+tag@example.com', '12345678')
+    expect(result).toBe('https://app.thunderbolt.io/auth/verify?email=user%2Btag%40example.com&otp=12345678')
   })
 
-  it('handles localhost origin', () => {
-    const result = buildVerifyUrl('http://localhost:1420', 'user@example.com', '123456')
-    expect(result).toBe('http://localhost:1420/auth/verify?email=user%40example.com&otp=123456')
+  it('handles localhost dev URL', () => {
+    const result = buildVerifyUrl('http://localhost:1420', 'user@example.com', '12345678')
+    expect(result).toBe('http://localhost:1420/auth/verify?email=user%40example.com&otp=12345678')
   })
 })

--- a/backend/src/auth/utils.test.ts
+++ b/backend/src/auth/utils.test.ts
@@ -54,9 +54,4 @@ describe('buildVerifyUrl', () => {
     const result = buildVerifyUrl('https://app.thunderbolt.io', 'user+tag@example.com', '12345678')
     expect(result).toBe('https://app.thunderbolt.io/auth/verify?email=user%2Btag%40example.com&otp=12345678')
   })
-
-  it('handles localhost dev URL', () => {
-    const result = buildVerifyUrl('http://localhost:1420', 'user@example.com', '12345678')
-    expect(result).toBe('http://localhost:1420/auth/verify?email=user%40example.com&otp=12345678')
-  })
 })

--- a/backend/src/auth/utils.tsx
+++ b/backend/src/auth/utils.tsx
@@ -5,12 +5,6 @@
 import { sendEmail, shouldSkipEmail } from '@/lib/resend'
 import { MagicLinkEmail } from '@/emails/magic-link'
 
-/** Deep link base URL for mobile apps (iOS/Android) */
-const deepLinkHost = 'https://app.thunderbolt.io'
-
-/** Platforms that support deep linking */
-const deepLinkPlatforms = ['ios', 'android']
-
 /** Tauri app origin - always included for mobile/desktop app support */
 const tauriOrigin = 'tauri://localhost'
 
@@ -37,43 +31,16 @@ export const parseTrustedOrigins = (envValue?: string): string[] => {
 }
 
 /**
- * Check if the client platform supports deep linking
+ * Build a verify URL pointing to the SPA's `/auth/verify` route. The host is always
+ * the app URL — web users open it in the browser, and iOS/Android Universal Links /
+ * App Links route the same URL into the native app when installed.
  */
-export const isDeepLinkPlatform = (request?: Request): boolean => {
-  const platform = request?.headers.get('x-client-platform')
-  return platform ? deepLinkPlatforms.includes(platform) : false
-}
-
-/**
- * Validate and extract origin from request
- * Returns the origin if trusted, otherwise falls back to first trusted origin
- */
-export const getValidatedOrigin = (trustedOrigins: string[], request?: Request): string => {
-  const origin = request?.headers.get('origin')
-  if (origin && trustedOrigins.includes(origin)) {
-    return origin
-  }
-  return trustedOrigins[0]
-}
-
-/**
- * Build a verify URL that embeds the email and OTP
- * When clicked, the frontend auto-submits the OTP via the standard emailOtp sign-in endpoint
- * Uses deep link URL for mobile platforms so the link opens the app
- */
-export const buildVerifyUrl = (
-  origin: string,
-  email: string,
-  otp: string,
-  request?: Request,
-  challengeToken?: string,
-): string => {
-  const baseUrl = isDeepLinkPlatform(request) ? deepLinkHost : origin
+export const buildVerifyUrl = (appUrl: string, email: string, otp: string, challengeToken?: string): string => {
   const params = new URLSearchParams({ email, otp })
   if (challengeToken) {
     params.set('challengeToken', challengeToken)
   }
-  return `${baseUrl}/auth/verify?${params.toString()}`
+  return `${appUrl}/auth/verify?${params.toString()}`
 }
 
 type SendSignInEmailParams = {

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -243,6 +243,34 @@ describe('Config Settings', () => {
     })
   })
 
+  describe('appUrl normalization', () => {
+    let savedAppUrl: string | undefined
+
+    beforeEach(() => {
+      clearSettingsCache()
+      savedAppUrl = process.env.APP_URL
+    })
+
+    afterEach(() => {
+      clearSettingsCache()
+      if (savedAppUrl === undefined) {
+        delete process.env.APP_URL
+      } else {
+        process.env.APP_URL = savedAppUrl
+      }
+    })
+
+    it('strips a trailing slash from APP_URL', () => {
+      process.env.APP_URL = 'https://app.thunderbolt.io/'
+      expect(getSettings().appUrl).toBe('https://app.thunderbolt.io')
+    })
+
+    it('leaves APP_URL untouched when there is no trailing slash', () => {
+      process.env.APP_URL = 'https://app.thunderbolt.io'
+      expect(getSettings().appUrl).toBe('https://app.thunderbolt.io')
+    })
+  })
+
   describe('Rate limiting settings', () => {
     const RATE_LIMIT_ENV_KEYS = ['RATE_LIMIT_ENABLED', 'TRUSTED_PROXY'] as const
 

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -48,7 +48,10 @@ const settingsSchema = z
     // General settings
     logLevel: z.enum(['DEBUG', 'INFO', 'WARN', 'ERROR']).default('INFO'),
     port: z.coerce.number().default(8000),
-    appUrl: z.string().default('http://localhost:1420'),
+    appUrl: z
+      .string()
+      .default('http://localhost:1420')
+      .transform((s) => s.replace(/\/$/, '')),
 
     // Analytics settings
     posthogHost: z.string().default('https://us.i.posthog.com'),


### PR DESCRIPTION
- Drop origin validation and deep-link platform branching in buildVerifyUrl; the SPA host (settings.appUrl) is the single source of truth, with iOS/Android Universal Links / App Links handling native app routing.
- Remove getValidatedOrigin and isDeepLinkPlatform helpers along with their tests now that the URL no longer depends on request headers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches passwordless sign-in link generation; a misconfigured or incorrectly normalized `APP_URL` could break login or send users to the wrong host. Logic is simplified and covered by updated tests, but it still affects an auth-critical path.
> 
> **Overview**
> Magic-link verify URLs for email OTP sign-in are now always generated from `settings.appUrl` (SPA host), rather than deriving the host from request `Origin` or client platform headers.
> 
> This removes the `getValidatedOrigin`/`isDeepLinkPlatform` branching and associated tests, simplifies `buildVerifyUrl`’s signature, and adds settings normalization/tests to strip a trailing slash from `APP_URL` to avoid double-slash URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e195d436e0e4cf3f85d6e2cce5b32ca169ae170d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->