### PR TITLE
perf(powersync): connect to cloud in background during init

### DIFF
--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -222,9 +222,15 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       schema: drizzleSchema,
     }) as unknown as AnyDrizzleDatabase
 
-    // Connect to PowerSync Cloud if sync is enabled
+    // Connect to PowerSync Cloud in the background. Do not block app init on the network
+    // round-trip: connectToSync transitively awaits PowerSync's _isReadyPromise (WASQLite
+    // WASM compile, OPFS setup, schema sync, offline-status read) plus /powersync/token and
+    // the Cloud stream open — together ~10s on cold refresh. Local queries via Drizzle still
+    // wait on _isReadyPromise internally, and `waitForInitialSync` registers a listener that
+    // resolves once `statusForPriority(1).hasSynced` flips true (instant for returning users
+    // via offline-status restore, or once the background connect lands for new users).
     if (isSyncEnabled()) {
-      await this.connectToSync()
+      void this.connectToSync()
     }
   }
 
@@ -449,7 +455,7 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
    * Resolves after initialSyncTimeoutMs if sync never completes (e.g. network down).
    */
   async waitForInitialSync(): Promise<void> {
-    if (!this.powerSync || !this._isConnected || !isSyncEnabled()) {
+    if (!this.powerSync || !isSyncEnabled()) {
       return
     }
 

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -280,6 +280,16 @@ export class PowerSyncDatabaseImpl implements DatabaseInterface {
       })
       console.info(`[PowerSync] powerSync.connect: ${Math.round(performance.now() - connectInnerStartedAt)}ms`)
 
+      // The fire-and-forget connect from initialize() can race with the user disabling sync
+      // mid-flight: disconnectFromSync would no-op while `_isConnected` is still false. Re-check
+      // the preference here; if the user opted out during the ~10s connect window, tear down
+      // immediately so we don't leave PowerSync connected against their will.
+      if (!isSyncEnabled()) {
+        console.info('[PowerSync] sync disabled during connect — disconnecting')
+        await this.powerSync.disconnect()
+        return
+      }
+
       this._isConnected = true
       console.info(`[PowerSync] Connected (total ${Math.round(performance.now() - connectStartedAt)}ms)`)
       this.logFullSyncWhenReady(connectStartedAt)


### PR DESCRIPTION
Cuts ~10s off cold refresh for logged-in users by moving the PowerSync connect off the critical path of `database.initialize()`.

## What's wrong today

Instrumentation from #922 revealed the dominant cost on a logged-in cold refresh:

```
[PowerSync] Connecting…
[PowerSync] connecting=true (9625ms after connect start)   ← 9.6s of LOCAL work
[PowerSync] /powersync/token: 697ms                         ← backend fine
[PowerSync] stream established (995ms in connecting state)  ← Cloud fine
[PowerSync] powerSync.connect: 10619ms
[init] step2_initializeDatabase: 10623ms
[init] complete (total 11324ms)
```

The 9.6s is `powerSync.connect()` awaiting PowerSync's internal `_isReadyPromise` (WASQLite WASM compile, OPFS init, schema sync, offline-status read) before it can even start the connect attempt. Because `database.initialize()` `await`s `connectToSync()`, the entire app render is gated on this serial chain.

## Changes

- **`database.initialize()` no longer `await`s `connectToSync()`.** It's fire-and-forget (`void this.connectToSync()`). The PowerSync engine still initializes; local queries via Drizzle still wait on `_isReadyPromise` internally, so reads are safe. The network round-trip to PowerSync Cloud no longer blocks `initData`.
- **`waitForInitialSync()` drops the `_isConnected` guard.** Without it, the function would early-return on cold refresh (background connect hasn't completed yet) and skip the priority-1 wait entirely — defeating the gate before `reconcileDefaults`. The `powerSync.waitForFirstSync({ priority: 1 })` call already handles the not-yet-connected case correctly via its internal listener.

## Expected log shape after this lands

```
[init] step2_initializeDatabase: <few ms>           ← no longer blocks
[init] step3_waitForInitialSync: <fast>             ← instant for returning users via offline-status restore
[init] step4_reconcileDefaults: <may grow>          ← first SQL await of _isReadyPromise
[init] complete (total ~X)                          ← should drop vs the 11.3s baseline

(background, after init resolves:)
[PowerSync] Connecting… → … → [PowerSync] Connected (total …)
```

## Behavioural notes

- **Returning users**: `currentStatus.statusForPriority(1).hasSynced` is restored from offline status during `_isReadyPromise`, so `waitForInitialSync` returns instantly. No behaviour change beyond the timing shift.
- **First sign-in on a new device**: `waitForInitialSync` still waits up to 10s for priority-1 buckets to arrive via the background connect, same as before. The wait just doesn't include the 9.6s of local PowerSync init that used to be inside `step2`.
- **Offline at refresh**: background connect fails quietly (already handled in `connectToSync`'s try/catch), `waitForInitialSync` times out at 10s, `reconcileDefaults` runs against local data only — same as before.

## Test plan

- [ ] Refresh `/` while logged in. Verify `[init] complete` total dropped vs the 11.3s baseline.
- [ ] Verify `[PowerSync] Connected (…)` prints **after** `[init] complete`.
- [ ] Sign in on a fresh device (no local data). Verify chat UI renders, then sync data populates as priority-1 lands.
- [ ] Reload offline. Verify app still renders with local data and no errors propagate from the dropped `await`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes init/sync ordering and sync-disable timing; returning users should see faster boot, but first-device and offline paths depend on waitForFirstSync behaving correctly without _isConnected.
> 
> **Overview**
> **PowerSync cloud connect no longer blocks app initialization.** `initialize()` starts `connectToSync()` in the background (`void`) instead of awaiting it, so cold refresh is not held on WASM/OPFS readiness plus token and stream setup (~10s).
> 
> **`waitForInitialSync()`** no longer requires `_isConnected` first, so the priority-1 sync gate still runs while connect is in flight (via `waitForFirstSync`).
> 
> **Race fix:** after a successful connect, sync is re-checked; if the user disabled sync during the window, PowerSync disconnects immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ddf0c1a79912dd5a40c29d27ca4bad15e2fda84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->