### PR TITLE
fix: defer skill-token highlight until token is committed

### DIFF
--- a/src/skills/highlight-skill-tokens.test.tsx
+++ b/src/skills/highlight-skill-tokens.test.tsx
@@ -51,17 +51,22 @@ describe('renderHighlightedSkillTokens', () => {
     expect(span?.textContent).toBe('/no-such-skill')
   })
 
-  it('paints an in-progress (end-of-input, no trailing space) token orange even when the slug resolves', () => {
-    // No trailing whitespace → in-progress regardless of resolution status.
+  it('leaves an in-progress (end-of-input, no trailing space) token uncolored even when the slug resolves', () => {
+    // No trailing whitespace → in-progress; the token inherits surrounding
+    // text color so the highlight doesn't flicker as the user types.
     const { container } = renderTokens('/meeting-notes')
     expect(container.querySelector('.text-sky-500')).toBeNull()
-    expect(container.querySelector('.text-orange-500')?.textContent).toBe('/meeting-notes')
+    expect(container.querySelector('.text-orange-500')).toBeNull()
+    expect(container.querySelector('.text-red-500')).toBeNull()
+    expect(container.textContent).toContain('/meeting-notes')
   })
 
-  it('paints in-progress orange even for an unknown slug — the user is still typing', () => {
+  it('leaves an in-progress unknown slug uncolored — the user is still typing', () => {
     const { container } = renderTokens('hello /partial')
     expect(container.querySelector('.text-red-500')).toBeNull()
-    expect(container.querySelector('.text-orange-500')?.textContent).toBe('/partial')
+    expect(container.querySelector('.text-orange-500')).toBeNull()
+    expect(container.querySelector('.text-sky-500')).toBeNull()
+    expect(container.textContent).toContain('/partial')
   })
 
   it('renders a mix of statuses in one string', () => {

--- a/src/skills/highlight-skill-tokens.tsx
+++ b/src/skills/highlight-skill-tokens.tsx
@@ -24,9 +24,11 @@ export type SkillStatusClassifier = (slug: string) => { status: SkillTokenStatus
 
 /**
  * Render the chat input's text with `/slug` tokens highlighted:
+ * - In-progress (still typing at end of input) → no special color; the token
+ *   inherits the surrounding text color so partial input doesn't flicker
+ *   between states as the user types.
  * - Committed (followed by whitespace) + enabled → blue, the green light.
- * - In-progress (still typing at end of input) OR committed + disabled →
- *   orange, the "still pending" / "needs attention" signal.
+ * - Committed + disabled → orange, the "needs attention" signal.
  * - Committed + unknown → red, "no skill by this name."
  *
  * Committed disabled / unknown tokens are wrapped in {@link SkillTokenPopover}
@@ -96,9 +98,11 @@ export const renderHighlightedSkillTokens = (value: string, classify: SkillStatu
 
 const colorClassFor = (committed: boolean, status: SkillTokenStatus): string => {
   if (!committed) {
-    // Still typing — orange regardless of resolution. Once the user adds a
-    // trailing space we re-classify against the three committed states.
-    return 'text-orange-500 dark:text-orange-400'
+    // Still typing — inherit the surrounding text color so the in-progress
+    // token doesn't flicker between states as each character arrives. Once
+    // the user adds a trailing space we re-classify against the three
+    // committed states below.
+    return ''
   }
   if (status === 'enabled') {
     return 'text-sky-500 dark:text-sky-400'


### PR DESCRIPTION
## Summary

Chris flagged that the in-progress skill token (`/dai...` while typing) flashes orange on every keystroke, which is jarring. The visual signal is meant to tell the user "this is a recognized skill" — applying it before they've finished typing inverts the intent.

This change defers the highlight: while the token is in-progress (no trailing whitespace yet), the span inherits the surrounding text color so the token looks identical to ordinary input. Once the user types a space, the existing committed-state classifier kicks in and paints the token blue (enabled), orange (disabled), or red (unknown) as before.

## Diff (in plain English)

In `colorClassFor` (`src/skills/highlight-skill-tokens.tsx`):

- **Before:** `!committed` → `text-orange-500 dark:text-orange-400`
- **After:** `!committed` → `''` (inherit surrounding color)

All three committed states are unchanged.

Updated the two test cases that asserted "in-progress = orange" to assert "in-progress = no color class applied; text still rendered."

## Test plan

- [x] `bun run type-check` clean
- [x] `bun test src/skills/highlight-skill-tokens.test.tsx` — 9/9 pass
- [ ] On preview env: type `/meeting-` slowly; confirm the token stays the normal text color throughout. Then type a space — confirm it flips to blue (or to the appropriate state if the slug doesn't resolve).
- [ ] Confirm a fully-committed `/meeting-notes ` (enabled) still renders blue; `/task-triage ` (disabled) renders orange; `/no-such-skill ` renders red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation change in chat input token highlighting; committed classification and popovers are untouched.
> 
> **Overview**
> **In-progress `/skill` tokens in the chat input overlay no longer get orange (or any) highlight** while the user is still typing (no trailing whitespace). They inherit normal text color so partial slugs don’t flicker on each keystroke.
> 
> **Committed tokens are unchanged:** after a trailing space, enabled stays sky, disabled orange, unknown red, including popovers for disabled/unknown.
> 
> Tests and `colorClassFor` docs were updated to match the new in-progress behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be5f1d297308d1e2767ee631d0a7adabb757b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->