### PR TITLE
chore: Update footer copywrite from MoFo to Mozilla.org

### DIFF
--- a/web/src/components/marketing/footer-section.tsx
+++ b/web/src/components/marketing/footer-section.tsx
@@ -46,7 +46,7 @@ export const FooterSection = ({ className = '' }: FooterSectionProps) => (
           <a href="https://blog.thunderbird.net/2020/01/thunderbirds-new-home/" className="border-b border-[#667085]/40" target="_blank" rel="noopener noreferrer">
             MZLA Technologies Corporation
           </a>
-          , a wholly owned subsidiary of Mozilla Foundation. Portions of this content are &copy;1998&ndash;2026 by individual contributors. Content available under a{' '}
+          , a wholly owned subsidiary of the not-for-profit Mozilla.org. Portions of this content are &copy;1998&ndash;2026 by individual contributors. Content available under a{' '}
           <a href="https://www.mozilla.org/foundation/licensing/website-content/" className="border-b border-[#667085]/40" target="_blank" rel="noopener noreferrer">
             Creative Commons license
           </a>

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -105,7 +105,7 @@ const isDocsActive = pathname.startsWith('/docs');
 						>
 							MZLA Technologies Corporation
 						</a>
-						, a wholly owned subsidiary of Mozilla Foundation. &copy; {new Date().getFullYear()}.
+						, a wholly owned subsidiary of the not-for-profit Mozilla.org. &copy; {new Date().getFullYear()}.
 						Content available under a{' '}
 						<a
 							href="https://www.mozilla.org/foundation/licensing/website-content/"


### PR DESCRIPTION
## Description of changes

Updated the footer components in the website with a subsidiary change from Mozilla Foundation -> Mozilla.org

## Limitations & Notes

There are other mentions of Mozilla Foundation in two blog posts and in the LICENSE file. I believe the former should stay as it is a snapshot in time and the latter should go through Legal first. (cc @kewisch)

## Related issues

Part of https://github.com/thunderbird/thunderbird-website/issues/1220#event-26191710357

## Screenshots

Before
<img width="1163" height="113" alt="image" src="https://github.com/user-attachments/assets/3a5873e8-fab4-404b-943a-74be2a399693" />


After
<img width="1175" height="116" alt="image" src="https://github.com/user-attachments/assets/c9b3bdfa-d47e-47c1-9456-cee882c61873" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only footer updates with no application logic, auth, or data handling changes.
> 
> **Overview**
> Updates site footer legal copy so MZLA is described as a wholly owned subsidiary of **the not-for-profit Mozilla.org** instead of **Mozilla Foundation**.
> 
> The same wording change is applied in the marketing `FooterSection` and in `BaseLayout.astro` so blog/docs pages and the marketing footer stay aligned. Links to MZLA and Creative Commons licensing are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434cf04fc11539145aae4a2221c25e18191d862d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->