### PR TITLE
test: remove debug console.logs from oidc-integration test

### DIFF
--- a/backend/src/auth/oidc-integration.test.ts
+++ b/backend/src/auth/oidc-integration.test.ts
@@ -62,45 +62,23 @@ describe('OIDC Integration', () => {
   let getSettingsSpy: ReturnType<typeof spyOn>
 
   beforeAll(async () => {
-    const t0 = Date.now()
-    console.log(`[OIDC-BEFOREALL] start t=0`)
-
     oidcServer = new OAuth2Server()
-    console.log(`[OIDC-BEFOREALL] after new OAuth2Server t=${Date.now() - t0}ms`)
-
     await oidcServer.issuer.keys.generate('RS256')
-    console.log(`[OIDC-BEFOREALL] after keys.generate t=${Date.now() - t0}ms`)
-
     await oidcServer.start(0, 'localhost')
-    console.log(`[OIDC-BEFOREALL] after server.start t=${Date.now() - t0}ms`)
 
     oidcIssuerUrl = oidcServer.issuer.url!
     const testEnv = await createTestDb()
-    console.log(`[OIDC-BEFOREALL] after createTestDb t=${Date.now() - t0}ms`)
-
     db = testEnv.db
     cleanup = testEnv.cleanup
-    console.log(`[OIDC-BEFOREALL] complete t=${Date.now() - t0}ms`)
   }, 60_000)
 
   afterAll(async () => {
-    const t0 = Date.now()
-    console.log(`[OIDC-AFTERALL] start`)
-
     if (oidcServer && (oidcServer as unknown as { listening: boolean }).listening) {
-      await oidcServer.stop().catch((err) => {
-        console.log(`[OIDC-AFTERALL] stop error: ${err?.message}`)
-      })
-      console.log(`[OIDC-AFTERALL] after server.stop t=${Date.now() - t0}ms`)
-    } else {
-      console.log(`[OIDC-AFTERALL] skipping server.stop (not listening)`)
+      await oidcServer.stop().catch(() => {})
     }
 
     if (cleanup) {
-      await cleanup().catch((err) => {
-        console.log(`[OIDC-AFTERALL] cleanup error: ${err?.message}`)
-      })
-      console.log(`[OIDC-AFTERALL] after cleanup t=${Date.now() - t0}ms`)
+      await cleanup().catch(() => {})
     }
   }, 60_000)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that removes verbose debug logging and simplifies cleanup error handling; no production code paths are modified.
> 
> **Overview**
> Removes temporary debug `console.log` timing statements from the OIDC integration test setup/teardown.
> 
> Simplifies `afterAll` cleanup by always attempting `oidcServer.stop()` and DB `cleanup()` and swallowing teardown errors instead of logging them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5849c8625165dd54d5cf8baf87510a598ce6b9c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->