### PR TITLE
fix: improve skill chip touch targets and long-press behavior on mobile

### DIFF
--- a/src/skills/suggestion-chip.tsx
+++ b/src/skills/suggestion-chip.tsx
@@ -107,7 +107,17 @@ export const SuggestionChip = ({
             clearLongPress()
             handleOpenChange(true)
           }}
-          className={`h-8 shrink-0 cursor-pointer rounded-full bg-card px-3 text-sm font-normal transition-opacity ${
+          // `h-[var(--touch-height-sm)]` resolves to 40px on mobile, 32px on
+          // desktop — keeps the compact desktop look while meeting the
+          // 40px-min touch target the rest of the app uses on touch devices.
+          //
+          // `select-none` + `[-webkit-touch-callout:none]` suppress the OS
+          // text-selection that fires on long-press on iOS / Android. Without
+          // them the chip's label gets highlighted (and on iOS the system
+          // share/copy callout pops) while our long-press timer is waiting
+          // to open the action menu. Leaving `touch-action` at its default
+          // so the chip strip's horizontal scroll on mobile still works.
+          className={`h-[var(--touch-height-sm)] shrink-0 cursor-pointer select-none rounded-full bg-card px-3 text-sm font-normal transition-opacity [-webkit-touch-callout:none] ${
             dimmed ? 'opacity-40' : ''
           }`}
           aria-label={`Pinned skill /${label}`}
@@ -132,7 +142,7 @@ export const SuggestionChip = ({
             onClick()
             handleOpenChange(false)
           }}
-          className="cursor-pointer"
+          className="min-h-[var(--min-touch-height)] cursor-pointer"
         >
           <Plus />
           Add to chat
@@ -142,7 +152,7 @@ export const SuggestionChip = ({
             onAddInstruction()
             handleOpenChange(false)
           }}
-          className="cursor-pointer"
+          className="min-h-[var(--min-touch-height)] cursor-pointer"
         >
           <File />
           Add instructions to chat
@@ -156,7 +166,7 @@ export const SuggestionChip = ({
             handleOpenChange(false)
             onReorder()
           }}
-          className="cursor-pointer"
+          className="min-h-[var(--min-touch-height)] cursor-pointer"
         >
           <ListOrdered />
           Reorder
@@ -168,7 +178,7 @@ export const SuggestionChip = ({
             handleOpenChange(false)
             onUnpin()
           }}
-          className="cursor-pointer"
+          className="min-h-[var(--min-touch-height)] cursor-pointer"
         >
           <Pin />
           Unpin


### PR DESCRIPTION
Hotfix for two mobile issues Chris flagged on the pinned skill shortcuts above the chat input:

1. **Long-press highlights the chip's text.** On iOS / Android, holding a pinned chip to open its action menu also triggered the OS text-selection (and the iOS share / copy callout) on the chip's label. Suppressed via `select-none` + `[-webkit-touch-callout:none]` on the chip button.

2. **Chip + dropdown items are too small for the 40 px min-touch target.** Switched the chip from a fixed `h-8` (32 px) to `h-[var(--touch-height-sm)]` — resolves to 40 px on mobile, 32 px on desktop, so the compact desktop look is unchanged. Each dropdown menu item gets `min-h-[var(--min-touch-height)]` — 40 px mobile / 0 desktop. Both follow the responsive-sizing pattern in `CLAUDE.md`.

Left `touch-action` at its default so the horizontal chip-strip scroll on mobile still works.

## Test plan

- [x] `bun run type-check`
- [x] `bun test --cwd=src --timeout 5000 skills/ components/chat/` — 348 pass, 0 fail
- [ ] Manual on a phone: long-press a chip, confirm no text highlight / no iOS callout, action menu opens
- [ ] Manual on a phone: chip is ≥40 px tall; each menu item is ≥40 px tall
- [ ] Manual on desktop: chip + menu items look the same as before
- [ ] Horizontal scroll of the chip strip still works on a phone with many pinned skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to chip and menu item sizing and selection suppression; no auth, data, or API logic.
> 
> **Overview**
> Pinned skill chips above chat input get **mobile touch and long-press fixes** in `SuggestionChip`.
> 
> The chip button no longer uses fixed `h-8`; it uses **`h-[var(--touch-height-sm)]`** (40px on mobile, 32px on desktop) and **`select-none`** plus **`[-webkit-touch-callout:none]`** so long-press opens the action menu without OS text selection or the iOS copy/share callout. **`touch-action`** is intentionally unchanged so the chip strip can still scroll horizontally on touch.
> 
> All four dropdown actions (**Add to chat**, **Add instructions**, **Reorder**, **Unpin**) now use **`min-h-[var(--min-touch-height)]`** for the app’s 40px minimum touch rows on mobile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c7b0ea1d4aafb9d309289d020ae315f2f69d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->