### PR TITLE
ci(THU-546): fix desktop release getting stuck in draft state

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -71,11 +71,9 @@ jobs:
       # Skip CrabNebula for nightly builds to prevent auto-updater from pushing unstable builds
       - name: Create CrabNebula Draft Release
         if: ${{ !inputs.nightly }}
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
         uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
         with:
-          command: release draft thunderbird/thunderbolt "$RELEASE_VERSION"
+          command: release draft thunderbird/thunderbolt ${{ inputs.version }}
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
 
   build:
@@ -352,11 +350,9 @@ jobs:
       # Skip CrabNebula for nightly builds
       - name: Upload to CrabNebula Cloud
         if: ${{ !inputs.nightly }}
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
         uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
         with:
-          command: release upload thunderbird/thunderbolt "$RELEASE_VERSION" --framework tauri
+          command: release upload thunderbird/thunderbolt ${{ inputs.version }} --framework tauri
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
 
   publish:
@@ -377,9 +373,7 @@ jobs:
       # Publish release on CrabNebula Cloud for auto-updates (skip for nightly to prevent unstable auto-updates)
       - name: Publish to CrabNebula Cloud
         if: ${{ !inputs.nightly }}
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
         uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
         with:
-          command: release publish thunderbird/thunderbolt "$RELEASE_VERSION" --framework tauri
+          command: release publish thunderbird/thunderbolt ${{ inputs.version }} --framework tauri
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -71,9 +71,11 @@ jobs:
       # Skip CrabNebula for nightly builds to prevent auto-updater from pushing unstable builds
       - name: Create CrabNebula Draft Release
         if: ${{ !inputs.nightly }}
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
         with:
-          command: release draft thunderbird/thunderbolt ${{ inputs.version }}
+          command: release draft thunderbird/thunderbolt "$RELEASE_VERSION"
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
 
   build:
@@ -350,33 +352,34 @@ jobs:
       # Skip CrabNebula for nightly builds
       - name: Upload to CrabNebula Cloud
         if: ${{ !inputs.nightly }}
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
         with:
-          command: release upload thunderbird/thunderbolt ${{ inputs.version }} --framework tauri
+          command: release upload thunderbird/thunderbolt "$RELEASE_VERSION" --framework tauri
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
 
   publish:
     name: Publish Release
     needs: [draft, build]
     # Run as long as the draft job succeeded, even if some builds failed.
-    if: always() && needs.draft.result == 'success'
+    if: ${{ !cancelled() && needs.draft.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Publish GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRERELEASE: ${{ inputs.nightly }}
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          TAG="v${{ inputs.version }}"
-          RELEASE_ID=$(gh api "/repos/${{ github.repository }}/releases/tags/$TAG" --jq '.id')
-          gh api --method PATCH "/repos/${{ github.repository }}/releases/$RELEASE_ID" \
-            -F draft=false \
-            -F prerelease=$PRERELEASE
+          gh release edit "v${RELEASE_VERSION}" --draft=false --prerelease="${PRERELEASE}"
 
       # Publish release on CrabNebula Cloud for auto-updates (skip for nightly to prevent unstable auto-updates)
       - name: Publish to CrabNebula Cloud
         if: ${{ !inputs.nightly }}
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
         with:
-          command: release publish thunderbird/thunderbolt ${{ inputs.version }} --framework tauri
+          command: release publish thunderbird/thunderbolt "$RELEASE_VERSION" --framework tauri
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -51,23 +51,6 @@ jobs:
         run: |
           echo "version=v$INPUT_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Create GitHub Release (Stable)
-        if: ${{ !inputs.nightly }}
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          tag_name: v${{ inputs.version }}
-          name: Release v${{ inputs.version }}
-          draft: true
-          prerelease: true
-          body: |
-            ## Release Candidate v${{ inputs.version }}
-
-            This is a release candidate. The final release will be created after successful builds.
-
-            ### Downloads
-
-            Binaries will be attached to this release after successful builds.
-
       - name: Create GitHub Release (Nightly)
         if: ${{ inputs.nightly }}
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
@@ -375,64 +358,20 @@ jobs:
   publish:
     name: Publish Release
     needs: [draft, build]
+    # Run as long as the draft job succeeded, even if some builds failed.
+    if: always() && needs.draft.result == 'success'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: v${{ inputs.version }}
-          fetch-depth: 0
-
-      - name: Publish GitHub Release (Stable)
-        if: ${{ !inputs.nightly }}
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          tag_name: v${{ inputs.version }}
-          draft: false
-          prerelease: false
-          name: Release v${{ inputs.version }}
-          body: |
-            ## Release v${{ inputs.version }}
-
-            ### Downloads
-
-            Download the appropriate installer for your platform below.
-
-            - **Windows**: `.msi` or `.exe` installer
-            - **macOS**: `.dmg` installer (Intel and Apple Silicon)
-            - **Linux**: `.AppImage`, `.deb`, or `.rpm` package
-
-            ### Release Notes
-
-            _Add your release notes here_
-
-            ---
-
-            **Note:** iOS builds are deployed separately via the iOS Release workflow.
-
-      - name: Publish GitHub Release (Nightly)
-        if: ${{ inputs.nightly }}
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          tag_name: v${{ inputs.version }}
-          draft: false
-          prerelease: true
-          name: Nightly Build v${{ inputs.version }}
-          body: |
-            ## Nightly Build v${{ inputs.version }}
-
-            **Warning:** This is an automated nightly build and may be unstable. Use at your own risk.
-
-            ### Downloads
-
-            Download the appropriate installer for your platform below.
-
-            - **Windows**: `.msi` or `.exe` installer
-            - **macOS**: `.dmg` installer (Intel and Apple Silicon)
-            - **Linux**: `.AppImage`, `.deb`, or `.rpm` package
-
-            ---
-
-            For stable releases, please visit the [latest release](../../releases/latest).
+      - name: Publish GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ inputs.nightly }}
+        run: |
+          TAG="v${{ inputs.version }}"
+          RELEASE_ID=$(gh api "/repos/${{ github.repository }}/releases/tags/$TAG" --jq '.id')
+          gh api --method PATCH "/repos/${{ github.repository }}/releases/$RELEASE_ID" \
+            -F draft=false \
+            -F prerelease=$PRERELEASE
 
       # Publish release on CrabNebula Cloud for auto-updates (skip for nightly to prevent unstable auto-updates)
       - name: Publish to CrabNebula Cloud


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes release publish gating and how stable GitHub releases are created; a partial failed build matrix could still publish if draft succeeded.
> 
> **Overview**
> Fixes desktop releases staying in **draft** by simplifying how GitHub releases are created and published in `desktop-release.yml`.
> 
> The **draft** job no longer runs a separate stable `action-gh-release` step (nightly draft creation is unchanged). **Publish** no longer depends on every matrix build succeeding: it runs when the draft job succeeds and the workflow was not cancelled. Publishing is unified into one step that runs `gh release edit` to clear draft and set prerelease from `inputs.nightly`, replacing duplicate stable/nightly `action-gh-release` publish steps and the checkout that fed them—so release notes bodies are no longer rewritten at publish time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1e9fa94595de5d9aaa9f33c74b60468fb4cba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->