### PR TITLE
fix: connection & feedback bugs

### DIFF
--- a/src/acp/acp-adapter.test.ts
+++ b/src/acp/acp-adapter.test.ts
@@ -1,0 +1,356 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * `connectAcpAdapter` tests cover two concerns:
+ *
+ *  1. Handshake-failure modes (Task C, preserved): a handshake that never
+ *     answers, or a transport that closes terminally mid-handshake, must REJECT
+ *     (so the chat's fetch throws and the sidebar spinner clears) instead of
+ *     hanging on a pending `initialize`.
+ *  2. Per-thread session multiplexing over ONE shared connection: two threads
+ *     (two ACP sessionIds) each receive only their own `session/update`
+ *     notifications (no cross-thread bleed), and each persists its own
+ *     `acpSessionId`.
+ *
+ * Everything is injected — no network. A `FakeConnection` stands in for the ACP
+ * SDK `ClientSideConnection`; a fake `openTransport` returns a stream plus a
+ * controllable `closed` promise. Fake timers (global) are advanced via
+ * `getClock()` inside `act` to drive the handshake timeout deterministically.
+ */
+
+import '@/testing-library'
+
+import { act } from '@testing-library/react'
+import type {
+  Agent as AcpSdkAgent,
+  Client,
+  InitializeRequest,
+  LoadSessionRequest,
+  NewSessionRequest,
+  PromptRequest,
+  SessionNotification,
+} from '@agentclientprotocol/sdk'
+import { describe, expect, it } from 'bun:test'
+import { getClock } from '@/testing-library'
+import type { Agent, AgentAdapterContext } from '@/types/acp'
+import type { AcpTransport } from './types'
+import { connectAcpAdapter, type AcpAdapterContext } from './acp-adapter'
+
+const remoteAgent: Agent = {
+  id: 'remote-foo',
+  name: 'Foo',
+  type: 'remote-acp',
+  transport: 'websocket',
+  url: 'wss://example.test/ws',
+  description: null,
+  icon: null,
+  isSystem: 0,
+  enabled: 1,
+  deletedAt: null,
+  userId: 'u1',
+}
+
+const baseCtx = (overrides: Partial<AcpAdapterContext> = {}): AcpAdapterContext => ({
+  httpClient: {} as AcpAdapterContext['httpClient'],
+  ...overrides,
+})
+
+/** Build a per-thread fetch context. `acpSessionId`/`onAcpSessionId` drive the
+ *  adapter's per-thread `loadSession`/`newSession` resolution. */
+const threadCtx = (threadId: string, overrides: Partial<AgentAdapterContext> = {}): AgentAdapterContext =>
+  ({
+    threadId,
+    acpSessionId: null,
+    onAcpSessionId: async () => {},
+    ...overrides,
+  }) as AgentAdapterContext
+
+/** A fake transport with a controllable `closed` promise so a test can fire a
+ *  terminal close on demand. `close` is counted so tests can assert the adapter
+ *  tears the transport down on a failed handshake (no leaked socket). */
+const buildFakeTransport = (): {
+  transport: AcpTransport
+  rejectClosed: (err: Error) => void
+  closeCalls: () => number
+} => {
+  let rejectClosed: (err: Error) => void = () => {}
+  let closeCount = 0
+  const closed = new Promise<void>((_, reject) => {
+    rejectClosed = reject
+  })
+  // Keep the rejection handled even when a test never fires it.
+  closed.catch(() => {})
+  const transport: AcpTransport = {
+    stream: { readable: new ReadableStream(), writable: new WritableStream() },
+    close: () => {
+      closeCount++
+    },
+    closed,
+  }
+  return { transport, rejectClosed, closeCalls: () => closeCount }
+}
+
+/** Build a fake `ClientSideConnection`. `initialize` is configurable (resolve
+ *  or hang). `newSession` hands out distinct ids per call. The `toClient`
+ *  factory is captured so a test can push `session/update` notifications through
+ *  the real routing path the adapter wires up. */
+const buildFakeConnection = (opts: { hangInitialize?: boolean; loadSession?: boolean } = {}) => {
+  const calls = {
+    initialize: [] as InitializeRequest[],
+    newSession: [] as NewSessionRequest[],
+    loadSession: [] as LoadSessionRequest[],
+    prompt: [] as PromptRequest[],
+  }
+  let client: Client | null = null
+  let newSessionCount = 0
+  // Gate prompt resolution so a test can hold both threads' turns open at once.
+  const promptGate = { release: () => {} }
+  const promptGatePromise = new Promise<void>((resolve) => {
+    promptGate.release = resolve
+  })
+
+  class FakeConnection {
+    constructor(toClient: (agent: AcpSdkAgent) => Client, _stream: AcpTransport['stream']) {
+      client = toClient({} as AcpSdkAgent)
+    }
+    initialize = (req: InitializeRequest) => {
+      calls.initialize.push(req)
+      if (opts.hangInitialize) {
+        return new Promise<never>(() => {})
+      }
+      return Promise.resolve({ protocolVersion: 1, agentCapabilities: { loadSession: opts.loadSession ?? false } })
+    }
+    newSession = (req: NewSessionRequest) => {
+      calls.newSession.push(req)
+      newSessionCount++
+      return Promise.resolve({ sessionId: `sess-${newSessionCount}` })
+    }
+    loadSession = (req: LoadSessionRequest) => {
+      calls.loadSession.push(req)
+      return Promise.resolve({})
+    }
+    prompt = async (req: PromptRequest) => {
+      calls.prompt.push(req)
+      await promptGatePromise
+      return { stopReason: 'end_turn' as const }
+    }
+  }
+
+  return {
+    FakeConnection,
+    calls,
+    pushUpdate: (n: SessionNotification) => client?.sessionUpdate(n),
+    releasePrompts: () => promptGate.release(),
+  }
+}
+
+/** Observe a connect promise's settlement as a tagged value so assertions
+ *  don't rely on `.rejects` (which hangs under fake timers when the promise was
+ *  created in a prior tick). */
+const observeConnect = (p: Promise<unknown>): Promise<{ rejected: boolean; message?: string }> =>
+  p.then(
+    () => ({ rejected: false }),
+    (err: Error) => ({ rejected: true, message: err.message }),
+  )
+
+const readSse = async (response: Response, max = 50): Promise<string[]> => {
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  const chunks: string[] = []
+  for (let i = 0; i < max; i++) {
+    const { value, done } = await reader.read()
+    if (done) {
+      chunks.push('[CLOSED]')
+      break
+    }
+    chunks.push(decoder.decode(value))
+  }
+  reader.releaseLock()
+  return chunks
+}
+
+const promptInit = (text: string): RequestInit => ({
+  method: 'POST',
+  body: JSON.stringify({ id: 't', messages: [{ role: 'user', parts: [{ type: 'text', text }] }] }),
+})
+
+describe('connectAcpAdapter — handshake failure modes', () => {
+  it('rejects after handshakeTimeoutMs when initialize never resolves and tears down the transport', async () => {
+    const { transport, closeCalls } = buildFakeTransport()
+    const { FakeConnection } = buildFakeConnection({ hangInitialize: true })
+
+    const observed = observeConnect(
+      connectAcpAdapter(remoteAgent, baseCtx(), {
+        openTransport: async () => transport,
+        ClientSideConnection: FakeConnection as never,
+        handshakeTimeoutMs: 5000,
+      }),
+    )
+
+    await act(async () => {
+      await getClock().tickAsync(5000)
+    })
+
+    const result = await observed
+    expect(result.rejected).toBe(true)
+    expect(result.message).toMatch(/handshake timed out after 5000ms/)
+    // The silent socket must be closed so it (and its reconnect machinery) can't leak.
+    expect(closeCalls()).toBeGreaterThanOrEqual(1)
+  })
+
+  it('rejects promptly when the transport closes terminally mid-handshake', async () => {
+    const { transport, rejectClosed } = buildFakeTransport()
+    const { FakeConnection } = buildFakeConnection({ hangInitialize: true })
+
+    const observed = observeConnect(
+      connectAcpAdapter(remoteAgent, baseCtx(), {
+        openTransport: async () => transport,
+        ClientSideConnection: FakeConnection as never,
+        handshakeTimeoutMs: 30_000,
+      }),
+    )
+
+    rejectClosed(new Error('ACP transport closed (code 4003)'))
+    await act(async () => {
+      await getClock().tickAsync(1)
+    })
+
+    const result = await observed
+    expect(result.rejected).toBe(true)
+    expect(result.message).toMatch(/code 4003/)
+  })
+
+  it('regression: a normal handshake resolves and fetch streams a terminal finish + [DONE]', async () => {
+    const { transport } = buildFakeTransport()
+    const { FakeConnection, calls, releasePrompts } = buildFakeConnection()
+
+    const adapter = await connectAcpAdapter(remoteAgent, baseCtx(), {
+      openTransport: async () => transport,
+      ClientSideConnection: FakeConnection as never,
+      handshakeTimeoutMs: 30_000,
+    })
+
+    // initialize runs at connect; the session is resolved lazily on first fetch.
+    expect(calls.initialize).toHaveLength(1)
+    expect(calls.newSession).toHaveLength(0)
+    expect(adapter.capabilities).toMatchObject({ loadSession: false })
+
+    const response = await adapter.fetch(promptInit('hi'), threadCtx('t1'))
+    expect(response.headers.get('content-type')).toBe('text/event-stream')
+    expect(calls.newSession).toHaveLength(1)
+
+    let sse: string[] = []
+    await act(async () => {
+      releasePrompts()
+      await getClock().runAllAsync()
+      sse = await readSse(response)
+    })
+
+    const joined = sse.join('')
+    expect(calls.prompt).toHaveLength(1)
+    expect(joined).toContain('"type":"finish"')
+    expect(joined).toContain('[DONE]')
+    // The body must close so the AI SDK leaves the streaming state.
+    expect(sse).toContain('[CLOSED]')
+  })
+})
+
+describe('connectAcpAdapter — per-thread session multiplexing over one connection', () => {
+  it('resolves a separate ACP session per thread and persists each independently', async () => {
+    const { transport } = buildFakeTransport()
+    const { FakeConnection, calls } = buildFakeConnection()
+
+    const adapter = await connectAcpAdapter(remoteAgent, baseCtx(), {
+      openTransport: async () => transport,
+      ClientSideConnection: FakeConnection as never,
+    })
+
+    const persistedA: string[] = []
+    const persistedB: string[] = []
+
+    await adapter.fetch(
+      promptInit('a'),
+      threadCtx('thread-A', { onAcpSessionId: async (s) => void persistedA.push(s) }),
+    )
+    await adapter.fetch(
+      promptInit('b'),
+      threadCtx('thread-B', { onAcpSessionId: async (s) => void persistedB.push(s) }),
+    )
+
+    // One connection, one initialize, but a distinct newSession per thread.
+    expect(calls.initialize).toHaveLength(1)
+    expect(calls.newSession).toHaveLength(2)
+    expect(persistedA).toEqual(['sess-1'])
+    expect(persistedB).toEqual(['sess-2'])
+
+    // A second send on thread-A reuses its cached session — no extra newSession.
+    await adapter.fetch(promptInit('a2'), threadCtx('thread-A'))
+    expect(calls.newSession).toHaveLength(2)
+  })
+
+  it('loadSession-capable agent reuses a thread acpSessionId without a newSession', async () => {
+    const { transport } = buildFakeTransport()
+    const { FakeConnection, calls } = buildFakeConnection({ loadSession: true })
+
+    const adapter = await connectAcpAdapter(remoteAgent, baseCtx(), {
+      openTransport: async () => transport,
+      ClientSideConnection: FakeConnection as never,
+    })
+
+    const persisted: string[] = []
+    await adapter.fetch(
+      promptInit('hi'),
+      threadCtx('thread-X', { acpSessionId: 'prior-sess', onAcpSessionId: async (s) => void persisted.push(s) }),
+    )
+
+    expect(calls.loadSession).toHaveLength(1)
+    expect(calls.loadSession[0]?.sessionId).toBe('prior-sess')
+    expect(calls.newSession).toHaveLength(0)
+    // loadSession reuses the existing id — nothing fresh to persist.
+    expect(persisted).toEqual([])
+  })
+
+  it('routes session/update notifications to the owning thread only — no cross-thread bleed', async () => {
+    const { transport } = buildFakeTransport()
+    const { FakeConnection, calls, pushUpdate, releasePrompts } = buildFakeConnection()
+
+    const adapter = await connectAcpAdapter(remoteAgent, baseCtx(), {
+      openTransport: async () => transport,
+      ClientSideConnection: FakeConnection as never,
+    })
+
+    // Two threads stream concurrently — prompts are gated open until released.
+    const responseA = await adapter.fetch(promptInit('a'), threadCtx('thread-A'))
+    const responseB = await adapter.fetch(promptInit('b'), threadCtx('thread-B'))
+
+    // thread-A → sess-1, thread-B → sess-2.
+    expect(calls.newSession).toHaveLength(2)
+
+    let sseA: string[] = []
+    let sseB: string[] = []
+    await act(async () => {
+      // Each notification targets exactly one session id; the other must not see it.
+      pushUpdate({
+        sessionId: 'sess-1',
+        update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ALPHA' } },
+      } as SessionNotification)
+      pushUpdate({
+        sessionId: 'sess-2',
+        update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'BETA' } },
+      } as SessionNotification)
+      releasePrompts()
+      await getClock().runAllAsync()
+      sseA = await readSse(responseA)
+      sseB = await readSse(responseB)
+    })
+
+    const joinedA = sseA.join('')
+    const joinedB = sseB.join('')
+    expect(joinedA).toContain('ALPHA')
+    expect(joinedA).not.toContain('BETA')
+    expect(joinedB).toContain('BETA')
+    expect(joinedB).not.toContain('ALPHA')
+  })
+})

--- a/src/acp/acp-adapter.ts
+++ b/src/acp/acp-adapter.ts
@@ -6,20 +6,30 @@
  * Generic ACP adapter. Used for both `remote-acp` and `managed-acp` agents —
  * the wire is identical, only the URL provenance differs.
  *
+ * One adapter owns ONE transport + ONE `ClientSideConnection` + ONE
+ * `initialize`, and MULTIPLEXES many per-thread ACP sessions over it. This is
+ * what lets a single agent connection be reused across every chat thread that
+ * targets that agent (see `src/acp/adapter-cache.ts`).
+ *
  * Lifecycle:
- *   1. `connectAcpAdapter(agent, ctx)` opens the transport, builds a
- *      `ClientSideConnection`, sends `initialize`, and stashes the agent
- *      capabilities reported by the server.
- *   2. If the chat thread carries a prior `acpSessionId` AND the agent
- *      advertises `loadSession`, the adapter calls `loadSession`. Otherwise
- *      it calls `newSession`, captures the fresh id, and notifies the chat
- *      layer via `ctx.onAcpSessionId(newId)`.
- *   3. Each `adapter.fetch(init, ctx)` parses the most recent user message,
- *      sends `prompt` with a single text `ContentBlock`, and pipes the
- *      `sessionUpdate` notifications through the translator into a
- *      `ReadableStream<Uint8Array>` that AI SDK consumes.
- *   4. `disconnect()` closes the transport (which aborts the SDK connection
- *      via its internal AbortSignal).
+ *   1. `connectAcpAdapter(agent, deps)` opens the transport, builds a
+ *      `ClientSideConnection`, and sends `initialize`. The handshake is raced
+ *      against the transport's terminal-close signal and a bounded timeout — a
+ *      permanently-failed or silent transport rejects loudly instead of hanging
+ *      the chat's fetch forever. NO per-thread session is resolved here.
+ *   2. Each `adapter.fetch(init, ctx)` resolves the calling thread's ACP
+ *      session lazily and once: if `ctx.acpSessionId` is set AND the agent
+ *      advertises `loadSession` it calls `loadSession`, otherwise it calls
+ *      `newSession`, captures the fresh id, and persists it via
+ *      `ctx.onAcpSessionId`. The resolved id is cached per thread so repeated
+ *      sends on the same thread never re-resolve. Both calls go through the
+ *      same handshake guard as `initialize`.
+ *   3. `session/update` notifications are routed by their `sessionId` to the
+ *      owning thread's translator via a `Map<sessionId, sink>`, so two threads
+ *      streaming at once never bleed into each other.
+ *   4. `disconnect()` closes the transport (which aborts the SDK connection via
+ *      its internal AbortSignal). Called only on real teardown — agent delete,
+ *      agent config edit, or sign-out.
  */
 
 import type {
@@ -33,14 +43,18 @@ import type {
 } from '@agentclientprotocol/sdk'
 import { ClientSideConnection as ClientSideConnectionImpl } from '@agentclientprotocol/sdk'
 import type { Agent, AgentAdapter, AgentAdapterContext, AgentCapabilities } from '@/types/acp'
-import type { FetchFn } from '@/lib/proxy-fetch'
 import type { ThunderboltUIMessage } from '@/types'
 import { openTransport } from './transports'
 import type { AcpTransport } from './types'
-import { createTranslatorStream, type SessionSideEffectSink } from './translators/acp-to-ai-sdk'
+import { createTranslatorStream } from './translators/acp-to-ai-sdk'
 import type { WebSocketFactory } from './transports/websocket'
 
 const protocolVersion = 1
+/** Connect-phase budget. Generous on purpose: a cold-starting upstream (e.g. a
+ *  Railway container) may take a while to answer `initialize`. This bounds ONLY
+ *  the handshake — never the prompt/streaming phase, which is legitimately long
+ *  and is torn down via the transport instead. */
+const defaultHandshakeTimeoutMs = 30_000
 /** ACP requires `cwd` on session/new + session/load. Browser/web agents have
  *  no real filesystem; we send a placeholder. The Haystack managed adapter
  *  and most remote agents ignore the field. */
@@ -60,20 +74,23 @@ const cancelledPermission: RequestPermissionFn = async () => ({
 })
 
 /** The minimum Client implementation we register with `ClientSideConnection`.
- *  We accept tool calls / session updates but never request files or terminals
- *  in MVP. All `sessionUpdate` notifications flow into the caller's sink, and
- *  permission prompts are forwarded to the supplied `requestPermission`. */
+ *  Session updates and permission prompts both carry an ACP `sessionId`, so we
+ *  route each to the owning thread's per-session handler. The handlers live in
+ *  caller-owned maps that the adapter mutates as threads start/stop prompting. */
 const createClientHandler = (
   onSessionUpdate: (notification: SessionNotification) => void,
-  requestPermission: RequestPermissionFn,
+  onRequestPermission: RequestPermissionFn,
 ): Client => ({
   sessionUpdate: async (params) => {
     onSessionUpdate(params)
   },
-  requestPermission,
+  requestPermission: onRequestPermission,
 })
 
-const adaptCapabilities = (response: InitializeResponse): AgentCapabilities => {
+/** Map the agent's `initialize` response to the flat {@link AgentCapabilities}
+ *  shape the UI cares about. Shared with the settings connection probe
+ *  (`./connection-test`) so both paths report capabilities identically. */
+export const adaptCapabilities = (response: InitializeResponse): AgentCapabilities => {
   const caps = response.agentCapabilities
   return {
     loadSession: caps?.loadSession ?? false,
@@ -116,29 +133,45 @@ export type AcpAdapterDeps = {
   webSocketFactory?: WebSocketFactory
   /** Override throttle for tests of the prompt → translator pipeline. */
   textDeltaThrottleMs?: number
+  /** Connect-phase timeout (ms). Defaults to a generous 30s. Tests inject a
+   *  small value to exercise the timeout path deterministically. */
+  handshakeTimeoutMs?: number
 }
 
+/** Connection-scoped context — everything needed to open ONE shared transport.
+ *  It deliberately omits per-thread fields (`acpSessionId`, `onAcpSessionId`,
+ *  `requestPermission`, `onSessionSideEffect`): those vary per thread and are
+ *  supplied on each `fetch` via {@link AgentAdapterContext}. */
 export type AcpAdapterContext = {
   httpClient: AgentAdapterContext['httpClient']
-  getProxyFetch: () => FetchFn
-  /** Persisted ACP session id from `chat_threads.acp_session_id` — null when
-   *  this is the first message in a thread or the agent doesn't support
-   *  `loadSession`. */
-  acpSessionId: string | null
-  onAcpSessionId: AgentAdapterContext['onAcpSessionId']
-  /** Invoked when the agent requests permission for a tool call. The chat
-   *  layer surfaces a dialog and resolves the response. Optional; defaults to
-   *  auto-cancelling so unwired agents stay safe. */
-  requestPermission?: RequestPermissionFn
-  /** Invoked when the agent emits a `current_mode_update` or
-   *  `config_option_update`. The chat layer reflects the new server state in
-   *  the store. Optional; default is no-op. */
-  onSessionSideEffect?: SessionSideEffectSink
 }
 
-/** Open and handshake an ACP adapter against `agent`. The returned adapter is
- *  bound to a single transport/connection — call `disconnect()` to tear it
- *  down when the chat session is destroyed. */
+/** Race a handshake step against a terminal-close signal and a timeout so a
+ *  permanently-failed or silent transport surfaces a loud error instead of
+ *  leaving `initialize`/`newSession` pending forever (the stuck-spinner bug).
+ *  The `terminalClose` promise is the transport's `closed` (rejects on terminal
+ *  close); when absent we fall back to timeout-only. */
+const withHandshakeGuard = async <T>(
+  step: Promise<T>,
+  terminalClose: Promise<void> | undefined,
+  timeoutMs: number,
+): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`ACP handshake timed out after ${timeoutMs}ms`)), timeoutMs)
+  })
+  const racers = terminalClose ? [step, terminalClose as Promise<never>, timeout] : [step, timeout]
+  try {
+    return await Promise.race(racers)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Open and handshake an ACP adapter against `agent`. The returned adapter owns
+ *  a single transport/connection and multiplexes per-thread sessions over it —
+ *  call `disconnect()` to tear it down on real teardown (agent delete / config
+ *  edit / sign-out), NOT on thread switch. */
 export const connectAcpAdapter = async (
   agent: Agent,
   ctx: AcpAdapterContext,
@@ -161,61 +194,111 @@ export const connectAcpAdapter = async (
     agentType: agent.type,
     signal: transportController.signal,
     webSocketFactory: deps.webSocketFactory,
-    // Managed-ACP needs the authenticated client to mint a single-use
-    // WebSocket ticket; remote-ACP ignores it (the universal proxy / native
-    // WebSocket carry their own auth).
+    // `httpClient` presence signals an authenticated cloud backend is wired:
+    // managed-ACP offers the signed bearer subprotocol when it's set; remote-ACP
+    // ignores it (the universal proxy / native WebSocket carry their own auth).
     httpClient: ctx.httpClient,
   })
 
-  // The `sessionUpdate` sink is rebound per prompt-turn so notifications from
-  // one prompt never leak into the next. While no prompt is active, updates
-  // are no-ops (the agent SHOULD only emit them inside a turn anyway).
-  let sessionUpdateSink: (notification: SessionNotification) => void = () => {}
+  // `session/update` notifications are routed to the owning thread's translator
+  // by ACP `sessionId`. While a thread isn't actively prompting its entry is
+  // absent and updates for it are dropped (the agent SHOULD only emit them
+  // inside a turn anyway). A per-session map — never a single last-writer-wins
+  // sink — is what prevents cross-thread bleed when two threads stream at once.
+  const sessionUpdateSinks = new Map<string, (notification: SessionNotification) => void>()
+  // Permission prompts also carry an ACP `sessionId`, so route them the same
+  // way. A thread registers its handler while connected; the fallback cancels.
+  const permissionHandlers = new Map<string, RequestPermissionFn>()
 
-  const requestPermission = ctx.requestPermission ?? cancelledPermission
+  const routeSessionUpdate = (notification: SessionNotification): void => {
+    sessionUpdateSinks.get(notification.sessionId)?.(notification)
+  }
+
+  const routePermission: RequestPermissionFn = (request) => {
+    const handler = permissionHandlers.get(request.sessionId)
+    return (handler ?? cancelledPermission)(request)
+  }
 
   const connection = new ConnectionCtor(
-    () => createClientHandler((n) => sessionUpdateSink(n), requestPermission),
+    () => createClientHandler(routeSessionUpdate, routePermission),
     transport.stream,
   )
 
-  const initializeResponse = await connection.initialize({
-    protocolVersion: protocolVersion,
-    clientInfo: { name: clientName, version: clientVersion },
-    clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
-  })
+  const handshakeTimeoutMs = deps.handshakeTimeoutMs ?? defaultHandshakeTimeoutMs
 
-  const capabilities = adaptCapabilities(initializeResponse)
-
-  const resolveSessionId = async (): Promise<string> => {
-    if (ctx.acpSessionId && capabilities.loadSession) {
-      await connection.loadSession({
-        sessionId: ctx.acpSessionId,
-        cwd: sessionCwd,
-        mcpServers: [],
-      })
-      return ctx.acpSessionId
+  // A timed-out or terminally-closed `initialize` must tear the transport down
+  // before rethrowing — otherwise the open WebSocket and its reconnect
+  // machinery leak. The error still surfaces loudly so the chat fetch fails.
+  const runInitialize = async (): Promise<AgentCapabilities> => {
+    try {
+      const initializeResponse = await withHandshakeGuard(
+        connection.initialize({
+          protocolVersion: protocolVersion,
+          clientInfo: { name: clientName, version: clientVersion },
+          clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+        }),
+        transport.closed,
+        handshakeTimeoutMs,
+      )
+      return adaptCapabilities(initializeResponse)
+    } catch (err) {
+      transportController.abort()
+      transport.close()
+      throw err
     }
-    const newSession = await connection.newSession({ cwd: sessionCwd, mcpServers: [] })
-    await ctx.onAcpSessionId(newSession.sessionId)
-    return newSession.sessionId
   }
 
-  const sessionId = await resolveSessionId()
+  const capabilities = await runInitialize()
 
-  const fetch = async (init: RequestInit, _context: AgentAdapterContext): Promise<Response> => {
+  // Resolved ACP session id per chat thread. `null` while a thread's first
+  // resolution is in flight is impossible — we store the in-flight promise so
+  // concurrent sends on the same thread dedupe to one load/new call.
+  const sessionByThread = new Map<string, Promise<string>>()
+
+  /** Resolve (and cache) the ACP session id for the calling thread. First send
+   *  on a thread runs `loadSession` (when supported + a prior id exists) or
+   *  `newSession`; subsequent sends reuse the cached id. */
+  const resolveThreadSession = (context: AgentAdapterContext): Promise<string> => {
+    const existing = sessionByThread.get(context.threadId)
+    if (existing) {
+      return existing
+    }
+    const resolve = (async (): Promise<string> => {
+      if (context.acpSessionId && capabilities.loadSession) {
+        await withHandshakeGuard(
+          connection.loadSession({ sessionId: context.acpSessionId, cwd: sessionCwd, mcpServers: [] }),
+          transport.closed,
+          handshakeTimeoutMs,
+        )
+        return context.acpSessionId
+      }
+      const newSession = await withHandshakeGuard(
+        connection.newSession({ cwd: sessionCwd, mcpServers: [] }),
+        transport.closed,
+        handshakeTimeoutMs,
+      )
+      await context.onAcpSessionId(newSession.sessionId)
+      return newSession.sessionId
+    })()
+    // Evict on failure so a transient handshake error doesn't poison the thread
+    // — the next send retries a fresh resolution.
+    resolve.catch(() => sessionByThread.delete(context.threadId))
+    sessionByThread.set(context.threadId, resolve)
+    return resolve
+  }
+
+  const fetch = async (init: RequestInit, context: AgentAdapterContext): Promise<Response> => {
     const promptText = extractUserPrompt(init)
+    const sessionId = await resolveThreadSession(context)
 
     const { body, translator, close } = createTranslatorStream({
       textDeltaThrottleMs: deps.textDeltaThrottleMs,
-      onSideEffect: ctx.onSessionSideEffect,
+      onSideEffect: context.onSessionSideEffect,
     })
 
-    sessionUpdateSink = (notification) => {
-      if (notification.sessionId !== sessionId) {
-        return
-      }
-      translator.handle(notification)
+    sessionUpdateSinks.set(sessionId, (notification) => translator.handle(notification))
+    if (context.requestPermission) {
+      permissionHandlers.set(sessionId, context.requestPermission)
     }
 
     translator.start()
@@ -235,7 +318,8 @@ export const connectAcpAdapter = async (
       } catch (err) {
         translator.error(err instanceof Error ? err.message : String(err))
       } finally {
-        sessionUpdateSink = () => {}
+        sessionUpdateSinks.delete(sessionId)
+        permissionHandlers.delete(sessionId)
         translator.finish()
         close()
       }

--- a/src/acp/adapter-cache.test.ts
+++ b/src/acp/adapter-cache.test.ts
@@ -1,0 +1,175 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * `adapter-cache` tests. The cache is module-global, so each test forgets prior
+ * entries via `clearAdapterCache` first. `connectToAgent` is injected as a
+ * counting fake (no `mock.module`, no network) so we can assert the cache opens
+ * exactly one connection per agent and reuses it across threads/sessions.
+ */
+
+import '@/testing-library'
+
+import { beforeEach, describe, expect, it } from 'bun:test'
+import type { ConnectToAgentContext } from './connect'
+import type { Agent, AgentAdapter } from '@/types/acp'
+import { clearAdapterCache, disposeAdapter, disposeAllAdapters, getOrConnectAdapter } from './adapter-cache'
+
+const agentA: Agent = {
+  id: 'agent-a',
+  name: 'A',
+  type: 'remote-acp',
+  transport: 'websocket',
+  url: 'wss://a.test/ws',
+  description: null,
+  icon: null,
+  isSystem: 0,
+  enabled: 1,
+  deletedAt: null,
+  userId: 'u1',
+}
+
+const agentB: Agent = { ...agentA, id: 'agent-b', url: 'wss://b.test/ws' }
+
+const ctx: ConnectToAgentContext = {
+  httpClient: {} as ConnectToAgentContext['httpClient'],
+  getProxyFetch: () => (async () => new Response('ok')) as never,
+}
+
+/** Build a fake adapter for `agent` that tracks disconnect calls. */
+const buildAdapter = (agent: Agent) => {
+  let disconnects = 0
+  const adapter: AgentAdapter = {
+    agent,
+    capabilities: null,
+    fetch: async () => new Response('ok'),
+    disconnect: () => {
+      disconnects++
+    },
+  }
+  return { adapter, disconnectCount: () => disconnects }
+}
+
+/** A counting fake `connectToAgent`. `delayMs` lets a test hold the connect
+ *  in-flight to exercise concurrent dedupe; `fail` exercises eviction. */
+const makeCounter = (
+  resolveFor: (agent: Agent) => AgentAdapter,
+  opts: { fail?: boolean; resolver?: { release: () => void; gate: Promise<void> } } = {},
+) => {
+  let calls = 0
+  const connectToAgent = (async (agent: Agent) => {
+    calls++
+    if (opts.resolver) {
+      await opts.resolver.gate
+    }
+    if (opts.fail) {
+      throw new Error('connect failed')
+    }
+    return resolveFor(agent)
+  }) as never
+  return { connectToAgent, callCount: () => calls }
+}
+
+describe('adapter-cache', () => {
+  beforeEach(() => {
+    clearAdapterCache()
+  })
+
+  it('reuses ONE adapter for the same agentId across two different sessionIds (connect once)', async () => {
+    const { adapter } = buildAdapter(agentA)
+    const { connectToAgent, callCount } = makeCounter(() => adapter)
+
+    // Two distinct "threads/sessions" route to the same agent.
+    const first = await getOrConnectAdapter(agentA, ctx, { connectToAgent })
+    const second = await getOrConnectAdapter(agentA, ctx, { connectToAgent })
+
+    expect(first).toBe(adapter)
+    expect(second).toBe(adapter)
+    expect(callCount()).toBe(1)
+  })
+
+  it('opens separate connections for different agents', async () => {
+    const a = buildAdapter(agentA)
+    const b = buildAdapter(agentB)
+    const { connectToAgent, callCount } = makeCounter((agent) => (agent.id === agentA.id ? a.adapter : b.adapter))
+
+    const ra = await getOrConnectAdapter(agentA, ctx, { connectToAgent })
+    const rb = await getOrConnectAdapter(agentB, ctx, { connectToAgent })
+
+    expect(ra).toBe(a.adapter)
+    expect(rb).toBe(b.adapter)
+    expect(callCount()).toBe(2)
+  })
+
+  it('dedupes concurrent first-use to a single connect', async () => {
+    const { adapter } = buildAdapter(agentA)
+    let release: () => void = () => {}
+    const gate = new Promise<void>((r) => {
+      release = r
+    })
+    const { connectToAgent, callCount } = makeCounter(() => adapter, { resolver: { release, gate } })
+
+    // Fire both before the connect resolves.
+    const p1 = getOrConnectAdapter(agentA, ctx, { connectToAgent })
+    const p2 = getOrConnectAdapter(agentA, ctx, { connectToAgent })
+    release()
+    const [r1, r2] = await Promise.all([p1, p2])
+
+    expect(r1).toBe(adapter)
+    expect(r2).toBe(adapter)
+    expect(callCount()).toBe(1)
+  })
+
+  it('disposeAdapter evicts and disconnects', async () => {
+    const { adapter, disconnectCount } = buildAdapter(agentA)
+    const { connectToAgent, callCount } = makeCounter(() => adapter)
+
+    await getOrConnectAdapter(agentA, ctx, { connectToAgent })
+    await disposeAdapter(agentA.id)
+
+    expect(disconnectCount()).toBe(1)
+
+    // Evicted → the next use reconnects.
+    await getOrConnectAdapter(agentA, ctx, { connectToAgent })
+    expect(callCount()).toBe(2)
+  })
+
+  it('disposeAdapter is a no-op for an agent with no cached connection', async () => {
+    await expect(disposeAdapter('never-connected')).resolves.toBeUndefined()
+  })
+
+  it('evicts a failed connect so the next call retries', async () => {
+    const { adapter } = buildAdapter(agentA)
+    const failing = makeCounter(() => adapter, { fail: true })
+
+    await expect(getOrConnectAdapter(agentA, ctx, { connectToAgent: failing.connectToAgent })).rejects.toThrow(
+      'connect failed',
+    )
+    expect(failing.callCount()).toBe(1)
+
+    // The poisoned entry was evicted — a retry connects again (and succeeds).
+    const succeeding = makeCounter(() => adapter)
+    const result = await getOrConnectAdapter(agentA, ctx, { connectToAgent: succeeding.connectToAgent })
+    expect(result).toBe(adapter)
+    expect(succeeding.callCount()).toBe(1)
+  })
+
+  it('disposeAllAdapters disconnects every cached adapter and clears', async () => {
+    const a = buildAdapter(agentA)
+    const b = buildAdapter(agentB)
+    const { connectToAgent, callCount } = makeCounter((agent) => (agent.id === agentA.id ? a.adapter : b.adapter))
+
+    await getOrConnectAdapter(agentA, ctx, { connectToAgent })
+    await getOrConnectAdapter(agentB, ctx, { connectToAgent })
+
+    await disposeAllAdapters()
+
+    expect(a.disconnectCount()).toBe(1)
+    expect(b.disconnectCount()).toBe(1)
+
+    // Cleared → reconnect on next use.
+    await getOrConnectAdapter(agentA, ctx, { connectToAgent })
+    expect(callCount()).toBe(3)
+  })
+})

--- a/src/acp/adapter-cache.ts
+++ b/src/acp/adapter-cache.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Global, lazy ACP adapter cache — ONE connection per agent, reused across
+ * every chat thread that targets that agent.
+ *
+ * Why module-level: a chat thread is created per `Chat` instance, so a
+ * per-instance cache would open a fresh transport for every thread (and leak
+ * N connections for N threads on the same agent). Hoisting the cache to module
+ * scope makes the connection follow the AGENT, not the thread, so switching
+ * threads on the same agent reuses the warm connection instead of reconnecting.
+ *
+ * Lazy: a connection opens only when `getOrConnectAdapter` is called, which the
+ * routing fetch does on the FIRST actual send of a thread the user opened.
+ * Nothing iterates agents or pre-warms on hydrate, so unopened history threads
+ * never open a connection.
+ *
+ * The cache stores the connect PROMISE (not the resolved adapter) so concurrent
+ * first-uses dedupe to a single connect. A rejected connect is evicted so the
+ * next call retries against a fresh transport instead of replaying a poisoned
+ * one.
+ *
+ * Teardown is explicit and rare: `disposeAdapter(agentId)` on agent delete or a
+ * connection-invalidating config edit (url/transport/type), and
+ * `disposeAllAdapters()` on sign-out. Thread switch does NOT dispose.
+ */
+
+import { connectToAgent as defaultConnectToAgent } from './connect'
+import type { ConnectToAgentContext, ConnectToAgentDeps } from './connect'
+import type { Agent, AgentAdapter } from '@/types/acp'
+
+const cache = new Map<string, Promise<AgentAdapter>>()
+
+/** DI seam so tests can inject a counting/fake `connectToAgent` without
+ *  `mock.module()`. Production omits and binds to the real entry point. */
+export type AdapterCacheDeps = {
+  connectToAgent?: typeof defaultConnectToAgent
+}
+
+/**
+ * Return the cached adapter for `agent`, connecting once on first use. Concurrent
+ * callers awaiting the same agent share a single in-flight connect. A failed
+ * connect is evicted so a later call can retry.
+ */
+export const getOrConnectAdapter = async (
+  agent: Agent,
+  ctx: ConnectToAgentContext,
+  deps: AdapterCacheDeps & ConnectToAgentDeps = {},
+): Promise<AgentAdapter> => {
+  const cached = cache.get(agent.id)
+  if (cached) {
+    return cached
+  }
+
+  const connect = deps.connectToAgent ?? defaultConnectToAgent
+  const pending = connect(agent, ctx, deps)
+  // Evict a failed connect so the poisoned promise isn't replayed on retry.
+  pending.catch(() => {
+    if (cache.get(agent.id) === pending) {
+      cache.delete(agent.id)
+    }
+  })
+  cache.set(agent.id, pending)
+  return pending
+}
+
+/** Await an in-flight (or settled) connect and disconnect the resulting adapter.
+ *  Awaiting first means we tear down a fully-formed adapter rather than racing
+ *  teardown against an open handshake. A connect that rejected was already
+ *  evicted by `getOrConnectAdapter`, so swallow its rejection here. */
+const disconnectPending = async (pending: Promise<AgentAdapter>): Promise<void> => {
+  const adapter = await pending.catch(() => null)
+  adapter?.disconnect()
+}
+
+/**
+ * Tear down and evict the cached adapter for `agentId`. Call on agent delete or
+ * a config edit that invalidates the warm connection (url/transport/type). A
+ * no-op when no connection exists for the agent.
+ */
+export const disposeAdapter = async (agentId: string): Promise<void> => {
+  const pending = cache.get(agentId)
+  if (!pending) {
+    return
+  }
+  cache.delete(agentId)
+  await disconnectPending(pending)
+}
+
+/**
+ * Tear down and evict every cached adapter. Call on sign-out so no agent
+ * connection survives across user identities.
+ */
+export const disposeAllAdapters = async (): Promise<void> => {
+  const pending = [...cache.values()]
+  cache.clear()
+  await Promise.all(pending.map(disconnectPending))
+}
+
+/**
+ * Forget every cached entry WITHOUT disconnecting. Use only for test isolation
+ * — the chat-store reset hook calls this so cache state never bleeds between
+ * tests. Production teardown goes through `disposeAdapter` / `disposeAllAdapters`.
+ */
+export const clearAdapterCache = (): void => {
+  cache.clear()
+}

--- a/src/acp/connect.test.ts
+++ b/src/acp/connect.test.ts
@@ -152,34 +152,47 @@ const buildFakeAcpDeps = (opts: { capabilities?: { loadSession?: boolean }; newS
   return { calls, FakeConnection, openTransport }
 }
 
+/** Build a prompt-only request body the ACP adapter's `fetch` can parse. */
+const promptInit = (text: string): RequestInit => ({
+  method: 'POST',
+  body: JSON.stringify({ id: 't1', messages: [{ role: 'user', parts: [{ type: 'text', text }] }] }),
+})
+
 describe('connectToAgent — remote-acp dispatch', () => {
-  it('sends initialize, then newSession when no acpSessionId is present', async () => {
+  it('sends initialize at connect, then newSession on first fetch when no acpSessionId is present', async () => {
     const { calls, FakeConnection, openTransport } = buildFakeAcpDeps({})
     const onAcpSessionId = mock(async (_id: string) => {})
 
     const adapter = await connectToAgent(
       remoteAgent,
-      { httpClient, getProxyFetch, acpSessionId: null, onAcpSessionId },
+      { httpClient, getProxyFetch },
       { openTransport, ClientSideConnection: FakeConnection as never },
     )
 
+    // initialize runs at connect; session resolution is now lazy/per-thread.
     expect(calls.initialize).toHaveLength(1)
+    expect(calls.newSession).toHaveLength(0)
+    expect(adapter.capabilities).toMatchObject({ loadSession: false })
+
+    await adapter.fetch(promptInit('hi'), baseAdapterContext({ acpSessionId: null, onAcpSessionId }))
+
     expect(calls.newSession).toHaveLength(1)
     expect(calls.loadSession).toHaveLength(0)
-    expect(adapter.capabilities).toMatchObject({ loadSession: false })
     expect(onAcpSessionId).toHaveBeenCalledWith('sess-new-1')
   })
 
-  it('sends loadSession when acpSessionId present AND capabilities.loadSession is true', async () => {
+  it('sends loadSession on fetch when acpSessionId present AND capabilities.loadSession is true', async () => {
     const { calls, FakeConnection, openTransport } = buildFakeAcpDeps({
       capabilities: { loadSession: true },
     })
 
-    await connectToAgent(
+    const adapter = await connectToAgent(
       remoteAgent,
-      { httpClient, getProxyFetch, acpSessionId: 'existing-sess', onAcpSessionId: async () => {} },
+      { httpClient, getProxyFetch },
       { openTransport, ClientSideConnection: FakeConnection as never },
     )
+
+    await adapter.fetch(promptInit('hi'), baseAdapterContext({ acpSessionId: 'existing-sess' }))
 
     expect(calls.newSession).toHaveLength(0)
     expect(calls.loadSession).toHaveLength(1)
@@ -193,11 +206,13 @@ describe('connectToAgent — remote-acp dispatch', () => {
     })
     const onAcpSessionId = mock(async (_id: string) => {})
 
-    await connectToAgent(
+    const adapter = await connectToAgent(
       remoteAgent,
-      { httpClient, getProxyFetch, acpSessionId: 'old-stale', onAcpSessionId },
+      { httpClient, getProxyFetch },
       { openTransport, ClientSideConnection: FakeConnection as never },
     )
+
+    await adapter.fetch(promptInit('hi'), baseAdapterContext({ acpSessionId: 'old-stale', onAcpSessionId }))
 
     expect(calls.loadSession).toHaveLength(0)
     expect(calls.newSession).toHaveLength(1)
@@ -209,7 +224,7 @@ describe('connectToAgent — remote-acp dispatch', () => {
 
     const adapter = await connectToAgent(
       remoteAgent,
-      { httpClient, getProxyFetch, acpSessionId: null, onAcpSessionId: async () => {} },
+      { httpClient, getProxyFetch },
       { openTransport, ClientSideConnection: FakeConnection as never },
     )
 

--- a/src/acp/connect.ts
+++ b/src/acp/connect.ts
@@ -3,38 +3,34 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * Public entry point for the chat layer. Given an `Agent` row + per-call
- * context, return an `AgentAdapter` whose `fetch(init, ctx)` produces a
- * streaming `Response` shaped for the AI SDK.
+ * Public entry point for the chat layer. Given an `Agent` row + a
+ * connection-scoped context, return an `AgentAdapter` whose `fetch(init, ctx)`
+ * produces a streaming `Response` shaped for the AI SDK.
  *
  *   - `built-in` → wraps `aiFetchStreamingResponse` (no ACP wire).
- *   - `remote-acp` / `managed-acp` → opens transport + ACP handshake.
+ *   - `remote-acp` / `managed-acp` → opens transport + ACP `initialize`.
  *
- * The chat layer caches one adapter per `(sessionId, agentId)` and tears it
- * down via `adapter.disconnect()` when the session ends or the user switches
- * agents mid-thread.
+ * The chat layer caches ONE adapter per agent (see `src/acp/adapter-cache.ts`)
+ * and reuses it across every thread that targets that agent. Per-thread ACP
+ * sessions, permission prompts, and side-effect sinks are supplied on each
+ * `adapter.fetch(init, ctx)` call — not here — so a single connection can
+ * multiplex many threads. The cache tears the adapter down via
+ * `adapter.disconnect()` only on real teardown (agent delete / config edit /
+ * sign-out), never on thread switch.
  */
 
 import type { HttpClient } from '@/lib/http'
 import type { FetchFn } from '@/lib/proxy-fetch'
 import type { Agent, AgentAdapter } from '@/types/acp'
-import { connectAcpAdapter, type AcpAdapterDeps, type RequestPermissionFn } from './acp-adapter'
+import { connectAcpAdapter, type AcpAdapterDeps } from './acp-adapter'
 import { createBuiltInAdapter, type BuiltInAdapterOptions } from './built-in-adapter'
-import type { SessionSideEffectSink } from './translators/acp-to-ai-sdk'
 
+/** Connection-scoped context handed to {@link connectToAgent}. Deliberately
+ *  carries only what's needed to OPEN a connection — per-thread fields travel
+ *  on each `adapter.fetch` call instead, so one connection serves many threads. */
 export type ConnectToAgentContext = {
   httpClient: HttpClient
   getProxyFetch: () => FetchFn
-  /** Persisted ACP session id from `chat_threads.acp_session_id`. Null for
-   *  the first message in a thread or for agents without `loadSession`. */
-  acpSessionId?: string | null
-  onAcpSessionId?: (sessionId: string) => Promise<void>
-  /** Forwarded to ACP adapters so they can prompt the UI for tool-call
-   *  approvals. Ignored for built-in agents. */
-  requestPermission?: RequestPermissionFn
-  /** Forwarded to ACP adapters so the chat layer can react to server-driven
-   *  mode and config updates. Ignored for built-in agents. */
-  onSessionSideEffect?: SessionSideEffectSink
 }
 
 export type ConnectToAgentDeps = BuiltInAdapterOptions & AcpAdapterDeps
@@ -50,19 +46,13 @@ export const connectToAgent = async (
   }
   return connectAcpAdapter(
     agent,
-    {
-      httpClient: ctx.httpClient,
-      getProxyFetch: ctx.getProxyFetch,
-      acpSessionId: ctx.acpSessionId ?? null,
-      onAcpSessionId: ctx.onAcpSessionId ?? (async () => {}),
-      requestPermission: ctx.requestPermission,
-      onSessionSideEffect: ctx.onSessionSideEffect,
-    },
+    { httpClient: ctx.httpClient },
     {
       openTransport: deps.openTransport,
       ClientSideConnection: deps.ClientSideConnection,
       webSocketFactory: deps.webSocketFactory,
       textDeltaThrottleMs: deps.textDeltaThrottleMs,
+      handshakeTimeoutMs: deps.handshakeTimeoutMs,
     },
   )
 }

--- a/src/acp/connection-test.test.ts
+++ b/src/acp/connection-test.test.ts
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * `testAcpConnection` probe tests. We inject a fake transport opener + a fake
+ * `ClientSideConnection` constructor via DI — no `mock.module()` of the shared
+ * SDK or transport modules (which would leak across files in CI).
+ */
+
+import '@/testing-library'
+
+import { act } from '@testing-library/react'
+import { describe, expect, it, mock } from 'bun:test'
+import { getClock } from '@/testing-library'
+import type { Agent as AcpSdkAgent, Client, InitializeRequest, InitializeResponse } from '@agentclientprotocol/sdk'
+import { testAcpConnection, type TestAcpConnectionResult } from './connection-test'
+import type { AcpTransport } from './types'
+
+type FakeAgentCapabilities = NonNullable<InitializeResponse['agentCapabilities']>
+
+const buildFakeDeps = (opts: {
+  initialize?: (req: InitializeRequest) => Promise<InitializeResponse>
+  capabilities?: FakeAgentCapabilities
+}) => {
+  const close = mock(() => {})
+  const stream = {
+    writable: new WritableStream(),
+    readable: new ReadableStream(),
+  }
+  const openTransport = mock(async (): Promise<AcpTransport> => ({ stream, close }))
+
+  const initialize =
+    opts.initialize ??
+    (async (_req: InitializeRequest): Promise<InitializeResponse> => ({
+      protocolVersion: 1,
+      agentCapabilities: opts.capabilities,
+    }))
+
+  class FakeConnection {
+    constructor(_toClient: (agent: AcpSdkAgent) => Client, _stream: AcpTransport['stream']) {}
+    initialize = initialize
+  }
+
+  return { close, openTransport, FakeConnection }
+}
+
+describe('testAcpConnection', () => {
+  it('returns success with mapped capabilities on a clean handshake', async () => {
+    const { close, openTransport, FakeConnection } = buildFakeDeps({
+      capabilities: {
+        loadSession: true,
+        promptCapabilities: { image: true, audio: false, embeddedContext: true },
+      },
+    })
+
+    const result = await testAcpConnection({
+      url: 'wss://example.test/ws',
+      openTransport: openTransport as never,
+      ClientSideConnection: FakeConnection as never,
+    })
+
+    expect(result).toEqual({
+      success: true,
+      capabilities: {
+        loadSession: true,
+        promptCapabilities: { image: true, audio: false, embeddedContext: true },
+      },
+    })
+    // Transport is always torn down.
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('defaults missing capability flags to false', async () => {
+    const { openTransport, FakeConnection } = buildFakeDeps({ capabilities: undefined })
+
+    const result = await testAcpConnection({
+      url: 'wss://example.test/ws',
+      openTransport: openTransport as never,
+      ClientSideConnection: FakeConnection as never,
+    })
+
+    expect(result).toEqual({
+      success: true,
+      capabilities: {
+        loadSession: false,
+        promptCapabilities: { image: false, audio: false, embeddedContext: false },
+      },
+    })
+  })
+
+  it('returns the error message when initialize rejects', async () => {
+    const { close, openTransport, FakeConnection } = buildFakeDeps({
+      initialize: async () => {
+        throw new Error('agent refused handshake')
+      },
+    })
+
+    const result = await testAcpConnection({
+      url: 'wss://example.test/ws',
+      openTransport: openTransport as never,
+      ClientSideConnection: FakeConnection as never,
+    })
+
+    expect(result).toEqual({ success: false, error: 'agent refused handshake' })
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps a network TypeError to a friendly "Could not reach agent"', async () => {
+    const openTransport = mock(async (): Promise<AcpTransport> => {
+      throw new TypeError('Failed to fetch')
+    })
+
+    const result = await testAcpConnection({
+      url: 'wss://unreachable.test/ws',
+      openTransport: openTransport as never,
+      ClientSideConnection: class {} as never,
+    })
+
+    expect(result).toEqual({ success: false, error: 'Could not reach agent' })
+  })
+
+  it('returns a timeout error when initialize never resolves', async () => {
+    const { close, openTransport, FakeConnection } = buildFakeDeps({
+      initialize: () => new Promise<InitializeResponse>(() => {}),
+    })
+
+    let resolved: TestAcpConnectionResult | undefined
+    const promise = testAcpConnection({
+      url: 'wss://slow.test/ws',
+      timeoutMs: 5000,
+      openTransport: openTransport as never,
+      ClientSideConnection: FakeConnection as never,
+    }).then((r) => {
+      resolved = r
+    })
+
+    await act(async () => {
+      await getClock().tickAsync(5000)
+    })
+    await promise
+
+    expect(resolved).toEqual({ success: false, error: 'Connection timed out' })
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/acp/connection-test.ts
+++ b/src/acp/connection-test.ts
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * One-shot connection probe for the "Add Custom Agent" settings dialog. Mirrors
+ * the model "Test Connection" flow: open the raw endpoint, run the ACP
+ * `initialize` handshake, and report success (with the agent's capabilities) or
+ * a user-facing error.
+ *
+ * Unlike {@link connectAcpAdapter}, this opens the endpoint via
+ * `openWebSocketTransport` *directly* — skipping the managed-ACP bearer /
+ * subprotocol routing in `openTransport`. Remote custom agents carry their own
+ * auth (or none), so the probe never needs a backend credential. The transport
+ * is always torn down in a `finally`, even on timeout, so no socket leaks.
+ */
+
+import type { Agent as AcpSdkAgent, ClientSideConnection, Client } from '@agentclientprotocol/sdk'
+import { ClientSideConnection as ClientSideConnectionImpl } from '@agentclientprotocol/sdk'
+import type { AgentCapabilities } from '@/types/acp'
+import { adaptCapabilities } from './acp-adapter'
+import { openWebSocketTransport, type WebSocketFactory } from './transports/websocket'
+import type { AcpTransport } from './types'
+
+const protocolVersion = 1
+const clientName = 'thunderbolt'
+const clientVersion = '0.2.0'
+const defaultTimeoutMs = 10000
+
+/** Minimal client handler: the probe never drives a session, so session updates
+ *  are dropped and any permission prompt is auto-cancelled (same cancelled shape
+ *  the adapter uses as its safe default). */
+const probeClient: Client = {
+  sessionUpdate: async () => {},
+  requestPermission: async () => ({ outcome: { outcome: 'cancelled' } }),
+}
+
+type OpenWebSocketTransport = typeof openWebSocketTransport
+
+type ClientSideConnectionCtor = new (
+  toClient: (agent: AcpSdkAgent) => Client,
+  stream: AcpTransport['stream'],
+) => ClientSideConnection
+
+export type TestAcpConnectionOptions = {
+  url: string
+  /** Caller-owned signal — aborting tears the probe's transport down. */
+  signal?: AbortSignal
+  /** Test seam — production omits and the factory builds a native WebSocket. */
+  webSocketFactory?: WebSocketFactory
+  /** Override the handshake timeout. Defaults to 10s, matching the model flow. */
+  timeoutMs?: number
+  /** Test seam — DI the transport opener. */
+  openTransport?: OpenWebSocketTransport
+  /** Test seam — DI the SDK connection constructor. */
+  ClientSideConnection?: ClientSideConnectionCtor
+}
+
+export type TestAcpConnectionResult =
+  | { success: true; capabilities: AgentCapabilities }
+  | { success: false; error: string }
+
+/** Translate a thrown probe error into a user-facing message. A bare network
+ *  `TypeError` (DNS failure, refused socket) carries no useful text, so we swap
+ *  in a friendly line; everything else surfaces its raw message. */
+const toUserError = (err: unknown): string => {
+  if (err instanceof TypeError) {
+    return 'Could not reach agent'
+  }
+  return err instanceof Error ? err.message : String(err)
+}
+
+/**
+ * Open `url`, run the ACP `initialize` handshake, and report the agent's
+ * capabilities. Races the handshake against `timeoutMs`; on timeout returns a
+ * timed-out error. Always closes the transport.
+ */
+export const testAcpConnection = async (opts: TestAcpConnectionOptions): Promise<TestAcpConnectionResult> => {
+  const openTransport = opts.openTransport ?? openWebSocketTransport
+  const ConnectionCtor = opts.ClientSideConnection ?? ClientSideConnectionImpl
+  const timeoutMs = opts.timeoutMs ?? defaultTimeoutMs
+
+  // `openWebSocketTransport` requires a concrete signal and already composes
+  // caller aborts internally, so forward the caller's signal directly (or a
+  // never-aborted one) — no intermediate controller needed.
+  const signal = opts.signal ?? new AbortController().signal
+
+  let transport: AcpTransport | null = null
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    transport = await openTransport({
+      url: opts.url,
+      signal,
+      webSocketFactory: opts.webSocketFactory,
+    })
+
+    const connection = new ConnectionCtor(() => probeClient, transport.stream)
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error('Connection timed out')), timeoutMs)
+    })
+
+    const response = await Promise.race([
+      connection.initialize({
+        protocolVersion,
+        clientInfo: { name: clientName, version: clientVersion },
+        clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+      }),
+      timeoutPromise,
+    ])
+
+    return { success: true, capabilities: adaptCapabilities(response) }
+  } catch (err) {
+    return { success: false, error: toUserError(err) }
+  } finally {
+    clearTimeout(timeoutId)
+    transport?.close()
+  }
+}

--- a/src/acp/index.ts
+++ b/src/acp/index.ts
@@ -13,4 +13,5 @@
 export { connectToAgent, type ConnectToAgentContext, type ConnectToAgentDeps } from './connect'
 export { createBuiltInAdapter } from './built-in-adapter'
 export { connectAcpAdapter } from './acp-adapter'
+export { testAcpConnection } from './connection-test'
 export type { AcpTransport, AiSdkChunk } from './types'

--- a/src/acp/translators/acp-to-ai-sdk.test.ts
+++ b/src/acp/translators/acp-to-ai-sdk.test.ts
@@ -121,8 +121,8 @@ describe('createTranslator — mapping', () => {
         rawOutput: { result: 'ok' },
       }),
     )
-    const last = chunks[chunks.length - 1]
-    expect(last).toMatchObject({ type: 'tool-output-available', toolCallId: 'tc1', output: { result: 'ok' } })
+    const output = chunks.find((c) => c.type === 'tool-output-available')
+    expect(output).toMatchObject({ type: 'tool-output-available', toolCallId: 'tc1', output: { result: 'ok' } })
   })
 
   it('tool_call_update (failed) emits tool-output-error', () => {
@@ -175,6 +175,108 @@ describe('createTranslator — mapping', () => {
     t.error('upstream blew up')
     const last = chunks[chunks.length - 1]
     expect(last).toMatchObject({ type: 'error', errorText: 'upstream blew up' })
+  })
+})
+
+describe('createTranslator — action durations', () => {
+  // Injectable epoch-millis clock the translator reads via `options.now`. We
+  // advance `value` between events so durations are deterministic and never read
+  // the real wall clock.
+  const fakeClock = () => {
+    let value = 0
+    return { now: () => value, advance: (ms: number) => (value += ms) }
+  }
+
+  it('emits reasoningTime keyed by toolCallId for a completed tool_call', () => {
+    const { emit, chunks } = collect()
+    const clock = fakeClock()
+    const t = createTranslator(emit, { now: clock.now })
+    t.start()
+    t.handle(notification({ sessionUpdate: 'tool_call', toolCallId: 'tc1', title: 'search', rawInput: {} }))
+    clock.advance(250)
+    t.handle(notification({ sessionUpdate: 'tool_call_update', toolCallId: 'tc1', status: 'completed', rawOutput: {} }))
+
+    const meta = chunks.filter((c) => c.type === 'message-metadata')
+    expect(meta).toHaveLength(1)
+    expect(meta[0]).toMatchObject({ type: 'message-metadata', messageMetadata: { reasoningTime: { tc1: 250 } } })
+  })
+
+  it('emits reasoningTime for a failed tool_call too', () => {
+    const { emit, chunks } = collect()
+    const clock = fakeClock()
+    const t = createTranslator(emit, { now: clock.now })
+    t.start()
+    t.handle(notification({ sessionUpdate: 'tool_call', toolCallId: 'tc1', title: 'search', rawInput: {} }))
+    clock.advance(40)
+    t.handle(
+      notification({ sessionUpdate: 'tool_call_update', toolCallId: 'tc1', status: 'failed', rawOutput: 'boom' }),
+    )
+
+    const meta = chunks.find((c) => c.type === 'message-metadata')
+    expect(meta).toMatchObject({ type: 'message-metadata', messageMetadata: { reasoningTime: { tc1: 40 } } })
+  })
+
+  it('does not re-emit a duration on a second terminal update for the same tool', () => {
+    const { emit, chunks } = collect()
+    const clock = fakeClock()
+    const t = createTranslator(emit, { now: clock.now })
+    t.start()
+    t.handle(notification({ sessionUpdate: 'tool_call', toolCallId: 'tc1', title: 'search', rawInput: {} }))
+    clock.advance(10)
+    t.handle(notification({ sessionUpdate: 'tool_call_update', toolCallId: 'tc1', status: 'completed', rawOutput: {} }))
+    clock.advance(10)
+    t.handle(notification({ sessionUpdate: 'tool_call_update', toolCallId: 'tc1', status: 'completed', rawOutput: {} }))
+
+    expect(chunks.filter((c) => c.type === 'message-metadata')).toHaveLength(1)
+  })
+
+  it('tracks independent durations per concurrent tool call', () => {
+    const { emit, chunks } = collect()
+    const clock = fakeClock()
+    const t = createTranslator(emit, { now: clock.now })
+    t.start()
+    t.handle(notification({ sessionUpdate: 'tool_call', toolCallId: 'a', title: 'read', rawInput: {} }))
+    clock.advance(100)
+    t.handle(notification({ sessionUpdate: 'tool_call', toolCallId: 'b', title: 'grep', rawInput: {} }))
+    clock.advance(100)
+    t.handle(notification({ sessionUpdate: 'tool_call_update', toolCallId: 'a', status: 'completed', rawOutput: {} }))
+    clock.advance(50)
+    t.handle(notification({ sessionUpdate: 'tool_call_update', toolCallId: 'b', status: 'completed', rawOutput: {} }))
+
+    const durations = chunks
+      .filter((c) => c.type === 'message-metadata')
+      .map((c) => (c.messageMetadata as { reasoningTime: Record<string, number> }).reasoningTime)
+    expect(durations).toEqual([{ a: 200 }, { b: 150 }])
+  })
+
+  it('emits reasoningTime keyed to reasoning-0 when reasoning ends at text-start', async () => {
+    const { emit, chunks } = collect()
+    const clock = fakeClock()
+    const t = createTranslator(emit, { now: clock.now, textDeltaThrottleMs: 100 })
+    t.start()
+    t.handle(notification({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'thinking' } }))
+    clock.advance(300)
+    // First text chunk marks the reasoning→text boundary.
+    t.handle(notification({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'answer' } }))
+
+    const meta = chunks.find((c) => c.type === 'message-metadata')
+    expect(meta).toMatchObject({ type: 'message-metadata', messageMetadata: { reasoningTime: { 'reasoning-0': 300 } } })
+    await act(async () => {
+      await getClock().tickAsync(100)
+    })
+  })
+
+  it('emits reasoning-0 duration at finish for a reasoning-only turn (no text)', () => {
+    const { emit, chunks } = collect()
+    const clock = fakeClock()
+    const t = createTranslator(emit, { now: clock.now, textDeltaThrottleMs: 100 })
+    t.start()
+    t.handle(notification({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'thinking' } }))
+    clock.advance(120)
+    t.finish()
+
+    const meta = chunks.find((c) => c.type === 'message-metadata')
+    expect(meta).toMatchObject({ type: 'message-metadata', messageMetadata: { reasoningTime: { 'reasoning-0': 120 } } })
   })
 })
 

--- a/src/acp/translators/acp-to-ai-sdk.ts
+++ b/src/acp/translators/acp-to-ai-sdk.ts
@@ -33,6 +33,12 @@ const sseDataPrefix = 'data: '
 const sseDataSuffix = '\n\n'
 const textDeltaThrottleMsDefault = 200
 
+// Key the reasoning duration to the first reasoning part in a group. The UI's
+// `groupMessageParts` labels reasoning items `reasoning-<counter>` (0-based per
+// message), and this translator emits a single reasoning stream, so its
+// duration always lands on `reasoning-0`.
+const reasoningDurationKey = 'reasoning-0'
+
 const encoder = new TextEncoder()
 
 const encodeChunk = (chunk: AiSdkChunk): Uint8Array =>
@@ -116,6 +122,9 @@ export type TranslateOptions = {
   /** Callback for non-stream session updates (mode change, config option
    *  change). Omit to keep the prior behavior of silently ignoring them. */
   onSideEffect?: SessionSideEffectSink
+  /** Epoch-millis clock used to measure per-action durations. Defaults to
+   *  `Date.now`. Inject a fake in tests so durations are deterministic. */
+  now?: () => number
 }
 
 /** Translation state for a single ACP prompt turn. Reused across many calls
@@ -146,6 +155,7 @@ export const createTranslator = (emit: (chunk: AiSdkChunk) => void, options: Tra
   const reasoningId = options.reasoningMessageId ?? 'acp-reasoning-0'
   const throttleMs = options.textDeltaThrottleMs ?? textDeltaThrottleMsDefault
   const sideEffect = options.onSideEffect ?? (() => {})
+  const now = options.now ?? Date.now
 
   const textThrottle = createThrottle('text', textId, emit)
   const reasoningThrottle = createThrottle('reasoning', reasoningId, emit)
@@ -155,6 +165,32 @@ export const createTranslator = (emit: (chunk: AiSdkChunk) => void, options: Tra
   // emits the right output chunk even if its raw output sneaks in via a prior
   // `in_progress` update.
   const toolStatus = new Map<string, ToolCallStatus>()
+  // Per-action start timestamps used to compute durations the UI renders.
+  // Tool calls key by `toolCallId` (the same id `groupMessageParts` assigns to
+  // a tool group item); reasoning keys by `reasoningDurationKey` (the first
+  // reasoning part in a group — the only reasoning stream this translator
+  // emits — which `groupMessageParts` labels `reasoning-0`).
+  const toolStartTimes = new Map<string, number>()
+  let reasoningStartTime: number | null = null
+  let reasoningDurationEmitted = false
+
+  // Emit a single duration into the running `reasoningTime` map. The AI SDK
+  // deep-merges successive `message-metadata` chunks, so one entry per action
+  // accumulates rather than overwrites — mirroring `createMessageMetadata`.
+  const emitDuration = (partId: string, elapsedMs: number): void => {
+    emit({ type: 'message-metadata', messageMetadata: { reasoningTime: { [partId]: elapsedMs } } })
+  }
+
+  // Reasoning truly ends when text generation begins (the reasoning stream stays
+  // open until then — see `message-metadata.ts`). Emit the reasoning duration at
+  // that boundary, or as a fallback when the turn finishes with no text.
+  const emitReasoningDuration = (): void => {
+    if (reasoningDurationEmitted || reasoningStartTime === null) {
+      return
+    }
+    reasoningDurationEmitted = true
+    emitDuration(reasoningDurationKey, now() - reasoningStartTime)
+  }
   // Haystack metadata accumulators. Backend emits these in `_meta` on
   // `agent_message_chunk` updates; references keyed by position so later chunks
   // override earlier ones for the same marker.
@@ -203,6 +239,7 @@ export const createTranslator = (emit: (chunk: AiSdkChunk) => void, options: Tra
       return
     }
     textStarted = true
+    emitReasoningDuration()
     emit({ type: 'text-start', id: textId })
   }
 
@@ -211,6 +248,7 @@ export const createTranslator = (emit: (chunk: AiSdkChunk) => void, options: Tra
       return
     }
     reasoningStarted = true
+    reasoningStartTime = now()
     emit({ type: 'reasoning-start', id: reasoningId })
   }
 
@@ -243,6 +281,7 @@ export const createTranslator = (emit: (chunk: AiSdkChunk) => void, options: Tra
       }
       case 'tool_call': {
         toolStatus.set(update.toolCallId, update.status ?? 'pending')
+        toolStartTimes.set(update.toolCallId, now())
         emit({
           type: 'tool-input-start',
           toolCallId: update.toolCallId,
@@ -270,14 +309,19 @@ export const createTranslator = (emit: (chunk: AiSdkChunk) => void, options: Tra
             toolCallId: update.toolCallId,
             errorText: typeof update.rawOutput === 'string' ? update.rawOutput : JSON.stringify(update.rawOutput ?? {}),
           })
-          return
+        } else {
+          // completed
+          emit({
+            type: 'tool-output-available',
+            toolCallId: update.toolCallId,
+            output: update.rawOutput ?? update.content ?? {},
+          })
         }
-        // completed
-        emit({
-          type: 'tool-output-available',
-          toolCallId: update.toolCallId,
-          output: update.rawOutput ?? update.content ?? {},
-        })
+        const startedAt = toolStartTimes.get(update.toolCallId)
+        if (startedAt !== undefined) {
+          toolStartTimes.delete(update.toolCallId)
+          emitDuration(update.toolCallId, now() - startedAt)
+        }
         return
       }
       case 'current_mode_update': {
@@ -307,6 +351,8 @@ export const createTranslator = (emit: (chunk: AiSdkChunk) => void, options: Tra
     flushThrottle(textThrottle)
     flushThrottle(reasoningThrottle)
     if (reasoningStarted) {
+      // Covers reasoning-only turns where no text-start boundary fired.
+      emitReasoningDuration()
       emit({ type: 'reasoning-end', id: reasoningId })
     }
     if (textStarted) {

--- a/src/acp/transports/websocket.test.ts
+++ b/src/acp/transports/websocket.test.ts
@@ -17,6 +17,9 @@ import { getClock } from '@/testing-library'
 import {
   authCloseCode,
   normalCloseCode,
+  proxyRejectCloseCode,
+  proxyForbiddenCloseCode,
+  serverErrorCloseCode,
   isReconnectableCloseCode,
   openWebSocketTransport,
   validateWebSocketUrl,
@@ -98,13 +101,22 @@ describe('validateWebSocketUrl', () => {
 })
 
 describe('isReconnectableCloseCode', () => {
-  it('does not reconnect on normal (1000) or auth (4001) close', () => {
+  it('is terminal for clean/auth/proxy-reject/server-error codes', () => {
     expect(isReconnectableCloseCode(normalCloseCode)).toBe(false)
     expect(isReconnectableCloseCode(authCloseCode)).toBe(false)
+    expect(isReconnectableCloseCode(proxyRejectCloseCode)).toBe(false)
+    expect(isReconnectableCloseCode(proxyForbiddenCloseCode)).toBe(false)
+    expect(isReconnectableCloseCode(serverErrorCloseCode)).toBe(false)
+    // Spelled-out codes to lock the contract from the task.
+    expect(isReconnectableCloseCode(4001)).toBe(false)
+    expect(isReconnectableCloseCode(4002)).toBe(false)
+    expect(isReconnectableCloseCode(4003)).toBe(false)
+    expect(isReconnectableCloseCode(1011)).toBe(false)
   })
-  it('reconnects on transient codes (1006, etc.)', () => {
+  it('reconnects on genuinely transient codes (1006, 1012, 1013)', () => {
     expect(isReconnectableCloseCode(1006)).toBe(true)
-    expect(isReconnectableCloseCode(1011)).toBe(true)
+    expect(isReconnectableCloseCode(1012)).toBe(true)
+    expect(isReconnectableCloseCode(1013)).toBe(true)
   })
 })
 
@@ -309,5 +321,94 @@ describe('openWebSocketTransport — reconnect', () => {
     })
     expect(sockets.length).toBe(1)
     transport.close()
+  })
+})
+
+describe('openWebSocketTransport — terminal-close signal (closed promise)', () => {
+  const openSingleSocket = async () => {
+    const sockets: FakeSocket[] = []
+    const factory = (): WebSocketLike => {
+      const s = new FakeSocket()
+      sockets.push(s)
+      queueMicrotask(() => s.open())
+      return asWebSocketLike(s)
+    }
+    const transport = await openWebSocketTransport({
+      url: 'wss://example.com/ws',
+      signal: new AbortController().signal,
+      webSocketFactory: factory,
+      isTauriIos: () => false,
+      backoffMs: () => 1,
+      maxReconnectAttempts: 3,
+    })
+    return { transport, sockets }
+  }
+
+  /** Settle a `closed` promise to a tagged result so a test can assert on it
+   *  without `.rejects` hanging when the promise never settles. */
+  const observeClosed = (closed: Promise<void> | undefined): Promise<{ rejected: boolean; message?: string }> => {
+    if (!closed) {
+      throw new Error('transport.closed missing')
+    }
+    return closed.then(
+      () => ({ rejected: false }),
+      (err: Error) => ({ rejected: true, message: err.message }),
+    )
+  }
+
+  it('rejects `closed` on a terminal close code (4003) and does not reconnect', async () => {
+    const { transport, sockets } = await openSingleSocket()
+    const observed = observeClosed(transport.closed)
+
+    sockets[0].emit('close', { code: proxyForbiddenCloseCode, reason: 'forbidden' })
+    await act(async () => {
+      await getClock().tickAsync(10)
+    })
+
+    const result = await observed
+    expect(result.rejected).toBe(true)
+    expect(result.message).toMatch(/code 4003/)
+    expect(sockets.length).toBe(1)
+  })
+
+  it('rejects `closed` when reconnect attempts are exhausted', async () => {
+    const sockets: FakeSocket[] = []
+    const factory = (): WebSocketLike => {
+      const s = new FakeSocket()
+      sockets.push(s)
+      queueMicrotask(() => {
+        if (sockets.length === 1) {
+          s.open()
+        } else {
+          s.failOpen('boom')
+        }
+      })
+      return asWebSocketLike(s)
+    }
+    const transport = await openWebSocketTransport({
+      url: 'wss://example.com/ws',
+      signal: new AbortController().signal,
+      webSocketFactory: factory,
+      isTauriIos: () => false,
+      backoffMs: () => 1,
+      maxReconnectAttempts: 3,
+    })
+    const observed = observeClosed(transport.closed)
+
+    sockets[0].emit('close', { code: 1006, reason: 'transient' })
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    const result = await observed
+    expect(result.rejected).toBe(true)
+    expect(result.message).toMatch(/reconnect attempts exhausted/)
+  })
+
+  it('resolves `closed` (no rejection) on caller-initiated close()', async () => {
+    const { transport } = await openSingleSocket()
+    transport.close()
+    const result = await observeClosed(transport.closed)
+    expect(result.rejected).toBe(false)
   })
 })

--- a/src/acp/transports/websocket.ts
+++ b/src/acp/transports/websocket.ts
@@ -9,7 +9,11 @@
  *
  * Reconnect strategy:
  *   - Up to 3 retries with exponential backoff (1s, 2s, 4s).
- *   - Don't reconnect on normal close (code 1000) or auth close (code 4001).
+ *   - Don't reconnect on terminal codes: normal (1000), auth (4001), the
+ *     universal-proxy hard rejects (4002/4003), or a server error (1011) —
+ *     retrying those can never succeed, so we fail fast.
+ *   - A terminal close (or exhausting reconnects) rejects the `closed` promise
+ *     so the handshake surfaces a loud error instead of hanging on `initialize`.
  *   - All retries respect the caller's `AbortController` — `disconnect()` aborts
  *     pending retries and resolves any in-flight wait immediately.
  *
@@ -23,7 +27,25 @@ import type { AcpTransport } from '../types'
 
 export const normalCloseCode = 1000
 export const authCloseCode = 4001
+/** Universal-proxy hard rejects: target not allowlisted (4002) and target
+ *  forbidden, e.g. `ws://`/localhost/private-host (4003). Retrying can never
+ *  succeed — the proxy will reject identically every time. */
+export const proxyRejectCloseCode = 4002
+export const proxyForbiddenCloseCode = 4003
+/** Server-side terminal failure (1011). The upstream gave up; reconnecting to
+ *  the same broken endpoint just burns the retry budget. */
+export const serverErrorCloseCode = 1011
 export const maxReconnectAttempts = 3
+
+/** Close codes that mean "do not bother reconnecting": a clean close, an auth
+ *  rejection, the proxy's two hard rejects, and a server-internal error. */
+const terminalCloseCodes = new Set([
+  normalCloseCode,
+  authCloseCode,
+  proxyRejectCloseCode,
+  proxyForbiddenCloseCode,
+  serverErrorCloseCode,
+])
 
 /** Subset of the native `WebSocket` interface used by the transport. Lets us
  *  inject a fake socket in tests without `mock.module()`. Events are typed
@@ -97,7 +119,7 @@ export const validateWebSocketUrl = (url: string, isTauriIos: IsTauriIosFn = def
   }
 }
 
-export const isReconnectableCloseCode = (code: number): boolean => code !== normalCloseCode && code !== authCloseCode
+export const isReconnectableCloseCode = (code: number): boolean => !terminalCloseCodes.has(code)
 
 export type WebSocketTransportOptions = {
   url: string
@@ -127,6 +149,24 @@ export const openWebSocketTransport = async (options: WebSocketTransportOptions)
     transportController.abort()
   } else {
     options.signal.addEventListener('abort', () => transportController.abort(), { once: true })
+  }
+
+  // `closed` rejects the moment the transport gives up (terminal close code or
+  // exhausted reconnects) so the adapter's handshake fails loudly instead of
+  // hanging on a pending `initialize`. Caller-initiated `close()` resolves it.
+  let settleClosed: ((reason: Error | null) => void) | null = null
+  const closed = new Promise<void>((resolve, reject) => {
+    settleClosed = (reason) => (reason ? reject(reason) : resolve())
+  })
+  // Avoid an unhandled-rejection warning when nothing races `closed`.
+  closed.catch(() => {})
+  const settleClosedOnce = (reason: Error | null): void => {
+    if (!settleClosed) {
+      return
+    }
+    const settle = settleClosed
+    settleClosed = null
+    settle(reason)
   }
 
   let currentSocket: WebSocketLike | null = null
@@ -215,8 +255,12 @@ export const openWebSocketTransport = async (options: WebSocketTransportOptions)
 
   const handleClose = (code: number): void => {
     if (transportController.signal.aborted || !isReconnectableCloseCode(code)) {
+      // A non-reconnectable code is a terminal failure the handshake must hear
+      // about; an already-aborted controller means the caller closed us (clean).
+      const terminal = !transportController.signal.aborted
       closeReadable()
       transportController.abort()
+      settleClosedOnce(terminal ? new Error(`ACP transport closed (code ${code})`) : null)
       return
     }
     connectWithRetry()
@@ -226,8 +270,9 @@ export const openWebSocketTransport = async (options: WebSocketTransportOptions)
         drainWriteQueue()
       })
       .catch(() => {
-        readableController?.close()
+        closeReadable()
         transportController.abort()
+        settleClosedOnce(new Error('ACP transport closed: reconnect attempts exhausted'))
       })
   }
 
@@ -279,6 +324,7 @@ export const openWebSocketTransport = async (options: WebSocketTransportOptions)
     transportController.abort()
     currentSocket?.close(normalCloseCode)
     closeReadable()
+    settleClosedOnce(null)
   }
 
   transportController.signal.addEventListener(
@@ -289,5 +335,5 @@ export const openWebSocketTransport = async (options: WebSocketTransportOptions)
     { once: true },
   )
 
-  return { stream, close }
+  return { stream, close, closed }
 }

--- a/src/acp/types.ts
+++ b/src/acp/types.ts
@@ -19,6 +19,12 @@ import type { Stream } from '@agentclientprotocol/sdk'
 export type AcpTransport = {
   stream: Stream
   close: () => void
+  /** Resolves when the transport closes cleanly; REJECTS when it closes
+   *  terminally (a non-reconnectable close code or exhausted reconnects) so the
+   *  handshake can race against it and fail loudly instead of hanging on a
+   *  pending `initialize`. Optional so simpler fake transports (tests) can omit
+   *  it — the adapter only races when it's present. */
+  closed?: Promise<void>
 }
 
 /** Inputs to `openTransport(...)`. WebSocket is the only remote transport;

--- a/src/chats/agent-routing.test.ts
+++ b/src/chats/agent-routing.test.ts
@@ -166,7 +166,7 @@ describe('createAgentRoutingFetch', () => {
     expect(adapterFetch).toHaveBeenCalledTimes(3)
   })
 
-  it('disconnects the stale adapter and connects a new one when selectedAgent changes mid-session', async () => {
+  it('routes to the new agent WITHOUT disconnecting the previous one when selectedAgent changes mid-session', async () => {
     resetStore()
     const first = buildFakeAdapter(remoteAgent)
     const second = buildFakeAdapter(otherRemoteAgent)
@@ -183,11 +183,15 @@ describe('createAgentRoutingFetch', () => {
     expect(first.fetch).toHaveBeenCalledTimes(1)
     expect(first.disconnect).not.toHaveBeenCalled()
 
-    // User switches to a different agent on the same thread.
-    useChatStore.getState().setSelectedAgent('t-switch', otherRemoteAgent)
+    // User switches to a different agent on the same thread. The previous
+    // agent's shared connection must stay warm — other threads may use it.
+    // Update the in-memory selection directly (this DB-free DI suite doesn't
+    // register a database; `setSelectedAgent` now persists the last-used agent
+    // via the DAL, which routing doesn't depend on).
+    hydrateSessionWith('t-switch', otherRemoteAgent)
 
     await customFetch('/chat', { method: 'POST', body: '{}' })
-    expect(first.disconnect).toHaveBeenCalledTimes(1)
+    expect(first.disconnect).not.toHaveBeenCalled()
     expect(connectToAgent).toHaveBeenCalledTimes(2)
     expect(second.fetch).toHaveBeenCalledTimes(1)
   })
@@ -195,20 +199,25 @@ describe('createAgentRoutingFetch', () => {
   it('persists ACP sessionId via updateChatThread when onAcpSessionId is invoked by the adapter', async () => {
     resetStore()
     const chatThread = { id: 'thread-77', acpSessionId: null } as ChatThread
-    const fetch = mock(async () => new Response('streamed'))
     const disconnect = mock(() => {})
     const fakeDb = { __id: 'fake-db' } as never
 
+    // `onAcpSessionId` now travels on the per-FETCH context (the shared
+    // connection resolves a session per thread), so capture it there.
     let capturedOnAcpSessionId: ((id: string) => Promise<void>) | null = null
-    const connectToAgent = mock(async (_agent: Agent, ctx: { onAcpSessionId: (id: string) => Promise<void> }) => {
+    const fetch = mock(async (_init: RequestInit, ctx: { onAcpSessionId: (id: string) => Promise<void> }) => {
       capturedOnAcpSessionId = ctx.onAcpSessionId
-      return {
-        agent: remoteAgent,
-        capabilities: null,
-        fetch: fetch as unknown as AgentAdapter['fetch'],
-        disconnect,
-      } as AgentAdapter
+      return new Response('streamed')
     })
+    const connectToAgent = mock(
+      async () =>
+        ({
+          agent: remoteAgent,
+          capabilities: null,
+          fetch: fetch as unknown as AgentAdapter['fetch'],
+          disconnect,
+        }) as AgentAdapter,
+    )
 
     const updateChatThread = mock(async () => {})
 
@@ -301,20 +310,23 @@ describe('createAgentRoutingFetch', () => {
 
   it('does NOT persist acpSessionId when the session has no chatThread (new chat)', async () => {
     resetStore()
-    const fetch = mock(async () => new Response('streamed'))
     const disconnect = mock(() => {})
     const fakeDb = { __id: 'fake-db' } as never
 
     let capturedOnAcpSessionId: ((id: string) => Promise<void>) | null = null
-    const connectToAgent = mock(async (_agent: Agent, ctx: { onAcpSessionId: (id: string) => Promise<void> }) => {
+    const fetch = mock(async (_init: RequestInit, ctx: { onAcpSessionId: (id: string) => Promise<void> }) => {
       capturedOnAcpSessionId = ctx.onAcpSessionId
-      return {
-        agent: remoteAgent,
-        capabilities: null,
-        fetch: fetch as unknown as AgentAdapter['fetch'],
-        disconnect,
-      } as AgentAdapter
+      return new Response('streamed')
     })
+    const connectToAgent = mock(
+      async () =>
+        ({
+          agent: remoteAgent,
+          capabilities: null,
+          fetch: fetch as unknown as AgentAdapter['fetch'],
+          disconnect,
+        }) as AgentAdapter,
+    )
 
     const updateChatThread = mock(async () => {})
 

--- a/src/chats/chat-instance-permission.test.ts
+++ b/src/chats/chat-instance-permission.test.ts
@@ -14,8 +14,7 @@ import type { RequestPermissionRequest, RequestPermissionResponse } from '@agent
 import type { HttpClient } from '@/lib/http'
 import type { FetchFn } from '@/lib/proxy-fetch'
 import { createMockChatInstance, hydrateStore, resetStore } from '@/test-utils/chat-store-mocks'
-import type { Agent, AgentAdapter } from '@/types/acp'
-import type { ConnectToAgentContext } from '@/acp'
+import type { Agent, AgentAdapter, AgentAdapterContext } from '@/types/acp'
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { useChatStore } from './chat-store'
 import { createAgentRoutingFetch } from './chat-instance'
@@ -45,19 +44,22 @@ describe('requestPermission bridge', () => {
   })
 
   it('routes the adapter requestPermission into the store and resolves on dialog response', async () => {
-    let capturedRequestPermission: ConnectToAgentContext['requestPermission'] | undefined
+    // `requestPermission` now travels on the per-FETCH context — a shared agent
+    // connection routes each thread's prompts to its own handler — so capture
+    // it from `adapter.fetch`, not the connect context.
+    let capturedRequestPermission: AgentAdapterContext['requestPermission'] | undefined
 
     const adapter: AgentAdapter = {
       agent: {} as Agent,
       capabilities: null,
-      fetch: async () => new Response('ok'),
+      fetch: async (_init: RequestInit, ctx: AgentAdapterContext) => {
+        capturedRequestPermission = ctx.requestPermission
+        return new Response('ok')
+      },
       disconnect: () => {},
     }
 
-    const connectToAgent = mock(async (_agent: Agent, ctx: ConnectToAgentContext) => {
-      capturedRequestPermission = ctx.requestPermission
-      return adapter
-    })
+    const connectToAgent = mock(async () => adapter)
 
     const fetch = createAgentRoutingFetch(sessionId, async () => {}, httpClient, getProxyFetch, {
       connectToAgent: connectToAgent as never,

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { connectToAgent as defaultConnectToAgent } from '@/acp'
+import type { connectToAgent as defaultConnectToAgent } from '@/acp'
+import { getOrConnectAdapter as defaultGetOrConnectAdapter } from '@/acp/adapter-cache'
 import type { SessionSideEffect } from '@/acp/translators/acp-to-ai-sdk'
 import { updateChatThread as defaultUpdateChatThread } from '@/dal/chat-threads'
 import { getDb as defaultGetDb } from '@/db/database'
@@ -10,7 +11,6 @@ import { isRateLimitError } from '@/lib/error-utils'
 import type { HttpClient } from '@/lib/http'
 import { trackEvent } from '@/lib/posthog'
 import type { FetchFn } from '@/lib/proxy-fetch'
-import type { AgentAdapter } from '@/types/acp'
 import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import { Chat } from '@ai-sdk/react'
 import type { RequestPermissionRequest, RequestPermissionResponse } from '@agentclientprotocol/sdk'
@@ -57,10 +57,13 @@ const applySessionSideEffect = (effect: SessionSideEffect): void => {
   }
 }
 
-/** DI seams for tests. Production binds to the real ACP entry point and the
- *  DAL's `updateChatThread`. Module-level functions are passed by reference so
- *  test files can swap in fakes without `mock.module()`. */
+/** DI seams for tests. Production binds to the real ACP cache + entry point and
+ *  the DAL's `updateChatThread`. Module-level functions are passed by reference
+ *  so test files can swap in fakes without `mock.module()`. `connectToAgent`
+ *  is forwarded through `getOrConnectAdapter` into the global cache so a test
+ *  can fake the connect while exercising the real reuse path. */
 export type CreateChatInstanceDeps = {
+  getOrConnectAdapter?: typeof defaultGetOrConnectAdapter
   connectToAgent?: typeof defaultConnectToAgent
   updateChatThread?: typeof defaultUpdateChatThread
   getDb?: typeof defaultGetDb
@@ -68,13 +71,20 @@ export type CreateChatInstanceDeps = {
 
 /**
  * Build the `customFetch` the AI SDK's transport invokes for every
- * `chat.sendMessage(...)`. The factory owns a per-session adapter cache keyed
- * by `(sessionId, agentId)`. When the user switches agents mid-thread the
- * key changes; we disconnect the stale adapter before connecting the new one.
+ * `chat.sendMessage(...)`. Each send routes to the GLOBAL per-agent adapter
+ * cache (`getOrConnectAdapter`): one transport + one `initialize` per agent,
+ * reused across every thread that targets it. Switching threads on the same
+ * agent reuses the warm connection — it is never torn down here.
  *
- * Built-in's `disconnect()` is a no-op (the AI SDK pipeline is stateless per
- * call), so always disconnecting on switch is safe regardless of which agent
- * type was active.
+ * Per-thread state (ACP session resolution, permission dialogs, side-effect
+ * sinks) is supplied on each `adapter.fetch(init, ctx)` call, so one connection
+ * multiplexes many threads without cross-thread bleed.
+ *
+ * `connectionStatus` reflects THIS thread's view: `connecting` is shown while
+ * the cache resolves the adapter for a newly-selected agent (instant on a warm
+ * cache), then `ready`. Switching the agent within a thread re-routes to a
+ * different cached connection but never disposes the previous one — other
+ * threads may still be using it.
  *
  * Exported separately so unit tests can drive it without spinning up
  * `@ai-sdk/react`'s `Chat` instance.
@@ -86,12 +96,11 @@ export const createAgentRoutingFetch = (
   getProxyFetch: () => FetchFn,
   deps: CreateChatInstanceDeps = {},
 ) => {
-  const connectToAgent = deps.connectToAgent ?? defaultConnectToAgent
+  const getOrConnectAdapter = deps.getOrConnectAdapter ?? defaultGetOrConnectAdapter
   const updateChatThread = deps.updateChatThread ?? defaultUpdateChatThread
   const getDb = deps.getDb ?? defaultGetDb
 
-  let cachedKey: string | null = null
-  let cachedAdapter: AgentAdapter | null = null
+  let routedAgentId: string | null = null
 
   return Object.assign(
     async (_requestInfo: RequestInfo | URL, init?: RequestInit) => {
@@ -108,7 +117,6 @@ export const createAgentRoutingFetch = (
       }
 
       const { chatThread, selectedAgent, selectedMode, selectedModel } = session
-      const cacheKey = `${id}:${selectedAgent.id}`
 
       // Save the user message before invoking the adapter. This serves three
       // purposes that previously only the built-in pipeline got for free:
@@ -130,41 +138,27 @@ export const createAgentRoutingFetch = (
         await updateChatThread(getDb(), chatThread.id, { acpSessionId: newSessionId })
       }
 
-      if (cacheKey !== cachedKey) {
-        // Agent swapped within this session — tear down the stale adapter
-        // BEFORE the new connect so any transport handles release promptly.
-        if (cachedAdapter) {
-          cachedAdapter.disconnect()
-          cachedAdapter = null
-        }
-        cachedKey = null
+      // Surface `connecting` only when routing to a different agent than this
+      // thread last used — a warm cache resolves instantly, but the per-thread
+      // UI still needs the transition for the cold-connect spinner.
+      const isNewAgent = selectedAgent.id !== routedAgentId
+      if (isNewAgent) {
         useChatStore.getState().updateSession(id, { connectionStatus: 'connecting', connectionError: null })
-        try {
-          cachedAdapter = await connectToAgent(
-            selectedAgent,
-            {
-              httpClient,
-              getProxyFetch,
-              acpSessionId: chatThread?.acpSessionId ?? null,
-              onAcpSessionId: persistAcpSessionId,
-              requestPermission: (request) => requestPermissionViaStore(id, request),
-              onSessionSideEffect: applySessionSideEffect,
-            },
-            {},
-          )
-        } catch (err) {
-          const error = err instanceof Error ? err : new Error(String(err))
-          useChatStore.getState().updateSession(id, { connectionStatus: 'error', connectionError: error })
-          throw error
-        }
-        cachedKey = cacheKey
-        useChatStore.getState().updateSession(id, { connectionStatus: 'ready', connectionError: null })
       }
 
-      const adapter = cachedAdapter
+      const adapter = await getOrConnectAdapter(
+        selectedAgent,
+        { httpClient, getProxyFetch },
+        { connectToAgent: deps.connectToAgent },
+      ).catch((err) => {
+        const error = err instanceof Error ? err : new Error(String(err))
+        useChatStore.getState().updateSession(id, { connectionStatus: 'error', connectionError: error })
+        throw error
+      })
 
-      if (!adapter) {
-        throw new Error('Adapter missing after connect — unreachable')
+      routedAgentId = selectedAgent.id
+      if (isNewAgent) {
+        useChatStore.getState().updateSession(id, { connectionStatus: 'ready', connectionError: null })
       }
 
       return adapter.fetch(init, {
@@ -178,6 +172,8 @@ export const createAgentRoutingFetch = (
         httpClient,
         getProxyFetch,
         onAcpSessionId: persistAcpSessionId,
+        requestPermission: (request) => requestPermissionViaStore(id, request),
+        onSessionSideEffect: applySessionSideEffect,
       })
     },
     {

--- a/src/components/settings/agents/add-custom-agent-dialog.test.tsx
+++ b/src/components/settings/agents/add-custom-agent-dialog.test.tsx
@@ -10,6 +10,7 @@ import {
   inferTransport,
   validateAgentUrl,
   type AddCustomAgentPayload,
+  type TestAcpConnectionFn,
 } from './add-custom-agent-dialog'
 
 afterEach(() => {
@@ -168,5 +169,87 @@ describe('AddCustomAgentDialog', () => {
 
     expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+})
+
+describe('AddCustomAgentDialog — connection status', () => {
+  const notIos = () => false
+
+  const renderWithProbe = (testAcpConnection: TestAcpConnectionFn) => {
+    const onSubmit = mock(async () => {})
+    const onOpenChange = mock(() => {})
+    render(
+      <AddCustomAgentDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+        isIos={notIos}
+        testAcpConnection={testAcpConnection}
+      />,
+    )
+    return { onSubmit, onOpenChange }
+  }
+
+  it('hides the Test Connection button until the URL is a valid WebSocket endpoint', () => {
+    renderWithProbe(async () => ({ success: true }))
+
+    expect(screen.queryByRole('button', { name: /test connection/i })).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'http://example.com' } })
+    expect(screen.queryByRole('button', { name: /test connection/i })).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://example.com/ws' } })
+    expect(screen.getByRole('button', { name: /test connection/i })).toBeInTheDocument()
+  })
+
+  it('renders the success StatusCard when the probe resolves success', async () => {
+    const probe = mock<TestAcpConnectionFn>(async () => ({ success: true }))
+    renderWithProbe(probe)
+
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://example.com/ws' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /test connection/i }))
+    })
+
+    expect(probe).toHaveBeenCalledWith({ url: 'wss://example.com/ws' })
+    expect(screen.getByText(/connection successful/i)).toBeInTheDocument()
+  })
+
+  it('renders the error StatusCard with the probe error message on failure', async () => {
+    const probe = mock<TestAcpConnectionFn>(async () => ({ success: false, error: 'Could not reach agent' }))
+    renderWithProbe(probe)
+
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://example.com/ws' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /test connection/i }))
+    })
+
+    expect(screen.getByText(/connection failed/i)).toBeInTheDocument()
+    expect(screen.getByText(/could not reach agent/i)).toBeInTheDocument()
+  })
+
+  it('does NOT gate Add Agent on the connection test (test is optional)', () => {
+    renderWithProbe(async () => ({ success: false, error: 'nope' }))
+
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'My Agent' } })
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://example.com/ws' } })
+
+    // Add Agent is enabled by name + url alone, regardless of any probe result.
+    expect(screen.getByRole('button', { name: /add agent/i })).not.toBeDisabled()
+  })
+
+  it('clears a prior connection result when the URL changes', async () => {
+    renderWithProbe(async () => ({ success: true }))
+
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://example.com/ws' } })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /test connection/i }))
+    })
+    expect(screen.getByText(/connection successful/i)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://other.com/ws' } })
+    expect(screen.queryByText(/connection successful/i)).not.toBeInTheDocument()
   })
 })

--- a/src/components/settings/agents/add-custom-agent-dialog.test.tsx
+++ b/src/components/settings/agents/add-custom-agent-dialog.test.tsx
@@ -84,10 +84,20 @@ describe('validateAgentUrl', () => {
 describe('AddCustomAgentDialog', () => {
   const notIos = () => false
 
-  it('keeps Add Agent disabled until both name and URL are filled', () => {
+  const succeedingProbe: TestAcpConnectionFn = async () => ({ success: true })
+
+  it('keeps Add Agent disabled until both name and URL are filled and the connection test succeeds', async () => {
     const onSubmit = mock(async () => {})
     const onOpenChange = mock(() => {})
-    render(<AddCustomAgentDialog open={true} onOpenChange={onOpenChange} onSubmit={onSubmit} isIos={notIos} />)
+    render(
+      <AddCustomAgentDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+        isIos={notIos}
+        testAcpConnection={succeedingProbe}
+      />,
+    )
 
     const submit = screen.getByRole('button', { name: /add agent/i })
     expect(submit).toBeDisabled()
@@ -96,17 +106,36 @@ describe('AddCustomAgentDialog', () => {
     expect(submit).toBeDisabled()
 
     fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://example.com/ws' } })
+    // Name + URL alone no longer enable Add — a successful test is required.
+    expect(submit).toBeDisabled()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /test connection/i }))
+    })
     expect(submit).not.toBeDisabled()
   })
 
   it('invokes onSubmit with websocket transport and trimmed values', async () => {
     const onSubmit = mock(async (_: AddCustomAgentPayload) => {})
     const onOpenChange = mock(() => {})
-    render(<AddCustomAgentDialog open={true} onOpenChange={onOpenChange} onSubmit={onSubmit} isIos={notIos} />)
+    render(
+      <AddCustomAgentDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+        isIos={notIos}
+        testAcpConnection={succeedingProbe}
+      />,
+    )
 
     fireEvent.change(screen.getByLabelText(/name/i), { target: { value: '  My Agent  ' } })
     fireEvent.change(screen.getByLabelText(/url/i), { target: { value: '  wss://example.com/ws  ' } })
     fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'Demo' } })
+
+    // Add is gated behind a successful test — run it first.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /test connection/i }))
+    })
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /add agent/i }))
@@ -123,7 +152,7 @@ describe('AddCustomAgentDialog', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
-  it('shows the iOS rejection inline for ws:// and does NOT call onSubmit', async () => {
+  it('shows the iOS rejection inline for ws:// at render time, keeps Add disabled, and does NOT call onSubmit', () => {
     const onSubmit = mock(async () => {})
     const onOpenChange = mock(() => {})
     render(<AddCustomAgentDialog open={true} onOpenChange={onOpenChange} onSubmit={onSubmit} isIos={() => true} />)
@@ -131,15 +160,13 @@ describe('AddCustomAgentDialog', () => {
     fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'iOS Agent' } })
     fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'ws://example.com/ws' } })
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /add agent/i }))
-    })
-
-    expect(onSubmit).not.toHaveBeenCalled()
+    // The error surfaces on entering the invalid URL — no Add click needed.
     expect(screen.getByRole('alert')).toHaveTextContent(/secure/i)
+    expect(screen.getByRole('button', { name: /add agent/i })).toBeDisabled()
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('shows an inline error for http:// (unsupported scheme) and does NOT call onSubmit', async () => {
+  it('shows an inline error for http:// (unsupported scheme) at render time and keeps Add disabled', () => {
     const onSubmit = mock(async () => {})
     const onOpenChange = mock(() => {})
     render(<AddCustomAgentDialog open={true} onOpenChange={onOpenChange} onSubmit={onSubmit} isIos={notIos} />)
@@ -147,15 +174,12 @@ describe('AddCustomAgentDialog', () => {
     fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Bad Agent' } })
     fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'http://example.com' } })
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /add agent/i }))
-    })
-
-    expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add agent/i })).toBeDisabled()
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('shows an inline error for unsupported schemes and does NOT call onSubmit', async () => {
+  it('shows an inline error for unsupported schemes at render time and keeps Add disabled', () => {
     const onSubmit = mock(async () => {})
     const onOpenChange = mock(() => {})
     render(<AddCustomAgentDialog open={true} onOpenChange={onOpenChange} onSubmit={onSubmit} isIos={notIos} />)
@@ -163,12 +187,9 @@ describe('AddCustomAgentDialog', () => {
     fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Bad Agent' } })
     fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'ftp://example.com' } })
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /add agent/i }))
-    })
-
-    expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add agent/i })).toBeDisabled()
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 })
 
@@ -188,6 +209,11 @@ describe('AddCustomAgentDialog — connection status', () => {
       />,
     )
     return { onSubmit, onOpenChange }
+  }
+
+  const fillNameAndUrl = () => {
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'My Agent' } })
+    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://example.com/ws' } })
   }
 
   it('hides the Test Connection button until the URL is a valid WebSocket endpoint', () => {
@@ -230,14 +256,30 @@ describe('AddCustomAgentDialog — connection status', () => {
     expect(screen.getByText(/could not reach agent/i)).toBeInTheDocument()
   })
 
-  it('does NOT gate Add Agent on the connection test (test is optional)', () => {
+  it('gates Add Agent on a successful connection test', async () => {
     renderWithProbe(async () => ({ success: false, error: 'nope' }))
 
-    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'My Agent' } })
-    fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'wss://example.com/ws' } })
+    const submit = screen.getByRole('button', { name: /add agent/i })
+    fillNameAndUrl()
 
-    // Add Agent is enabled by name + url alone, regardless of any probe result.
-    expect(screen.getByRole('button', { name: /add agent/i })).not.toBeDisabled()
+    // Name + URL alone do not enable Add.
+    expect(submit).toBeDisabled()
+
+    // A failed test leaves Add disabled.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /test connection/i }))
+    })
+    expect(submit).toBeDisabled()
+
+    // Re-entering a valid URL clears the failure; a successful test enables Add.
+    cleanup()
+    renderWithProbe(async () => ({ success: true }))
+    const submitAfterSuccess = screen.getByRole('button', { name: /add agent/i })
+    fillNameAndUrl()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /test connection/i }))
+    })
+    expect(submitAfterSuccess).not.toBeDisabled()
   })
 
   it('clears a prior connection result when the URL changes', async () => {

--- a/src/components/settings/agents/add-custom-agent-dialog.tsx
+++ b/src/components/settings/agents/add-custom-agent-dialog.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useState } from 'react'
+import { useReducer } from 'react'
+import { Check, Loader2, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -13,7 +14,9 @@ import {
   ResponsiveModalTitle,
 } from '@/components/ui/responsive-modal'
 import { Dialog } from '@/components/ui/dialog'
+import { StatusCard } from '@/components/ui/status-card'
 import { getPlatform, isTauri } from '@/lib/platform'
+import { testAcpConnection as defaultTestAcpConnection } from '@/acp'
 
 /** Maps a user-entered URL to the ACP transport flavor we support, or `null`
  *  when the scheme is unsupported (or the URL is malformed). WebSocket is the
@@ -59,38 +62,116 @@ export type AddCustomAgentPayload = {
   transport: 'websocket'
 }
 
+/** Async probe signature the dialog uses to test a remote agent endpoint.
+ *  Production wires the real `testAcpConnection`; tests inject a stub. */
+export type TestAcpConnectionFn = (opts: {
+  url: string
+}) => Promise<{ success: true } | { success: false; error: string }>
+
 type AddCustomAgentDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
   onSubmit: (payload: AddCustomAgentPayload) => Promise<void> | void
   /** Test/DI override for the iOS guard. Production callers omit this. */
   isIos?: () => boolean
+  /** Test/DI override for the connection probe. Production callers omit this. */
+  testAcpConnection?: TestAcpConnectionFn
 }
 
-export const AddCustomAgentDialog = ({ open, onOpenChange, onSubmit, isIos }: AddCustomAgentDialogProps) => {
-  const [name, setName] = useState('')
-  const [url, setUrl] = useState('')
-  const [description, setDescription] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [submitting, setSubmitting] = useState(false)
+type AgentDialogState = {
+  name: string
+  url: string
+  description: string
+  error: string | null
+  submitting: boolean
+  isTestingConnection: boolean
+  connectionStatus: 'idle' | 'success' | 'error'
+  connectionError: string | null
+}
 
-  const trimmedName = name.trim()
-  const trimmedUrl = url.trim()
-  const trimmedDescription = description.trim()
-  const canSubmit = trimmedName.length > 0 && trimmedUrl.length > 0 && !submitting
+type AgentDialogAction =
+  | { type: 'SET_NAME'; value: string }
+  | { type: 'SET_URL'; value: string }
+  | { type: 'SET_DESCRIPTION'; value: string }
+  | { type: 'SET_ERROR'; error: string }
+  | { type: 'START_SUBMIT' }
+  | { type: 'END_SUBMIT' }
+  | { type: 'START_CONNECTION_TEST' }
+  | { type: 'CONNECTION_TEST_SUCCESS' }
+  | { type: 'CONNECTION_TEST_FAILURE'; error: string }
+  | { type: 'RESET' }
 
-  const resetForm = () => {
-    setName('')
-    setUrl('')
-    setDescription('')
-    setError(null)
+const initialState: AgentDialogState = {
+  name: '',
+  url: '',
+  description: '',
+  error: null,
+  submitting: false,
+  isTestingConnection: false,
+  connectionStatus: 'idle',
+  connectionError: null,
+}
+
+const agentDialogReducer = (state: AgentDialogState, action: AgentDialogAction): AgentDialogState => {
+  switch (action.type) {
+    case 'SET_NAME':
+      return { ...state, name: action.value }
+    case 'SET_URL':
+      // Editing the URL invalidates any prior validation error or connection
+      // result — the user is targeting a (potentially) different endpoint.
+      return { ...state, url: action.value, error: null, connectionStatus: 'idle', connectionError: null }
+    case 'SET_DESCRIPTION':
+      return { ...state, description: action.value }
+    case 'SET_ERROR':
+      return { ...state, error: action.error }
+    case 'START_SUBMIT':
+      return { ...state, submitting: true, error: null }
+    case 'END_SUBMIT':
+      return { ...state, submitting: false }
+    case 'START_CONNECTION_TEST':
+      return { ...state, isTestingConnection: true, connectionStatus: 'idle', connectionError: null }
+    case 'CONNECTION_TEST_SUCCESS':
+      return { ...state, isTestingConnection: false, connectionStatus: 'success' }
+    case 'CONNECTION_TEST_FAILURE':
+      return { ...state, isTestingConnection: false, connectionStatus: 'error', connectionError: action.error }
+    case 'RESET':
+      return initialState
+    default:
+      return state
   }
+}
+
+export const AddCustomAgentDialog = ({
+  open,
+  onOpenChange,
+  onSubmit,
+  isIos,
+  testAcpConnection = defaultTestAcpConnection,
+}: AddCustomAgentDialogProps) => {
+  const [state, dispatch] = useReducer(agentDialogReducer, initialState)
+
+  const trimmedName = state.name.trim()
+  const trimmedUrl = state.url.trim()
+  const trimmedDescription = state.description.trim()
+  const canSubmit = trimmedName.length > 0 && trimmedUrl.length > 0 && !state.submitting
+  // The probe is only meaningful once the URL is a valid WebSocket endpoint.
+  const canTestConnection = trimmedUrl.length > 0 && !('error' in validateAgentUrl(trimmedUrl, isIos))
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {
-      resetForm()
+      dispatch({ type: 'RESET' })
     }
     onOpenChange(next)
+  }
+
+  const handleTestConnection = async () => {
+    dispatch({ type: 'START_CONNECTION_TEST' })
+    const result = await testAcpConnection({ url: trimmedUrl })
+    if (result.success) {
+      dispatch({ type: 'CONNECTION_TEST_SUCCESS' })
+      return
+    }
+    dispatch({ type: 'CONNECTION_TEST_FAILURE', error: result.error })
   }
 
   const handleSubmit = async () => {
@@ -99,19 +180,18 @@ export const AddCustomAgentDialog = ({ open, onOpenChange, onSubmit, isIos }: Ad
     }
     const result = validateAgentUrl(trimmedUrl, isIos)
     if ('error' in result) {
-      setError(result.error)
+      dispatch({ type: 'SET_ERROR', error: result.error })
       return
     }
-    setSubmitting(true)
-    setError(null)
+    dispatch({ type: 'START_SUBMIT' })
     await onSubmit({
       name: trimmedName,
       url: trimmedUrl,
       description: trimmedDescription.length > 0 ? trimmedDescription : null,
       transport: result.transport,
     })
-    setSubmitting(false)
-    resetForm()
+    dispatch({ type: 'END_SUBMIT' })
+    dispatch({ type: 'RESET' })
     onOpenChange(false)
   }
 
@@ -130,8 +210,8 @@ export const AddCustomAgentDialog = ({ open, onOpenChange, onSubmit, isIos }: Ad
             <Input
               id="agent-name"
               placeholder="My Agent"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
+              value={state.name}
+              onChange={(e) => dispatch({ type: 'SET_NAME', value: e.target.value })}
               autoComplete="off"
             />
           </div>
@@ -140,13 +220,8 @@ export const AddCustomAgentDialog = ({ open, onOpenChange, onSubmit, isIos }: Ad
             <Input
               id="agent-url"
               placeholder="wss://example.com/ws"
-              value={url}
-              onChange={(e) => {
-                setUrl(e.target.value)
-                if (error) {
-                  setError(null)
-                }
-              }}
+              value={state.url}
+              onChange={(e) => dispatch({ type: 'SET_URL', value: e.target.value })}
               autoComplete="off"
             />
             <p className="text-[length:var(--font-size-xs)] text-muted-foreground">
@@ -158,14 +233,56 @@ export const AddCustomAgentDialog = ({ open, onOpenChange, onSubmit, isIos }: Ad
             <Input
               id="agent-description"
               placeholder="Optional"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
+              value={state.description}
+              onChange={(e) => dispatch({ type: 'SET_DESCRIPTION', value: e.target.value })}
               autoComplete="off"
             />
           </div>
-          {error && (
+          {canTestConnection && (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={handleTestConnection}
+              disabled={state.isTestingConnection}
+            >
+              {state.isTestingConnection ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Testing Agent...
+                </>
+              ) : (
+                'Test Connection'
+              )}
+            </Button>
+          )}
+          {state.connectionStatus === 'success' && (
+            <StatusCard
+              title={
+                <>
+                  <Check className="h-5 w-5 text-green-600" />
+                  Connection successful!
+                </>
+              }
+              description="Successfully connected to the agent."
+              className="border-green-200/50 dark:border-green-500/20"
+            />
+          )}
+          {state.connectionStatus === 'error' && (
+            <StatusCard
+              title={
+                <>
+                  <X className="h-5 w-5 text-red-600" />
+                  Connection failed
+                </>
+              }
+              description={state.connectionError || 'Could not connect to the agent.'}
+              className="bg-red-50/50 dark:bg-red-500/10 border-red-200/50 dark:border-red-500/20"
+            />
+          )}
+          {state.error && (
             <p role="alert" className="text-[length:var(--font-size-sm)] text-destructive">
-              {error}
+              {state.error}
             </p>
           )}
         </div>

--- a/src/components/settings/agents/add-custom-agent-dialog.tsx
+++ b/src/components/settings/agents/add-custom-agent-dialog.tsx
@@ -82,7 +82,6 @@ type AgentDialogState = {
   name: string
   url: string
   description: string
-  error: string | null
   submitting: boolean
   isTestingConnection: boolean
   connectionStatus: 'idle' | 'success' | 'error'
@@ -93,7 +92,6 @@ type AgentDialogAction =
   | { type: 'SET_NAME'; value: string }
   | { type: 'SET_URL'; value: string }
   | { type: 'SET_DESCRIPTION'; value: string }
-  | { type: 'SET_ERROR'; error: string }
   | { type: 'START_SUBMIT' }
   | { type: 'END_SUBMIT' }
   | { type: 'START_CONNECTION_TEST' }
@@ -105,7 +103,6 @@ const initialState: AgentDialogState = {
   name: '',
   url: '',
   description: '',
-  error: null,
   submitting: false,
   isTestingConnection: false,
   connectionStatus: 'idle',
@@ -117,15 +114,13 @@ const agentDialogReducer = (state: AgentDialogState, action: AgentDialogAction):
     case 'SET_NAME':
       return { ...state, name: action.value }
     case 'SET_URL':
-      // Editing the URL invalidates any prior validation error or connection
-      // result — the user is targeting a (potentially) different endpoint.
-      return { ...state, url: action.value, error: null, connectionStatus: 'idle', connectionError: null }
+      // Editing the URL invalidates any prior connection result — the user is
+      // targeting a (potentially) different endpoint, so Add must be re-gated.
+      return { ...state, url: action.value, connectionStatus: 'idle', connectionError: null }
     case 'SET_DESCRIPTION':
       return { ...state, description: action.value }
-    case 'SET_ERROR':
-      return { ...state, error: action.error }
     case 'START_SUBMIT':
-      return { ...state, submitting: true, error: null }
+      return { ...state, submitting: true }
     case 'END_SUBMIT':
       return { ...state, submitting: false }
     case 'START_CONNECTION_TEST':
@@ -153,9 +148,16 @@ export const AddCustomAgentDialog = ({
   const trimmedName = state.name.trim()
   const trimmedUrl = state.url.trim()
   const trimmedDescription = state.description.trim()
-  const canSubmit = trimmedName.length > 0 && trimmedUrl.length > 0 && !state.submitting
+  const validation = validateAgentUrl(trimmedUrl, isIos)
+  // Surface an invalid-URL error at render time (once the field is non-empty)
+  // so the user sees why Test Connection is unavailable and Add stays gated.
+  const urlError = trimmedUrl.length > 0 && 'error' in validation ? validation.error : null
+  // Add is gated behind a successful Test Connection — a valid name, URL, and a
+  // confirmed connection are all required before the agent can be created.
+  const canSubmit =
+    trimmedName.length > 0 && trimmedUrl.length > 0 && state.connectionStatus === 'success' && !state.submitting
   // The probe is only meaningful once the URL is a valid WebSocket endpoint.
-  const canTestConnection = trimmedUrl.length > 0 && !('error' in validateAgentUrl(trimmedUrl, isIos))
+  const canTestConnection = trimmedUrl.length > 0 && !urlError
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {
@@ -175,12 +177,9 @@ export const AddCustomAgentDialog = ({
   }
 
   const handleSubmit = async () => {
-    if (!canSubmit) {
-      return
-    }
-    const result = validateAgentUrl(trimmedUrl, isIos)
-    if ('error' in result) {
-      dispatch({ type: 'SET_ERROR', error: result.error })
+    // `canSubmit` already requires a successful connection test, which is only
+    // reachable for a valid WebSocket URL — so `validation` carries a transport.
+    if (!canSubmit || 'error' in validation) {
       return
     }
     dispatch({ type: 'START_SUBMIT' })
@@ -188,7 +187,7 @@ export const AddCustomAgentDialog = ({
       name: trimmedName,
       url: trimmedUrl,
       description: trimmedDescription.length > 0 ? trimmedDescription : null,
-      transport: result.transport,
+      transport: validation.transport,
     })
     dispatch({ type: 'END_SUBMIT' })
     dispatch({ type: 'RESET' })
@@ -280,9 +279,9 @@ export const AddCustomAgentDialog = ({
               className="bg-red-50/50 dark:bg-red-500/10 border-red-200/50 dark:border-red-500/20"
             />
           )}
-          {state.error && (
+          {urlError && (
             <p role="alert" className="text-[length:var(--font-size-sm)] text-destructive">
-              {state.error}
+              {urlError}
             </p>
           )}
         </div>

--- a/src/dal/agents.test.ts
+++ b/src/dal/agents.test.ts
@@ -7,11 +7,35 @@ import { agentsSystemTable, agentsTable } from '@/db/tables'
 import { builtInAgent } from '@/defaults/agents'
 import { HttpError, type HttpClient, type ResponsePromise } from '@/lib/http'
 import { refreshSystemAgents } from '@/db/seeding/seed-agents'
+import { clearAdapterCache, getOrConnectAdapter } from '@/acp/adapter-cache'
+import type { AgentAdapter } from '@/types/acp'
 import type { AgentDiscoveryResponse } from '@shared/acp-types'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { composeAllAgents, createAgent, deleteAgent, getAgentSecrets, setAgentSecrets, updateAgent } from './agents'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 import type { Agent } from '@/types/acp'
+
+/** Seed the global adapter cache with a fake connection for `agentId` and hand
+ *  back a disconnect spy so a test can assert the DAL disposed it. */
+const seedCachedAdapter = async (agentId: string) => {
+  let disconnects = 0
+  const adapter: AgentAdapter = {
+    agent: { id: agentId } as Agent,
+    capabilities: null,
+    fetch: async () => new Response('ok'),
+    disconnect: () => {
+      disconnects++
+    },
+  }
+  await getOrConnectAdapter(
+    { id: agentId } as Agent,
+    { httpClient: {} as HttpClient, getProxyFetch: () => null as never },
+    {
+      connectToAgent: (async () => adapter) as never,
+    },
+  )
+  return { disconnectCount: () => disconnects }
+}
 
 beforeAll(async () => {
   await setupTestDatabase()
@@ -23,6 +47,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await resetTestDatabase()
+  clearAdapterCache()
 })
 
 /** Build a stub HttpClient where `get` resolves to a JSON payload or throws.
@@ -118,6 +143,38 @@ describe('agents DAL', () => {
       const row = await getDb().select().from(agentsTable).get()
       expect(row?.name).toBe('Untouched')
     })
+
+    it('disposes the warm ACP connection when the wire identity (url) changes', async () => {
+      await createAgent(getDb(), {
+        id: 'a-url',
+        name: 'Wired',
+        type: 'remote-acp',
+        transport: 'websocket',
+        url: 'wss://old/ws',
+        userId: 'u1',
+      })
+      const cached = await seedCachedAdapter('a-url')
+
+      await updateAgent(getDb(), 'a-url', { url: 'wss://new/ws' })
+
+      expect(cached.disconnectCount()).toBe(1)
+    })
+
+    it('does NOT dispose the connection on a non-wire patch (rename only)', async () => {
+      await createAgent(getDb(), {
+        id: 'a-name',
+        name: 'Before',
+        type: 'remote-acp',
+        transport: 'websocket',
+        url: 'wss://keep/ws',
+        userId: 'u1',
+      })
+      const cached = await seedCachedAdapter('a-name')
+
+      await updateAgent(getDb(), 'a-name', { name: 'After' })
+
+      expect(cached.disconnectCount()).toBe(0)
+    })
   })
 
   describe('deleteAgent', () => {
@@ -140,6 +197,22 @@ describe('agents DAL', () => {
 
     it('refuses to delete the built-in agent', async () => {
       await expect(deleteAgent(getDb(), builtInAgent.id)).rejects.toThrow(/built-in/)
+    })
+
+    it('disposes the agent warm ACP connection on delete', async () => {
+      await createAgent(getDb(), {
+        id: 'a-disp',
+        name: 'Doomed',
+        type: 'remote-acp',
+        transport: 'websocket',
+        url: 'wss://x',
+        userId: 'u1',
+      })
+      const cached = await seedCachedAdapter('a-disp')
+
+      await deleteAgent(getDb(), 'a-disp')
+
+      expect(cached.disconnectCount()).toBe(1)
     })
   })
 

--- a/src/dal/agents.ts
+++ b/src/dal/agents.ts
@@ -7,6 +7,7 @@ import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { useDatabase } from '@/contexts'
 import { selectBuiltInAgentEnabled, useConfigStore } from '@/api/config-store'
+import { disposeAdapter } from '@/acp/adapter-cache'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { agentsSecretsTable, agentsSystemTable, agentsTable } from '../db/tables'
 import { builtInAgent } from '../defaults/agents'
@@ -139,9 +140,17 @@ export type UpdateAgentPatch = Partial<
   Pick<CreateAgentInput, 'name' | 'type' | 'transport' | 'url' | 'description' | 'icon' | 'enabled'>
 >
 
+/** Patch fields whose change invalidates a warm ACP connection — the wire
+ *  identity (endpoint + transport + agent type). Editing any of these means the
+ *  next chat must reconnect, so the cached adapter is disposed. */
+const connectionInvalidatingFields: ReadonlyArray<keyof UpdateAgentPatch> = ['url', 'transport', 'type']
+
 /** Patch an existing custom agent. Built-in and system agents are not editable
  *  through the DAL — built-in lives in code, system rows live in the local-only
- *  `agents_system` table which `updateAgent` never touches. */
+ *  `agents_system` table which `updateAgent` never touches.
+ *
+ *  Editing the wire identity (url/transport/type) disposes the agent's warm ACP
+ *  connection so the next chat reconnects against the new endpoint. */
 export const updateAgent = async (db: AnyDrizzleDatabase, id: string, patch: UpdateAgentPatch): Promise<void> => {
   if (id === builtInAgent.id) {
     throw new Error(`updateAgent: refusing to edit built-in agent "${id}"`)
@@ -153,11 +162,16 @@ export const updateAgent = async (db: AnyDrizzleDatabase, id: string, patch: Upd
     .update(agentsTable)
     .set(patch)
     .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+
+  if (connectionInvalidatingFields.some((field) => field in patch)) {
+    await disposeAdapter(id)
+  }
 }
 
 /** Soft delete a custom agent. Never hard-delete — sets `deletedAt` and lets
  *  PowerSync replicate the tombstone. Built-ins/system rows are not in this
- *  table and cannot be removed. */
+ *  table and cannot be removed. Disposes the agent's warm ACP connection so a
+ *  deleted agent leaves no live transport behind. */
 export const deleteAgent = async (db: AnyDrizzleDatabase, id: string): Promise<void> => {
   if (id === builtInAgent.id) {
     throw new Error(`deleteAgent: refusing to delete built-in agent "${id}"`)
@@ -166,6 +180,8 @@ export const deleteAgent = async (db: AnyDrizzleDatabase, id: string): Promise<v
     .update(agentsTable)
     .set({ deletedAt: nowIso() })
     .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+
+  await disposeAdapter(id)
 }
 
 /** Read credentials for an agent from the local-only secrets table.

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { disposeAllAdapters } from '@/acp/adapter-cache'
 import { setSyncEnabled } from '@/db/powersync'
 import { clearAuthToken, clearDeviceId } from '@/lib/auth-token'
 import { resetAppDir } from '@/lib/fs'
@@ -27,6 +28,15 @@ type ClearLocalDataOptions = {
  */
 export const clearLocalData = async (options?: ClearLocalDataOptions): Promise<void> => {
   const { disableSync = true, clearEncryptionKeys = true, clearDatabase = true, clearAuth = true } = options ?? {}
+
+  // Tear down every warm ACP connection first so no agent transport survives
+  // across user identities (sign-out, account deletion, device revocation all
+  // funnel through here).
+  try {
+    await disposeAllAdapters()
+  } catch (error) {
+    console.error('[clearLocalData] Failed to dispose ACP adapters:', error)
+  }
 
   if (disableSync) {
     try {

--- a/src/routes/settings/agents/index.tsx
+++ b/src/routes/settings/agents/index.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button'
 import { PageHeader } from '@/components/ui/page-header'
 import { AgentList } from '@/components/settings/agents/agent-list'
 import { AddCustomAgentDialog, type AddCustomAgentPayload } from '@/components/settings/agents/add-custom-agent-dialog'
+import { testAcpConnection } from '@/acp'
 import { createAgent, deleteAgent, updateAgent, useAllAgents } from '@/dal'
 import { useDatabase } from '@/contexts'
 import { useAuth } from '@/contexts'
@@ -105,7 +106,12 @@ export default function AgentsSettingsPage({ isStandalone }: AgentsSettingsPageP
 
       <AgentList agents={agents} currentUserId={currentUserId} onToggle={handleToggle} onDelete={handleDelete} />
 
-      <AddCustomAgentDialog open={dialogOpen} onOpenChange={setDialogOpen} onSubmit={handleSubmit} />
+      <AddCustomAgentDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSubmit={handleSubmit}
+        testAcpConnection={testAcpConnection}
+      />
     </div>
   )
 }

--- a/src/test-utils/chat-store-mocks.ts
+++ b/src/test-utils/chat-store-mocks.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { clearAdapterCache } from '@/acp/adapter-cache'
 import { useChatStore } from '@/chats/chat-store'
 import { builtInAgent } from '@/defaults/agents'
 import type { AutomationRun, ChatThread, Mode, Model, ThunderboltUIMessage } from '@/types'
@@ -243,6 +244,10 @@ export const hydrateStore = (state: {
  * Resets the store to initial state for testing
  */
 export const resetStore = () => {
+  // The per-agent adapter cache is module-global, so a fresh test must forget
+  // any connection a prior test opened — otherwise a cache hit would suppress
+  // the next test's injected `connectToAgent`.
+  clearAdapterCache()
   useChatStore.setState({
     currentSessionId: null,
     mcpClients: [],

--- a/src/types/acp.ts
+++ b/src/types/acp.ts
@@ -11,8 +11,10 @@
  */
 
 import type { MCPClient } from '@ai-sdk/mcp'
+import type { RequestPermissionRequest, RequestPermissionResponse } from '@agentclientprotocol/sdk'
 import type { HttpClient } from '@/lib/http'
 import type { FetchFn } from '@/lib/proxy-fetch'
+import type { SessionSideEffectSink } from '@/acp/translators/acp-to-ai-sdk'
 import type { ChatThread, Mode, Model, SaveMessagesFunction } from '@/types'
 
 /** Capabilities advertised by an ACP agent on `initialize`. Stored on the
@@ -62,6 +64,14 @@ export type AgentAdapterContext = {
    *  The chat layer persists it on `chatThreads.acpSessionId` so future loads
    *  can call `session/load` when the agent supports it. */
   onAcpSessionId: (sessionId: string) => Promise<void>
+  /** Invoked when the agent requests permission for a tool call on THIS
+   *  thread's ACP session. The chat layer surfaces a dialog and resolves the
+   *  response. Optional; a shared ACP connection routes each thread's prompts
+   *  to its own handler so dialogs never cross threads. */
+  requestPermission?: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>
+  /** Invoked when the agent emits a `current_mode_update` or
+   *  `config_option_update` on this thread's session. Optional; default no-op. */
+  onSessionSideEffect?: SessionSideEffectSink
 }
 
 /** Runtime adapter wrapping either the built-in pipeline or an ACP transport.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core ACP lifecycle (multiplexing, cache teardown, WebSocket terminal closes) and chat routing; broad test coverage reduces but does not eliminate regression risk in concurrent threads and agent switching.
> 
> **Overview**
> Refactors **ACP** so each agent keeps **one shared WebSocket + `initialize`**, with **per-thread** `loadSession` / `newSession`, permissions, and streaming handled on each `fetch` via a global **`adapter-cache`** (no reconnect on thread switch; dispose on agent delete, wire config changes, or sign-out).
> 
> **Handshake reliability:** `initialize` / session steps race a **timeout** and the transport’s **`closed`** rejection; failed handshakes **close** the socket. WebSocket treats proxy/auth/server codes as **non-reconnectable** and surfaces terminal failures through **`closed`**.
> 
> **UX:** Add Custom Agent requires a successful **Test Connection** (`testAcpConnection` probe). The ACP→AI SDK translator emits **`reasoningTime`** metadata for tools and reasoning.
> 
> Chat routing uses the cache instead of disconnecting the previous agent when switching agents mid-thread; **`onAcpSessionId`** / **`requestPermission`** move to per-fetch context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8f90db8bffa9318f866d78cbd3d32211207df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->