### PR TITLE
fix(deploy): drop per-PR database before stack destroy

### DIFF
--- a/.github/workflows/preview-destroy.yml
+++ b/.github/workflows/preview-destroy.yml
@@ -48,8 +48,27 @@ jobs:
             fi
           fi
 
-  destroy:
+  drop-db:
     needs: resolve-pr
+    if: needs.resolve-pr.outputs.is_internal == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Drop per-stack database
+        # Must run before `pulumi destroy` — the per-stack secrets and backend
+        # task definition disappear with the stack, and we need both to invoke
+        # the drop. Script is idempotent if the stack is already partially gone.
+        run: ./scripts/drop-preview-db.sh "${{ needs.resolve-pr.outputs.pr_number }}"
+
+  destroy:
+    needs: [resolve-pr, drop-db]
     if: needs.resolve-pr.outputs.is_internal == 'true'
     uses: ./.github/workflows/stack-deploy.yml
     with:
@@ -61,7 +80,7 @@ jobs:
     secrets: inherit
 
   comment:
-    needs: [resolve-pr, destroy]
+    needs: [resolve-pr, drop-db, destroy]
     if: ${{ needs.resolve-pr.outputs.is_internal == 'true' && github.event.pull_request.number }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview-destroy.yml
+++ b/.github/workflows/preview-destroy.yml
@@ -69,7 +69,9 @@ jobs:
 
   destroy:
     needs: [resolve-pr, drop-db]
-    if: needs.resolve-pr.outputs.is_internal == 'true'
+    # Run even if drop-db failed — a flaky DB drop must not orphan the whole
+    # stack (ECS services, ALB, secrets) and leak cost indefinitely.
+    if: ${{ always() && needs.resolve-pr.result == 'success' && needs.resolve-pr.outputs.is_internal == 'true' }}
     uses: ./.github/workflows/stack-deploy.yml
     with:
       action: destroy
@@ -81,7 +83,7 @@ jobs:
 
   comment:
     needs: [resolve-pr, drop-db, destroy]
-    if: ${{ needs.resolve-pr.outputs.is_internal == 'true' && github.event.pull_request.number }}
+    if: ${{ always() && needs.resolve-pr.result == 'success' && needs.resolve-pr.outputs.is_internal == 'true' && github.event.pull_request.number }}
     runs-on: ubuntu-latest
     steps:
       - name: Update sticky comment to note teardown

--- a/scripts/drop-preview-db.sh
+++ b/scripts/drop-preview-db.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# -----------------------------------------------------------------------------
+# drop-preview-db.sh
+# -----------------------------------------------------------------------------
+# Drops the per-stack logical Postgres database for a PR preview environment.
+#
+# The shared-postgres preview model (THU-495) gives each PR its own logical DB
+# (e.g. `preview_pr_851`) on a single shared Postgres instance. Pulumi destroy
+# tears down ECS/ALB/secrets but does not drop the logical DB, so schema state
+# (notably `__drizzle_migrations` content hashes) leaks across destroy/deploy
+# cycles and causes drizzle-kit to fail on the next deploy when migrations
+# have been re-edited.
+#
+# This script runs as part of `Preview Destroy` *before* `pulumi destroy`,
+# while the per-stack secrets and backend task definition still exist. It
+# registers a one-off task definition derived from the backend's, overrides
+# the entryPoint to bypass the migrate-on-boot logic, and invokes a tiny
+# DROP DATABASE against `POSTGRES_ADMIN_URL`.
+#
+# Usage: drop-preview-db.sh <PR_NUMBER>
+# Requires: AWS creds with ECS + Logs perms; AWS_REGION set (default us-east-1).
+#
+# Idempotent: if the stack's resources are already gone, exits 0 with a note.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+PR_NUMBER="${1:?PR number required}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+STACK="preview-pr-${PR_NUMBER}"
+BACKEND_FAMILY="tb-${STACK}-backend"
+BE_SVC_PREFIX="tb-${STACK}-be-svc-"
+SHARED_CLUSTER_PREFIX="tb-previews-shared-cluster-"
+
+log() { echo "[drop-preview-db] $*"; }
+
+CLUSTER=$(aws ecs list-clusters --region "$AWS_REGION" \
+  --query "clusterArns[?contains(@, '${SHARED_CLUSTER_PREFIX}')] | [0]" --output text)
+if [ -z "$CLUSTER" ] || [ "$CLUSTER" = "None" ]; then
+  log "No shared cluster found — nothing to drop."
+  exit 0
+fi
+
+SVC=$(aws ecs list-services --cluster "$CLUSTER" --region "$AWS_REGION" \
+  --query "serviceArns[?contains(@, '${BE_SVC_PREFIX}')] | [0]" --output text)
+if [ -z "$SVC" ] || [ "$SVC" = "None" ]; then
+  log "No backend service for ${STACK} — stack already torn down or never deployed. Skipping."
+  exit 0
+fi
+
+TASKDEF=$(aws ecs list-task-definitions --family-prefix "$BACKEND_FAMILY" --status ACTIVE --region "$AWS_REGION" \
+  --query 'taskDefinitionArns | [-1]' --output text)
+if [ -z "$TASKDEF" ] || [ "$TASKDEF" = "None" ]; then
+  log "No backend task definition for ${STACK} — skipping."
+  exit 0
+fi
+
+NETCONF=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SVC" --region "$AWS_REGION" \
+  --query 'services[0].networkConfiguration' --output json)
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+aws ecs describe-task-definition --task-definition "$TASKDEF" --region "$AWS_REGION" \
+  --query 'taskDefinition' > "$WORKDIR/source.json"
+
+DROP_CMD='bun -e '\''import postgres from "postgres"; const target = new URL(process.env.DATABASE_URL); const dbName = target.pathname.replace(/^\//, ""); if (!/^[a-zA-Z0-9_]+$/.test(dbName)) { console.error("refusing drop on invalid name:", dbName); process.exit(1); } const admin = postgres(process.env.POSTGRES_ADMIN_URL); console.log("dropping", dbName); await admin.unsafe(`DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE)`); await admin.end(); console.log("done")'\'
+
+jq --arg cmd "$DROP_CMD" --arg family "tb-${STACK}-db-drop" '
+  {containerDefinitions, family: $family, taskRoleArn, executionRoleArn, networkMode, requiresCompatibilities, cpu, memory}
+  | .containerDefinitions[0].entryPoint = ["sh", "-c"]
+  | .containerDefinitions[0].command = [$cmd]
+' "$WORKDIR/source.json" > "$WORKDIR/drop-taskdef.json"
+
+DROP_TASKDEF=$(aws ecs register-task-definition --cli-input-json "file://$WORKDIR/drop-taskdef.json" --region "$AWS_REGION" \
+  --query 'taskDefinition.taskDefinitionArn' --output text)
+log "Registered drop task def: $DROP_TASKDEF"
+
+TASK_ARN=$(aws ecs run-task \
+  --cluster "$CLUSTER" \
+  --task-definition "$DROP_TASKDEF" \
+  --launch-type FARGATE \
+  --network-configuration "$NETCONF" \
+  --started-by "preview-destroy-pr-${PR_NUMBER}" \
+  --region "$AWS_REGION" \
+  --query 'tasks[0].taskArn' --output text)
+log "Drop task started: $TASK_ARN"
+
+aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK_ARN" --region "$AWS_REGION"
+
+EXIT_CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" --region "$AWS_REGION" \
+  --query 'tasks[0].containers[0].exitCode' --output text)
+log "Drop task exit code: $EXIT_CODE"
+
+TASK_ID="${TASK_ARN##*/}"
+LOG_GROUP=$(jq -r '.containerDefinitions[0].logConfiguration.options."awslogs-group"' "$WORKDIR/source.json")
+LOG_PREFIX=$(jq -r '.containerDefinitions[0].logConfiguration.options."awslogs-stream-prefix"' "$WORKDIR/source.json")
+CONTAINER_NAME=$(jq -r '.containerDefinitions[0].name' "$WORKDIR/source.json")
+log "--- task logs ---"
+aws logs get-log-events \
+  --log-group-name "$LOG_GROUP" \
+  --log-stream-name "${LOG_PREFIX}/${CONTAINER_NAME}/${TASK_ID}" \
+  --start-from-head --limit 50 --region "$AWS_REGION" \
+  --query 'events[].message' --output text || log "(no logs available)"
+
+aws ecs deregister-task-definition --task-definition "$DROP_TASKDEF" --region "$AWS_REGION" >/dev/null
+log "Deregistered drop task def"
+
+if [ "$EXIT_CODE" != "0" ]; then
+  log "ERROR: drop task exited with code $EXIT_CODE"
+  exit 1
+fi
+
+log "Per-stack database for ${STACK} dropped successfully"


### PR DESCRIPTION
- add scripts/drop-preview-db.sh to invoke backend DROP DATABASE via ECS
- run drop-db job before destroy so per-stack secrets/task def still exist
- without this, the per-PR database lingers after the stack is torn down

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automated Postgres database deletion during preview teardown via a one-off ECS task; failures could unintentionally drop the wrong DB if env vars/task definition are misconfigured, though basic name validation and idempotent checks reduce risk.
> 
> **Overview**
> Preview teardown now includes a **new `drop-db` job** that runs *before* `pulumi destroy` and invokes `scripts/drop-preview-db.sh` to remove the per-PR logical Postgres database while the stack’s secrets and backend task definition still exist.
> 
> The workflow was adjusted so `destroy` and the PR comment step run with `always()` semantics after PR resolution, ensuring the stack is still destroyed (and the comment still posts) even if the DB drop step flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57afff3400edf6e65fd7fc1052acda7aec70e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->