### PR TITLE
fix(auth): raise /get-session rate limit to 30 req/sec

### DIFF
--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -167,6 +167,9 @@ export const createAuth = (database: typeof DbType, emailDeps: AuthEmailDeps = {
       enabled: settings.rateLimitEnabled,
       window: 60,
       max: 10,
+      customRules: {
+        '/get-session': { window: 1, max: 30 },
+      },
     },
     advanced: {
       ipAddress: {


### PR DESCRIPTION
Better Auth's global rate limit (10 req/min, IP-keyed) was too tight for `/get-session`, which the frontend hits on tab focus, route changes, and the 401 retry path. Add a per-path override via `rateLimit.customRules` to allow 30 requests per second without touching the global default used by other auth endpoints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path rate-limit tuning for a read-only session probe; other auth endpoints keep the stricter global limit.
> 
> **Overview**
> Adds a **Better Auth** `rateLimit.customRules` entry for **`/get-session`**: **30 requests per 1-second window** per IP, while the global auth limit stays **10 per 60 seconds** for other routes.
> 
> This targets session polling from the frontend (tab focus, navigation, 401 retry) without loosening rate limits on sign-in and other sensitive auth endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94780733a347fda8885874799fe5b2684a6cc7fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->