### PR TITLE
fix: align pin-skill button height with suggestion chips

### DIFF
--- a/src/components/chat/chat-skills-bar.tsx
+++ b/src/components/chat/chat-skills-bar.tsx
@@ -118,7 +118,7 @@ export const ChatSkillsBar = ({
                   size="icon-sm"
                   aria-label="Pin a skill"
                   disabled={pinnable.length === 0}
-                  className={`size-8 shrink-0 cursor-pointer rounded-full bg-card transition-opacity disabled:cursor-not-allowed disabled:opacity-40 ${
+                  className={`shrink-0 cursor-pointer rounded-full bg-card transition-opacity disabled:cursor-not-allowed disabled:opacity-40 ${
                     openChipId ? 'opacity-40' : ''
                   }`}
                 >


### PR DESCRIPTION
## Summary

Drop the stray `size-8` from the "+" (pin-skill) button in the chat composer. The button already passes `size="icon-sm"`, which expands to `size-[var(--touch-height-sm)]` — the responsive 40px-mobile / 32px-desktop touch target the rest of the composer uses. The hardcoded `size-8` in className was overriding it with a fixed 32px, leaving the button visibly off-height relative to the neighbouring `SuggestionChip` (which uses `h-[var(--touch-height-sm)]` correctly).

Removing the override lets the variant land, so the chips and the + button share the same responsive height on both mobile and desktop.

Per CLAUDE.md "Responsive Sizing": touch heights must use `var(--touch-height-*)`, not raw Tailwind `size-N`.

## Test plan

- [x] `bun run type-check` clean
- [x] `bun test src/components/chat/chat-skills-bar.test.tsx` — 4/4 pass
- [x] Verify on mobile preview env: the + button now matches chip height (no visible gap as in the reporter screenshot)
- [x] Verify on desktop: no regression — both render at 32px and align

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-className UI tweak in the skills bar with no logic, auth, or data changes.
> 
> **Overview**
> Removes the hardcoded **`size-8`** class from the chat composer’s **“Pin a skill”** (`+`) button so **`size="icon-sm"`** can apply **`size-[var(--touch-height-sm)]`**, matching neighboring **`SuggestionChip`** heights (responsive 40px mobile / 32px desktop) instead of a fixed 32px override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbcb28ecc6b25b9992d90ccbcc09c4462833ebe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->