### PR TITLE
fix: align skills popover positioning and hover radius

### DIFF
--- a/src/components/chat/chat-skills-bar.tsx
+++ b/src/components/chat/chat-skills-bar.tsx
@@ -166,7 +166,22 @@ export const ChatSkillsBar = ({
             </TooltipTrigger>
             <TooltipContent>{addTooltip}</TooltipContent>
           </Tooltip>
-          <PopoverContent side="top" align="start" sideOffset={6} className="w-72 max-w-[calc(100vw-2rem)] p-1">
+          {/*
+            `collisionPadding={16}` keeps the popover 16px off the viewport
+            edges. On mobile the content is sized to `calc(100vw-2rem)` (32px
+            narrower than the viewport), so collision avoidance pins it to a
+            16px-both-sides margin — i.e. full-width and centered on the chat
+            input — mirroring the chip dropdown. On desktop the fixed `w-72`
+            leaves room, so the padding never shifts the `align="start"`
+            anchor off the `+` button.
+          */}
+          <PopoverContent
+            side="top"
+            align="start"
+            sideOffset={6}
+            collisionPadding={16}
+            className={isMobile ? 'w-[calc(100vw-2rem)] p-1' : 'w-72 max-w-[calc(100vw-2rem)] p-1'}
+          >
             <ul className="max-h-64 overflow-y-auto">
               {pinnable.map((skill) => (
                 <li key={skill.id}>
@@ -185,7 +200,11 @@ export const ChatSkillsBar = ({
                         console.warn('togglePin failed:', error)
                       }
                     }}
-                    className="flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent"
+                    // `rounded-xl` (not `rounded-md`) so the hover highlight
+                    // sits concentrically inside the `rounded-2xl` container's
+                    // `p-1` padding — outer radius minus 4px padding. Matches
+                    // the slash autocomplete popover.
+                    className="flex w-full cursor-pointer flex-col gap-0.5 rounded-xl px-2 py-1.5 text-left transition-colors hover:bg-accent"
                   >
                     <span className="truncate text-[length:var(--font-size-body)] text-foreground">/{skill.name}</span>
                     {skill.description && (

--- a/src/skills/suggestion-chip.tsx
+++ b/src/skills/suggestion-chip.tsx
@@ -134,6 +134,11 @@ export const SuggestionChip = ({
       <DropdownMenuContent
         side="top"
         align="start"
+        // `sideOffset={12}` matches the `gap-3` (12px) between the chips bar
+        // and the chat input below it, so the menu sits off the chip by the
+        // same gap the chip sits off the chat area. The default 4px read as
+        // cramped.
+        sideOffset={12}
         collisionPadding={16}
         className={isMobile ? 'w-[calc(100vw-2rem)] min-w-56 rounded-2xl' : 'min-w-56 rounded-2xl'}
       >
@@ -142,7 +147,7 @@ export const SuggestionChip = ({
             onClick()
             handleOpenChange(false)
           }}
-          className="min-h-[var(--min-touch-height)] cursor-pointer"
+          className="min-h-[var(--min-touch-height)] cursor-pointer rounded-xl"
         >
           <Plus />
           Add to chat
@@ -152,7 +157,7 @@ export const SuggestionChip = ({
             onAddInstruction()
             handleOpenChange(false)
           }}
-          className="min-h-[var(--min-touch-height)] cursor-pointer"
+          className="min-h-[var(--min-touch-height)] cursor-pointer rounded-xl"
         >
           <File />
           Add instructions to chat
@@ -166,7 +171,7 @@ export const SuggestionChip = ({
             handleOpenChange(false)
             onReorder()
           }}
-          className="min-h-[var(--min-touch-height)] cursor-pointer"
+          className="min-h-[var(--min-touch-height)] cursor-pointer rounded-xl"
         >
           <ListOrdered />
           Reorder
@@ -178,7 +183,7 @@ export const SuggestionChip = ({
             handleOpenChange(false)
             onUnpin()
           }}
-          className="min-h-[var(--min-touch-height)] cursor-pointer"
+          className="min-h-[var(--min-touch-height)] cursor-pointer rounded-xl"
         >
           <Pin />
           Unpin


### PR DESCRIPTION
## Summary

Three UI hotfixes for the skills affordances on the chat page (reported by Chris):

1. **Plus popover hover radius** — the "pin a skill" popover's hover highlight used `rounded-md` (6/8px), too sharp inside the `rounded-2xl` container's `p-1` padding. Changed to `rounded-xl` so the highlight is concentric with the container (outer − 4px), matching the slash autocomplete popover.

2. **Mobile plus popover full-width & centered** — on mobile the popover now sizes to `w-[calc(100vw-2rem)]` with `collisionPadding={16}`, pinning it to a 16px margin on both sides (full-width, centered on the chat input area) instead of left-aligned to the `+` button. Desktop keeps the fixed `w-72` anchored to the button.

3. **Chip context menu spacing & item radius** — long-press / right-click menu on a pinned chip:
   - Added `sideOffset={12}` so the menu sits off the chip by the same 12px (`gap-3`) gap that separates the chip from the chat input (was a cramped 4px default).
   - Overrode the menu items' inherited `rounded-md` with `rounded-xl` so the hover highlight is concentric with the `rounded-2xl` container.

## Testing

- `bunx tsc --noEmit` clean
- `bun test src/skills/` and `src/components/chat/chat-skills-bar.test.tsx` — all pass (115 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only positioning and border-radius tweaks on chat skills UI; no behavior, data, or auth changes.
> 
> **Overview**
> Polishes **skills** popovers on chat so mobile layout and hover radii match other chat menus (e.g. slash autocomplete).
> 
> In **`chat-skills-bar`**, the **Pin a skill** (`+`) popover gains **`collisionPadding={16}`** and a mobile-only **`w-[calc(100vw-2rem)]`** so it spans the input with 16px side margins instead of hugging the `+` button; desktop keeps **`w-72`**. List rows use **`rounded-xl`** hover corners inside the **`rounded-2xl`** shell (was **`rounded-md`**).
> 
> In **`suggestion-chip`**, the pinned-chip menu uses **`sideOffset={12}`** (aligned with the chips-to-input gap) and each menu item gets **`rounded-xl`** for the same concentric highlight treatment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e567016bb2776103ef98209747640c026057d050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->