### PR TITLE
perf(powersync): speed up first sync via priority buckets

### DIFF
--- a/deploy/config/powersync-config.yaml
+++ b/deploy/config/powersync-config.yaml
@@ -14,21 +14,26 @@ port: 8080
 sync_rules:
   content: |
     bucket_definitions:
-      user_data:
+      user_essentials:
+        priority: 1
         parameters: SELECT request.user_id() as user_id
         data:
           - SELECT * FROM powersync.settings WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.models WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.modes WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.model_profiles WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.devices WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.chat_threads WHERE user_id = bucket.user_id
+      user_data:
+        priority: 2
+        parameters: SELECT request.user_id() as user_id
+        data:
           - SELECT * FROM powersync.chat_messages WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.models WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.skills WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.modes WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.model_profiles WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.devices WHERE user_id = bucket.user_id
 
 client_auth:
   supabase: false

--- a/deploy/config/powersync-config.yaml
+++ b/deploy/config/powersync-config.yaml
@@ -34,6 +34,7 @@ sync_rules:
           - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.skills WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.agents WHERE user_id = bucket.user_id
 
 client_auth:
   supabase: false

--- a/deploy/k8s/templates/configmaps.yaml
+++ b/deploy/k8s/templates/configmaps.yaml
@@ -40,6 +40,7 @@ data:
               - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
+              - SELECT * FROM powersync.skills WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
 
     client_auth:

--- a/deploy/k8s/templates/configmaps.yaml
+++ b/deploy/k8s/templates/configmaps.yaml
@@ -22,20 +22,25 @@ data:
     sync_rules:
       content: |
         bucket_definitions:
-          user_data:
+          user_essentials:
+            priority: 1
             parameters: SELECT request.user_id() as user_id
             data:
               - SELECT * FROM powersync.settings WHERE user_id = bucket.user_id
-              - SELECT * FROM powersync.chat_threads WHERE user_id = bucket.user_id
-              - SELECT * FROM powersync.chat_messages WHERE user_id = bucket.user_id
-              - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.models WHERE user_id = bucket.user_id
-              - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
-              - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
-              - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.modes WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.model_profiles WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.devices WHERE user_id = bucket.user_id
+              - SELECT * FROM powersync.chat_threads WHERE user_id = bucket.user_id
+          user_data:
+            priority: 2
+            parameters: SELECT request.user_id() as user_id
+            data:
+              - SELECT * FROM powersync.chat_messages WHERE user_id = bucket.user_id
+              - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
+              - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
+              - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
+              - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
 
     client_auth:
       supabase: false

--- a/deploy/k8s/templates/configmaps.yaml
+++ b/deploy/k8s/templates/configmaps.yaml
@@ -42,6 +42,7 @@ data:
               - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.skills WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
+              - SELECT * FROM powersync.agents WHERE user_id = bucket.user_id
 
     client_auth:
       supabase: false

--- a/powersync-service/config/config.yaml
+++ b/powersync-service/config/config.yaml
@@ -14,22 +14,26 @@ port: 8080
 sync_rules:
   content: |
     bucket_definitions:
-      user_data:
+      user_essentials:
+        priority: 1
         parameters: SELECT request.user_id() as user_id
         data:
           - SELECT * FROM powersync.settings WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.models WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.modes WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.model_profiles WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.devices WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.chat_threads WHERE user_id = bucket.user_id
+      user_data:
+        priority: 2
+        parameters: SELECT request.user_id() as user_id
+        data:
           - SELECT * FROM powersync.chat_messages WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.models WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.skills WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.modes WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.model_profiles WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.devices WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.agents WHERE user_id = bucket.user_id
 
 client_auth:
   supabase: false

--- a/powersync-service/config/config.yaml
+++ b/powersync-service/config/config.yaml
@@ -34,6 +34,7 @@ sync_rules:
           - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.skills WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
+          - SELECT * FROM powersync.agents WHERE user_id = bucket.user_id
 
 client_auth:
   supabase: false

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -47,6 +47,17 @@ export const getPowerSyncDatabaseConfig = (
 /** Max time to wait for initial sync before continuing (e.g. when network is down) */
 const initialSyncTimeoutMs = 10_000
 
+/**
+ * Sync rule priority we block app init on. Matches the `user_essentials` bucket in
+ * `powersync-service/config/config.yaml` (and the PowerSync Cloud dashboard rules):
+ * settings, models, modes, model_profiles, devices, chat_threads. Lower-priority buckets
+ * (chat_messages, tasks, etc.) stream in the background after the app is interactive.
+ *
+ * Falls back to global `hasSynced` if the deployed sync rules don't declare priorities yet
+ * (see `SyncStatus.statusForPriority`).
+ */
+const initialSyncPriority = 1
+
 /** Custom event name for sync enabled changes */
 export const syncEnabledChangeEvent = 'powersync_sync_enabled_change'
 
@@ -383,43 +394,28 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
   }
 
   /**
-   * Wait for PowerSync to complete its initial sync.
-   * This ensures data from the cloud is available before reconciling defaults.
+   * Wait for PowerSync's priority-1 buckets to complete their initial sync (essentials —
+   * settings, models, modes, model_profiles, devices, chat_threads). Lower-priority data
+   * (chat_messages, tasks, etc.) continues streaming in the background.
+   *
    * Resolves after initialSyncTimeoutMs if sync never completes (e.g. network down).
    */
   async waitForInitialSync(): Promise<void> {
-    // Skip if sync is disabled or not connected
     if (!this.powerSync || !this._isConnected || !isSyncEnabled()) {
       return
     }
 
-    // Check if already synced
-    const status = this.powerSync.currentStatus
-    if (status?.hasSynced) {
-      return
+    const abortController = new AbortController()
+    const timeoutId = setTimeout(() => {
+      console.warn('Initial sync timed out after', initialSyncTimeoutMs / 1000, 'seconds')
+      abortController.abort()
+    }, initialSyncTimeoutMs)
+
+    try {
+      await this.powerSync.waitForFirstSync({ signal: abortController.signal, priority: initialSyncPriority })
+    } finally {
+      clearTimeout(timeoutId)
     }
-
-    let unsubscribe: (() => void) | undefined
-    const syncPromise = new Promise<void>((resolve) => {
-      unsubscribe = this.powerSync!.registerListener({
-        statusChanged: (newStatus) => {
-          if (newStatus.hasSynced) {
-            unsubscribe?.()
-            resolve()
-          }
-        },
-      })
-    })
-
-    const timeoutPromise = new Promise<void>((resolve) => {
-      setTimeout(() => {
-        unsubscribe?.()
-        console.warn('Initial sync timed out after', initialSyncTimeoutMs / 1000, 'seconds')
-        resolve()
-      }, initialSyncTimeoutMs)
-    })
-
-    await Promise.race([syncPromise, timeoutPromise])
   }
 
   async close(): Promise<void> {

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -413,8 +413,11 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       }, initialSyncTimeoutMs)
     })
 
-    await Promise.race([this.powerSync.waitForFirstSync({ priority: initialSyncPriority }), timeoutPromise])
-    clearTimeout(timeoutId)
+    try {
+      await Promise.race([this.powerSync.waitForFirstSync({ priority: initialSyncPriority }), timeoutPromise])
+    } finally {
+      clearTimeout(timeoutId)
+    }
   }
 
   async close(): Promise<void> {

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -405,6 +405,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       return
     }
 
+    const abortController = new AbortController()
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     const timeoutPromise = new Promise<void>((resolve) => {
       timeoutId = setTimeout(() => {
@@ -414,9 +415,19 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
     })
 
     try {
-      await Promise.race([this.powerSync.waitForFirstSync({ priority: initialSyncPriority }), timeoutPromise])
+      await Promise.race([
+        this.powerSync.waitForFirstSync({ signal: abortController.signal, priority: initialSyncPriority }),
+        timeoutPromise,
+      ])
+    } catch (error) {
+      // First sync is best-effort — the app must boot regardless. Swallow any unexpected
+      // rejection so it never propagates to the initialization caller.
+      console.warn('waitForInitialSync failed; continuing without sync gate:', error)
     } finally {
       clearTimeout(timeoutId)
+      // Disposes the listener inside waitForFirstSync if the timeout won the race (or if
+      // sync already resolved, this is a no-op on the already-disposed listener).
+      abortController.abort()
     }
   }
 

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -405,17 +405,16 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       return
     }
 
-    const abortController = new AbortController()
-    const timeoutId = setTimeout(() => {
-      console.warn('Initial sync timed out after', initialSyncTimeoutMs / 1000, 'seconds')
-      abortController.abort()
-    }, initialSyncTimeoutMs)
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(() => {
+        console.warn('Initial sync timed out after', initialSyncTimeoutMs / 1000, 'seconds')
+        resolve()
+      }, initialSyncTimeoutMs)
+    })
 
-    try {
-      await this.powerSync.waitForFirstSync({ signal: abortController.signal, priority: initialSyncPriority })
-    } finally {
-      clearTimeout(timeoutId)
-    }
+    await Promise.race([this.powerSync.waitForFirstSync({ priority: initialSyncPriority }), timeoutPromise])
+    clearTimeout(timeoutId)
   }
 
   async close(): Promise<void> {

--- a/src/db/powersync/middleware/EncryptionMiddleware.ts
+++ b/src/db/powersync/middleware/EncryptionMiddleware.ts
@@ -51,9 +51,7 @@ const decryptEntry = async (entry: SyncEntry) => {
  */
 export const encryptionMiddleware: DataTransformMiddleware = {
   async transform(bucket) {
-    for (const entry of bucket.data) {
-      await decryptEntry(entry)
-    }
+    await Promise.all(bucket.data.map(decryptEntry))
     return bucket
   },
 }


### PR DESCRIPTION
- Parallelize sync entry decryption in `EncryptionMiddleware` (`Promise.all` over `bucket.data`) so per-entry AES-GCM work is no longer serialized — the bottleneck for users with many encrypted rows per bucket.
- Split the sync rules into two priority buckets in all three configs (`powersync-service/`, `deploy/config/`, `deploy/k8s/`):
  - `user_essentials` (priority 1): `settings`, `models`, `modes`, `model_profiles`, `devices`, `chat_threads`.
  - `user_data` (priority 2): `chat_messages`, `tasks`, `mcp_servers`, `prompts`, `skills`, `triggers`.
- Replace the homemade `Promise.race` in `waitForInitialSync` with PowerSync's native `waitForFirstSync({ signal, priority: 1 })` driven by an `AbortController` that aborts at the existing 10s budget. App init now unblocks as soon as the priority-1 essentials land; everything else streams in the background.

## Deploy note

Prod uses the **PowerSync Cloud dashboard sync rules**, not the YAML files in this PR. Until those are updated to declare the same priorities, `statusForPriority(1)` falls back to global `hasSynced` (`@powersync/common` `SyncStatus.statusForPriority`) so the FE change degrades to current behavior. Mirror the bucket split in the dashboard after this lands for the speed-up to take effect.

## Test plan

- [ ] First-launch on a fresh device: app init unblocks well before 10s once priority-1 buckets are synced.
- [ ] Returning user: `hasSynced` persisted from prior session → `waitForInitialSync` returns immediately.
- [ ] Offline launch: still hits the 10s timeout and continues (logged via `console.warn`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which data is available before app init and reorders sync rules across environments; misaligned Cloud dashboard rules would negate the benefit but fall back safely to full-sync gating.
> 
> **Overview**
> Splits PowerSync sync rules from a single **`user_data`** bucket into **`user_essentials`** (priority 1) and **`user_data`** (priority 2) across local, deploy, and K8s configs—moving settings, models, modes, profiles, devices, and chat threads into essentials while heavier tables (messages, tasks, MCP, etc.) sync later. **`agents`** is added to the lower-priority bucket in deploy YAML (already present in the service config).
> 
> The client gates app init on **priority 1** only: **`waitForInitialSync`** now uses **`waitForFirstSync({ priority: 1 })`** with **`AbortController`** plus the existing 10s timeout, instead of waiting for global **`hasSynced`**. **`EncryptionMiddleware`** decrypts bucket rows in parallel via **`Promise.all`**.
> 
> **Deploy note:** Production PowerSync Cloud dashboard rules must mirror the priority split for the speed-up; without priorities, behavior falls back to waiting for full sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc5e929ae2a34294fa5b0ba7dc6cc96ba423336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->