### PR TITLE
perf(THU-198): lazy-load AI SDK provider packages

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -22,9 +22,6 @@ import type { FetchFn } from '@/lib/proxy-fetch'
 import { createToolset, getAvailableTools } from '@/lib/tools'
 import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import type { SourceMetadata } from '@/types/source'
-import { createAnthropic } from '@ai-sdk/anthropic'
-import { createOpenAI } from '@ai-sdk/openai'
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import type { HttpClient } from '@/lib/http'
 import type { SecureClient } from 'tinfoil'
 import { v7 as uuidv7 } from 'uuid'
@@ -54,13 +51,6 @@ import { createMessageMetadata } from './message-metadata'
 const fetch: typeof baseFetch = (input, init) =>
   baseFetch(input, isSsoMode() ? { ...init, credentials: 'include' } : init)
 fetch.preconnect = baseFetch.preconnect
-
-export const ollama = createOpenAI({
-  baseURL: 'http://localhost:11434/v1',
-  // compatibility: 'compatible',
-  apiKey: 'ollama',
-  fetch,
-})
 
 // Reuse one SecureClient across requests so attestation runs once per page load.
 // The `tinfoil` module is dynamically imported so its attestation/crypto deps
@@ -123,9 +113,11 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
       // GPT OSS (vendor: 'openai') uses createOpenAI with .chat() to force Chat Completions API
       // (AI SDK 5 defaults createOpenAI to Responses API which our backend doesn't support)
       if (modelConfig.vendor === 'openai') {
+        const { createOpenAI } = await import('@ai-sdk/openai')
         const provider = createOpenAI({ baseURL: cloudUrl, apiKey: token, fetch: providerFetch })
         return provider.chat(modelConfig.model)
       }
+      const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible')
       const provider = createOpenAICompatible({
         name: 'thunderbolt',
         baseURL: cloudUrl,
@@ -140,6 +132,7 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
       // X-Proxy-Passthrough-Authorization; Standalone mode (Tauri) hits
       // Anthropic directly via the Rust HTTP plugin. Either way, the user's
       // Anthropic key never goes through Thunderbolt's session auth path.
+      const { createAnthropic } = await import('@ai-sdk/anthropic')
       const anthropic = createAnthropic({
         apiKey: modelConfig.apiKey || '',
         fetch: getProxyFetch(),
@@ -150,6 +143,7 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
       if (!modelConfig.apiKey) {
         throw new Error('No API key provided')
       }
+      const { createOpenAI } = await import('@ai-sdk/openai')
       const openai = createOpenAI({
         apiKey: modelConfig.apiKey,
         fetch: getProxyFetch(),
@@ -160,6 +154,7 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
       if (!modelConfig.url) {
         throw new Error('No URL provided for custom provider')
       }
+      const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible')
       const openaiCompatible = createOpenAICompatible({
         name: 'custom',
         baseURL: modelConfig.url,
@@ -174,6 +169,7 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
       }
       // Using OpenAI-compatible approach until @openrouter/ai-sdk-provider supports Vercel AI SDK v5
       // https://github.com/OpenRouterTeam/ai-sdk-provider/pull/77
+      const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible')
       const openrouter = createOpenAICompatible({
         name: 'openrouter',
         baseURL: 'https://openrouter.ai/api/v1',
@@ -187,6 +183,7 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
         throw new Error('No API key provided')
       }
       const client = await getTinfoilClient()
+      const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible')
       const tinfoil = createOpenAICompatible({
         name: 'tinfoil',
         baseURL: client.getBaseURL()!,

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { aiFetchStreamingResponse } from '@/ai/fetch'
 import { isRateLimitError } from '@/lib/error-utils'
 import type { HttpClient } from '@/lib/http'
 import { trackEvent } from '@/lib/posthog'
@@ -42,6 +41,9 @@ export const createChatInstance = (
         throw new Error('No session found')
       }
 
+      // `fetch.ts` carries the Vercel AI SDK + all provider SDKs; importing
+      // it on first send keeps that weight out of the entry chunk.
+      const { aiFetchStreamingResponse } = await import('@/ai/fetch')
       return aiFetchStreamingResponse({
         init,
         saveMessages,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bundle-splitting only; provider behavior is unchanged aside from removing the unused Ollama export.
> 
> **Overview**
> This PR **shrinks the initial JS bundle** by deferring heavy AI provider dependencies until they are actually needed.
> 
> **`createModel`** now **dynamic-imports** `@ai-sdk/openai`, `@ai-sdk/openai-compatible`, and `@ai-sdk/anthropic` inside each provider branch, so only the SDK for the selected model is loaded. The unused **Ollama** client export was removed.
> 
> **Chat sends** load `@/ai/fetch` on the **first message** via `await import('@/ai/fetch')` in `chat-instance`, keeping the Vercel AI SDK stack out of the entry chunk until a user starts streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3794193875673db990a8c2db2b54ef0bd58929ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->