### PR TITLE
fix(android): keep WryActivity.getId() from R8 to fix release crash

### DIFF
--- a/src-tauri/gen/android/app/proguard-rules.pro
+++ b/src-tauri/gen/android/app/proguard-rules.pro
@@ -19,3 +19,12 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# tao calls WryActivity.getId() via JNI from Rust at every activity lifecycle
+# event (onCreate, onSaveInstanceState, onDestroy). R8 strips the
+# Kotlin-generated getter because there are no Java/Kotlin call sites, which
+# crashes release builds with `Err(JavaException)` at tao/.../ndk_glue.rs:393.
+# The shipped wry proguard-wry.pro template misses this rule.
+-keepclassmembers class net.thunderbird.thunderbolt.WryActivity {
+    int getId();
+}


### PR DESCRIPTION
## Summary

Release Android builds crash on launch with `SIGABRT` from a Rust panic at `tao-0.35.0/src/platform_impl/android/ndk_glue.rs:393` — `called Result::unwrap() on an Err value: JavaException`.

`tao` calls `WryActivity.getId()` via JNI on every activity lifecycle event (onCreate, onSaveInstanceState, onDestroy). The Kotlin `var id: Int = 0` on `WryActivity` synthesizes a `getId()` getter, but it has no Java/Kotlin call sites (only field-level reads/writes inside the same class). R8 strips it, so the JNI lookup throws `NoSuchMethodError` and tao aborts the process.

The bundled `wry-0.55.0/src/android/kotlin/proguard-wry.pro` template keeps `setWebView`, `getAppClass`, `getVersion`, `startActivity` but is missing `int getId()`. Adding the keep rule in `proguard-rules.pro` restores the getter in the minified DEX.

Only the release build is affected — `debug` has `isMinifyEnabled = false`, which is why this never showed up in `tauri android dev`.

## Verification

- Pre-fix DEX dump of the installed prod `WryActivity`: field `id` renamed to `y`, no `getId` in virtual methods → confirmed strip.
- Post-fix DEX dump: `getId` present on `WryActivity` virtual methods.
- Patched release APK launches successfully on the emulator (no `SIGABRT`, WebView initializes, React app renders).

## Follow-up

Worth filing upstream against [tauri-apps/wry](https://github.com/tauri-apps/wry) so the `proguard-wry.pro` template ships with this rule by default — every Tauri Android release build with `isMinifyEnabled = true` and tao ≥ 0.32 hits this.

## Test plan

- [ ] CI Android release build succeeds
- [ ] Install the resulting APK/AAB on a device and confirm the app launches past the splash without crashing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-config change that only affects Android release shrinking/obfuscation; it may slightly increase APK size but prevents a JNI lookup crash in production.
> 
> **Overview**
> Prevents Android release builds from crashing due to R8 stripping the Kotlin-generated `WryActivity.getId()` method that is invoked via JNI.
> 
> Adds a ProGuard `-keepclassmembers` rule for `net.thunderbird.thunderbolt.WryActivity#getId()` (with explanatory comments) so the method remains available at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b858247d2c77a12f851cd27bfe652aa413f1554d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->