### PR TITLE
chore(powersync): instrument connect lifecycle for prod investigation

### DIFF
--- a/src/db/powersync/connector.ts
+++ b/src/db/powersync/connector.ts
@@ -89,15 +89,18 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
   async fetchCredentials(): Promise<PowerSyncCredentials | null> {
     const hadToken = Boolean(getAuthToken())
     const ssoMode = isSsoMode()
+    const startedAt = performance.now()
     try {
       if (!hadToken && !ssoMode) {
         return null
       }
 
+      const tokenRequestStartedAt = performance.now()
       const response = await this.fetchFn(`${this.backendUrl}/powersync/token`, {
         headers: getAuthenticatedHeaders(),
         credentials: ssoMode ? 'include' : undefined,
       })
+      console.info(`[PowerSync] /powersync/token: ${Math.round(performance.now() - tokenRequestStartedAt)}ms`)
 
       if (!response.ok) {
         const status = response.status
@@ -144,6 +147,8 @@ export class ThunderboltConnector implements PowerSyncBackendConnector {
       console.error('Error fetching PowerSync credentials:', error)
       trackSyncEvent('sync_credentials_error', { had_token: hadToken, error: sanitizeErrorForTracking(error) })
       return null
+    } finally {
+      console.info(`[PowerSync] fetchCredentials: ${Math.round(performance.now() - startedAt)}ms`)
     }
   }
 

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { fetchConfig } from '@/api/config'
 import { getLocalSetting, useLocalSettingsStore } from '@/stores/local-settings-store'
 import { withTimeout } from '@/lib/timeout'
 import type { AbstractPowerSyncDatabase } from '@powersync/common'
@@ -245,15 +244,27 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
     const connectStartedAt = performance.now()
     console.info('[PowerSync] Connecting…')
 
+    // Temporary status listener used only to time the connect() lifecycle; disposed
+    // before the long-lived sync-tracker listener is attached below.
+    let connectingEnteredAt: number | null = null
+    const disposeConnectTimer = this.powerSync.registerListener({
+      statusChanged: (status) => {
+        if (status.connecting && connectingEnteredAt === null) {
+          connectingEnteredAt = performance.now()
+          console.info(
+            `[PowerSync] connecting=true (${Math.round(connectingEnteredAt - connectStartedAt)}ms after connect start)`,
+          )
+        } else if (!status.connecting && connectingEnteredAt !== null) {
+          console.info(
+            `[PowerSync] stream established (${Math.round(performance.now() - connectingEnteredAt)}ms in connecting state)`,
+          )
+          connectingEnteredAt = null
+        }
+      },
+    })
+
     try {
       const cloudUrl = getLocalSetting('cloudUrl')
-
-      // Re-fetch config before connecting so the upload encoder has the correct E2EE flag.
-      // If /config failed at app init (e.g. offline), this retries before sync starts.
-      const fetchConfigStartedAt = performance.now()
-      await fetchConfig(cloudUrl)
-      console.info(`[PowerSync] fetchConfig: ${Math.round(performance.now() - fetchConfigStartedAt)}ms`)
-
       const connector = new ThunderboltConnector(cloudUrl)
       // Use HTTP streaming to avoid WebSocket "invalid opcode 7" with self-hosted service (ws library).
       const connectInnerStartedAt = performance.now()
@@ -272,6 +283,8 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
     } catch (error) {
       console.warn('Failed to connect to PowerSync Cloud:', error)
       trackSyncEvent('sync_connect_error', { error: sanitizeErrorForTracking(error) })
+    } finally {
+      disposeConnectTimer()
     }
   }
 


### PR DESCRIPTION
Follow-up to #920. Splits the previously-opaque `powerSync.connect()` (observed at **7.8s on logged-in refresh** in prod) into measurable sub-steps so we can identify whether the cost is backend, PowerSync Cloud, or local.

## Changes

- **Time `fetchCredentials` and `/v1/powersync/token` in `ThunderboltConnector`** — separates the round-trip to our backend from the rest of credential resolution. Wrapped in `try/finally` so the timing log always prints even on early returns or errors.
- **Time the connect-state lifecycle in `connectToSync`** — registers a short-lived `statusChanged` listener that logs:
  - when `connecting` flips to `true` (i.e. SharedWorker is up and waitForReady has resolved)
  - how long the client stays in `connecting` until the stream is established
  The listener is disposed in `finally` before the long-lived sync-status tracker takes over.
- **Drop the redundant `fetchConfig(cloudUrl)` inside `connectToSync`** — `useAppInitialization`'s `step0_fetchConfig` already hydrates the store; the duplicate call was a flat ~240ms tax on every connect. Removes the now-unused import.

## What we'll see in the logs

```
[PowerSync] Connecting…
[PowerSync] connecting=true (Xms after connect start)        ← SharedWorker boot + waitForReady
[PowerSync] /powersync/token: Yms                            ← backend token endpoint round-trip
[PowerSync] fetchCredentials: Zms                            ← ~Y + JWT parse / null handling
[PowerSync] stream established (Wms in connecting state)     ← network round-trip to PowerSync Cloud
[PowerSync] powerSync.connect: Nms                           ← total connect
[PowerSync] Connected (total Nms)
```

## Hypothesis

The no-refresh path (waitlist → login → enable sync) measured **1.1s** for the same connect call. The refresh path measured **7.8s**. The most likely explanation is cold backend lambda + cold DB pool on `/v1/powersync/token` when no recent API call has warmed the container. These logs will confirm or rule that out.

## Test plan

- [ ] Deploy and refresh `/` while logged in. Verify the four new `[PowerSync]` lines print and `powerSync.connect:` matches the sum of the substeps.
- [ ] Verify no `[PowerSync] fetchConfig:` log appears (removed).
- [ ] Compare `/powersync/token` time on refresh vs immediately-after-sign-in to validate the cold-start hypothesis.