### PR TITLE
fix(THU-541): repair backend dev script (broken on main since 2026-05-13)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Thunderbolt Backend rewritten with TypeScript + Elysia",
   "type": "module",
   "scripts": {
-    "dev": "./scripts/dev.sh",
+    "dev": "bun --watch src/index.ts",
     "build": "bun build --compile --minify-whitespace --minify-syntax --target bun --outfile server src/cluster.ts",
     "start": "./server",
     "test": "bun test",


### PR DESCRIPTION
## Summary

- `backend/scripts/dev.sh` was deleted by `62b9922c` (`chore: extract dev-env items into separate stacked PR`), but `backend/package.json:7` still referenced it
- `make dev` / `cd backend && bun run dev` has been broken on main since that landed (2026-05-13) with `./scripts/dev.sh: No such file or directory`
- Frontend boots, backend dies immediately, app is unusable for any dev hitting `make dev`

## Fix

```diff
-    "dev": "./scripts/dev.sh",
+    "dev": "bun --watch src/index.ts",
```

Bun auto-loads `backend/.env` from `cwd`, so the shell-sourcing dance the deleted script did is unnecessary. Restoring the 1Password (`op run`) integration the old script supported is left to the [stacked PR that originally extracted it](https://github.com/thunderbird/thunderbolt/commit/62b9922c).

## Test plan

- [ ] `cd backend && bun run dev` boots the backend on :8000
- [ ] `make dev` boots backend (:8000) + frontend (:1420) together
- [ ] Devs not using `op run` see no regression

Closes [THU-541](https://linear.app/mozilla-thunderbolt/issue/THU-541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single npm script change with no runtime, auth, or data-path impact.
> 
> **Overview**
> Repairs the broken **backend dev** workflow by pointing `package.json`'s `dev` script at **`bun --watch src/index.ts`** instead of the removed **`./scripts/dev.sh`**.
> 
> After the dev script was deleted elsewhere, **`bun run dev`** / **`make dev`** failed immediately with a missing file, so the backend never started. The new command matches how E2E already starts the server and relies on Bun loading **`backend/.env`** from the working directory—no shell wrapper required for the common case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9575ebfca4635b4cb84caf62b2beb462f222790b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->