### PR TITLE
fix(THU-561): pin cloudUrl in SignInModal sent-state test

### DIFF
--- a/src/components/sign-in-modal.test.tsx
+++ b/src/components/sign-in-modal.test.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { useLocalSettingsStore } from '@/stores/local-settings-store'
 import type { ConsoleSpies } from '@/test-utils/console-spies'
 import { setupConsoleSpy } from '@/test-utils/console-spies'
 import { createTestProvider } from '@/test-utils/test-provider'
@@ -86,6 +87,12 @@ describe('SignInModal', () => {
     const { httpClient, fetchSpy } = createSpyHttpClient(undefined, waitlistResponse)
     mockHttpClient = httpClient
     mockFetchSpy = fetchSpy
+    // Pin `cloudUrl` to a localhost value so the post-submit assertion in
+    // `shows sent state after successful submission` is deterministic. The
+    // store *defaults* to localhost, but `VITE_THUNDERBOLT_CLOUD_URL`
+    // overrides that default in CI — leaving the test order-dependent
+    // under `--randomize`. See THU-561.
+    useLocalSettingsStore.setState({ cloudUrl: 'http://localhost:8000/v1' })
   })
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary

Fixes [THU-561](https://linear.app/mozilla-thunderbolt/issue/THU-561/flaky-signinmodal-shows-sent-state-after-successful-submission-test).

`SignInModal > form submission > shows sent state after successful submission` (`src/components/sign-in-modal.test.tsx:255`) fails deterministically on some CI seeds. It asserts the *localhost* variant of the post-submit screen ("Check the backend logs" / matches `/localhost/`). That branch is gated on `isLocalhostUrl(cloudUrl)` reading from `useLocalSettingsStore`. The store's default *would* be `http://localhost:8000/v1`, but `VITE_THUNDERBOLT_CLOUD_URL` overrides it in CI — leaving the assertion dependent on whatever a prior randomized test happened to leak into the store.

The fix pins `cloudUrl` to a localhost value inside the existing `beforeEach`, so the test is deterministic under any seed or env var.

## Audit

Grepped the entire `src` tree for `isLocalhost*` / `Check the backend logs` references in test files — only this one consumes the branch under test. No other sign-in or auth test is affected.

## Test plan

- [x] `bun run type-check` clean
- [x] `bun test src/components/sign-in-modal.test.tsx` → 24/24 pass
- [x] `bun test --cwd=src --randomize` → 2485 pass / 1 skip / 0 fail
- [ ] Re-run a few times to confirm stability across seeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only setup change; no production sign-in or auth behavior is modified.
> 
> **Overview**
> Pins **`cloudUrl`** in `sign-in-modal.test.tsx` **`beforeEach`** via `useLocalSettingsStore.setState({ cloudUrl: 'http://localhost:8000/v1' })` so the post-submit “sent” test always hits the **localhost** UI branch (`Check the backend logs` / `/localhost/`).
> 
> Without this, CI **`VITE_THUNDERBOLT_CLOUD_URL`** and randomized test order could leave a non-localhost URL in the store, making that assertion flaky (**THU-561**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d597dcdcc8da1dca6e8912692e606c2a86ba9163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->