### PR TITLE
THU-516: Workspaces schema, sync rules, and upload handler

### DIFF
--- a/backend/drizzle/0016_ancient_zarek.sql
+++ b/backend/drizzle/0016_ancient_zarek.sql
@@ -1,0 +1,136 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-- 1. New tables: workspaces, workspace_members, pending_memberships (all synced via PowerSync).
+CREATE TABLE "powersync"."workspaces" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"slug" text,
+	"welcome_message" text,
+	"is_public" boolean DEFAULT false NOT NULL,
+	"created_by" text NOT NULL,
+	"is_personal" boolean DEFAULT false NOT NULL,
+	"icon" text,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	"deleted_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "powersync"."workspace_members" (
+	"workspace_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"role" text NOT NULL,
+	"joined_at" timestamp NOT NULL,
+	"removed_at" timestamp,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "workspace_members_workspace_id_user_id_pk" PRIMARY KEY("workspace_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "powersync"."pending_memberships" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"email" text NOT NULL,
+	"role" text NOT NULL,
+	"added_by" text NOT NULL,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+
+-- 2. Drop existing user_id FKs on workspace-scoped tables so we can alter the column.
+ALTER TABLE "powersync"."chat_messages" DROP CONSTRAINT "chat_messages_user_id_user_id_fk";--> statement-breakpoint
+ALTER TABLE "powersync"."chat_threads" DROP CONSTRAINT "chat_threads_user_id_user_id_fk";--> statement-breakpoint
+ALTER TABLE "powersync"."mcp_servers" DROP CONSTRAINT "mcp_servers_user_id_user_id_fk";--> statement-breakpoint
+ALTER TABLE "powersync"."model_profiles" DROP CONSTRAINT "model_profiles_user_id_user_id_fk";--> statement-breakpoint
+ALTER TABLE "powersync"."models" DROP CONSTRAINT "models_user_id_user_id_fk";--> statement-breakpoint
+ALTER TABLE "powersync"."modes" DROP CONSTRAINT "modes_user_id_user_id_fk";--> statement-breakpoint
+ALTER TABLE "powersync"."prompts" DROP CONSTRAINT "prompts_user_id_user_id_fk";--> statement-breakpoint
+ALTER TABLE "powersync"."tasks" DROP CONSTRAINT "tasks_user_id_user_id_fk";--> statement-breakpoint
+ALTER TABLE "powersync"."triggers" DROP CONSTRAINT "triggers_user_id_user_id_fk";--> statement-breakpoint
+
+-- 3. Drop existing primary keys.
+--    Single-column id PK on chat_messages / chat_threads / mcp_servers / triggers uses the
+--    Postgres default name "<table>_pkey". Composite (id, user_id) PKs use Drizzle's naming.
+ALTER TABLE "powersync"."chat_messages" DROP CONSTRAINT "chat_messages_pkey";--> statement-breakpoint
+ALTER TABLE "powersync"."chat_threads" DROP CONSTRAINT "chat_threads_pkey";--> statement-breakpoint
+ALTER TABLE "powersync"."mcp_servers" DROP CONSTRAINT "mcp_servers_pkey";--> statement-breakpoint
+ALTER TABLE "powersync"."triggers" DROP CONSTRAINT "triggers_pkey";--> statement-breakpoint
+ALTER TABLE "powersync"."model_profiles" DROP CONSTRAINT "model_profiles_id_user_id_pk";--> statement-breakpoint
+ALTER TABLE "powersync"."models" DROP CONSTRAINT "models_id_user_id_pk";--> statement-breakpoint
+ALTER TABLE "powersync"."modes" DROP CONSTRAINT "modes_id_user_id_pk";--> statement-breakpoint
+ALTER TABLE "powersync"."prompts" DROP CONSTRAINT "prompts_id_user_id_pk";--> statement-breakpoint
+ALTER TABLE "powersync"."tasks" DROP CONSTRAINT "tasks_id_user_id_pk";--> statement-breakpoint
+
+-- 4. Relax user_id to nullable on workspace-scoped tables (content survives author deletion).
+ALTER TABLE "powersync"."chat_messages" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."chat_threads" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."mcp_servers" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."model_profiles" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."models" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."modes" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."prompts" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."tasks" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."triggers" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+
+-- 5. Add workspace_id column. Safe as NOT NULL because the DB resets on this release (no rows).
+ALTER TABLE "powersync"."chat_messages" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."chat_threads" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."mcp_servers" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."model_profiles" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."models" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."modes" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."prompts" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."tasks" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "powersync"."triggers" ADD COLUMN "workspace_id" text NOT NULL;--> statement-breakpoint
+
+-- 6. Add uniform composite primary keys (id, workspace_id) per Decision 17.
+ALTER TABLE "powersync"."chat_messages" ADD CONSTRAINT "chat_messages_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+ALTER TABLE "powersync"."chat_threads" ADD CONSTRAINT "chat_threads_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+ALTER TABLE "powersync"."mcp_servers" ADD CONSTRAINT "mcp_servers_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+ALTER TABLE "powersync"."model_profiles" ADD CONSTRAINT "model_profiles_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+ALTER TABLE "powersync"."models" ADD CONSTRAINT "models_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+ALTER TABLE "powersync"."modes" ADD CONSTRAINT "modes_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+ALTER TABLE "powersync"."prompts" ADD CONSTRAINT "prompts_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+ALTER TABLE "powersync"."tasks" ADD CONSTRAINT "tasks_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+ALTER TABLE "powersync"."triggers" ADD CONSTRAINT "triggers_id_workspace_id_pk" PRIMARY KEY("id","workspace_id");--> statement-breakpoint
+
+-- 7. Foreign keys for the new tables and the new workspace_id / relaxed user_id columns.
+ALTER TABLE "powersync"."workspaces" ADD CONSTRAINT "workspaces_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."workspace_members" ADD CONSTRAINT "workspace_members_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."workspace_members" ADD CONSTRAINT "workspace_members_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."pending_memberships" ADD CONSTRAINT "pending_memberships_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."pending_memberships" ADD CONSTRAINT "pending_memberships_added_by_user_id_fk" FOREIGN KEY ("added_by") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."chat_messages" ADD CONSTRAINT "chat_messages_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."chat_messages" ADD CONSTRAINT "chat_messages_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."chat_threads" ADD CONSTRAINT "chat_threads_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."chat_threads" ADD CONSTRAINT "chat_threads_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."mcp_servers" ADD CONSTRAINT "mcp_servers_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."mcp_servers" ADD CONSTRAINT "mcp_servers_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."model_profiles" ADD CONSTRAINT "model_profiles_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."model_profiles" ADD CONSTRAINT "model_profiles_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."models" ADD CONSTRAINT "models_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."models" ADD CONSTRAINT "models_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."modes" ADD CONSTRAINT "modes_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."modes" ADD CONSTRAINT "modes_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."prompts" ADD CONSTRAINT "prompts_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."prompts" ADD CONSTRAINT "prompts_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."tasks" ADD CONSTRAINT "tasks_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."tasks" ADD CONSTRAINT "tasks_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."triggers" ADD CONSTRAINT "triggers_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "powersync"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "powersync"."triggers" ADD CONSTRAINT "triggers_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+
+-- 8. Indexes.
+CREATE UNIQUE INDEX "workspaces_personal_per_user_idx" ON "powersync"."workspaces" USING btree ("created_by") WHERE is_personal = true;--> statement-breakpoint
+CREATE UNIQUE INDEX "workspaces_slug_idx" ON "powersync"."workspaces" USING btree ("slug") WHERE slug IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_workspace_members_user_id" ON "powersync"."workspace_members" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "pending_memberships_workspace_email_idx" ON "powersync"."pending_memberships" USING btree ("workspace_id",lower("email"));--> statement-breakpoint
+CREATE INDEX "idx_pending_memberships_workspace_id" ON "powersync"."pending_memberships" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_chat_messages_workspace_id" ON "powersync"."chat_messages" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_chat_threads_workspace_id" ON "powersync"."chat_threads" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_mcp_servers_workspace_id" ON "powersync"."mcp_servers" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_model_profiles_workspace_id" ON "powersync"."model_profiles" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_models_workspace_id" ON "powersync"."models" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_modes_workspace_id" ON "powersync"."modes" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_prompts_workspace_id" ON "powersync"."prompts" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_tasks_workspace_id" ON "powersync"."tasks" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "idx_triggers_workspace_id" ON "powersync"."triggers" USING btree ("workspace_id");

--- a/backend/drizzle/meta/0016_snapshot.json
+++ b/backend/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,2770 @@
+{
+  "id": "1056bb9a-9fad-4525-8edf-f02252fc720a",
+  "prevId": "7428a54d-23a7-4f14-afc9-51ae5a251906",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_deviceId_idx": {
+          "name": "session_deviceId_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_batch_id_idx": {
+          "name": "waitlist_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.chat_messages": {
+      "name": "chat_messages",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache": {
+          "name": "cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_workspace_id": {
+          "name": "idx_chat_messages_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_user_id": {
+          "name": "idx_chat_messages_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_workspace_id_workspaces_id_fk": {
+          "name": "chat_messages_workspace_id_workspaces_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_user_id_user_id_fk": {
+          "name": "chat_messages_user_id_user_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_messages_id_workspace_id_pk": {
+          "name": "chat_messages_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.chat_threads": {
+      "name": "chat_threads",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_triggered_by_automation": {
+          "name": "was_triggered_by_automation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_workspace_id": {
+          "name": "idx_chat_threads_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_id": {
+          "name": "idx_chat_threads_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_workspace_id_workspaces_id_fk": {
+          "name": "chat_threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_user_id_user_id_fk": {
+          "name": "chat_threads_user_id_user_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_threads_id_workspace_id_pk": {
+          "name": "chat_threads_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.devices": {
+      "name": "devices",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trusted": {
+          "name": "trusted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approval_pending": {
+          "name": "approval_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mlkem_public_key": {
+          "name": "mlkem_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_devices_user_id": {
+          "name": "idx_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_servers_workspace_id": {
+          "name": "idx_mcp_servers_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_servers_user_id": {
+          "name": "idx_mcp_servers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_workspace_id_workspaces_id_fk": {
+          "name": "mcp_servers_workspace_id_workspaces_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_servers_user_id_user_id_fk": {
+          "name": "mcp_servers_user_id_user_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_servers_id_workspace_id_pk": {
+          "name": "mcp_servers_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.model_profiles": {
+      "name": "model_profiles",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_threshold": {
+          "name": "nudge_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_system_message_mode_developer": {
+          "name": "use_system_message_mode_developer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tools_override": {
+          "name": "tools_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_previews_override": {
+          "name": "link_previews_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_mode_addendum": {
+          "name": "chat_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_mode_addendum": {
+          "name": "search_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "research_mode_addendum": {
+          "name": "research_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citation_reinforcement_enabled": {
+          "name": "citation_reinforcement_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "citation_reinforcement_prompt": {
+          "name": "citation_reinforcement_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_final_step": {
+          "name": "nudge_final_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_preventive": {
+          "name": "nudge_preventive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_retry": {
+          "name": "nudge_retry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_final_step": {
+          "name": "nudge_search_final_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_preventive": {
+          "name": "nudge_search_preventive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_retry": {
+          "name": "nudge_search_retry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_model_profiles_workspace_id": {
+          "name": "idx_model_profiles_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_profiles_user_id": {
+          "name": "idx_model_profiles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_profiles_workspace_id_workspaces_id_fk": {
+          "name": "model_profiles_workspace_id_workspaces_id_fk",
+          "tableFrom": "model_profiles",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_profiles_user_id_user_id_fk": {
+          "name": "model_profiles_user_id_user_id_fk",
+          "tableFrom": "model_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "model_profiles_id_workspace_id_pk": {
+          "name": "model_profiles_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.models": {
+      "name": "models",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "tool_usage": {
+          "name": "tool_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_confidential": {
+          "name": "is_confidential",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "start_with_reasoning": {
+          "name": "start_with_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "supports_parallel_tool_calls": {
+          "name": "supports_parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_models_workspace_id": {
+          "name": "idx_models_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_models_user_id": {
+          "name": "idx_models_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "models_workspace_id_workspaces_id_fk": {
+          "name": "models_workspace_id_workspaces_id_fk",
+          "tableFrom": "models",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "models_user_id_user_id_fk": {
+          "name": "models_user_id_user_id_fk",
+          "tableFrom": "models",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "models_id_workspace_id_pk": {
+          "name": "models_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.modes": {
+      "name": "modes",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_modes_workspace_id": {
+          "name": "idx_modes_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_modes_user_id": {
+          "name": "idx_modes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "modes_workspace_id_workspaces_id_fk": {
+          "name": "modes_workspace_id_workspaces_id_fk",
+          "tableFrom": "modes",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "modes_user_id_user_id_fk": {
+          "name": "modes_user_id_user_id_fk",
+          "tableFrom": "modes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "modes_id_workspace_id_pk": {
+          "name": "modes_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.pending_memberships": {
+      "name": "pending_memberships",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_memberships_workspace_email_idx": {
+          "name": "pending_memberships_workspace_email_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_memberships_workspace_id": {
+          "name": "idx_pending_memberships_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_memberships_workspace_id_workspaces_id_fk": {
+          "name": "pending_memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "pending_memberships",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_memberships_added_by_user_id_fk": {
+          "name": "pending_memberships_added_by_user_id_fk",
+          "tableFrom": "pending_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.prompts": {
+      "name": "prompts",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_prompts_workspace_id": {
+          "name": "idx_prompts_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prompts_user_id": {
+          "name": "idx_prompts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prompts_workspace_id_workspaces_id_fk": {
+          "name": "prompts_workspace_id_workspaces_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prompts_user_id_user_id_fk": {
+          "name": "prompts_user_id_user_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompts_id_workspace_id_pk": {
+          "name": "prompts_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.settings": {
+      "name": "settings",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_settings_user_id": {
+          "name": "idx_settings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "settings_user_id_user_id_fk": {
+          "name": "settings_user_id_user_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_id_user_id_pk": {
+          "name": "settings_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.tasks": {
+      "name": "tasks",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_workspace_id": {
+          "name": "idx_tasks_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_user_id": {
+          "name": "idx_tasks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_workspace_id_workspaces_id_fk": {
+          "name": "tasks_workspace_id_workspaces_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_user_id_user_id_fk": {
+          "name": "tasks_user_id_user_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tasks_id_workspace_id_pk": {
+          "name": "tasks_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.triggers": {
+      "name": "triggers",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_time": {
+          "name": "trigger_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_triggers_workspace_id": {
+          "name": "idx_triggers_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_triggers_user_id": {
+          "name": "idx_triggers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triggers_workspace_id_workspaces_id_fk": {
+          "name": "triggers_workspace_id_workspaces_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "triggers_user_id_user_id_fk": {
+          "name": "triggers_user_id_user_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "triggers_id_workspace_id_pk": {
+          "name": "triggers_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.workspace_members": {
+      "name": "workspace_members",
+      "schema": "powersync",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_members_user_id": {
+          "name": "idx_workspace_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_user_id_fk": {
+          "name": "workspace_members_user_id_user_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_workspace_id_user_id_pk": {
+          "name": "workspace_members_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.workspaces": {
+      "name": "workspaces",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspaces_personal_per_user_idx": {
+          "name": "workspaces_personal_per_user_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_personal = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_slug_idx": {
+          "name": "workspaces_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slug IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_created_by_user_id_fk": {
+          "name": "workspaces_created_by_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expire_idx": {
+          "name": "rate_limits_expire_idx",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encryption_metadata": {
+      "name": "encryption_metadata",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canary_iv": {
+          "name": "canary_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_ctext": {
+          "name": "canary_ctext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_secret_hash": {
+          "name": "canary_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encryption_metadata_user_id_user_id_fk": {
+          "name": "encryption_metadata_user_id_user_id_fk",
+          "tableFrom": "encryption_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.envelopes": {
+      "name": "envelopes",
+      "schema": "",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_ck": {
+          "name": "wrapped_ck",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_envelopes_user_id": {
+          "name": "idx_envelopes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "envelopes_device_id_devices_id_fk": {
+          "name": "envelopes_device_id_devices_id_fk",
+          "tableFrom": "envelopes",
+          "tableTo": "devices",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "envelopes_user_id_user_id_fk": {
+          "name": "envelopes_user_id_user_id_fk",
+          "tableFrom": "envelopes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_challenge": {
+      "name": "otp_challenge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_token": {
+          "name": "challenge_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "otp_challenge_email_unique": {
+          "name": "otp_challenge_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1778537774824,
       "tag": "0015_panoramic_sheva_callister",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1779197290032,
+      "tag": "0016_ancient_zarek",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -5,7 +5,15 @@
 import type { Settings } from '@/config/settings'
 import { createBetterAuthPlugin } from '@/auth/elysia-plugin'
 import { session as sessionTable, user as userTable } from '@/db/auth-schema'
-import { devicesTable, mcpServersTable, modelsTable, promptsTable, settingsTable } from '@/db/schema'
+import {
+  chatThreadsTable,
+  devicesTable,
+  mcpServersTable,
+  modelsTable,
+  settingsTable,
+  workspaceMembersTable,
+  workspacesTable,
+} from '@/db/schema'
 import { createTestDb } from '@/test-utils/db'
 import { createHmac } from 'crypto'
 import { eq } from 'drizzle-orm'
@@ -89,6 +97,28 @@ describe('PowerSync API', () => {
     Authorization: `Bearer ${signToken(bearer)}`,
     'X-Device-ID': deviceId,
   })
+
+  /** Insert a workspace plus an active membership row for the user. */
+  const insertWorkspaceWithMember = async (
+    workspaceId: string,
+    userId: string,
+    { role = 'owner', removed = false }: { role?: 'owner' | 'admin' | 'member'; removed?: boolean } = {},
+  ) => {
+    const now = new Date()
+    await db.insert(workspacesTable).values({
+      id: workspaceId,
+      name: `Workspace ${workspaceId}`,
+      createdBy: userId,
+      isPersonal: false,
+    })
+    await db.insert(workspaceMembersTable).values({
+      workspaceId,
+      userId,
+      role,
+      joinedAt: now,
+      removedAt: removed ? now : null,
+    })
+  }
 
   /** Insert a trusted device so it passes validateDeviceForSync. */
   const insertTrustedDevice = async (deviceId: string, userId: string) => {
@@ -1373,8 +1403,9 @@ describe('PowerSync API', () => {
       expect(rows[0]?.value).toBe('updated')
     })
 
-    it('converts deleted_at ISO string to Date in PATCH (prompts soft delete)', async () => {
+    it('converts deleted_at ISO string to Date in PATCH (chat thread soft delete)', async () => {
       const userId = 'user-patch-deleted-at'
+      const workspaceId = 'ws-patch-deleted-at'
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
 
@@ -1395,11 +1426,12 @@ describe('PowerSync API', () => {
         userId,
       })
       await insertTrustedDevice('test-device-id', userId)
-      await db.insert(promptsTable).values({
-        id: 'prompt-to-soft-delete',
-        title: 'My Prompt',
-        prompt: 'Hello',
-        modelId: 'gpt-4',
+      await insertWorkspaceWithMember(workspaceId, userId)
+      await db.insert(chatThreadsTable).values({
+        id: 'thread-to-soft-delete',
+        title: 'My Thread',
+        modeId: 'default',
+        workspaceId,
         userId,
       })
 
@@ -1412,9 +1444,9 @@ describe('PowerSync API', () => {
             operations: [
               {
                 op: 'PATCH' as const,
-                type: 'prompts',
-                id: 'prompt-to-soft-delete',
-                data: { deleted_at: deletedAtIso, model_id: null, prompt: null, title: null },
+                type: 'chat_threads',
+                id: 'thread-to-soft-delete',
+                data: { deleted_at: deletedAtIso, mode_id: null, title: null },
               },
             ],
           }),
@@ -1422,11 +1454,10 @@ describe('PowerSync API', () => {
       )
       expect(response.status).toBe(200)
 
-      const rows = await db.select().from(promptsTable).where(eq(promptsTable.id, 'prompt-to-soft-delete'))
+      const rows = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, 'thread-to-soft-delete'))
       expect(rows).toHaveLength(1)
       expect(rows[0]?.deletedAt).toEqual(new Date(deletedAtIso))
-      expect(rows[0]?.modelId).toBeNull()
-      expect(rows[0]?.prompt).toBeNull()
+      expect(rows[0]?.modeId).toBeNull()
       expect(rows[0]?.title).toBeNull()
     })
 
@@ -1580,7 +1611,7 @@ describe('PowerSync API', () => {
       expect(rows[0]?.userId).toBe(userA)
     })
 
-    it('blocks DELETE on devices table (must use dedicated revoke API)', async () => {
+    it('silently drops DELETE on devices table (devices is not writable; revoke goes through REST)', async () => {
       const userId = 'user-delete-device-blocked'
       const deviceId = 'device-to-delete-blocked'
       const now = new Date()
@@ -1623,11 +1654,10 @@ describe('PowerSync API', () => {
           }),
         }),
       )
-      expect(response.status).toBe(400)
-      const body = (await response.json()) as { code: string }
-      expect(body.code).toBe('UPLOAD_OPERATION_FAILED')
+      // Per Option C: devices is not in writableTables, so the op is silently skipped — the
+      // batch reports success, but the device row is untouched.
+      expect(response.status).toBe(200)
 
-      // Device must still exist
       const devices = await db.select().from(devicesTable).where(eq(devicesTable.id, deviceId))
       expect(devices).toHaveLength(1)
       expect(devices[0]?.trusted).toBe(true)
@@ -1850,7 +1880,7 @@ describe('PowerSync API', () => {
       expect(themeRows.find((r) => r.userId === userB)?.value).toBe('system')
     })
 
-    it('returns 400 when an operation fails (invalid table, empty payload, etc.)', async () => {
+    it('returns 400 with table/id/op details when an operation fails', async () => {
       const userId = 'user-upload-fail'
       const now = new Date()
       const expiresAt = new Date(now.getTime() + 3600 * 1000)
@@ -1874,19 +1904,14 @@ describe('PowerSync API', () => {
       })
       await insertTrustedDevice('test-device-id', userId)
 
+      // DELETE on a non-existent settings row returns 0 affected → applyOperation returns false
+      // → API surfaces 400 with the failing op's identity.
       const response = await app.handle(
         new Request('http://localhost/powersync/upload', {
           method: 'PUT',
           headers: uploadHeaders('bearer-upload-fail'),
           body: JSON.stringify({
-            operations: [
-              {
-                op: 'PUT' as const,
-                type: 'nonexistent_table',
-                id: 'some_id',
-                data: { value: 'x' },
-              },
-            ],
+            operations: [{ op: 'DELETE' as const, type: 'settings', id: 'no_such_key' }],
           }),
         }),
       )
@@ -1894,9 +1919,342 @@ describe('PowerSync API', () => {
       const data = (await response.json()) as { error: string; code: string; table: string; id: string; op: string }
       expect(data.error).toBe('Upload operation failed')
       expect(data.code).toBe('UPLOAD_OPERATION_FAILED')
-      expect(data.table).toBe('nonexistent_table')
-      expect(data.id).toBe('some_id')
-      expect(data.op).toBe('PUT')
+      expect(data.table).toBe('settings')
+      expect(data.id).toBe('no_such_key')
+      expect(data.op).toBe('DELETE')
+    })
+
+    // ---------------------------------------------------------------------
+    // Write-path policy (Decision 14 of the workspaces spec).
+    // Only chat_threads, chat_messages, tasks, and settings are writable via PowerSync.
+    // Workspace-scoped writes additionally require an active workspace_members row.
+    // ---------------------------------------------------------------------
+
+    const setupAuthedUser = async (label: string) => {
+      const userId = `user-${label}`
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+      await db.insert(userTable).values({
+        id: userId,
+        name: label,
+        email: `${label}@example.com`,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await db.insert(sessionTable).values({
+        id: `session-${label}`,
+        expiresAt,
+        token: `bearer-${label}`,
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+      await insertTrustedDevice('test-device-id', userId)
+      return { userId, token: `bearer-${label}` }
+    }
+
+    it('PUT to chat_threads succeeds for an active workspace member', async () => {
+      const { userId, token } = await setupAuthedUser('ws-write-ok')
+      const workspaceId = 'ws-write-ok'
+      await insertWorkspaceWithMember(workspaceId, userId)
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'chat_threads',
+                id: 'thread-ok',
+                data: { workspace_id: workspaceId, title: 'Hello' },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+      const rows = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, 'thread-ok'))
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.workspaceId).toBe(workspaceId)
+      expect(rows[0]?.userId).toBe(userId)
+    })
+
+    it('rejects PUT to chat_threads when the user is not a member of the workspace', async () => {
+      const { userId, token } = await setupAuthedUser('ws-not-member')
+      const otherUserId = 'user-other-owner'
+      const workspaceId = 'ws-not-member'
+
+      await db.insert(userTable).values({
+        id: otherUserId,
+        name: 'Other',
+        email: 'other@example.com',
+        emailVerified: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      await insertWorkspaceWithMember(workspaceId, otherUserId) // not the authenticated user
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'chat_threads',
+                id: 'thread-denied',
+                data: { workspace_id: workspaceId, title: 'forbidden' },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(400)
+      const body = (await response.json()) as { code: string; table: string }
+      expect(body.code).toBe('UPLOAD_OPERATION_FAILED')
+      expect(body.table).toBe('chat_threads')
+      const rows = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, 'thread-denied'))
+      expect(rows).toHaveLength(0)
+      // The authenticated user should not be retained even via attribution.
+      expect(userId).not.toBe(otherUserId)
+    })
+
+    it('rejects PUT to chat_threads when the user has been removed from the workspace', async () => {
+      const { token, userId } = await setupAuthedUser('ws-removed')
+      const workspaceId = 'ws-removed'
+      await insertWorkspaceWithMember(workspaceId, userId, { removed: true })
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'chat_threads',
+                id: 'thread-after-removal',
+                data: { workspace_id: workspaceId, title: 'late' },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(400)
+      const body = (await response.json()) as { code: string }
+      expect(body.code).toBe('UPLOAD_OPERATION_FAILED')
+    })
+
+    it('rejects PUT to chat_threads when workspace_id is missing from op.data', async () => {
+      const { token, userId } = await setupAuthedUser('ws-no-id')
+      await insertWorkspaceWithMember('ws-no-id', userId)
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'chat_threads',
+                id: 'thread-no-ws',
+                data: { title: 'missing workspace_id' },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(400)
+      const body = (await response.json()) as { code: string }
+      expect(body.code).toBe('UPLOAD_OPERATION_FAILED')
+    })
+
+    it('PUT to settings succeeds without workspace_id (settings is account-level)', async () => {
+      const { userId, token } = await setupAuthedUser('settings-no-ws')
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'settings',
+                id: 'preferred_name',
+                data: { value: 'Settings User' },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+      const rows = await db.select().from(settingsTable).where(eq(settingsTable.key, 'preferred_name'))
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.userId).toBe(userId)
+      expect(rows[0]?.value).toBe('Settings User')
+    })
+
+    // Tables that are synced but not writable via PowerSync — the only legitimate write path is
+    // REST. Per Option C of the upload-handler design, non-writable ops are silently skipped
+    // (logged server-side) instead of failing the batch — a stale/buggy client can't poison
+    // sync for legitimate ops in the same batch.
+    const nonWritableTables: { table: string; data: Record<string, unknown> }[] = [
+      { table: 'models', data: { workspace_id: 'any', name: 'GPT', provider: 'openai' } },
+      { table: 'modes', data: { workspace_id: 'any', name: 'chat', label: 'Chat' } },
+      { table: 'prompts', data: { workspace_id: 'any', title: 'p', prompt: 'p' } },
+      { table: 'mcp_servers', data: { workspace_id: 'any', name: 's', url: 'https://x' } },
+      { table: 'triggers', data: { workspace_id: 'any', trigger_type: 'time' } },
+      { table: 'model_profiles', data: { workspace_id: 'any', temperature: 0.5 } },
+      { table: 'devices', data: { name: 'spoof' } },
+      { table: 'workspaces', data: { name: 'sneaky', created_by: 'spoof', is_personal: false } },
+      { table: 'workspace_members', data: { workspace_id: 'any', user_id: 'spoof', role: 'owner' } },
+      { table: 'pending_memberships', data: { workspace_id: 'any', email: 'a@b.c', role: 'admin', added_by: 'spoof' } },
+    ]
+
+    for (const { table, data } of nonWritableTables) {
+      it(`silently drops PUT to ${table} (not in writableTables) without poisoning the batch`, async () => {
+        const { token } = await setupAuthedUser(`reject-${table}`)
+        const response = await app.handle(
+          new Request('http://localhost/powersync/upload', {
+            method: 'PUT',
+            headers: uploadHeaders(token),
+            body: JSON.stringify({
+              operations: [{ op: 'PUT' as const, type: table, id: `drop-${table}`, data }],
+            }),
+          }),
+        )
+        expect(response.status).toBe(200)
+        const body = (await response.json()) as { success: boolean }
+        expect(body.success).toBe(true)
+      })
+    }
+
+    it('silently drops PATCH on a non-writable table', async () => {
+      const { token } = await setupAuthedUser('patch-non-writable')
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PATCH' as const,
+                type: 'models',
+                id: 'any-model-id',
+                data: { name: 'Renamed' },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+      const body = (await response.json()) as { success: boolean }
+      expect(body.success).toBe(true)
+    })
+
+    it('applies writable ops even when a non-writable op comes first in the batch', async () => {
+      const { userId, token } = await setupAuthedUser('mixed-first')
+      const workspaceId = 'ws-mixed-first'
+      await insertWorkspaceWithMember(workspaceId, userId)
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'models',
+                id: 'first-dropped',
+                data: { workspace_id: workspaceId, name: 'dropped' },
+              },
+              {
+                op: 'PUT' as const,
+                type: 'chat_threads',
+                id: 'thread-after-skip',
+                data: { workspace_id: workspaceId, title: 'kept' },
+              },
+              { op: 'PUT' as const, type: 'settings', id: 'after-skip', data: { value: 'kept' } },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+      const threads = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, 'thread-after-skip'))
+      expect(threads).toHaveLength(1)
+      const settings = await db.select().from(settingsTable).where(eq(settingsTable.key, 'after-skip'))
+      expect(settings).toHaveLength(1)
+      const models = await db.select().from(modelsTable).where(eq(modelsTable.id, 'first-dropped'))
+      expect(models).toHaveLength(0)
+    })
+
+    it('drops non-writable ops but still applies the writable ones in the same batch', async () => {
+      const { userId, token } = await setupAuthedUser('mixed-batch')
+      const workspaceId = 'ws-mixed'
+      await insertWorkspaceWithMember(workspaceId, userId)
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PUT' as const,
+                type: 'chat_threads',
+                id: 'thread-mixed',
+                data: { workspace_id: workspaceId, title: 'kept' },
+              },
+              {
+                op: 'PUT' as const,
+                type: 'models',
+                id: 'model-mixed',
+                data: { workspace_id: workspaceId, name: 'dropped' },
+              },
+              { op: 'PUT' as const, type: 'settings', id: 'pref', data: { value: 'kept' } },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+      const threads = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, 'thread-mixed'))
+      expect(threads).toHaveLength(1)
+      const settings = await db.select().from(settingsTable).where(eq(settingsTable.key, 'pref'))
+      expect(settings).toHaveLength(1)
+      // The non-writable models op was silently skipped — no row inserted.
+      const models = await db.select().from(modelsTable).where(eq(modelsTable.id, 'model-mixed'))
+      expect(models).toHaveLength(0)
+    })
+
+    it('applies a batch of writes in the same workspace (sanity check for batched membership)', async () => {
+      const { token, userId } = await setupAuthedUser('ws-batch')
+      const workspaceId = 'ws-batch'
+      await insertWorkspaceWithMember(workspaceId, userId)
+
+      const operations = Array.from({ length: 5 }, (_, i) => ({
+        op: 'PUT' as const,
+        type: 'chat_threads',
+        id: `batch-thread-${i}`,
+        data: { workspace_id: workspaceId, title: `t${i}` },
+      }))
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders(token),
+          body: JSON.stringify({ operations }),
+        }),
+      )
+      expect(response.status).toBe(200)
+      const rows = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.workspaceId, workspaceId))
+      expect(rows).toHaveLength(5)
     })
 
     it('returns 200 with empty operations array', async () => {

--- a/backend/src/api/powersync.ts
+++ b/backend/src/api/powersync.ts
@@ -5,7 +5,7 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import type { Settings } from '@/config/settings'
 import { isOriginAllowed } from '@/config/settings'
-import { applyOperation, getActiveSessionByToken, getDeviceById, getUserById, upsertDevice } from '@/dal'
+import { applyOperations, getActiveSessionByToken, getDeviceById, getUserById, upsertDevice } from '@/dal'
 import type { db as DbType } from '@/db/client'
 import { verifySignedBearerToken } from '@/auth/bearer-token'
 import { safeErrorHandler } from '@/middleware/error-handling'
@@ -235,22 +235,18 @@ export const createPowerSyncRoutes = (auth: Auth, settings: Settings, database: 
           return validation.body
         }
 
-        const operations = body.operations
-
-        // Process operations sequentially to maintain order.
-        // If any operation fails, return 4xx so the client does not call transaction.complete()
-        // and PowerSync will retry the batch.
-        for (const op of operations) {
-          const ok = await applyOperation(database, op, user.id)
-          if (!ok) {
-            set.status = 400
-            return {
-              error: 'Upload operation failed',
-              code: 'UPLOAD_OPERATION_FAILED',
-              table: op.type,
-              id: op.id,
-              op: op.op,
-            }
+        // Process operations sequentially to maintain order. Workspace-membership lookups are
+        // cached for the batch by applyOperations. If any operation fails, return 4xx so the
+        // client does not call transaction.complete() and PowerSync will retry the batch.
+        const result = await applyOperations(database, body.operations, user.id)
+        if (!result.ok) {
+          set.status = 400
+          return {
+            error: 'Upload operation failed',
+            code: 'UPLOAD_OPERATION_FAILED',
+            table: result.failure.table,
+            id: result.failure.id,
+            op: result.failure.op,
           }
         }
 

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -23,7 +23,10 @@ export { getActiveSessionByToken, linkSessionToDevice, revokeDeviceSessions } fr
 export { getWaitlistByEmail, createWaitlistEntry, approveWaitlistEntry } from './waitlist'
 
 // PowerSync
-export { applyOperation } from './powersync'
+export { applyOperation, applyOperations } from './powersync'
+
+// Workspaces
+export { isActiveWorkspaceMember } from './workspaces'
 
 // OTP Challenge (session binding)
 export {

--- a/backend/src/dal/powersync.ts
+++ b/backend/src/dal/powersync.ts
@@ -9,19 +9,24 @@ import {
   powersyncPkColumn,
   powersyncTablesByName,
 } from '@/db/powersync-schema'
-import { type PowerSyncTableName, powersyncTableNames } from '@shared/powersync-tables'
+import type { PowerSyncTableName } from '@shared/powersync-tables'
 import { and, eq } from 'drizzle-orm'
 import type { AnyPgTable } from 'drizzle-orm/pg-core'
+import { isActiveWorkspaceMember } from './workspaces'
 
-const validTables = new Set<string>(powersyncTableNames)
+/**
+ * Tables clients may write to via PowerSync upload. Everything else (including new synced tables)
+ * is rejected by default — workspace config writes flow through REST endpoints per Decision 14
+ * of the workspaces spec. Narrowing this set is also the security boundary that prevents a
+ * malicious client from inserting a `workspace_members` row to self-promote.
+ */
+const writableTables = new Set<string>(['chat_threads', 'chat_messages', 'tasks', 'settings'])
 
-/** DB column names that clients cannot set via PowerSync upload (server-managed fields). */
-const uploadDenyColumns: Partial<Record<PowerSyncTableName, string[]>> = {
-  devices: ['revoked_at', 'trusted', 'public_key', 'mlkem_public_key', 'approval_pending'],
-}
-
-/** Tables that cannot be deleted via PowerSync upload — must use dedicated API endpoints. */
-const uploadDenyDelete = new Set<PowerSyncTableName>(['devices'])
+/**
+ * Subset of writable tables that are workspace-scoped (require an active membership check on PUT).
+ * `settings` is account-level and is excluded — the user_id override on its write path is enough.
+ */
+const workspaceScopedWritableTables = new Set<string>(['chat_threads', 'chat_messages', 'tasks'])
 
 type PowerSyncOperation = {
   op: 'PUT' | 'PATCH' | 'DELETE'
@@ -60,16 +65,45 @@ const toSchemaRecord = (
   return out
 }
 
+type MembershipCache = Map<string, boolean>
+
 /**
- * Apply a single PowerSync operation using Drizzle's query builder (parameterized, no raw SQL).
- * The user_id is always set to the authenticated user to ensure data isolation.
+ * Look up workspace membership through the cache, populating it on miss. The cache is scoped
+ * to a single upload batch — see `applyOperations`.
+ */
+const checkMembershipCached = async (
+  database: typeof DbType,
+  workspaceId: string,
+  userId: string,
+  cache: MembershipCache,
+): Promise<boolean> => {
+  const key = `${workspaceId}:${userId}`
+  const cached = cache.get(key)
+  if (cached !== undefined) {
+    return cached
+  }
+  const isMember = await isActiveWorkspaceMember(database, workspaceId, userId)
+  cache.set(key, isMember)
+  return isMember
+}
+
+/**
+ * Apply a single PowerSync upload operation using Drizzle's query builder (parameterized, no raw SQL).
+ *
+ * The user_id is always overridden with the authenticated user's id to prevent forgery. Writes are
+ * rejected for any table not in `writableTables`. For workspace-scoped writable tables, PUT
+ * operations additionally require an active workspace membership.
+ *
+ * Pass a shared `membershipCache` when applying multiple operations in the same upload batch to
+ * avoid redundant `workspace_members` lookups — see `applyOperations`.
  */
 export const applyOperation = async (
   database: typeof DbType,
   op: PowerSyncOperation,
   userId: string,
+  membershipCache: MembershipCache = new Map(),
 ): Promise<boolean> => {
-  if (!validTables.has(op.type)) {
+  if (!writableTables.has(op.type)) {
     return false
   }
 
@@ -85,14 +119,25 @@ export const applyOperation = async (
   const validDbNames = new Set(Object.keys(dbNameToKey))
   const tableWithUserId = table as AnyPgTable & { userId: typeof table.userId }
 
+  // PUT on workspace-scoped writable tables must include a workspace_id in the payload, and the
+  // authenticated user must be an active member of that workspace. settings is exempt — it's
+  // account-level and protected by the user_id override alone.
+  if (op.op === 'PUT' && workspaceScopedWritableTables.has(op.type)) {
+    const workspaceId = op.data?.workspace_id
+    if (typeof workspaceId !== 'string' || workspaceId.length === 0) {
+      return false
+    }
+    const isMember = await checkMembershipCached(database, workspaceId, userId, membershipCache)
+    if (!isMember) {
+      return false
+    }
+  }
+
   switch (op.op) {
     case 'PUT': {
       const payload = { ...(op.data ?? {}) } as Record<string, unknown>
       delete payload.id
       delete payload.user_id
-      for (const col of uploadDenyColumns[tableName] ?? []) {
-        delete payload[col]
-      }
       const rawData: Record<string, unknown> = { ...payload, id: op.id, user_id: userId }
       const schemaValues = toSchemaRecord(rawData, validDbNames, dbNameToKey)
       if (Object.keys(schemaValues).length === 0) {
@@ -123,9 +168,6 @@ export const applyOperation = async (
       const patchPayload = { ...op.data } as Record<string, unknown>
       delete patchPayload.id
       delete patchPayload.user_id
-      for (const col of uploadDenyColumns[tableName] ?? []) {
-        delete patchPayload[col]
-      }
       const schemaPatch = toSchemaRecord(patchPayload, validDbNames, dbNameToKey)
       if (Object.keys(schemaPatch).length === 0) {
         return false
@@ -140,10 +182,6 @@ export const applyOperation = async (
       return patched.length > 0
     }
     case 'DELETE': {
-      if (uploadDenyDelete.has(tableName)) {
-        return false
-      }
-
       const deleted = await database
         .delete(table)
         .where(and(eq(pkColumn, op.id), eq(tableWithUserId.userId, userId)))
@@ -152,5 +190,45 @@ export const applyOperation = async (
       return deleted.length > 0
     }
   }
-  return false
+}
+
+export type ApplyOperationsResult =
+  | { ok: true }
+  | {
+      ok: false
+      failure: { table: string; id: string; op: 'PUT' | 'PATCH' | 'DELETE' }
+    }
+
+/**
+ * Apply a batch of PowerSync upload operations sequentially. Workspace-membership lookups are
+ * memoized for the lifetime of the call so a batch with many ops in the same workspace only
+ * hits `workspace_members` once.
+ *
+ * Ops targeting a non-writable table are skipped (logged, not surfaced) so a stale or buggy
+ * client can't poison the batch — retry would never resolve a table-not-allowlisted condition.
+ * Every other failure (missing workspace_id, removed member, no matching row on PATCH/DELETE,
+ * etc.) bubbles up so the API returns 4xx and PowerSync retries.
+ */
+export const applyOperations = async (
+  database: typeof DbType,
+  operations: PowerSyncOperation[],
+  userId: string,
+): Promise<ApplyOperationsResult> => {
+  const membershipCache: MembershipCache = new Map()
+  for (const op of operations) {
+    if (!writableTables.has(op.type)) {
+      console.warn('powersync.upload.dropped_non_writable', {
+        table: op.type,
+        op: op.op,
+        id: op.id,
+        userId,
+      })
+      continue
+    }
+    const ok = await applyOperation(database, op, userId, membershipCache)
+    if (!ok) {
+      return { ok: false, failure: { table: op.type, id: op.id, op: op.op } }
+    }
+  }
+  return { ok: true }
 }

--- a/backend/src/dal/workspaces.test.ts
+++ b/backend/src/dal/workspaces.test.ts
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { user } from '@/db/auth-schema'
+import { workspaceMembersTable, workspacesTable } from '@/db/schema'
+import { createTestDb } from '@/test-utils/db'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { isActiveWorkspaceMember } from './workspaces'
+
+describe('workspaces DAL', () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  const insertUser = async (id: string, email: string) => {
+    const now = new Date()
+    await db.insert(user).values({
+      id,
+      name: id,
+      email,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+  }
+
+  const insertWorkspace = async (id: string, createdBy: string) => {
+    await db.insert(workspacesTable).values({
+      id,
+      name: `Workspace ${id}`,
+      createdBy,
+      isPersonal: false,
+    })
+  }
+
+  const insertMember = async (
+    workspaceId: string,
+    userId: string,
+    { role = 'member', removedAt = null }: { role?: 'owner' | 'admin' | 'member'; removedAt?: Date | null } = {},
+  ) => {
+    await db.insert(workspaceMembersTable).values({
+      workspaceId,
+      userId,
+      role,
+      joinedAt: new Date(),
+      removedAt,
+    })
+  }
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('isActiveWorkspaceMember', () => {
+    it('returns true for an active member', async () => {
+      await insertUser('u-active', 'active@test.com')
+      await insertWorkspace('ws-active', 'u-active')
+      await insertMember('ws-active', 'u-active', { role: 'owner' })
+
+      expect(await isActiveWorkspaceMember(db, 'ws-active', 'u-active')).toBe(true)
+    })
+
+    it('returns false when the user has no membership row', async () => {
+      await insertUser('u-stranger', 'stranger@test.com')
+      await insertUser('u-owner', 'owner@test.com')
+      await insertWorkspace('ws-stranger', 'u-owner')
+      await insertMember('ws-stranger', 'u-owner', { role: 'owner' })
+
+      expect(await isActiveWorkspaceMember(db, 'ws-stranger', 'u-stranger')).toBe(false)
+    })
+
+    it('returns false when the membership has removed_at set', async () => {
+      await insertUser('u-removed', 'removed@test.com')
+      await insertWorkspace('ws-removed', 'u-removed')
+      await insertMember('ws-removed', 'u-removed', { role: 'member', removedAt: new Date() })
+
+      expect(await isActiveWorkspaceMember(db, 'ws-removed', 'u-removed')).toBe(false)
+    })
+
+    it('returns false when the workspace does not exist', async () => {
+      await insertUser('u-ghost', 'ghost@test.com')
+
+      expect(await isActiveWorkspaceMember(db, 'ws-does-not-exist', 'u-ghost')).toBe(false)
+    })
+
+    it('isolates membership per (workspace, user) — one user is active, another is not', async () => {
+      await insertUser('u-alice', 'alice@test.com')
+      await insertUser('u-bob', 'bob@test.com')
+      await insertWorkspace('ws-shared', 'u-alice')
+      await insertMember('ws-shared', 'u-alice', { role: 'owner' })
+      await insertMember('ws-shared', 'u-bob', { role: 'member', removedAt: new Date() })
+
+      expect(await isActiveWorkspaceMember(db, 'ws-shared', 'u-alice')).toBe(true)
+      expect(await isActiveWorkspaceMember(db, 'ws-shared', 'u-bob')).toBe(false)
+    })
+
+    it('isolates membership per workspace — same user active in one, not in another', async () => {
+      await insertUser('u-multi', 'multi@test.com')
+      await insertWorkspace('ws-a', 'u-multi')
+      await insertWorkspace('ws-b', 'u-multi')
+      await insertMember('ws-a', 'u-multi', { role: 'owner' })
+      // No membership row in ws-b
+
+      expect(await isActiveWorkspaceMember(db, 'ws-a', 'u-multi')).toBe(true)
+      expect(await isActiveWorkspaceMember(db, 'ws-b', 'u-multi')).toBe(false)
+    })
+  })
+})

--- a/backend/src/dal/workspaces.ts
+++ b/backend/src/dal/workspaces.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { db as DbType } from '@/db/client'
+import { workspaceMembersTable } from '@/db/powersync-schema'
+import { and, eq, isNull } from 'drizzle-orm'
+
+/**
+ * Returns true if the user has a `workspace_members` row in the workspace with `removed_at IS NULL`.
+ * The PowerSync upload handler uses this on every PUT to workspace-scoped tables; the REST
+ * workspace endpoints will use it in the `workspaceAuth` middleware (BE-3).
+ */
+export const isActiveWorkspaceMember = async (
+  database: typeof DbType,
+  workspaceId: string,
+  userId: string,
+): Promise<boolean> => {
+  const rows = await database
+    .select({ workspaceId: workspaceMembersTable.workspaceId })
+    .from(workspaceMembersTable)
+    .where(
+      and(
+        eq(workspaceMembersTable.workspaceId, workspaceId),
+        eq(workspaceMembersTable.userId, userId),
+        isNull(workspaceMembersTable.removedAt),
+      ),
+    )
+    .limit(1)
+
+  return rows.length > 0
+}

--- a/backend/src/db/powersync-schema.ts
+++ b/backend/src/db/powersync-schema.ts
@@ -14,8 +14,9 @@ import {
   real,
   text,
   timestamp,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core'
-import { getTableColumns } from 'drizzle-orm'
+import { getTableColumns, sql } from 'drizzle-orm'
 import { user } from './auth-schema'
 
 /**
@@ -24,6 +25,87 @@ import { user } from './auth-schema'
  */
 
 const powersyncSchema = pgSchema('powersync')
+
+// ---------------------------------------------------------------------------
+// Workspace management
+// ---------------------------------------------------------------------------
+
+/** Workspace entity — every user has a personal workspace plus zero or more shared ones. */
+export const workspacesTable = powersyncSchema.table(
+  'workspaces',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    slug: text('slug'),
+    welcomeMessage: text('welcome_message'),
+    isPublic: boolean('is_public').notNull().default(false),
+    createdBy: text('created_by')
+      .notNull()
+      .references(() => user.id),
+    isPersonal: boolean('is_personal').notNull().default(false),
+    icon: text('icon'),
+    createdAt: timestamp('created_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
+    deletedAt: timestamp('deleted_at'),
+  },
+  (table) => [
+    uniqueIndex('workspaces_personal_per_user_idx')
+      .on(table.createdBy)
+      .where(sql`is_personal = true`),
+    uniqueIndex('workspaces_slug_idx')
+      .on(table.slug)
+      .where(sql`slug IS NOT NULL`),
+  ],
+)
+
+/** Workspace membership with role assignment. */
+export const workspaceMembersTable = powersyncSchema.table(
+  'workspace_members',
+  {
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    role: text('role', { enum: ['owner', 'admin', 'member'] }).notNull(),
+    joinedAt: timestamp('joined_at').notNull(),
+    removedAt: timestamp('removed_at'),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.workspaceId, table.userId] }),
+    index('idx_workspace_members_user_id').on(table.userId),
+  ],
+)
+
+/**
+ * Direct-add for users without an account yet. Syncs only to workspace owners/admins via the
+ * workspace_admin_data bucket (role-filtered). Writes go through REST endpoints, never PowerSync.
+ */
+export const pendingMembershipsTable = powersyncSchema.table(
+  'pending_memberships',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    email: text('email').notNull(),
+    role: text('role', { enum: ['owner', 'admin', 'member'] }).notNull(),
+    addedBy: text('added_by')
+      .notNull()
+      .references(() => user.id),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('pending_memberships_workspace_email_idx').on(table.workspaceId, sql`lower(${table.email})`),
+    index('idx_pending_memberships_workspace_id').on(table.workspaceId),
+  ],
+)
+
+// ---------------------------------------------------------------------------
+// User content + workspace config
+// ---------------------------------------------------------------------------
 
 export const settingsTable = powersyncSchema.table(
   'settings',
@@ -43,7 +125,7 @@ export const settingsTable = powersyncSchema.table(
 export const chatThreadsTable = powersyncSchema.table(
   'chat_threads',
   {
-    id: text('id').primaryKey(),
+    id: text('id').notNull(),
     title: text('title'),
     isEncrypted: integer('is_encrypted').default(0),
     triggeredBy: text('triggered_by'),
@@ -51,17 +133,22 @@ export const chatThreadsTable = powersyncSchema.table(
     contextSize: integer('context_size'),
     modeId: text('mode_id'),
     deletedAt: timestamp('deleted_at'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [index('idx_chat_threads_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_chat_threads_workspace_id').on(table.workspaceId),
+    index('idx_chat_threads_user_id').on(table.userId),
+  ],
 )
 
 export const chatMessagesTable = powersyncSchema.table(
   'chat_messages',
   {
-    id: text('id').primaryKey(),
+    id: text('id').notNull(),
     content: text('content'),
     role: text('role'),
     parts: text('parts'),
@@ -71,11 +158,16 @@ export const chatMessagesTable = powersyncSchema.table(
     cache: text('cache'),
     metadata: text('metadata'),
     deletedAt: timestamp('deleted_at'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [index('idx_chat_messages_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_chat_messages_workspace_id').on(table.workspaceId),
+    index('idx_chat_messages_user_id').on(table.userId),
+  ],
 )
 
 export const tasksTable = powersyncSchema.table(
@@ -87,11 +179,16 @@ export const tasksTable = powersyncSchema.table(
     isComplete: integer('is_complete').default(0),
     defaultHash: text('default_hash'),
     deletedAt: timestamp('deleted_at'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [primaryKey({ columns: [table.id, table.userId] }), index('idx_tasks_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_tasks_workspace_id').on(table.workspaceId),
+    index('idx_tasks_user_id').on(table.userId),
+  ],
 )
 
 export const modelsTable = powersyncSchema.table(
@@ -115,17 +212,22 @@ export const modelsTable = powersyncSchema.table(
     defaultHash: text('default_hash'),
     vendor: text('vendor'),
     description: text('description'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [primaryKey({ columns: [table.id, table.userId] }), index('idx_models_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_models_workspace_id').on(table.workspaceId),
+    index('idx_models_user_id').on(table.userId),
+  ],
 )
 
 export const mcpServersTable = powersyncSchema.table(
   'mcp_servers',
   {
-    id: text('id').primaryKey(),
+    id: text('id').notNull(),
     name: text('name'),
     type: text('type', { enum: ['http', 'stdio'] }).default('http'),
     url: text('url'),
@@ -135,11 +237,16 @@ export const mcpServersTable = powersyncSchema.table(
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
     deletedAt: timestamp('deleted_at'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [index('idx_mcp_servers_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_mcp_servers_workspace_id').on(table.workspaceId),
+    index('idx_mcp_servers_user_id').on(table.userId),
+  ],
 )
 
 export const promptsTable = powersyncSchema.table(
@@ -151,27 +258,37 @@ export const promptsTable = powersyncSchema.table(
     modelId: text('model_id'),
     deletedAt: timestamp('deleted_at'),
     defaultHash: text('default_hash'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [primaryKey({ columns: [table.id, table.userId] }), index('idx_prompts_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_prompts_workspace_id').on(table.workspaceId),
+    index('idx_prompts_user_id').on(table.userId),
+  ],
 )
 
 export const triggersTable = powersyncSchema.table(
   'triggers',
   {
-    id: text('id').primaryKey(),
+    id: text('id').notNull(),
     triggerType: text('trigger_type', { enum: ['time'] }),
     triggerTime: text('trigger_time'),
     promptId: text('prompt_id'),
     isEnabled: integer('is_enabled').default(1),
     deletedAt: timestamp('deleted_at'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [index('idx_triggers_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_triggers_workspace_id').on(table.workspaceId),
+    index('idx_triggers_user_id').on(table.userId),
+  ],
 )
 
 export const modesTable = powersyncSchema.table(
@@ -186,11 +303,16 @@ export const modesTable = powersyncSchema.table(
     order: integer('order').default(0),
     defaultHash: text('default_hash'),
     deletedAt: timestamp('deleted_at'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [primaryKey({ columns: [table.id, table.userId] }), index('idx_modes_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_modes_workspace_id').on(table.workspaceId),
+    index('idx_modes_user_id').on(table.userId),
+  ],
 )
 
 export const modelProfilesTable = powersyncSchema.table(
@@ -218,11 +340,16 @@ export const modelProfilesTable = powersyncSchema.table(
     providerOptions: text('provider_options'),
     defaultHash: text('default_hash'),
     deletedAt: timestamp('deleted_at'),
-    userId: text('user_id')
+    workspaceId: text('workspace_id')
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
+      .references(() => workspacesTable.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => user.id, { onDelete: 'set null' }),
   },
-  (table) => [primaryKey({ columns: [table.id, table.userId] }), index('idx_model_profiles_user_id').on(table.userId)],
+  (table) => [
+    primaryKey({ columns: [table.id, table.workspaceId] }),
+    index('idx_model_profiles_workspace_id').on(table.workspaceId),
+    index('idx_model_profiles_user_id').on(table.userId),
+  ],
 )
 
 /** Synced via PowerSync. Device list, status, and public key for encryption. */
@@ -261,6 +388,9 @@ export const powersyncTablesByName = {
   modes: modesTable,
   model_profiles: modelProfilesTable,
   devices: devicesTable,
+  workspaces: workspacesTable,
+  workspace_members: workspaceMembersTable,
+  pending_memberships: pendingMembershipsTable,
 } satisfies Record<PowerSyncTableName, AnyPgTable>
 
 /**
@@ -289,23 +419,31 @@ export const powersyncPkColumn: Record<PowerSyncTableName, AnyPgColumn> = {
   modes: modesTable.id,
   model_profiles: modelProfilesTable.id,
   devices: devicesTable.id,
+  workspaces: workspacesTable.id,
+  workspace_members: workspaceMembersTable.workspaceId,
+  pending_memberships: pendingMembershipsTable.id,
 }
 
 /**
  * Conflict target for each PowerSync table (for INSERT ON CONFLICT).
- * Tables with default data (settings, models, modes, tasks, prompts) use composite primary keys (id/key + user_id)
- * so each user can have their own row with the same default ID. See docs/composite-primary-keys-and-default-data.md.
+ * Workspace-scoped tables use composite primary keys (id, workspace_id) per Decision 17 of the
+ * workspaces spec — uniform across both user-private (chat_threads, chat_messages, tasks) and
+ * shared-config (models, modes, prompts, model_profiles, mcp_servers, triggers) tables. Settings
+ * is account-level and keeps its (id, user_id) composite. See docs/composite-primary-keys-and-default-data.md.
  */
 export const powersyncConflictTarget: Record<PowerSyncTableName, AnyPgColumn[]> = {
   settings: [settingsTable.key, settingsTable.userId],
-  chat_threads: [chatThreadsTable.id],
-  chat_messages: [chatMessagesTable.id],
-  tasks: [tasksTable.id, tasksTable.userId],
-  models: [modelsTable.id, modelsTable.userId],
-  mcp_servers: [mcpServersTable.id],
-  prompts: [promptsTable.id, promptsTable.userId],
-  triggers: [triggersTable.id],
-  modes: [modesTable.id, modesTable.userId],
-  model_profiles: [modelProfilesTable.id, modelProfilesTable.userId],
+  chat_threads: [chatThreadsTable.id, chatThreadsTable.workspaceId],
+  chat_messages: [chatMessagesTable.id, chatMessagesTable.workspaceId],
+  tasks: [tasksTable.id, tasksTable.workspaceId],
+  models: [modelsTable.id, modelsTable.workspaceId],
+  mcp_servers: [mcpServersTable.id, mcpServersTable.workspaceId],
+  prompts: [promptsTable.id, promptsTable.workspaceId],
+  triggers: [triggersTable.id, triggersTable.workspaceId],
+  modes: [modesTable.id, modesTable.workspaceId],
+  model_profiles: [modelProfilesTable.id, modelProfilesTable.workspaceId],
   devices: [devicesTable.id],
+  workspaces: [workspacesTable.id],
+  workspace_members: [workspaceMembersTable.workspaceId, workspaceMembersTable.userId],
+  pending_memberships: [pendingMembershipsTable.id],
 }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -8,7 +8,7 @@ export * from './auth-schema'
 // Re-export waitlist schema
 export * from './waitlist-schema'
 
-// Re-export PowerSync schema tables
+// Re-export PowerSync schema tables (includes workspace management tables)
 export * from './powersync-schema'
 
 // Re-export rate limit schema

--- a/deploy/config/powersync-config.yaml
+++ b/deploy/config/powersync-config.yaml
@@ -14,20 +14,58 @@ port: 8080
 sync_rules:
   content: |
     bucket_definitions:
-      user_data:
+      # Account-level data — one bucket per user, always present.
+      account_data:
         parameters: SELECT request.user_id() as user_id
         data:
-          - SELECT * FROM powersync.settings WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.chat_threads WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.chat_messages WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.models WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.modes WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.model_profiles WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.devices WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.settings WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.workspaces
+              WHERE deleted_at IS NULL
+              AND id IN (
+                SELECT workspace_id FROM powersync.workspace_members
+                WHERE user_id = bucket.user_id AND removed_at IS NULL
+              )
+
+      # Workspace data — one bucket instance per active workspace membership.
+      # workspace_members is included so every active member sees the full roster (needed for the
+      # settings / member-management UI). User-private rows (chat_threads, chat_messages, tasks)
+      # are filtered to the requester.
+      workspace_data:
+        parameters: |
+          SELECT wm.workspace_id
+          FROM powersync.workspace_members wm
+          WHERE wm.user_id = request.user_id()
+            AND wm.removed_at IS NULL
+        data:
+          - SELECT * FROM powersync.workspace_members WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.chat_threads
+              WHERE workspace_id = bucket.workspace_id
+              AND user_id = request.user_id()
+          - SELECT * FROM powersync.chat_messages
+              WHERE workspace_id = bucket.workspace_id
+              AND user_id = request.user_id()
+          - SELECT * FROM powersync.tasks
+              WHERE workspace_id = bucket.workspace_id
+              AND user_id = request.user_id()
+          - SELECT * FROM powersync.models WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.modes WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.prompts WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.model_profiles WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.mcp_servers WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.triggers WHERE workspace_id = bucket.workspace_id
+
+      # Admin-only workspace data — one bucket instance per workspace where the user is owner/admin.
+      # Demoting a user to 'member' drops the bucket and purges pending_memberships from their device.
+      workspace_admin_data:
+        parameters: |
+          SELECT wm.workspace_id
+          FROM powersync.workspace_members wm
+          WHERE wm.user_id = request.user_id()
+            AND wm.removed_at IS NULL
+            AND wm.role IN ('owner', 'admin')
+        data:
+          - SELECT * FROM powersync.pending_memberships WHERE workspace_id = bucket.workspace_id
 
 client_auth:
   supabase: false

--- a/powersync-service/config/config.yaml
+++ b/powersync-service/config/config.yaml
@@ -14,20 +14,58 @@ port: 8080
 sync_rules:
   content: |
     bucket_definitions:
-      user_data:
+      # Account-level data — one bucket per user, always present.
+      account_data:
         parameters: SELECT request.user_id() as user_id
         data:
-          - SELECT * FROM powersync.settings WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.chat_threads WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.chat_messages WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.models WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.modes WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.model_profiles WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.devices WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.settings WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.workspaces
+              WHERE deleted_at IS NULL
+              AND id IN (
+                SELECT workspace_id FROM powersync.workspace_members
+                WHERE user_id = bucket.user_id AND removed_at IS NULL
+              )
+
+      # Workspace data — one bucket instance per active workspace membership.
+      # workspace_members is included so every active member sees the full roster (needed for the
+      # settings / member-management UI). User-private rows (chat_threads, chat_messages, tasks)
+      # are filtered to the requester.
+      workspace_data:
+        parameters: |
+          SELECT wm.workspace_id
+          FROM powersync.workspace_members wm
+          WHERE wm.user_id = request.user_id()
+            AND wm.removed_at IS NULL
+        data:
+          - SELECT * FROM powersync.workspace_members WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.chat_threads
+              WHERE workspace_id = bucket.workspace_id
+              AND user_id = request.user_id()
+          - SELECT * FROM powersync.chat_messages
+              WHERE workspace_id = bucket.workspace_id
+              AND user_id = request.user_id()
+          - SELECT * FROM powersync.tasks
+              WHERE workspace_id = bucket.workspace_id
+              AND user_id = request.user_id()
+          - SELECT * FROM powersync.models WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.modes WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.prompts WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.model_profiles WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.mcp_servers WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.triggers WHERE workspace_id = bucket.workspace_id
+
+      # Admin-only workspace data — one bucket instance per workspace where the user is owner/admin.
+      # Demoting a user to 'member' drops the bucket and purges pending_memberships from their device.
+      workspace_admin_data:
+        parameters: |
+          SELECT wm.workspace_id
+          FROM powersync.workspace_members wm
+          WHERE wm.user_id = request.user_id()
+            AND wm.removed_at IS NULL
+            AND wm.role IN ('owner', 'admin')
+        data:
+          - SELECT * FROM powersync.pending_memberships WHERE workspace_id = bucket.workspace_id
 
 client_auth:
   supabase: false

--- a/shared/powersync-tables.ts
+++ b/shared/powersync-tables.ts
@@ -21,6 +21,9 @@ export const powersyncTableNames = [
   'modes',
   'model_profiles',
   'devices',
+  'workspaces',
+  'workspace_members',
+  'pending_memberships',
 ] as const
 
 export type PowerSyncTableName = (typeof powersyncTableNames)[number]
@@ -44,4 +47,7 @@ export const powersyncTableToQueryKeys: {
   modes: [['modes']],
   model_profiles: [['modelProfiles']],
   devices: [['devices']],
+  workspaces: [['workspaces']],
+  workspace_members: [['workspaceMembers']],
+  pending_memberships: [['pendingMemberships']],
 }


### PR DESCRIPTION
The "backend-only" coordination PR for the workspaces feature, per the two-PR rule for synced-table changes in CLAUDE.md. Bundles the upload-handler refactor (BE-6) into the same PR because the schema change creates a privilege-escalation surface (`workspace_members` becoming auto-writable) that must close atomically with the schema.

No user-visible changes.

## Summary

**Schema**
- New synced tables: `workspaces`, `workspace_members`, `pending_memberships` — all in the `powersync` schema; defined in `backend/src/db/powersync-schema.ts`
- `workspace_id text NOT NULL` (FK → `workspaces.id ON DELETE CASCADE`) added to the 9 workspace-scoped tables (`chat_threads`, `chat_messages`, `tasks`, `models`, `modes`, `prompts`, `model_profiles`, `mcp_servers`, `triggers`)
- Uniform composite PK `(id, workspace_id)` across all 9 workspace-scoped tables (Decision 17; deviates from the spec's split design — chosen for uniformity)
- `user_id` on those 9 tables relaxed from `NOT NULL + CASCADE` to nullable + `SET NULL` so workspace content survives author deletion
- `settings` and `devices` unchanged (account-level)
- Migration `0016_ancient_zarek.sql` hand-corrected for drizzle-kit's known issues (statement ordering + missing single-column PK constraint names)

**Sync rules** (both `deploy/config/powersync-config.yaml` and `powersync-service/config/config.yaml`)
- `account_data` bucket — `devices`, `settings`, and `workspaces` metadata filtered to the user's active memberships
- `workspace_data` bucket (parameterized by membership) — `workspace_members` (full roster, visible to every active member), user-private `chat_threads`/`chat_messages`/`tasks`, and shared workspace config
- `workspace_admin_data` bucket (parameterized by role) — `pending_memberships`, only attached to owners/admins; demoting drops the bucket and purges the rows

**Upload handler** (`backend/src/dal/powersync.ts`)
- `validTables` replaced with explicit `writableTables = {chat_threads, chat_messages, tasks, settings}` — workspace config writes flow through REST per Decision 14
- Workspace membership check on PUT for the workspace-scoped writable tables (extract `workspace_id` from `op.data`, verify `removed_at IS NULL`); `settings` exempt as account-level
- New `applyOperations` wrapper owns the per-batch membership cache so a batch with many ops in the same workspace only hits `workspace_members` once
- Non-writable ops are **silently skipped** with a server log (`powersync.upload.dropped_non_writable`) instead of failing the batch — prevents a stale or buggy client from poisoning sync of legitimate ops alongside the bad ones; retry would never resolve a not-allowlisted condition anyway
- New `isActiveWorkspaceMember` DAL helper in `backend/src/dal/workspaces.ts` (will be reused by the REST `workspaceAuth` middleware in PR 4)

## Deploy steps — per environment, in order

1. Merge this PR
2. Run `bun db migrate` in the target environment to apply `0016_ancient_zarek.sql`
3. **Manually update PowerSync Cloud dashboard sync rules** to match `deploy/config/powersync-config.yaml` (the three buckets above)
4. Smoke test with a synthetic user — verify they receive exactly `account_data` (after PR 2 seeds the personal workspace, also one `workspace_data`)

⚠️ Do not merge the frontend schema PR (THU-518 / FE-1) until step 3 is complete in production. Skipping the dashboard step is the documented silent-failure mode of the two-PR rule.

## Expected CI breakage

Frontend typecheck fails with one error in `src/db/powersync/schema.ts:25` — `syncedTables` is missing entries for `workspaces`, `workspace_members`, `pending_memberships`. This is the intentional intermediate state of the two-PR rule; resolved by THU-518 / FE-1 which adds the matching frontend SQLite tables.

## Tests

- 80 backend tests pass (74 in `powersync.test.ts`, 6 in `workspaces.test.ts`)
- New coverage: workspace membership PUT validation (member/non-member/removed/missing-workspace_id), the 10 non-writable tables (silent skip), mixed-batch behavior (non-writable in first/middle position doesn't poison writables), PATCH on non-writable, DELETE on devices (now silently skipped), `isActiveWorkspaceMember` DAL isolation across workspaces and users

## Test plan

- [ ] Run `bun db migrate` against a fresh DB — confirm clean apply
- [ ] Run `bun test src/api/powersync.test.ts src/dal/workspaces.test.ts` — all 80 pass
- [ ] After dashboard update in staging, verify a synthetic user receives `account_data` (single bucket, no other content yet — PR 2 lands personal-workspace creation)