### PR TITLE
fix(auth): use app subdomain for mobile OAuth redirect URI

### DIFF
--- a/src/lib/oauth-redirect.ts
+++ b/src/lib/oauth-redirect.ts
@@ -8,7 +8,7 @@ import { isMobile, isTauri } from '@/lib/platform'
  * Determines the correct OAuth redirect URI based on the platform
  *
  * - Web: Uses the web callback route at the current origin
- * - Mobile (iOS/Android): Uses App Link / Universal Link (https://thunderbolt.io/oauth/callback)
+ * - Mobile (iOS/Android): Uses App Link / Universal Link (https://app.thunderbolt.io/oauth/callback)
  * - Desktop (Tauri): Uses local webview callback
  *
  * @returns The appropriate redirect URI for the current platform
@@ -20,7 +20,7 @@ export const getOAuthRedirectUri = (): string => {
 
   if (isMobile()) {
     // Mobile: Use App Link / Universal Link (verified HTTPS domain)
-    return 'https://thunderbolt.io/oauth/callback'
+    return 'https://app.thunderbolt.io/oauth/callback'
   }
 
   return window.location.origin + '/oauth-callback.html'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the mobile OAuth redirect URI domain, which can break sign-in if provider redirect allowlists or deep-link handling aren’t updated consistently.
> 
> **Overview**
> Updates `getOAuthRedirectUri` to use `https://app.thunderbolt.io/oauth/callback` (instead of `https://thunderbolt.io/oauth/callback`) for mobile (iOS/Android) OAuth redirects, and adjusts the inline documentation accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0721d11584ea6d8819487969b306f3fa1bdbd5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->