### PR TITLE
feat(THU-197): lazy-load posthog sdk until user opts in

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -227,7 +227,10 @@ export const App = () => {
             <HttpClientProvider httpClient={initData.httpClient}>
               <AuthProvider cloudUrl={initData.cloudUrl}>
                 <SignInModalProvider>
-                  <PostHogProvider client={initData.posthogClient}>
+                  <PostHogProvider
+                    initialClient={initData.posthogClient}
+                    telemetryAvailable={initData.telemetryAvailable}
+                  >
                     <TrayProvider tray={initData.tray} window={initData.window}>
                       <MCPProvider>
                         <HapticsProvider>

--- a/src/hooks/use-analytics.tsx
+++ b/src/hooks/use-analytics.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { isTauri } from '@/lib/platform'
-import { usePostHog } from 'posthog-js/react'
+import { usePosthog } from '@/lib/posthog'
 import { useEffect, useRef } from 'react'
 import { useLocation } from 'react-router'
 
@@ -12,7 +12,7 @@ import { useLocation } from 'react-router'
  */
 export const usePageTracking = () => {
   const location = useLocation()
-  const posthog = usePostHog()
+  const posthog = usePosthog()
   const previousUrl = useRef<string | null>(null)
 
   useEffect(() => {

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -14,7 +14,7 @@ import { createAppDir, resetAppDir } from '@/lib/fs'
 import { isSsoMode } from '@/lib/auth-mode'
 import { createAuthenticatedClient } from '@/lib/http'
 import { getDatabasePath, getDatabaseType } from '@/lib/platform'
-import { initPosthog, type PosthogInitResult, trackError } from '@/lib/posthog'
+import { initPosthog, type PostHogInitResult, trackError } from '@/lib/posthog'
 import { reconcileDefaults } from '@/lib/reconcile-defaults'
 import { TrayManager } from '@/lib/tray'
 import type { InitData } from '@/types'
@@ -50,7 +50,7 @@ const initializeTray = async (): Promise<{ tray: TrayIcon | undefined; window: W
   return await TrayManager.initIfSupported()
 }
 
-const initializePostHog = async (httpClient?: HttpClient): Promise<PosthogInitResult> => {
+const initializePostHog = async (httpClient?: HttpClient): Promise<PostHogInitResult> => {
   const result = await initPosthog(httpClient)
   return result.success ? result.data : { client: null, telemetryAvailable: false }
 }
@@ -151,7 +151,7 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
   }
 
   // Step 8: PostHog initialization (non-critical).
-  let posthogResult: PosthogInitResult = { client: null, telemetryAvailable: false }
+  let posthogResult: PostHogInitResult = { client: null, telemetryAvailable: false }
   try {
     posthogResult = await initializePostHog(client)
   } catch (error) {

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -14,14 +14,13 @@ import { createAppDir, resetAppDir } from '@/lib/fs'
 import { isSsoMode } from '@/lib/auth-mode'
 import { createAuthenticatedClient } from '@/lib/http'
 import { getDatabasePath, getDatabaseType } from '@/lib/platform'
-import { initPosthog, trackError } from '@/lib/posthog'
+import { initPosthog, type PosthogInitResult, trackError } from '@/lib/posthog'
 import { reconcileDefaults } from '@/lib/reconcile-defaults'
 import { TrayManager } from '@/lib/tray'
 import type { InitData } from '@/types'
 import type { HandleError, HandleResult } from '@/types/handle-errors'
 import type { TrayIcon } from '@tauri-apps/api/tray'
 import type { Window } from '@tauri-apps/api/window'
-import type { PostHog } from 'posthog-js'
 import { useCallback, useEffect, useState } from 'react'
 
 const createAppDirectory = async (): Promise<string> => {
@@ -51,9 +50,9 @@ const initializeTray = async (): Promise<{ tray: TrayIcon | undefined; window: W
   return await TrayManager.initIfSupported()
 }
 
-const initializePostHog = async (httpClient?: HttpClient): Promise<PostHog | null> => {
+const initializePostHog = async (httpClient?: HttpClient): Promise<PosthogInitResult> => {
   const result = await initPosthog(httpClient)
-  return result.success ? result.data : null
+  return result.success ? result.data : { client: null, telemetryAvailable: false }
 }
 
 const executeInitializationSteps = async (httpClient?: HttpClient): Promise<HandleResult<InitData>> => {
@@ -151,10 +150,10 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     trackError(trayError, { initialization_step: 'tray' })
   }
 
-  // Step 8: PostHog initialization (non-critical)
-  let posthogClient: PostHog | null = null
+  // Step 8: PostHog initialization (non-critical).
+  let posthogResult: PosthogInitResult = { client: null, telemetryAvailable: false }
   try {
-    posthogClient = await initializePostHog(client)
+    posthogResult = await initializePostHog(client)
   } catch (error) {
     console.warn('Unexpected error during PostHog initialization:', error)
   }
@@ -165,7 +164,8 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
       db,
       cloudUrl,
       experimentalFeatureTasks,
-      posthogClient,
+      posthogClient: posthogResult.client,
+      telemetryAvailable: posthogResult.telemetryAvailable,
       httpClient: client,
       ...tray,
     },

--- a/src/lib/posthog.test.ts
+++ b/src/lib/posthog.test.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { updateSettings } from '@/dal'
+import { getDb } from '@/db/database'
 import { createClient, type HttpClient } from '@/lib/http'
 import type { HandleError } from '@/types/handle-errors'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
@@ -233,5 +235,39 @@ describe('trackError test cases', () => {
       $exception_message: 'Could not create app directory',
       $exception_stack: undefined,
     })
+  })
+})
+
+describe('initPosthog consent gating', () => {
+  beforeEach(() => {
+    resetPosthogClient()
+    mockPosthogInit.mockReset()
+  })
+
+  it('skips SDK init when data_collection is false but still reports telemetryAvailable', async () => {
+    await updateSettings(getDb(), { data_collection: false })
+
+    const result = await initPosthog(createMockHttpClient('test-key'))
+
+    expect(result.success).toBe(true)
+    if (!result.success) {
+      return
+    }
+    expect(result.data).toEqual({ client: null, telemetryAvailable: true })
+    expect(mockPosthogInit).not.toHaveBeenCalled()
+
+    // Restore default so other tests aren't affected.
+    await updateSettings(getDb(), { data_collection: true })
+  })
+
+  it('reports telemetryAvailable: false when no API key is configured', async () => {
+    const result = await initPosthog(createMockHttpClient(''))
+
+    expect(result.success).toBe(true)
+    if (!result.success) {
+      return
+    }
+    expect(result.data).toEqual({ client: null, telemetryAvailable: false })
+    expect(mockPosthogInit).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -9,9 +9,8 @@ import { getLocalSetting } from '@/stores/local-settings-store'
 import { createHandleError } from '@/lib/error-utils'
 import { createClient } from '@/lib/http'
 import type { HandleError, HandleResult } from '@/types/handle-errors'
-import posthog, { type PostHog } from 'posthog-js'
-import { PostHogProvider as PostHogReactProvider } from 'posthog-js/react'
-import { createContext, useContext, type ReactNode } from 'react'
+import type { PostHog } from 'posthog-js'
+import { createContext, useContext, useMemo, useState, type Dispatch, type ReactNode, type SetStateAction } from 'react'
 
 let posthogClient: PostHog | null = null
 
@@ -48,11 +47,17 @@ export const sanitizeUrl = (url: string): string => {
   return url
 }
 
+export type PosthogInitResult = {
+  client: PostHog | null
+  telemetryAvailable: boolean
+}
+
 /**
- * Initialize Posthog analytics and return the client
- * @param httpClient - Optional HTTP client for dependency injection. If not provided, creates a client with cloudUrl from settings as prefixUrl
+ * Initialize PostHog analytics. Loads `posthog-js` via dynamic import only
+ * after the user has opted in, so the SDK lives in an async chunk.
+ * `telemetryAvailable` reports whether the backend has an API key configured.
  */
-export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult<PostHog | null>> => {
+export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult<PosthogInitResult>> => {
   try {
     const cloudUrl = getLocalSetting('cloudUrl')
     const debugPosthog = getLocalSetting('debugPosthog')
@@ -68,15 +73,18 @@ export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult
 
     if (!apiKey) {
       console.warn('Posthog analytics disabled - no API key provided')
-      return { success: true, data: null }
+      return { success: true, data: { client: null, telemetryAvailable: false } }
     }
 
-    // Use the cloudUrl proxy for PostHog analytics
-    const apiHost = `${cloudUrl}/posthog`
+    if (!dataCollection) {
+      // Don't load the SDK until the user opts in.
+      return { success: true, data: { client: null, telemetryAvailable: true } }
+    }
 
     if (!posthogClient) {
+      const { default: posthog } = await import('posthog-js')
+      const apiHost = `${cloudUrl}/posthog`
       posthogClient = posthog.init(apiKey, {
-        opt_out_capturing_by_default: !dataCollection,
         api_host: apiHost,
         debug: debugPosthog,
         autocapture: false,
@@ -111,7 +119,7 @@ export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult
       }) as PostHog
     }
 
-    return { success: true, data: posthogClient }
+    return { success: true, data: { client: posthogClient, telemetryAvailable: true } }
   } catch (error) {
     console.warn('Failed to initialize PostHog, continuing without analytics:', error)
     return {
@@ -123,19 +131,49 @@ export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult
 
 const TelemetryAvailableContext = createContext(false)
 
+type PosthogClientContextValue = {
+  client: PostHog | null
+  setClient: Dispatch<SetStateAction<PostHog | null>>
+}
+
+const PosthogClientContext = createContext<PosthogClientContextValue | null>(null)
+
 /**
- * Whether telemetry is actually wired up (i.e. a PostHog client was successfully initialized
- * because the backend supplied a public API key). Self-hosted deployments without a configured
- * key return false here regardless of the user's `data_collection` consent setting.
+ * True when the backend has a PostHog API key configured. Independent of the
+ * user's `data_collection` consent.
  */
 export const useTelemetryAvailable = () => useContext(TelemetryAvailableContext)
 
-/**
- * PostHog Provider component for React
- */
-export const PostHogProvider = ({ children, client }: { children: ReactNode; client: PostHog | null }) => {
-  const inner = client ? <PostHogReactProvider client={client}>{children}</PostHogReactProvider> : children
-  return <TelemetryAvailableContext.Provider value={!!client}>{inner}</TelemetryAvailableContext.Provider>
+const usePosthogClientContext = (): PosthogClientContextValue => {
+  const ctx = useContext(PosthogClientContext)
+  if (!ctx) {
+    throw new Error('usePosthog must be used inside <PostHogProvider>')
+  }
+  return ctx
+}
+
+/** Loaded PostHog client, or null when the SDK has not been initialized. */
+export const usePosthog = (): PostHog | null => usePosthogClientContext().client
+
+/** Publish a freshly-loaded client into the tree after a lazy opt-in init. */
+export const useSetPosthog = (): Dispatch<SetStateAction<PostHog | null>> => usePosthogClientContext().setClient
+
+export const PostHogProvider = ({
+  children,
+  initialClient,
+  telemetryAvailable,
+}: {
+  children: ReactNode
+  initialClient: PostHog | null
+  telemetryAvailable: boolean
+}) => {
+  const [client, setClient] = useState<PostHog | null>(initialClient)
+  const value = useMemo(() => ({ client, setClient }), [client])
+  return (
+    <TelemetryAvailableContext.Provider value={telemetryAvailable}>
+      <PosthogClientContext.Provider value={value}>{children}</PosthogClientContext.Provider>
+    </TelemetryAvailableContext.Provider>
+  )
 }
 
 export type EventType =

--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -138,7 +138,11 @@ type PostHogClientContextValue = {
   setClient: Dispatch<SetStateAction<PostHog | null>>
 }
 
-const PostHogClientContext = createContext<PostHogClientContextValue | null>(null)
+// Safe default so consumers outside <PostHogProvider> no-op instead of crashing.
+const PostHogClientContext = createContext<PostHogClientContextValue>({
+  client: null,
+  setClient: () => {},
+})
 
 /**
  * True when the backend has a PostHog API key configured. Independent of the
@@ -146,19 +150,11 @@ const PostHogClientContext = createContext<PostHogClientContextValue | null>(nul
  */
 export const useTelemetryAvailable = () => useContext(TelemetryAvailableContext)
 
-const usePostHogClientContext = (): PostHogClientContextValue => {
-  const ctx = useContext(PostHogClientContext)
-  if (!ctx) {
-    throw new Error('PostHog hooks must be used inside <PostHogProvider>')
-  }
-  return ctx
-}
-
 /** Loaded PostHog client, or null when the SDK has not been initialized. */
-export const usePosthog = (): PostHog | null => usePostHogClientContext().client
+export const usePosthog = (): PostHog | null => useContext(PostHogClientContext).client
 
 /** Publish a freshly-loaded client into the tree after a lazy opt-in init. */
-export const useSetPosthog = (): Dispatch<SetStateAction<PostHog | null>> => usePostHogClientContext().setClient
+export const useSetPosthog = (): Dispatch<SetStateAction<PostHog | null>> => useContext(PostHogClientContext).setClient
 
 export const PostHogProvider = ({
   children,

--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -47,7 +47,7 @@ export const sanitizeUrl = (url: string): string => {
   return url
 }
 
-export type PosthogInitResult = {
+export type PostHogInitResult = {
   client: PostHog | null
   telemetryAvailable: boolean
 }
@@ -57,7 +57,7 @@ export type PosthogInitResult = {
  * after the user has opted in, so the SDK lives in an async chunk.
  * `telemetryAvailable` reports whether the backend has an API key configured.
  */
-export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult<PosthogInitResult>> => {
+export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult<PostHogInitResult>> => {
   try {
     const cloudUrl = getLocalSetting('cloudUrl')
     const debugPosthog = getLocalSetting('debugPosthog')
@@ -131,12 +131,12 @@ export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult
 
 const TelemetryAvailableContext = createContext(false)
 
-type PosthogClientContextValue = {
+type PostHogClientContextValue = {
   client: PostHog | null
   setClient: Dispatch<SetStateAction<PostHog | null>>
 }
 
-const PosthogClientContext = createContext<PosthogClientContextValue | null>(null)
+const PostHogClientContext = createContext<PostHogClientContextValue | null>(null)
 
 /**
  * True when the backend has a PostHog API key configured. Independent of the
@@ -144,19 +144,19 @@ const PosthogClientContext = createContext<PosthogClientContextValue | null>(nul
  */
 export const useTelemetryAvailable = () => useContext(TelemetryAvailableContext)
 
-const usePosthogClientContext = (): PosthogClientContextValue => {
-  const ctx = useContext(PosthogClientContext)
+const usePostHogClientContext = (): PostHogClientContextValue => {
+  const ctx = useContext(PostHogClientContext)
   if (!ctx) {
-    throw new Error('usePosthog must be used inside <PostHogProvider>')
+    throw new Error('PostHog hooks must be used inside <PostHogProvider>')
   }
   return ctx
 }
 
 /** Loaded PostHog client, or null when the SDK has not been initialized. */
-export const usePosthog = (): PostHog | null => usePosthogClientContext().client
+export const usePosthog = (): PostHog | null => usePostHogClientContext().client
 
 /** Publish a freshly-loaded client into the tree after a lazy opt-in init. */
-export const useSetPosthog = (): Dispatch<SetStateAction<PostHog | null>> => usePosthogClientContext().setClient
+export const useSetPosthog = (): Dispatch<SetStateAction<PostHog | null>> => usePostHogClientContext().setClient
 
 export const PostHogProvider = ({
   children,
@@ -171,7 +171,7 @@ export const PostHogProvider = ({
   const value = useMemo(() => ({ client, setClient }), [client])
   return (
     <TelemetryAvailableContext.Provider value={telemetryAvailable}>
-      <PosthogClientContext.Provider value={value}>{children}</PosthogClientContext.Provider>
+      <PostHogClientContext.Provider value={value}>{children}</PostHogClientContext.Provider>
     </TelemetryAvailableContext.Provider>
   )
 }

--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -67,8 +67,10 @@ export const initPosthog = async (httpClient?: HttpClient): Promise<HandleResult
     })
 
     const client = httpClient ?? createClient({ prefixUrl: cloudUrl })
+    // Cap the config fetch so a slow/hung network doesn't block app startup;
+    // a failure here is non-fatal and falls through to the catch below.
     const { public_posthog_api_key: apiKey } = await client
-      .get('posthog/config')
+      .get('posthog/config', { timeout: 3000 })
       .json<{ public_posthog_api_key?: string }>()
 
     if (!apiKey) {

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -143,8 +143,21 @@ export default function PreferencesSettingsPage() {
   const { data: unitsOptionsData, isLoading: unitsOptionsLoading } = useUnitsOptions()
   const { data: countryUnitsData, isLoading: countryUnitsLoading } = useCountryUnits()
 
+  const enableTelemetryCapture = async () => {
+    let client = postHog
+    if (!client && telemetryAvailable) {
+      const result = await initPosthog(httpClient)
+      if (result.success && result.data.client) {
+        client = result.data.client
+        setPostHog(client)
+      }
+    }
+    client?.opt_in_capturing()
+  }
+
   const handleEnableTelemetry = async (featureName?: string | null) => {
     await dataCollection.setValue(true)
+    await enableTelemetryCapture()
     if (featureName === 'experimentalFeatureTasks') {
       await experimentalFeatureTasks.setValue(true)
     }
@@ -188,16 +201,7 @@ export default function PreferencesSettingsPage() {
     await dataCollection.setValue(value)
 
     if (value) {
-      // Lazy-init when the user opts in after startup.
-      let client = postHog
-      if (!client && telemetryAvailable) {
-        const result = await initPosthog(httpClient)
-        if (result.success && result.data.client) {
-          client = result.data.client
-          setPostHog(client)
-        }
-      }
-      client?.opt_in_capturing()
+      await enableTelemetryCapture()
       trackEvent('settings_data_collection_enabled')
     } else {
       trackEvent('settings_data_collection_disabled')

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -12,7 +12,7 @@ import { useUnitsOptions } from '@/hooks/use-units-options'
 import { privacyPolicyUrl } from '@/lib/constants'
 import { extractCountryFromLocation } from '@/lib/country-utils'
 import { clearLocalData } from '@/lib/cleanup'
-import { trackEvent, useTelemetryAvailable } from '@/lib/posthog'
+import { initPosthog, trackEvent, usePosthog, useSetPosthog, useTelemetryAvailable } from '@/lib/posthog'
 import type { CountryUnitsData } from '@/types'
 import { useHttpClient } from '@/contexts'
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
@@ -41,7 +41,6 @@ import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { SectionCard } from '@/components/ui/section-card'
 import { Switch } from '@/components/ui/switch'
-import { usePostHog } from 'posthog-js/react'
 import { usePowerSyncStatus } from '@/hooks/use-powersync-status'
 import { useSyncEnabledToggle } from '@/hooks/use-sync-enabled-toggle'
 
@@ -96,7 +95,8 @@ export default function PreferencesSettingsPage() {
   const telemetryRequiredModalRef = useRef<TelemetryRequiredModalRef>(null)
   const telemetryWarningModalRef = useRef<TelemetryWarningModalRef>(null)
 
-  const postHog = usePostHog()
+  const postHog = usePosthog()
+  const setPostHog = useSetPosthog()
   const telemetryAvailable = useTelemetryAvailable()
 
   const httpClient = useHttpClient()
@@ -188,11 +188,20 @@ export default function PreferencesSettingsPage() {
     await dataCollection.setValue(value)
 
     if (value) {
-      postHog.opt_in_capturing()
+      // Lazy-init when the user opts in after startup.
+      let client = postHog
+      if (!client && telemetryAvailable) {
+        const result = await initPosthog(httpClient)
+        if (result.success && result.data.client) {
+          client = result.data.client
+          setPostHog(client)
+        }
+      }
+      client?.opt_in_capturing()
       trackEvent('settings_data_collection_enabled')
     } else {
       trackEvent('settings_data_collection_disabled')
-      postHog.opt_out_capturing()
+      postHog?.opt_out_capturing()
       // Also disable experimental features
       await experimentalFeatureTasks.setValue(false)
       trackEvent('settings_experimental_feature_tasks_disabled')

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type InitData = {
   tray: TrayIcon | undefined
   window: Window | undefined
   posthogClient: PostHog | null
+  telemetryAvailable: boolean
   httpClient: HttpClient
   experimentalFeatureTasks: boolean
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes analytics initialization/consent flow and provider wiring, which could affect telemetry capture and settings behavior if the gating/state updates are incorrect.
> 
> **Overview**
> **Lazy-loads PostHog until the user opts in to data collection.** `initPosthog` now returns `{ client, telemetryAvailable }`, dynamically imports `posthog-js` only after consent, and uses a short timeout when fetching the backend API key.
> 
> Updates app initialization and the top-level `PostHogProvider` to propagate `telemetryAvailable` separately from the client, and refactors consumers (`usePageTracking`, Preferences telemetry toggle) to use a new internal `usePosthog`/`useSetPosthog` context so telemetry can be initialized later when a user enables it. Adds tests covering consent gating and “no API key” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fe9137a8c6a8e2bc086dc90e0ad299be158bce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->