### PR TITLE
ci(THU-514): enforce PR title convention

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,48 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check legacy THU-XXX format
+        id: legacy
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ ^THU-[0-9]+:[[:space:]].+ ]]; then
+            echo "matches=true" >> "$GITHUB_OUTPUT"
+            echo "PR title uses legacy THU-XXX format; skipping Conventional Commits check."
+          else
+            echo "matches=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate Conventional Commits format
+        if: steps.legacy.outputs.matches != 'true'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            perf
+            test
+            ci
+            build
+            style
+          requireScope: false

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,32 @@ Our release process uses GitHub Actions to automate building and publishing rele
 - **Desktop**: Linux, macOS (Intel + Apple Silicon), Windows (x64 + ARM64)
 - **Mobile**: iOS (TestFlight), Android (Play Store Internal Track)
 
+## PR Title Convention
+
+PR titles are validated by `.github/workflows/lint-pr-title.yml` and drive automated changelog generation (since the repo uses squash-merge, the PR title becomes the commit on `main`).
+
+Two formats are accepted:
+
+**Conventional Commits** (preferred):
+
+```
+<type>[(<scope>)]: <description>
+
+feat(THU-58): add changelog automation
+fix: remove invalid header on mobile
+chore(deps): bump @tauri-apps/api to 2.11.0
+```
+
+Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `ci`, `build`, `style`.
+
+**Legacy `THU-XXX:` format** (accepted, prefer Conventional going forward):
+
+```
+THU-58: add changelog automation
+```
+
+Invalid titles (e.g. `random text`, missing type, missing description) fail the `Lint PR Title` check and block merge.
+
 ## Quick Start
 
 The easiest way to create a release is via GitHub Actions:


### PR DESCRIPTION
- Add Lint PR Title workflow accepting Conventional Commits or legacy THU-XXX format
- Document the convention in RELEASE.md so contributors know what's required
- Since main uses squash-merge, the PR title becomes the commit message and feeds future changelog automation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a GitHub Actions PR-title lint check and documentation only; it may block merges if titles don’t match the allowed patterns.
> 
> **Overview**
> Adds a new `Lint PR Title` GitHub Actions workflow that validates PR titles on open/edit/sync, accepting either Conventional Commits (with an allowed type list) or the legacy `THU-XXX:` pattern.
> 
> Updates `RELEASE.md` to document the required PR title formats and note that failing the check will block merges and is used for future changelog generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13aa6889c88624d96d2f0abfd5c19f318cdcabe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->