### PR TITLE
chore(deps): batch dependabot patches (#879, #899, #900, #901)

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -196,7 +196,7 @@ jobs:
           echo "✅ Metal Toolchain removed"
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
+        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1
         with:
           ruby-version: '3.0'
           bundler-cache: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
             --json-output semgrep.json
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         if: always() && hashFiles('semgrep.sarif') != ''
         continue-on-error: true
         with:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Generate release token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install git-cliff
         if: ${{ !inputs.nightly }}
-        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
         with:
           tool: git-cliff
 

--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -37,7 +37,7 @@
       "devDependencies": {
         "@electric-sql/pglite-socket": "^0.1.4",
         "@eslint/js": "^10.0.1",
-        "@react-email/ui": "6.1.4",
+        "@react-email/ui": "6.1.5",
         "@types/react": "^19.1.10",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
@@ -387,7 +387,7 @@
 
     "@react-email/render": ["@react-email/render@2.0.8", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ=="],
 
-    "@react-email/ui": ["@react-email/ui@6.1.4", "", { "dependencies": { "esbuild": "0.28.0", "next": "16.2.6" } }, "sha512-FyMCx7uNV0ugZY9ZWNAnWFTrXnYOhRQm97ybbZapJCQLu6uhZHmluXv2HcsSZ0RaMAzuLJgw0ziLQjq4uYEiNg=="],
+    "@react-email/ui": ["@react-email/ui@6.1.5", "", { "dependencies": { "esbuild": "0.28.0", "next": "16.2.6" } }, "sha512-IJYZFEk3+VjM0hoPXXIiarps1MNOopQgycKMYzhG1iRHut32JKFMt9J0KFu7qmif5wpbGGxv6MhurdW3MG0WEA=="],
 
     "@scalar/openapi-types": ["@scalar/openapi-types@0.1.1", "", {}, "sha512-NMy3QNk6ytcCoPUGJH0t4NNr36OWXgZhA3ormr3TvhX1NDgoF95wFyodGVH8xiHeUyn2/FxtETm8UBLbB5xEmg=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@electric-sql/pglite-socket": "^0.1.4",
     "@eslint/js": "^10.0.1",
-    "@react-email/ui": "6.1.4",
+    "@react-email/ui": "6.1.5",
     "@types/react": "^19.1.10",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",

--- a/deploy/pulumi/bun.lock
+++ b/deploy/pulumi/bun.lock
@@ -8,7 +8,7 @@
         "@pulumi/aws": "^7.27.0",
         "@pulumi/awsx": "^3.5.0",
         "@pulumi/cloudflare": "^6.14.0",
-        "@pulumi/docker-build": "^0.0.16",
+        "@pulumi/docker-build": "^0.0.17",
         "@pulumi/eks": "^4.0.0",
         "@pulumi/keycloak": "^6.10.1",
         "@pulumi/kubernetes": "^4.0.0",
@@ -195,7 +195,7 @@
 
     "@pulumi/docker": ["@pulumi/docker@4.11.2", "", { "dependencies": { "@pulumi/pulumi": "^3.142.0", "semver": "^5.4.0" } }, "sha512-mm8Uscb/3S7OieYyg1E/vvFx3OS4bAkZvtFvi1yTqYda9NbnYOMbJi7a5fU5xB0N0Kd/uliS8olJ/e6nnvVVPg=="],
 
-    "@pulumi/docker-build": ["@pulumi/docker-build@0.0.16", "", { "dependencies": { "@pulumi/pulumi": "^3.142.0" } }, "sha512-T/k14ppyODV6+J+KvzkbFDfKyKESv5JqbiUZgtfjm+fQoIueuovjMmg1/jQnkhUeS748YAwI46JNR9c5w7lQdw=="],
+    "@pulumi/docker-build": ["@pulumi/docker-build@0.0.17", "", { "dependencies": { "@pulumi/pulumi": "^3.142.0" } }, "sha512-PpPxo8f2nt9VAPeBvpW5grmSFCJh+ediqObKgLFkhQ9D/zJ7vnNEaVKn7cCAvM0ive11Sl50U79Oym3OO8MkHg=="],
 
     "@pulumi/eks": ["@pulumi/eks@4.2.0", "", { "dependencies": { "@pulumi/aws": "^7.14.0", "@pulumi/kubernetes": "^4.19.0", "@pulumi/pulumi": "^3.142.0", "https-proxy-agent": "^5.0.1", "js-yaml": "^4.1.0", "netmask": "^2.0.2", "semver": "^7.3.7", "which": "^1.3.1" } }, "sha512-myGhOksnF/BUun7oWvuphp+2l6CNV9meE7Gu/8+JulcOhA2jYttGdSI+15BvUnDNgUBv3qNlu+NQ473C3q4Wvg=="],
 

--- a/deploy/pulumi/package.json
+++ b/deploy/pulumi/package.json
@@ -7,7 +7,7 @@
     "@pulumi/aws": "^7.27.0",
     "@pulumi/awsx": "^3.5.0",
     "@pulumi/cloudflare": "^6.14.0",
-    "@pulumi/docker-build": "^0.0.16",
+    "@pulumi/docker-build": "^0.0.17",
     "@pulumi/eks": "^4.0.0",
     "@pulumi/keycloak": "^6.10.1",
     "@pulumi/kubernetes": "^4.0.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4379,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,7 +39,7 @@ tauri = { version = "2.11.2", features = [
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-os = "2.3.2"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.143"
+serde_json = "1.0.150"
 anyhow = "1.0.99"
 tokio = "1.52.3"
 tauri-plugin-devtools = "2.0.1"


### PR DESCRIPTION
## Summary

Lands four safe patch-level dependabot PRs in a single batch — same shape as #893. Lockfiles regenerated locally with bun (dependabot doesn't support bun).

## Commit

- **`60058a7c`** — chore(deps): batch dependabot patches (#879, #899, #900, #901)

## Landed PRs

### npm — deploy/pulumi
- **#879** — `@pulumi/docker-build` `^0.0.16` → `^0.0.17` — patch bump in the pulumi docker-build provider

### npm — backend
- **#899** — `@react-email/ui` `6.1.4` → `6.1.5` — patch bump in the dev-only react-email UI kit. No transitive churn (same `esbuild@0.28.0` + `next@16.2.6` deps)

### Cargo — src-tauri
- **#900** — `serde_json` `1.0.149` → `1.0.150` — patch bump in `Cargo.toml`, `Cargo.lock` refreshed

### GitHub Actions
- **#901** — actions group across 1 directory with 4 updates:
  - `github/codeql-action/upload-sarif` v4.35.3 → **v4.35.5** (`.github/workflows/security.yml`)
  - `actions/create-github-app-token` v3.1.1 → **v3.2.0** (`.github/workflows/version-bump.yml`)
  - `ruby/setup-ruby` SHA bump, still tagged `v1` (`.github/workflows/ios-release.yml`)
  - `taiki-e/install-action` SHA bump, still tagged `v2` (`.github/workflows/version-bump.yml`)

## Verification

- ✅ `cargo check` in `src-tauri/` — compiles cleanly with `serde_json@1.0.150` (full tauri tree, 25.95s)
- ✅ `bun run type-check` in `backend/` — clean
- ✅ `bun run lint` in `backend/` — 0 errors (81 pre-existing warnings, unchanged)
- ✅ Both `bun.lock` diffs reviewed — minimal: just the version + integrity hash bumps, no transitive churn

## Side notes

While running `bun install` in `backend/`, two small lockfile drifts surfaced and were captured (no `package.json` edits made):

- `@opentelemetry/exporter-trace-otlp-proto@0.218.0` — added to the lockfile (already in `package.json`, just missing from the lockfile)
- `@types/bun` / `bun-types` resolved minor patch within their existing `^` ranges

## Not in this PR

- **#841** — `exa-js` `1.10.3` → `2.12.1` (backend): major SDK rewrite, not attempted. Separate PR.
- **#881** — `vite` `7.3.3` → `8.0.13`: already in flight as PR #898.

## Test plan

- [ ] CI: workflows pass (especially `security.yml` with the new codeql v4.35.5 SARIF uploader and `version-bump.yml` with the new app-token v3.2.0)
- [ ] iOS release workflow: confirm `ruby/setup-ruby` still resolves `ruby-version: '3.0'` correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-only version and CI action SHA updates with no product code changes; release/version-bump workflows use updated tokens but remain the same steps.
> 
> **Overview**
> This PR **batches four patch-level dependency updates** (Dependabot-style) with matching lockfile refreshes—no application logic changes.
> 
> **GitHub Actions** pins move forward in `security.yml` (`upload-sarif` to CodeQL **v4.35.5**), `version-bump.yml` (`create-github-app-token` **v3.2.0**, `taiki-e/install-action` SHA), and `ios-release.yml` (`ruby/setup-ruby` SHA, still **v1**).
> 
> **npm:** `backend` bumps dev-only **`@react-email/ui`** `6.1.4` → `6.1.5`; **`deploy/pulumi`** bumps **`@pulumi/docker-build`** `^0.0.16` → `^0.0.17` with `bun.lock` updates.
> 
> **Rust:** `src-tauri` bumps direct **`serde_json`** `1.0.149` → `1.0.150` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60058a7c3eb9af6bfae5e6ef88581b37613bc0af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->