### PR TITLE
fix(deploy): provision per-PR Keycloak OIDC client

### DIFF
--- a/.github/workflows/previews-shared-deploy.yml
+++ b/.github/workflows/previews-shared-deploy.yml
@@ -39,16 +39,6 @@ on:
         type: string
         default: 'powersync.shared.preview.thunderbolt.io'
         required: true
-      pr_api_host_pattern:
-        description: 'Wildcard pattern for per-PR API hostnames (used in Keycloak realm OIDC client redirect URIs)'
-        type: string
-        default: 'api-pr-*.preview.thunderbolt.io'
-        required: true
-      pr_app_host_pattern:
-        description: 'Wildcard pattern for per-PR app hostnames (used in Keycloak realm webOrigins)'
-        type: string
-        default: 'app-pr-*.preview.thunderbolt.io'
-        required: true
       region:
         description: 'AWS region'
         type: choice
@@ -113,8 +103,6 @@ jobs:
           INPUT_VERSION: ${{ steps.version.outputs.version }}
           INPUT_AUTH_HOSTNAME: ${{ inputs.auth_hostname || 'auth.shared.preview.thunderbolt.io' }}
           INPUT_POWERSYNC_HOSTNAME: ${{ inputs.powersync_hostname || 'powersync.shared.preview.thunderbolt.io' }}
-          INPUT_PR_API_HOST_PATTERN: ${{ inputs.pr_api_host_pattern || 'api-pr-*.preview.thunderbolt.io' }}
-          INPUT_PR_APP_HOST_PATTERN: ${{ inputs.pr_app_host_pattern || 'app-pr-*.preview.thunderbolt.io' }}
           INPUT_GHCR_PAT: ${{ secrets.GHCR_PAT }}
           INPUT_CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
           INPUT_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -127,8 +115,6 @@ jobs:
           pulumi config set version "$INPUT_VERSION" -s "$INPUT_STACK_NAME" --non-interactive
           pulumi config set authHostname "$INPUT_AUTH_HOSTNAME" -s "$INPUT_STACK_NAME" --non-interactive
           pulumi config set powersyncHostname "$INPUT_POWERSYNC_HOSTNAME" -s "$INPUT_STACK_NAME" --non-interactive
-          pulumi config set prApiHostPattern "$INPUT_PR_API_HOST_PATTERN" -s "$INPUT_STACK_NAME" --non-interactive
-          pulumi config set prAppHostPattern "$INPUT_PR_APP_HOST_PATTERN" -s "$INPUT_STACK_NAME" --non-interactive
 
           if [ -n "$INPUT_GHCR_PAT" ]; then
             pulumi config set --secret ghcrToken "$INPUT_GHCR_PAT" -s "$INPUT_STACK_NAME" --non-interactive

--- a/deploy/pulumi/SHARED.md
+++ b/deploy/pulumi/SHARED.md
@@ -118,9 +118,13 @@ on the shared model.
      bastion infra.
   3. Lambda triggered by Pulumi.
   Phase 3 will pick option 1 unless we hit issues.
-- **Per-PR Keycloak OIDC client.** Use `@pulumi/keycloak` provider against the
+- ~~**Per-PR Keycloak OIDC client.** Use `@pulumi/keycloak` provider against the
   shared Keycloak admin API. Provider needs admin creds — shared stack exports
-  them. Resource: `keycloak.openid.Client`.
+  them. Resource: `keycloak.openid.Client`.~~ Done — `per-pr-stack.ts` provisions
+  `thunderbolt-app-<stack>` with exact-match redirect/origin URIs. Required
+  because Keycloak only honors `*` as a trailing path wildcard (no hostname
+  wildcards), so the prior shared-client + `api-pr-*.…` redirect URI approach
+  never matched any real PR.
 - **PowerSync wildcard JWT issuer.** Per-PR backends sign JWTs with the shared
   PowerSync JWT secret. PowerSync verifies signatures regardless of which PR
   issued them. ✓ no per-PR config needed.

--- a/deploy/pulumi/bun.lock
+++ b/deploy/pulumi/bun.lock
@@ -10,6 +10,7 @@
         "@pulumi/cloudflare": "^6.14.0",
         "@pulumi/docker-build": "^0.0.15",
         "@pulumi/eks": "^4.0.0",
+        "@pulumi/keycloak": "^6.10.1",
         "@pulumi/kubernetes": "^4.0.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/random": "^4.19.2",
@@ -197,6 +198,8 @@
     "@pulumi/docker-build": ["@pulumi/docker-build@0.0.15", "", { "dependencies": { "@pulumi/pulumi": "^3.142.0" } }, "sha512-abtz4zCbePBkpj73M7mJWqXktM9muEAUOxRu8PKErbsqv5M3NfALCMULsDxA1a9vEImHa6ZC9rAe1liXbsinFg=="],
 
     "@pulumi/eks": ["@pulumi/eks@4.2.0", "", { "dependencies": { "@pulumi/aws": "^7.14.0", "@pulumi/kubernetes": "^4.19.0", "@pulumi/pulumi": "^3.142.0", "https-proxy-agent": "^5.0.1", "js-yaml": "^4.1.0", "netmask": "^2.0.2", "semver": "^7.3.7", "which": "^1.3.1" } }, "sha512-myGhOksnF/BUun7oWvuphp+2l6CNV9meE7Gu/8+JulcOhA2jYttGdSI+15BvUnDNgUBv3qNlu+NQ473C3q4Wvg=="],
+
+    "@pulumi/keycloak": ["@pulumi/keycloak@6.10.1", "", { "dependencies": { "@pulumi/pulumi": "^3.142.0" } }, "sha512-Mm16SjiXI1aMSa0HvH3ipRFoL+6wNNm5SQKKgBT0ZtxpDCXO1LsDtTPP4GITynwrrx/V6hgUwcWV8N2kigmgGQ=="],
 
     "@pulumi/kubernetes": ["@pulumi/kubernetes@4.30.0", "", { "dependencies": { "@pulumi/pulumi": "^3.142.0", "glob": "^12.0.0", "shell-quote": "^1.6.1" } }, "sha512-ZCS4HwBvcxfdPDw44L1/SCqoIttCVugx/FZzqRFRq+leKRIfigAYt4sILXlqulNtX6XjlWVzZO8zva3Ygk7hGA=="],
 

--- a/deploy/pulumi/index.ts
+++ b/deploy/pulumi/index.ts
@@ -58,9 +58,6 @@ if (isSharedStack) {
   const powersyncJwtSecret =
     config.getSecret('powersyncJwtSecret') ??
     new random.RandomPassword(`${name}-powersync-jwt-secret`, { length: 64, special: false }).result
-  const oidcClientSecret =
-    config.getSecret('oidcClientSecret') ??
-    new random.RandomPassword(`${name}-oidc-client-secret`, { length: 48, special: false }).result
 
   const outputs = createSharedStack({
     name,
@@ -69,8 +66,6 @@ if (isSharedStack) {
     ghcrToken: config.getSecret('ghcrToken'),
     authHostname: config.require('authHostname'),
     powersyncHostname: config.require('powersyncHostname'),
-    prApiHostPattern: config.require('prApiHostPattern'),
-    prAppHostPattern: config.require('prAppHostPattern'),
     cloudflareZoneId: config.get('cloudflareZoneId'),
     cloudflareApiToken: config.getSecret('cloudflareApiToken'),
     aiSecrets: {
@@ -84,7 +79,6 @@ if (isSharedStack) {
     powersyncDbPassword,
     keycloakAdminPassword,
     powersyncJwtSecret,
-    oidcClientSecret,
   })
 
   // The full shape goes into stack outputs so per-PR StackReference reads work.

--- a/deploy/pulumi/package.json
+++ b/deploy/pulumi/package.json
@@ -9,6 +9,7 @@
     "@pulumi/cloudflare": "^6.14.0",
     "@pulumi/docker-build": "^0.0.15",
     "@pulumi/eks": "^4.0.0",
+    "@pulumi/keycloak": "^6.10.1",
     "@pulumi/kubernetes": "^4.0.0",
     "@pulumi/pulumi": "^3.0.0",
     "@pulumi/random": "^4.19.2"

--- a/deploy/pulumi/src/per-pr-stack.ts
+++ b/deploy/pulumi/src/per-pr-stack.ts
@@ -4,7 +4,9 @@
 
 import * as aws from '@pulumi/aws'
 import * as cloudflare from '@pulumi/cloudflare'
+import * as keycloak from '@pulumi/keycloak'
 import * as pulumi from '@pulumi/pulumi'
+import * as random from '@pulumi/random'
 import type { SharedStackOutputs } from './shared'
 
 /**
@@ -201,8 +203,57 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
     )
   }
 
-  // -------- 6. Per-PR secrets --------
+  // -------- 6. Per-PR Keycloak OIDC client --------
+  // Keycloak only honors `*` as a trailing path wildcard in `validRedirectUris` —
+  // hostname wildcards aren't supported — so the shared client can't cover every
+  // PR's `api-pr-<n>` host. Each per-PR stack instead provisions its own client
+  // in the shared `thunderbolt` realm with exact-match redirect/origin URIs.
+  const keycloakProvider = new keycloak.Provider(`${name}-keycloak`, {
+    url: shared.keycloakUrl,
+    realm: 'master',
+    clientId: 'admin-cli',
+    username: shared.keycloakAdminUsername,
+    password: shared.keycloakAdminPassword,
+  })
+
+  const oidcClientSecretValue = new random.RandomPassword(`${name}-oidc-client-secret`, {
+    length: 48,
+    special: false,
+  }).result
+
+  const oidcClientIdValue = `thunderbolt-app-${args.stackName}`
+  const apiCallbackUrl = pulumi.interpolate`https://${args.hostnames.api}/v1/api/auth/sso/callback/sso`
+
+  const oidcClient = new keycloak.openid.Client(
+    `${name}-oidc-client`,
+    {
+      realmId: shared.keycloakRealm,
+      clientId: oidcClientIdValue,
+      name: oidcClientIdValue,
+      enabled: true,
+      accessType: 'CONFIDENTIAL',
+      clientSecret: oidcClientSecretValue,
+      standardFlowEnabled: true,
+      directAccessGrantsEnabled: false,
+      validRedirectUris: [apiCallbackUrl],
+      webOrigins: [pulumi.interpolate`https://${args.hostnames.app}`],
+    },
+    { provider: keycloakProvider },
+  )
+
+  // -------- 7. Per-PR secrets --------
   const dbName = dbNameFromStack(args.stackName)
+
+  const oidcClientSecretArn = (() => {
+    const s = new aws.secretsmanager.Secret(`${name}-oidc-client-secret`, {
+      tags: { Name: `${name}-oidc-client-secret` },
+    })
+    new aws.secretsmanager.SecretVersion(`${name}-oidc-client-secret-version`, {
+      secretId: s.id,
+      secretString: oidcClient.clientSecret,
+    })
+    return s.arn
+  })()
 
   const betterAuthSecretArn = (() => {
     const s = new aws.secretsmanager.Secret(`${name}-better-auth-secret`, {
@@ -234,7 +285,7 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
     secretString: pulumi.interpolate`postgresql://postgres:${shared.postgresPassword}@${shared.postgresHost}:${shared.postgresPort}/postgres`,
   })
 
-  // -------- 7. Per-PR exec role policy: read per-PR secrets + shared secrets --------
+  // -------- 8. Per-PR exec role policy: read per-PR secrets + shared secrets --------
   new aws.iam.RolePolicy(`${name}-exec-secrets-policy`, {
     role: execRole.name,
     policy: pulumi.jsonStringify({
@@ -248,8 +299,8 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
             betterAuthSecretArn,
             databaseUrlSecret.arn,
             postgresAdminUrlSecret.arn,
+            oidcClientSecretArn,
             // Shared (consumed by per-PR backend at startup)
-            shared.oidcClientSecretArn,
             shared.powersyncJwtSecretArn,
             shared.anthropicApiKeySecretArn,
             shared.fireworksApiKeySecretArn,
@@ -262,7 +313,7 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
     }),
   })
 
-  // -------- 8. Per-PR ECS services (backend / frontend / marketing) --------
+  // -------- 9. Per-PR ECS services (backend / frontend / marketing) --------
   const beImage = `${imagePrefix}/thunderbolt-backend:${version}`
   const feImage = `${imagePrefix}/thunderbolt-frontend:${version}`
   const mkImage = `${imagePrefix}/thunderbolt-marketing:${version}`
@@ -291,7 +342,7 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
           { name: 'WAITLIST_ENABLED', value: 'false' },
           { name: 'DATABASE_DRIVER', value: 'postgres' },
           { name: 'OIDC_ISSUER', value: shared.keycloakIssuerUrl },
-          { name: 'OIDC_CLIENT_ID', value: shared.oidcClientId },
+          { name: 'OIDC_CLIENT_ID', value: oidcClient.clientId },
           { name: 'BETTER_AUTH_URL', value: apiUrl },
           { name: 'APP_URL', value: appUrl },
           // TRUSTED_ORIGINS includes the shared auth subdomain (Better Auth's SSO
@@ -312,7 +363,7 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
         secrets: [
           { name: 'DATABASE_URL', valueFrom: databaseUrlSecret.arn },
           { name: 'POSTGRES_ADMIN_URL', valueFrom: postgresAdminUrlSecret.arn },
-          { name: 'OIDC_CLIENT_SECRET', valueFrom: shared.oidcClientSecretArn },
+          { name: 'OIDC_CLIENT_SECRET', valueFrom: oidcClientSecretArn },
           { name: 'BETTER_AUTH_SECRET', valueFrom: betterAuthSecretArn },
           { name: 'POWERSYNC_JWT_SECRET', valueFrom: shared.powersyncJwtSecretArn },
           { name: 'ANTHROPIC_API_KEY', valueFrom: shared.anthropicApiKeySecretArn },
@@ -396,7 +447,7 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
     loadBalancers: [{ targetGroupArn: marketingTg.arn, containerName: 'marketing', containerPort: 80 }],
   })
 
-  // -------- 9. Outputs --------
+  // -------- 10. Outputs --------
   // Auth + powersync URLs come from the shared stack so users see consistent
   // hostnames per environment regardless of which PR they came in through.
   const authUrl = shared.keycloakIssuerUrl.apply((u) => u.replace(/\/realms\/.*$/, ''))

--- a/deploy/pulumi/src/shared.ts
+++ b/deploy/pulumi/src/shared.ts
@@ -55,17 +55,6 @@ export type SharedStackArgs = {
   keycloakAdminPassword: pulumi.Output<string>
   /** PowerSync JWT signing secret (per-PR backends sign with this; PowerSync verifies). */
   powersyncJwtSecret: pulumi.Output<string>
-  /**
-   * Wildcard hostname for per-PR API subdomains, e.g. `api-pr-*.preview.thunderbolt.io`.
-   * The shared Keycloak realm registers a single OIDC client whose `redirectUris`
-   * field uses this wildcard, so all per-PR backends share one client_id/secret
-   * but Keycloak validates the redirect target matches the wildcard pattern.
-   */
-  prApiHostPattern: pulumi.Input<string>
-  /** Wildcard hostname for per-PR app subdomains, e.g. `app-pr-*.preview.thunderbolt.io`. */
-  prAppHostPattern: pulumi.Input<string>
-  /** Shared OIDC client secret (random per shared-stack; used by all per-PR backends). */
-  oidcClientSecret: pulumi.Output<string>
 }
 
 /**
@@ -121,10 +110,22 @@ export type SharedStackOutputs = {
   powersyncJwtSecretArn: pulumi.Output<string>
   /** Per-PR backends fetch tokens from `${keycloakIssuerUrl}/.well-known/...`. */
   keycloakIssuerUrl: pulumi.Output<string>
-  /** OIDC client id all per-PR backends use against the shared Keycloak realm. */
-  oidcClientId: pulumi.Output<string>
-  /** Secrets Manager ARN holding the OIDC client secret for the above client. */
-  oidcClientSecretArn: pulumi.Output<string>
+  /**
+   * Base URL of the shared Keycloak (no realm suffix). Per-PR stacks point the
+   * `@pulumi/keycloak` provider at this URL to provision their own OIDC client.
+   */
+  keycloakUrl: pulumi.Output<string>
+  /** Realm where per-PR OIDC clients are created. */
+  keycloakRealm: pulumi.Output<string>
+  /** Admin username for the Keycloak admin API (master realm). */
+  keycloakAdminUsername: pulumi.Output<string>
+  /**
+   * Admin password for the Keycloak admin API. Exposed in plaintext through
+   * StackReference (encrypted at rest in Pulumi state) so per-PR stacks can
+   * construct the keycloak.Provider without a Secrets Manager round-trip at
+   * preview time. Same pattern as `postgresPassword`.
+   */
+  keycloakAdminPassword: pulumi.Output<string>
 
   // -- Shared AI provider secrets (same values across all per-PR stacks) --
   anthropicApiKeySecretArn: pulumi.Output<string>
@@ -360,14 +361,6 @@ export const createSharedStack = (args: SharedStackArgs): SharedStackOutputs => 
     secretString: args.powersyncJwtSecret,
   })
 
-  const oidcClientSecretSecret = new aws.secretsmanager.Secret(`${name}-oidc-client-secret`, {
-    tags: { Name: `${name}-oidc-client-secret` },
-  })
-  new aws.secretsmanager.SecretVersion(`${name}-oidc-client-secret-version`, {
-    secretId: oidcClientSecretSecret.id,
-    secretString: args.oidcClientSecret,
-  })
-
   // AI provider secrets — created in the shared stack so per-PR stacks just reference
   // them. Per-PR exec roles grant GetSecretValue against these ARNs (passed via
   // StackReference outputs).
@@ -515,11 +508,17 @@ export const createSharedStack = (args: SharedStackArgs): SharedStackOutputs => 
   }, { dependsOn: [listener] })
 
   // -------- 9. Keycloak ECS service --------
-  // The shared Keycloak imports the `thunderbolt` realm at boot. Per-PR backends
-  // each register a Keycloak OIDC client (via the @pulumi/keycloak provider in
-  // per-pr-stack.ts) with its own redirect URI matching the PR's `api-pr-<n>` host.
+  // The shared Keycloak imports the `thunderbolt` realm at boot. Per-PR stacks
+  // each register their own `keycloak.openid.Client` resource in `per-pr-stack.ts`
+  // — with `validRedirectUris` and `webOrigins` scoped to that PR's hostnames —
+  // because Keycloak's redirect URI matching only honors `*` as a path suffix
+  // (no hostname wildcards), so the previous wildcard `api-pr-*.…` redirect URI
+  // never matched any real PR host. The `thunderbolt-app` client baked into the
+  // realm import still exists but is unused for preview-pr traffic.
   const kcImage = `${imagePrefix}/thunderbolt-keycloak:${version}`
   const kcAuthUrl = pulumi.interpolate`https://${args.authHostname}`
+  const keycloakRealm = 'thunderbolt'
+  const keycloakAdminUsername = 'admin'
   const kcTaskDef = new aws.ecs.TaskDefinition(`${name}-kc-task`, {
     family: `${name}-keycloak`,
     requiresCompatibilities: ['FARGATE'],
@@ -535,24 +534,11 @@ export const createSharedStack = (args: SharedStackArgs): SharedStackOutputs => 
         essential: true,
         command: ['start-dev', '--import-realm'],
         environment: [
-          { name: 'KC_BOOTSTRAP_ADMIN_USERNAME', value: 'admin' },
+          { name: 'KC_BOOTSTRAP_ADMIN_USERNAME', value: keycloakAdminUsername },
           { name: 'KC_BOOTSTRAP_ADMIN_PASSWORD', value: args.keycloakAdminPassword },
           { name: 'KC_HTTP_PORT', value: '8080' },
           { name: 'KC_HOSTNAME', value: kcAuthUrl },
           { name: 'KC_PROXY_HEADERS', value: 'xforwarded' },
-          // The shared Keycloak realm registers ONE `thunderbolt-app` client. Its
-          // redirectUris / webOrigins use wildcards (`api-pr-*.…`) so every per-PR
-          // backend can use the same client_id + client_secret without per-PR realm
-          // mutation. Tradeoff vs. dynamic per-PR clients: less isolation between PRs,
-          // but no Keycloak admin API plumbing needed in per-pr-stack.ts.
-          { name: 'OIDC_REDIRECT_URI', value: pulumi.interpolate`https://${args.prApiHostPattern}/v1/api/auth/sso/callback/sso` },
-          { name: 'OIDC_WEB_ORIGIN', value: pulumi.interpolate`https://${args.prAppHostPattern}` },
-          // The realm import substitutes ${OIDC_CLIENT_SECRET} into the
-          // `thunderbolt-app` client's `secret` field. Without this, Keycloak would
-          // fall back to the realm file's built-in default and per-PR backends —
-          // which receive the random secret via `oidcClientSecretArn` — would fail
-          // OIDC token exchange.
-          { name: 'OIDC_CLIENT_SECRET', value: args.oidcClientSecret },
         ],
         portMappings: [{ containerPort: 8080 }],
         logConfiguration: logConfig('keycloak'),
@@ -603,9 +589,11 @@ export const createSharedStack = (args: SharedStackArgs): SharedStackOutputs => 
     powersyncHost: pulumi.output(`powersync.${NAMESPACE_DOMAIN}`),
     powersyncPublicUrl: pulumi.interpolate`https://${args.powersyncHostname}`,
     powersyncJwtSecretArn: powersyncJwtSecretSecret.arn,
-    keycloakIssuerUrl: pulumi.interpolate`${kcAuthUrl}/realms/thunderbolt`,
-    oidcClientId: pulumi.output('thunderbolt-app'),
-    oidcClientSecretArn: oidcClientSecretSecret.arn,
+    keycloakIssuerUrl: pulumi.interpolate`${kcAuthUrl}/realms/${keycloakRealm}`,
+    keycloakUrl: kcAuthUrl,
+    keycloakRealm: pulumi.output(keycloakRealm),
+    keycloakAdminUsername: pulumi.output(keycloakAdminUsername),
+    keycloakAdminPassword: args.keycloakAdminPassword,
 
     anthropicApiKeySecretArn: aiSecretArns.anthropicApiKey,
     fireworksApiKeySecretArn: aiSecretArns.fireworksApiKey,
@@ -649,8 +637,10 @@ export const loadSharedStackOutputs = (ref: pulumi.StackReference): SharedStackO
     powersyncPublicUrl: get<string>('powersyncPublicUrl'),
     powersyncJwtSecretArn: get<string>('powersyncJwtSecretArn'),
     keycloakIssuerUrl: get<string>('keycloakIssuerUrl'),
-    oidcClientId: get<string>('oidcClientId'),
-    oidcClientSecretArn: get<string>('oidcClientSecretArn'),
+    keycloakUrl: get<string>('keycloakUrl'),
+    keycloakRealm: get<string>('keycloakRealm'),
+    keycloakAdminUsername: get<string>('keycloakAdminUsername'),
+    keycloakAdminPassword: get<string>('keycloakAdminPassword'),
     anthropicApiKeySecretArn: get<string>('anthropicApiKeySecretArn'),
     fireworksApiKeySecretArn: get<string>('fireworksApiKeySecretArn'),
     mistralApiKeySecretArn: get<string>('mistralApiKeySecretArn'),


### PR DESCRIPTION
## Summary

- Replaces the shared `thunderbolt-app` Keycloak client + `api-pr-*.…` wildcard `redirectUris` (which Keycloak never honored — it only allows `*` as a path suffix, not in the hostname) with a dynamically provisioned per-PR `keycloak.openid.Client` resource.
- Each `preview-pr-N` stack now creates `thunderbolt-app-preview-pr-N` in the shared `thunderbolt` realm via the `@pulumi/keycloak` provider, with exact-match `validRedirectUris` (`https://api-pr-N.preview.thunderbolt.io/v1/api/auth/sso/callback/sso`) and `webOrigins` (`https://app-pr-N.preview.thunderbolt.io`). Client secret is random per-PR and stored in AWS Secrets Manager next to `BETTER_AUTH_SECRET`.
- Shared stack now exports `keycloakUrl`, `keycloakRealm`, `keycloakAdminUsername`, `keycloakAdminPassword` (admin creds plaintext through StackReference, same pattern as `postgresPassword`); drops `oidcClientId`, `oidcClientSecretArn`, `prApiHostPattern`, `prAppHostPattern`, and the broken `OIDC_REDIRECT_URI`/`OIDC_WEB_ORIGIN`/`OIDC_CLIENT_SECRET` env vars on the shared Keycloak container.

Fixes `Invalid parameter: redirect_uri` on `app-pr-*.preview.thunderbolt.io` SSO sign-in.

## Test plan

- [ ] Deploy `previews-shared` and confirm Keycloak boots cleanly (realm imports without the removed env vars).
- [ ] Deploy a `preview-pr-N` stack against the updated shared stack; verify `thunderbolt-app-preview-pr-N` appears in the shared Keycloak realm with the expected `validRedirectUris` / `webOrigins`.
- [ ] Hit `https://app-pr-N.preview.thunderbolt.io`, click sign-in, complete the SSO flow against the shared Keycloak — no `Invalid parameter: redirect_uri`.
- [ ] Destroy the per-PR stack; verify the Keycloak client is removed from the realm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Keycloak/OIDC provisioning and secret wiring for preview stacks, which can break SSO login and requires updates to both shared and per-PR Pulumi stacks/outputs.
> 
> **Overview**
> Fixes preview SSO redirect failures by **replacing the shared Keycloak OIDC client + hostname-wildcard redirect/origin config** with **per-PR `keycloak.openid.Client` resources** created during each `preview-pr-*` deployment.
> 
> The shared Pulumi stack drops `prApiHostPattern`/`prAppHostPattern` and the shared OIDC client secret, and instead exports `keycloakUrl`, realm, and admin credentials for per-PR stacks to manage clients. Per-PR stacks now generate/store a per-PR OIDC client secret in Secrets Manager and wire backend env/secrets to use the per-PR `clientId`/`clientSecret`.
> 
> Workflow and docs are updated accordingly, and Pulumi deps add `@pulumi/keycloak`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3a9a58f0670c02b320553826eb6262194729f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->