### PR TITLE
THU-507: Device ID standardization

### DIFF
--- a/src/api/encryption.test.ts
+++ b/src/api/encryption.test.ts
@@ -4,7 +4,8 @@
 
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
 import { type HttpClient } from '@/contexts'
-import { createClient } from '@/lib/http'
+import { getAuthToken } from '@/lib/auth-token'
+import { createAuthenticatedClient } from '@/lib/http'
 import { registerDevice, storeEnvelope, fetchMyEnvelope, fetchCanary } from './encryption'
 
 const deviceIdKey = 'thunderbolt_device_id'
@@ -41,7 +42,9 @@ const createCapturingHttpClient = (
   }
 
   return {
-    httpClient: createClient({ fetch: mockFetch as unknown as typeof fetch, prefixUrl: 'http://test-api.local' }),
+    httpClient: createAuthenticatedClient('http://test-api.local', getAuthToken, {
+      fetch: mockFetch as unknown as typeof fetch,
+    }),
     getLastRequest: () => lastRequest,
   }
 }
@@ -80,6 +83,7 @@ describe('encryption API client', () => {
       })
       expect(req.headers.get('authorization')).toBe('Bearer test-token')
       expect(req.headers.get('x-device-id')).toBe('test-device-id')
+      expect(req.headers.get('x-device-name')).toBeTruthy()
       expect(result).toEqual(mockResponse)
     })
 
@@ -144,6 +148,7 @@ describe('encryption API client', () => {
       expect(req.url).toContain('/devices/me/envelope')
       expect(req.method).toBe('GET')
       expect(req.headers.get('x-device-id')).toBe('test-device-id')
+      expect(req.headers.get('x-device-name')).toBeTruthy()
       expect(result).toEqual(mockResponse)
     })
   })
@@ -159,6 +164,8 @@ describe('encryption API client', () => {
       expect(req.url).toContain('/encryption/canary')
       expect(req.method).toBe('GET')
       expect(req.headers.get('authorization')).toBe('Bearer test-token')
+      expect(req.headers.get('x-device-id')).toBe('test-device-id')
+      expect(req.headers.get('x-device-name')).toBeTruthy()
       expect(result).toEqual(mockResponse)
     })
   })

--- a/src/api/encryption.ts
+++ b/src/api/encryption.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { type HttpClient } from '@/contexts'
-import { getAuthToken, getDeviceId } from '@/lib/auth-token'
 
 // =============================================================================
 // Response types (matching backend)
@@ -18,23 +17,6 @@ type FetchEnvelopeResponse = { trusted: boolean; wrappedCK: string }
 type FetchCanaryResponse = { canaryIv: string; canaryCtext: string }
 
 // =============================================================================
-// Auth headers helper
-// =============================================================================
-
-export const authHeaders = (): Record<string, string> => {
-  const headers: Record<string, string> = {}
-  const token = getAuthToken()
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`
-  }
-  const deviceId = getDeviceId()
-  if (deviceId) {
-    headers['X-Device-ID'] = deviceId
-  }
-  return headers
-}
-
-// =============================================================================
 // API functions
 // =============================================================================
 
@@ -42,13 +24,7 @@ export const authHeaders = (): Record<string, string> => {
 export const registerDevice = async (
   httpClient: HttpClient,
   params: { deviceId: string; publicKey: string; mlkemPublicKey: string; name?: string },
-): Promise<RegisterDeviceResponse> =>
-  httpClient
-    .post('devices', {
-      json: params,
-      headers: authHeaders(),
-    })
-    .json<RegisterDeviceResponse>()
+): Promise<RegisterDeviceResponse> => httpClient.post('devices', { json: params }).json<RegisterDeviceResponse>()
 
 /** Store a wrapped content key (envelope) for a device. Optionally includes canary on first setup or secret for recovery. */
 export const storeEnvelope = async (
@@ -57,60 +33,39 @@ export const storeEnvelope = async (
 ): Promise<StoreEnvelopeResponse> => {
   const { deviceId, ...body } = params
   return httpClient
-    .post(`devices/${encodeURIComponent(deviceId)}/envelope`, {
-      json: body,
-      headers: authHeaders(),
-    })
+    .post(`devices/${encodeURIComponent(deviceId)}/envelope`, { json: body })
     .json<StoreEnvelopeResponse>()
 }
 
 /** Fetch the wrapped content key for the current device. */
 export const fetchMyEnvelope = async (httpClient: HttpClient): Promise<FetchEnvelopeResponse> =>
-  httpClient
-    .get('devices/me/envelope', {
-      headers: authHeaders(),
-    })
-    .json<FetchEnvelopeResponse>()
+  httpClient.get('devices/me/envelope').json<FetchEnvelopeResponse>()
 
 /** Fetch the canary for recovery key verification. */
 export const fetchCanary = async (httpClient: HttpClient): Promise<FetchCanaryResponse> =>
-  httpClient
-    .get('encryption/canary', {
-      headers: authHeaders(),
-    })
-    .json<FetchCanaryResponse>()
+  httpClient.get('encryption/canary').json<FetchCanaryResponse>()
 
 /** Deny a pending device (called by a trusted device). Requires canary proof-of-CK-possession. */
 export const denyDevice = async (httpClient: HttpClient, deviceId: string, canarySecret: string): Promise<void> => {
-  await httpClient.post(`devices/${encodeURIComponent(deviceId)}/deny`, {
-    json: { canarySecret },
-    headers: authHeaders(),
-  })
+  await httpClient.post(`devices/${encodeURIComponent(deviceId)}/deny`, { json: { canarySecret } })
 }
 
 /** Revoke a device. Includes canary proof-of-CK-possession when E2EE is active. */
 export const revokeDevice = async (httpClient: HttpClient, deviceId: string, canarySecret?: string): Promise<void> => {
   await httpClient.post(`account/devices/${encodeURIComponent(deviceId)}/revoke`, {
     json: canarySecret ? { canarySecret } : {},
-    headers: authHeaders(),
   })
 }
 
 /** Cancel this device's pending approval state (called by the pending device itself). */
 export const cancelPending = async (httpClient: HttpClient): Promise<void> => {
-  await httpClient.post('devices/me/cancel-pending', {
-    headers: authHeaders(),
-  })
+  await httpClient.post('devices/me/cancel-pending')
 }
 
 /** Check if the user has encryption set up (canary exists on server). */
 export const checkCanaryExists = async (httpClient: HttpClient): Promise<boolean> => {
   try {
-    await httpClient
-      .get('encryption/canary', {
-        headers: authHeaders(),
-      })
-      .json()
+    await httpClient.get('encryption/canary').json()
     return true
   } catch (err) {
     if (err instanceof Error && 'response' in err) {

--- a/src/db/powersync/connector.test.ts
+++ b/src/db/powersync/connector.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { clearAuthToken, setAuthToken } from '@/lib/auth-token'
+import { clearAuthToken, clearDeviceId, setAuthToken } from '@/lib/auth-token'
 import { getClock } from '@/testing-library'
 import { act } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
@@ -118,6 +118,7 @@ describe('ThunderboltConnector', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
     window.dispatchEvent = dispatchSpy as unknown as typeof window.dispatchEvent
     clearAuthToken()
+    clearDeviceId()
   })
 
   afterEach(() => {
@@ -160,8 +161,12 @@ describe('ThunderboltConnector', () => {
       expiresAt: new Date(tokenData.expiresAt),
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url] = fetchMock.mock.calls[0] as [string]
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/powersync/token')
+    const headers = init.headers as Record<string, string>
+    expect(headers['Authorization']).toBe(`Bearer ${authToken}`)
+    expect(headers['X-Device-ID']).toBeTruthy()
+    expect(headers['X-Device-Name']).toBeTruthy()
   })
 
   it('fetchCredentials returns null and dispatches event when backend returns 410', async () => {

--- a/src/db/powersync/connector.ts
+++ b/src/db/powersync/connector.ts
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getDeviceId, getAuthToken } from '@/lib/auth-token'
+import { getAuthenticatedHeaders, getAuthToken } from '@/lib/auth-token'
 import { isSsoMode } from '@/lib/auth-mode'
-import { getDeviceDisplayName } from '@/lib/platform'
 import type { AbstractPowerSyncDatabase, PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web'
 import { encodeForUpload } from '@/db/encryption'
 import { sanitizeErrorForTracking, trackSyncEvent } from './sync-tracker'
@@ -65,23 +64,6 @@ export const handleCredentialsInvalidIfNeeded = (status: number, body: ErrorBody
 }
 
 /**
- * Build headers with Authorization Bearer token and device id/name if available.
- */
-const buildHeaders = (additionalHeaders?: Record<string, string>): Record<string, string> => {
-  const headers: Record<string, string> = { ...additionalHeaders }
-  const token = getAuthToken()
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`
-  }
-  const deviceId = getDeviceId()
-  if (deviceId) {
-    headers['X-Device-ID'] = deviceId
-    headers['X-Device-Name'] = getDeviceDisplayName()
-  }
-  return headers
-}
-
-/**
  * PowerSync connector that handles authentication and data upload.
  * - fetchCredentials: Gets JWT tokens from the backend (requires auth)
  * - uploadData: Sends local changes to the backend for persistence (requires auth)
@@ -102,7 +84,7 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
       }
 
       const response = await fetch(`${this.backendUrl}/powersync/token`, {
-        headers: buildHeaders(),
+        headers: getAuthenticatedHeaders(),
         credentials: ssoMode ? 'include' : undefined,
       })
 
@@ -174,7 +156,7 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
 
       const response = await fetch(`${this.backendUrl}/powersync/upload`, {
         method: 'PUT',
-        headers: { ...buildHeaders(), 'Content-Type': 'application/json' },
+        headers: { ...getAuthenticatedHeaders(), 'Content-Type': 'application/json' },
         body: JSON.stringify({ operations }),
         credentials: isSsoMode() ? 'include' : undefined,
       })

--- a/src/lib/auth-token.test.ts
+++ b/src/lib/auth-token.test.ts
@@ -3,7 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { beforeAll, beforeEach, describe, expect, it } from 'bun:test'
-import { clearAuthToken, getAuthToken, setAuthToken } from './auth-token'
+import {
+  clearAuthToken,
+  clearDeviceId,
+  getAuthenticatedHeaders,
+  getAuthToken,
+  getDeviceId,
+  setAuthToken,
+} from './auth-token'
 
 beforeAll(() => {
   if (typeof localStorage === 'undefined') {
@@ -25,6 +32,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   clearAuthToken()
+  clearDeviceId()
 })
 
 describe('auth-token', () => {
@@ -67,6 +75,36 @@ describe('auth-token', () => {
       expect(getAuthToken()).toBeNull()
       setAuthToken('other')
       expect(getAuthToken()).toBe('other')
+    })
+  })
+
+  describe('getAuthenticatedHeaders', () => {
+    it('returns Authorization, X-Device-ID, and X-Device-Name when token and device ID exist', () => {
+      setAuthToken('my-token')
+      getDeviceId() // ensure device ID is created
+
+      const headers = getAuthenticatedHeaders()
+
+      expect(headers['Authorization']).toBe('Bearer my-token')
+      expect(headers['X-Device-ID']).toBeTruthy()
+      expect(headers['X-Device-Name']).toBeTruthy()
+    })
+
+    it('returns device headers but no Authorization when no auth token', () => {
+      getDeviceId() // ensure device ID is created
+
+      const headers = getAuthenticatedHeaders()
+
+      expect(headers['Authorization']).toBeUndefined()
+      expect(headers['X-Device-ID']).toBeTruthy()
+      expect(headers['X-Device-Name']).toBeTruthy()
+    })
+
+    it('returns consistent device ID across calls', () => {
+      const headers1 = getAuthenticatedHeaders()
+      const headers2 = getAuthenticatedHeaders()
+
+      expect(headers1['X-Device-ID']).toBe(headers2['X-Device-ID'])
     })
   })
 })

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -11,6 +11,8 @@
  * TODO: once we have a proper encryption middleware, we should store the auth token in the settings database.
  */
 
+import { getDeviceDisplayName } from '@/lib/platform'
+
 const deviceIdKey = 'thunderbolt_device_id'
 const authTokenKey = 'thunderbolt_auth_token'
 
@@ -40,4 +42,22 @@ export const clearAuthToken = (): void => {
 /** Clear the device ID (for revoked devices — forces a new ID on next login). */
 export const clearDeviceId = (): void => {
   localStorage.removeItem(deviceIdKey)
+}
+
+/**
+ * Build authenticated headers (Authorization + device identity).
+ * Single source of truth for callers that cannot use the HTTP client (e.g. PowerSync connector).
+ */
+export const getAuthenticatedHeaders = (): Record<string, string> => {
+  const headers: Record<string, string> = {}
+  const token = getAuthToken()
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+  const deviceId = getDeviceId()
+  if (deviceId) {
+    headers['X-Device-ID'] = deviceId
+    headers['X-Device-Name'] = getDeviceDisplayName()
+  }
+  return headers
 }

--- a/src/lib/http.test.ts
+++ b/src/lib/http.test.ts
@@ -139,11 +139,69 @@ describe('createAuthenticatedClient', () => {
     const client = createAuthenticatedClient('https://api.example.com', () => 'app-token', { fetch })
 
     // Normal app API call with other headers but no Authorization
-    await client.get('data', { headers: { 'X-Device-ID': 'device-123' } })
+    await client.get('data', { headers: { 'X-Custom': 'value' } })
 
     const req = fetch.mock.calls[0][0] as Request
     expect(req.headers.get('Authorization')).toBe('Bearer app-token')
-    expect(req.headers.get('X-Device-ID')).toBe('device-123')
+    expect(req.headers.get('X-Custom')).toBe('value')
+  })
+
+  describe('device identity headers', () => {
+    const deviceIdKey = 'thunderbolt_device_id'
+
+    beforeEach(() => {
+      localStorage.setItem(deviceIdKey, 'test-device-id')
+    })
+
+    afterEach(() => {
+      localStorage.removeItem(deviceIdKey)
+    })
+
+    it('injects X-Device-ID and X-Device-Name for app backend requests (relative URL)', async () => {
+      const fetch = mockFetch()
+      const client = createAuthenticatedClient('https://api.example.com', () => 'app-token', { fetch })
+
+      await client.get('data')
+
+      const req = fetch.mock.calls[0][0] as Request
+      expect(req.headers.get('X-Device-ID')).toBe('test-device-id')
+      expect(req.headers.get('X-Device-Name')).toBeTruthy()
+    })
+
+    it('injects device headers for absolute URL matching prefixUrl', async () => {
+      const fetch = mockFetch()
+      const client = createAuthenticatedClient('https://api.example.com', () => 'app-token', { fetch })
+
+      await client.get('https://api.example.com/v1/foo')
+
+      const req = fetch.mock.calls[0][0] as Request
+      expect(req.headers.get('X-Device-ID')).toBe('test-device-id')
+      expect(req.headers.get('X-Device-Name')).toBeTruthy()
+    })
+
+    it('does NOT inject device headers for external API URLs', async () => {
+      const fetch = mockFetch()
+      const client = createAuthenticatedClient('https://api.example.com', () => 'app-token', { fetch })
+
+      await client.get('https://www.googleapis.com/gmail/v1/users/me/messages', {
+        headers: { Authorization: 'Bearer google-oauth-token' },
+      })
+
+      const req = fetch.mock.calls[0][0] as Request
+      expect(req.headers.get('X-Device-ID')).toBeNull()
+      expect(req.headers.get('X-Device-Name')).toBeNull()
+    })
+
+    it('does NOT inject device headers for unrelated external URLs', async () => {
+      const fetch = mockFetch()
+      const client = createAuthenticatedClient('https://api.example.com', () => 'app-token', { fetch })
+
+      await client.get('https://other.com/data')
+
+      const req = fetch.mock.calls[0][0] as Request
+      expect(req.headers.get('X-Device-ID')).toBeNull()
+      expect(req.headers.get('X-Device-Name')).toBeNull()
+    })
   })
 
   describe('session expiry detection', () => {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -8,6 +8,9 @@
  * error throwing on non-2xx, prefixUrl, and beforeRequest hooks.
  */
 
+import { getDeviceId } from '@/lib/auth-token'
+import { getDeviceDisplayName } from '@/lib/platform'
+
 export class HttpError extends Error {
   response: Response
   constructor(response: Response) {
@@ -162,12 +165,20 @@ export const createAuthenticatedClient = (
     hooks: {
       beforeRequest: [
         (request) => {
-          if (request.headers.has('Authorization')) {
-            return
+          if (!request.headers.has('Authorization')) {
+            const token = getToken()
+            if (token) {
+              request.headers.set('Authorization', `Bearer ${token}`)
+            }
           }
-          const token = getToken()
-          if (token) {
-            request.headers.set('Authorization', `Bearer ${token}`)
+          // Inject device identity headers only for app backend requests (not external APIs).
+          // Uses the same prefix guard as the afterResponse 401 handler below.
+          if (request.url === prefixUrl || request.url.startsWith(normalizedPrefix)) {
+            const deviceId = getDeviceId()
+            if (deviceId) {
+              request.headers.set('X-Device-ID', deviceId)
+              request.headers.set('X-Device-Name', getDeviceDisplayName())
+            }
           }
         },
       ],


### PR DESCRIPTION
## Summary

- Add `X-Device-ID` and `X-Device-Name` headers to `createAuthenticatedClient()` so every authenticated request to our backend includes device identity automatically (URL-prefix guard prevents headers from leaking to external APIs like Google/Microsoft OAuth)
- Create `getAuthenticatedHeaders()` in `src/lib/auth-token.ts` as the single source of truth for authenticated headers, used by the PowerSync connector (which requires raw `fetch()`)
- Remove duplicate header builders: `authHeaders()` from `src/api/encryption.ts` and `buildHeaders()` from `src/db/powersync/connector.ts`

## Test plan

- [x] TypeScript compiles with no errors
- [x] All frontend tests pass (2173/2173)
- [x] All backend tests pass (742/742)
- [x] ESLint: 0 errors
- [x] Encryption API calls include `X-Device-ID` + `X-Device-Name` via HTTP client hook
- [x] PowerSync token/upload include device headers via `getAuthenticatedHeaders()`
- [x] External API calls (Google, Microsoft OAuth) do NOT receive device headers
- [x] New tests for device header injection, `getAuthenticatedHeaders()`, and connector header verification

Closes THU-507

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request authentication/identity plumbing by auto-injecting `X-Device-ID`/`X-Device-Name` and centralizing header construction; mistakes could break backend auth flows or leak headers if the URL guard is wrong.
> 
> **Overview**
> Standardizes device identity propagation by automatically attaching `X-Device-ID` and `X-Device-Name` to authenticated requests made to the app backend (via `createAuthenticatedClient`), with a prefix/URL guard to avoid leaking these headers to external APIs.
> 
> Centralizes raw-`fetch` auth header creation in `getAuthenticatedHeaders()` (used by the PowerSync connector) and removes duplicated per-API header builders from the encryption API client and PowerSync connector. Tests are updated/added to assert device header injection, external-API non-injection, and connector/encryption calls including the new headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90df9d78b7ad75f432b4b911b9c558e1d1fbc19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->