### PR TITLE
perf(app): instrument cold start and eager-load WaitlistPage

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,6 +17,7 @@ import { RevokedDeviceModal } from '@/components/revoked-device-modal'
 import ChatLayout from '@/layout/main-layout'
 import SettingsLayout from '@/settings/layout'
 import WaitlistLayout from '@/waitlist/layout'
+import WaitlistPage from '@/waitlist/waitlist-page'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { HapticsProvider } from '@/hooks/use-haptics'
 import {
@@ -79,7 +80,6 @@ const McpServersPage = lazy(() => import('@/settings/mcp-servers'))
 const SkillsPage = lazy(() => import('@/settings/skills'))
 const AgentsSettingsPage = lazy(() => import('@/routes/settings/agents'))
 const IntegrationsPage = lazy(() => import('@/settings/integrations'))
-const WaitlistPage = lazy(() => import('@/waitlist/waitlist-page'))
 
 // Lazily import SSO components so non-enterprise deployments don't pay
 // for the extra bundle size and attack surface.

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -242,21 +242,30 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       return // Already connected
     }
 
+    const connectStartedAt = performance.now()
+    console.info('[PowerSync] Connecting…')
+
     try {
       const cloudUrl = getLocalSetting('cloudUrl')
 
       // Re-fetch config before connecting so the upload encoder has the correct E2EE flag.
       // If /config failed at app init (e.g. offline), this retries before sync starts.
+      const fetchConfigStartedAt = performance.now()
       await fetchConfig(cloudUrl)
+      console.info(`[PowerSync] fetchConfig: ${Math.round(performance.now() - fetchConfigStartedAt)}ms`)
 
       const connector = new ThunderboltConnector(cloudUrl)
       // Use HTTP streaming to avoid WebSocket "invalid opcode 7" with self-hosted service (ws library).
+      const connectInnerStartedAt = performance.now()
       await this.powerSync.connect(connector, {
         connectionMethod: SyncStreamConnectionMethod.HTTP,
         crudUploadThrottleMs: 5000,
       })
+      console.info(`[PowerSync] powerSync.connect: ${Math.round(performance.now() - connectInnerStartedAt)}ms`)
+
       this._isConnected = true
-      console.info('PowerSync connected')
+      console.info(`[PowerSync] Connected (total ${Math.round(performance.now() - connectStartedAt)}ms)`)
+      this.logFullSyncWhenReady(connectStartedAt)
       startSyncStatusListener(this.powerSync, getPowerSyncDatabaseConfig())
       trackSyncEvent('sync_connect')
       this.startVisibilityReconnect()
@@ -264,6 +273,32 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       console.warn('Failed to connect to PowerSync Cloud:', error)
       trackSyncEvent('sync_connect_error', { error: sanitizeErrorForTracking(error) })
     }
+  }
+
+  /**
+   * Logs when the full sync (all priorities) completes, measured from the time connectToSync started.
+   * One-shot: disposes itself once `hasSynced` is true.
+   */
+  private logFullSyncWhenReady(connectStartedAt: number): void {
+    if (!this.powerSync) {
+      return
+    }
+    if (this.powerSync.currentStatus?.hasSynced) {
+      console.info(
+        `[PowerSync] Full sync already complete (${Math.round(performance.now() - connectStartedAt)}ms since connect)`,
+      )
+      return
+    }
+    const dispose = this.powerSync.registerListener({
+      statusChanged: (status) => {
+        if (status.hasSynced) {
+          console.info(
+            `[PowerSync] Full sync complete (${Math.round(performance.now() - connectStartedAt)}ms since connect)`,
+          )
+          dispose()
+        }
+      },
+    })
   }
 
   /**
@@ -405,11 +440,16 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       return
     }
 
+    const startedAt = performance.now()
+    console.info(`[PowerSync] Waiting for priority-${initialSyncPriority} sync…`)
+
     const abortController = new AbortController()
     let timeoutId: ReturnType<typeof setTimeout> | undefined
+    let timedOut = false
     const timeoutPromise = new Promise<void>((resolve) => {
       timeoutId = setTimeout(() => {
-        console.warn('Initial sync timed out after', initialSyncTimeoutMs / 1000, 'seconds')
+        timedOut = true
+        console.warn(`[PowerSync] Priority-${initialSyncPriority} sync timed out after ${initialSyncTimeoutMs / 1000}s`)
         resolve()
       }, initialSyncTimeoutMs)
     })
@@ -419,10 +459,15 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
         this.powerSync.waitForFirstSync({ signal: abortController.signal, priority: initialSyncPriority }),
         timeoutPromise,
       ])
+      if (!timedOut) {
+        console.info(
+          `[PowerSync] Priority-${initialSyncPriority} sync complete (${Math.round(performance.now() - startedAt)}ms)`,
+        )
+      }
     } catch (error) {
       // First sync is best-effort — the app must boot regardless. Swallow any unexpected
       // rejection so it never propagates to the initialization caller.
-      console.warn('waitForInitialSync failed; continuing without sync gate:', error)
+      console.warn('[PowerSync] waitForInitialSync failed; continuing without sync gate:', error)
     } finally {
       clearTimeout(timeoutId)
       // Disposes the listener inside waitForFirstSync if the timeout won the race (or if

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -56,15 +56,27 @@ const initializePostHog = async (httpClient?: HttpClient): Promise<PostHog | nul
   return result.success ? result.data : null
 }
 
+const time = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+  const startedAt = performance.now()
+  try {
+    return await fn()
+  } finally {
+    console.info(`[init] ${label}: ${Math.round(performance.now() - startedAt)}ms`)
+  }
+}
+
 const executeInitializationSteps = async (httpClient?: HttpClient): Promise<HandleResult<InitData>> => {
+  const totalStartedAt = performance.now()
+  console.info('[init] start')
+
   // Step 0: Fetch backend config and hydrate store (only on success).
   // When fetch fails (offline/error), the store retains its persisted localStorage value.
-  await fetchConfig(getLocalSetting('cloudUrl'), httpClient)
+  await time('step0_fetchConfig', () => fetchConfig(getLocalSetting('cloudUrl'), httpClient))
 
   // Step 1: App directory creation
   let appDirPath: string
   try {
-    appDirPath = await createAppDirectory()
+    appDirPath = await time('step1_createAppDir', () => createAppDirectory())
   } catch (error) {
     console.error('Failed to create app directory:', error)
     const appDirError = createHandleError('APP_DIR_CREATION_FAILED', 'Failed to create app directory', error)
@@ -79,7 +91,7 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
   let db: AnyDrizzleDatabase
   let database: Database
   try {
-    const result = await initializeDatabase(appDirPath)
+    const result = await time('step2_initializeDatabase', () => initializeDatabase(appDirPath))
     db = result.db
     database = result.database
   } catch (error) {
@@ -95,7 +107,7 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
   // Step 3: Wait for PowerSync initial sync before reconciling defaults
   // This ensures synced data from the cloud is available before we check for missing defaults
   try {
-    await database.waitForInitialSync()
+    await time('step3_waitForInitialSync', () => database.waitForInitialSync())
   } catch (error) {
     // Non-critical - log and continue
     console.warn('Failed to wait for initial sync:', error)
@@ -103,7 +115,7 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
 
   // Step 4: Reconcile defaults
   try {
-    await reconcileDefaultSettings(db)
+    await time('step4_reconcileDefaults', () => reconcileDefaultSettings(db))
   } catch (error) {
     console.error('Failed to reconcile default settings:', error)
     const reconcileError = createHandleError('RECONCILE_DEFAULTS_FAILED', 'Failed to reconcile default settings', error)
@@ -116,9 +128,11 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
 
   // Step 5: Get cloud url and experimental feature tasks
   const cloudUrl = getLocalSetting('cloudUrl')
-  const { experimentalFeatureTasks } = await getSettings(db, {
-    experimental_feature_tasks: false,
-  })
+  const { experimentalFeatureTasks } = await time('step5_getSettings', () =>
+    getSettings(db, {
+      experimental_feature_tasks: false,
+    }),
+  )
 
   // Step 6: HTTP client initialization (use provided client or create one)
   let client: HttpClient
@@ -144,7 +158,7 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
   // Step 7: Tray initialization (non-critical)
   let tray: { tray: TrayIcon | undefined; window: Window | undefined } = { tray: undefined, window: undefined }
   try {
-    tray = await initializeTray()
+    tray = await time('step7_initializeTray', () => initializeTray())
   } catch (error) {
     console.warn('Failed to initialize tray, continuing without tray support:', error)
     const trayError = createHandleError('TRAY_INIT_FAILED', 'Failed to initialize tray', error)
@@ -154,10 +168,12 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
   // Step 8: PostHog initialization (non-critical)
   let posthogClient: PostHog | null = null
   try {
-    posthogClient = await initializePostHog(client)
+    posthogClient = await time('step8_initializePostHog', () => initializePostHog(client))
   } catch (error) {
     console.warn('Unexpected error during PostHog initialization:', error)
   }
+
+  console.info(`[init] complete (total ${Math.round(performance.now() - totalStartedAt)}ms)`)
 
   return {
     success: true,


### PR DESCRIPTION
Diagnosing the recent waitlist cold-start regression (3–5s on https://app.thunderbolt.io/). Two commits:

- **Eager-load `WaitlistPage`** — kills the lazy-chunk waterfall introduced by #878 for users hitting `/waitlist`. The route is fully gated (waitlisted users hit it on every cold start), so the extra round-trip cost more than the inlined bytes saved.
- **Instrument `useAppInitialization`** — wraps every init step (`step0_fetchConfig`, `step2_initializeDatabase`, `step4_reconcileDefaults`, etc.) with `performance.now()` deltas and prints `[init] step{N}: {ms}ms` to the console. Pairs with the `[PowerSync]` connect/sync timings already shipped in #914 — together they cover the full cold-start chain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are console timing logs and a bundle-loading tweak for a gated route; no auth, sync protocol, or data-handling behavior changes.
> 
> **Overview**
> Addresses waitlist **cold-start regression** by loading **`WaitlistPage`** in the main bundle instead of `lazy()`, so waitlisted users on `/waitlist` no longer pay an extra async chunk round-trip on every load.
> 
> Adds **startup observability**: `useAppInitialization` wraps each init step in a `time()` helper that logs `[init] step{N}_…` and total duration, and **PowerSync** logs connect/`fetchConfig`/`powerSync.connect` timings, priority-1 `waitForInitialSync` completion vs timeout, and a one-shot **full sync** log when `hasSynced` becomes true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4e65b2dfc9dcd658201864fece69a2edd0b7e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->