### PR TITLE
feat(THU-569): add quiz widget with persisted answers

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -13,6 +13,8 @@ import {
   shouldRetry,
 } from '@/ai/step-logic'
 import { getAllSkills, getIntegrationStatus, getModel, getModelProfile, getSettings } from '@/dal'
+import { getMessage } from '@/dal/chat-messages'
+import { collectQuizEntriesFromCache, formatQuizResultsNote } from '@/widgets/quiz/lib'
 import { extractLastUserText, resolveSkillTokenInstructions } from '@/skills/resolve-skill-system-messages'
 import { getDb } from '@/db/database'
 import { getLocalSetting } from '@/stores/local-settings-store'
@@ -445,12 +447,28 @@ export const aiFetchStreamingResponse = async ({
     }
     const skillSystemMessages = resolveSkillTokenInstructions(lastUserText, instructionBySlug)
 
+    // Surface the user's persisted quiz answers (stored in each assistant
+    // message's cache by the quiz widget) so the model can report scores
+    // without asking the user to re-enter their choices.
+    const quizEntries = (
+      await Promise.all(
+        messages
+          .filter((message) => message.role === 'assistant')
+          .map(async (message) => {
+            const stored = await getMessage(db, message.id)
+            return stored?.cache ? collectQuizEntriesFromCache(stored.cache as Record<string, unknown>) : []
+          }),
+      )
+    ).flat()
+    const quizResultsNote = formatQuizResultsNote(quizEntries)
+    const systemNotes = [...skillSystemMessages, ...(quizResultsNote ? [quizResultsNote] : [])]
+
     const stream = createUIMessageStream({
       generateId: uuidv7,
       execute: async ({ writer }) => {
         const baseMessages = await convertToModelMessages(messages)
         let currentMessages: typeof baseMessages = [
-          ...skillSystemMessages.map((content) => ({ role: 'system' as const, content })),
+          ...systemNotes.map((content) => ({ role: 'system' as const, content })),
           ...baseMessages,
         ]
         let attemptNumber = 1

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -22,6 +22,7 @@ import * as citation from './citation'
 import * as connectIntegration from './connect-integration'
 import * as documentResult from './document-result'
 import * as linkPreview from './link-preview'
+import * as quiz from './quiz'
 import * as weatherForecast from './weather-forecast'
 
 // Re-export components for easy importing
@@ -29,6 +30,7 @@ export { CitationBadge } from './citation'
 export { ConnectIntegrationWidget } from './connect-integration'
 export { DocumentResultWidget } from './document-result'
 export { LinkPreview, LinkPreviewSkeleton, LinkPreviewWidget } from './link-preview'
+export { Quiz } from './quiz'
 export { WeatherForecastWidget } from './weather-forecast'
 
 /**
@@ -55,6 +57,10 @@ export const widgetRegistry = [
   {
     name: 'link-preview' as const,
     module: linkPreview,
+  },
+  {
+    name: 'quiz' as const,
+    module: quiz,
   },
 ] as const
 
@@ -105,3 +111,4 @@ export type WidgetCacheData =
   | linkPreview.CacheData
   | weatherForecast.CacheData
   | citation.CacheData
+  | quiz.CacheData

--- a/src/widgets/quiz/display.tsx
+++ b/src/widgets/quiz/display.tsx
@@ -1,0 +1,214 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Check, Lightbulb, Sparkles, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { gradeQuiz, optionLetter, type QuizData, type QuizOption } from './lib'
+
+export type QuizSubmission = {
+  selectedIds: string[]
+  correct: boolean | null
+}
+
+type QuizProps = QuizData & {
+  /** Restores a previously-answered quiz (from the message cache). */
+  initialSelectedIds?: string[]
+  initialSubmitted?: boolean
+  /** Fired once when the user commits an answer, for persistence. */
+  onSubmit?: (submission: QuizSubmission) => void
+}
+
+/** Visual state of a single option, derived from selection + submission. */
+type OptionStatus = 'idle' | 'selected' | 'correct' | 'incorrect' | 'missed'
+
+const getOptionStatus = ({
+  option,
+  isSelected,
+  submitted,
+  isGraded,
+}: {
+  option: QuizOption
+  isSelected: boolean
+  submitted: boolean
+  isGraded: boolean
+}): OptionStatus => {
+  if (!submitted || !isGraded) {
+    return isSelected ? 'selected' : 'idle'
+  }
+  if (option.isCorrect && isSelected) return 'correct'
+  if (option.isCorrect && !isSelected) return 'missed'
+  if (!option.isCorrect && isSelected) return 'incorrect'
+  return 'idle'
+}
+
+const statusStyles: Record<OptionStatus, string> = {
+  idle: 'border-border bg-card hover:bg-accent hover:border-border',
+  selected: 'border-primary bg-accent ring-1 ring-primary',
+  correct: 'border-emerald-500/60 bg-emerald-50 dark:bg-emerald-950/30',
+  incorrect: 'border-red-500/60 bg-red-50 dark:bg-red-950/30',
+  missed: 'border-emerald-500/40 bg-emerald-50/50 dark:bg-emerald-950/15',
+}
+
+const badgeStyles: Record<OptionStatus, string> = {
+  idle: 'border-border text-muted-foreground',
+  selected: 'border-primary bg-primary text-primary-foreground',
+  correct: 'border-emerald-500 bg-emerald-500 text-white',
+  incorrect: 'border-red-500 bg-red-500 text-white',
+  missed: 'border-emerald-500 text-emerald-600 dark:text-emerald-400',
+}
+
+export const Quiz = ({
+  prompt,
+  mode,
+  options,
+  explanation,
+  initialSelectedIds,
+  initialSubmitted,
+  onSubmit,
+}: QuizProps) => {
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(initialSelectedIds))
+  const [submitted, setSubmitted] = useState(initialSubmitted ?? false)
+
+  const isGraded = mode !== 'choice'
+  const isMultiple = mode === 'multiple'
+  const result = useMemo(
+    () => (submitted ? gradeQuiz({ prompt, mode, options }, selected) : null),
+    [submitted, prompt, mode, options, selected],
+  )
+
+  const commit = (ids: Set<string>) => {
+    setSubmitted(true)
+    onSubmit?.({
+      selectedIds: [...ids],
+      correct: gradeQuiz({ prompt, mode, options }, ids),
+    })
+  }
+
+  const toggleOption = (id: string) => {
+    if (submitted) return
+
+    if (!isGraded) {
+      // `choice` mode: selecting an option commits the choice immediately.
+      const next = new Set([id])
+      setSelected(next)
+      commit(next)
+      return
+    }
+
+    setSelected((prev) => {
+      if (isMultiple) {
+        const next = new Set(prev)
+        next.has(id) ? next.delete(id) : next.add(id)
+        return next
+      }
+      return new Set([id])
+    })
+  }
+
+  const label = isGraded ? (isMultiple ? 'Select all that apply' : 'Choose one') : 'Your call'
+
+  return (
+    <div className="my-4 w-full">
+      <div className="overflow-hidden rounded-2xl border border-border bg-card">
+        <div className="flex flex-col gap-4 p-4 md:p-5">
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-1.5 text-[length:var(--font-size-xs)] font-medium uppercase tracking-wide text-muted-foreground">
+              <Sparkles className="size-[var(--icon-size-sm)]" />
+              <span>{label}</span>
+            </div>
+            <p className="text-[length:var(--font-size-body)] font-medium leading-snug text-foreground">{prompt}</p>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {options.map((option, index) => {
+              const isSelected = selected.has(option.id)
+              const status = getOptionStatus({ option, isSelected, submitted, isGraded })
+              const showCorrect = status === 'correct' || status === 'missed'
+              const showIncorrect = status === 'incorrect'
+
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  disabled={submitted}
+                  onClick={() => toggleOption(option.id)}
+                  className={cn(
+                    'group flex w-full items-center gap-3 rounded-xl border px-3.5 text-left transition-all',
+                    'min-h-[var(--touch-height-lg)] py-2.5',
+                    'disabled:cursor-default focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50',
+                    !submitted && 'cursor-pointer active:scale-[0.99]',
+                    statusStyles[status],
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'flex size-6 shrink-0 items-center justify-center border text-[length:var(--font-size-xs)] font-semibold transition-colors',
+                      isMultiple ? 'rounded-md' : 'rounded-full',
+                      badgeStyles[status],
+                    )}
+                  >
+                    {showCorrect ? (
+                      <Check className="size-3.5" strokeWidth={3} />
+                    ) : showIncorrect ? (
+                      <X className="size-3.5" strokeWidth={3} />
+                    ) : (
+                      optionLetter(index)
+                    )}
+                  </span>
+                  <span className="flex-1 text-[length:var(--font-size-sm)] leading-snug text-foreground">
+                    {option.text}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+
+          {isGraded && !submitted && (
+            <Button
+              size="default"
+              disabled={selected.size === 0}
+              onClick={() => commit(selected)}
+              className="w-full md:w-auto md:self-end"
+            >
+              Check answer
+            </Button>
+          )}
+
+          {submitted && isGraded && (
+            <div
+              className={cn(
+                'flex items-start gap-2.5 rounded-xl border p-3 text-[length:var(--font-size-sm)]',
+                result
+                  ? 'border-emerald-500/40 bg-emerald-50 text-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-200'
+                  : 'border-red-500/40 bg-red-50 text-red-800 dark:bg-red-950/30 dark:text-red-200',
+              )}
+            >
+              <span className="mt-0.5 shrink-0">
+                {result ? (
+                  <Check className="size-[var(--icon-size-sm)]" strokeWidth={2.5} />
+                ) : (
+                  <X className="size-[var(--icon-size-sm)]" strokeWidth={2.5} />
+                )}
+              </span>
+              <div className="flex flex-col gap-1">
+                <span className="font-medium">{result ? 'Correct!' : 'Not quite.'}</span>
+                {explanation && <span className="text-foreground/80">{explanation}</span>}
+              </div>
+            </div>
+          )}
+
+          {submitted && !isGraded && (
+            <div className="flex items-center gap-2 text-[length:var(--font-size-sm)] text-muted-foreground">
+              <Lightbulb className="size-[var(--icon-size-sm)] shrink-0" />
+              <span>Got it — working on that next.</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/widgets/quiz/index.ts
+++ b/src/widgets/quiz/index.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export { Quiz } from './display'
+export { instructions } from './instructions'
+export {
+  collectQuizEntriesFromCache,
+  formatQuizResultsNote,
+  gradeQuiz,
+  optionLetter,
+  type QuizCacheEntry,
+  type QuizData,
+  type QuizMode,
+  type QuizOption,
+} from './lib'
+export { parse, schema } from './schema'
+export type { CacheData, QuizWidget } from './schema'
+export { QuizWidget as Component } from './widget'

--- a/src/widgets/quiz/instructions.ts
+++ b/src/widgets/quiz/instructions.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const instructions = `## Quiz
+<widget:quiz mode="MODE" prompt="QUESTION" options='JSON_ARRAY' explanation="WHY" />
+An interactive multiple-choice quiz the user can answer inline. Prefer this over a markdown list whenever you ask the user a multiple-choice question.
+- mode: "single" (exactly one correct answer), "multiple" (one or more correct answers), or "choice" (no correct answer — an open prompt like "What do you want to do next?")
+- prompt: the question or prompt text
+- options: a JSON array wrapped in SINGLE quotes. Each option is {"id":"a","text":"..."}; for graded modes add "isCorrect":true to correct options. Never set isCorrect in "choice" mode.
+- explanation (optional): a short note shown after the user answers (graded modes only)
+Emit one widget per question. Do not also list the answers in text — the widget reveals them.
+Example: <widget:quiz mode="single" prompt="What is the capital of France?" options='[{"id":"a","text":"Paris","isCorrect":true},{"id":"b","text":"Lyon"},{"id":"c","text":"Marseille"}]' explanation="Paris has been France's capital since 508 AD." />`

--- a/src/widgets/quiz/lib.test.ts
+++ b/src/widgets/quiz/lib.test.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import {
+  collectQuizEntriesFromCache,
+  formatQuizResultsNote,
+  gradeQuiz,
+  optionLetter,
+  type QuizCacheEntry,
+  type QuizData,
+} from './lib'
+
+const singleQuiz: QuizData = {
+  prompt: 'Capital of France?',
+  mode: 'single',
+  options: [
+    { id: 'a', text: 'Paris', isCorrect: true },
+    { id: 'b', text: 'Lyon' },
+  ],
+}
+
+const multiQuiz: QuizData = {
+  prompt: 'Pick the encryption standards',
+  mode: 'multiple',
+  options: [
+    { id: 'a', text: 'OpenPGP', isCorrect: true },
+    { id: 'b', text: 'S/MIME', isCorrect: true },
+    { id: 'c', text: 'Base64' },
+  ],
+}
+
+describe('gradeQuiz', () => {
+  test('single: correct only when the right option is chosen', () => {
+    expect(gradeQuiz(singleQuiz, new Set(['a']))).toBe(true)
+    expect(gradeQuiz(singleQuiz, new Set(['b']))).toBe(false)
+  })
+
+  test('multiple: all-or-nothing', () => {
+    expect(gradeQuiz(multiQuiz, new Set(['a', 'b']))).toBe(true)
+    expect(gradeQuiz(multiQuiz, new Set(['a']))).toBe(false) // missing one
+    expect(gradeQuiz(multiQuiz, new Set(['a', 'b', 'c']))).toBe(false) // extra wrong
+  })
+
+  test('choice: nothing to grade', () => {
+    expect(gradeQuiz({ ...singleQuiz, mode: 'choice' }, new Set(['a']))).toBeNull()
+  })
+})
+
+describe('optionLetter', () => {
+  test('maps index to letter', () => {
+    expect(optionLetter(0)).toBe('A')
+    expect(optionLetter(2)).toBe('C')
+  })
+})
+
+describe('collectQuizEntriesFromCache', () => {
+  test('pulls only quiz-namespaced entries', () => {
+    const entry: QuizCacheEntry = {
+      prompt: 'Capital of France?',
+      mode: 'single',
+      selectedIds: ['b'],
+      chosen: ['Lyon'],
+      correct: false,
+    }
+    const cache = {
+      'quiz/Capital of France?': entry,
+      'linkPreview/https://x.com': { title: 'x' },
+      'weatherForecast/Seattle': { days: [] },
+    }
+    expect(collectQuizEntriesFromCache(cache)).toEqual([entry])
+  })
+
+  test('ignores malformed entries', () => {
+    expect(collectQuizEntriesFromCache({ 'quiz/bad': { prompt: 'x' } })).toEqual([])
+  })
+})
+
+describe('formatQuizResultsNote', () => {
+  test('returns null with no entries', () => {
+    expect(formatQuizResultsNote([])).toBeNull()
+  })
+
+  test('summarizes graded answers with a score', () => {
+    const note = formatQuizResultsNote([
+      { prompt: 'Q1', mode: 'single', selectedIds: ['a'], chosen: ['Paris'], correct: true },
+      { prompt: 'Q2', mode: 'single', selectedIds: ['b'], chosen: ['Thames'], correct: false },
+    ])
+    expect(note).toContain('"Q1" — chose "Paris" — correct')
+    expect(note).toContain('"Q2" — chose "Thames" — incorrect')
+    expect(note).toContain('Score: 1/2 (50%).')
+  })
+
+  test('omits score for ungraded choice answers', () => {
+    const note = formatQuizResultsNote([
+      { prompt: 'What next?', mode: 'choice', selectedIds: ['draft'], chosen: ['Draft a reply'], correct: null },
+    ])
+    expect(note).toContain('"What next?" — chose "Draft a reply"')
+    expect(note).not.toContain('Score:')
+  })
+})

--- a/src/widgets/quiz/lib.ts
+++ b/src/widgets/quiz/lib.ts
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Quiz widget interaction modes:
+ * - `single`   — exactly one correct answer (graded, radio-style)
+ * - `multiple` — one or more correct answers (graded, checkbox-style)
+ * - `choice`   — no correct answer, an open prompt like "What do you want to do next?"
+ */
+export type QuizMode = 'single' | 'multiple' | 'choice'
+
+export type QuizOption = {
+  id: string
+  text: string
+  /** Only meaningful for `single` / `multiple` modes. Ignored for `choice`. */
+  isCorrect?: boolean
+}
+
+export type QuizData = {
+  /** The question or prompt shown above the options. */
+  prompt: string
+  mode: QuizMode
+  options: QuizOption[]
+  /** Optional context shown after the quiz is answered (graded modes only). */
+  explanation?: string
+}
+
+/**
+ * Grades a set of selected option ids against the quiz answer key.
+ * Returns `null` for `choice` mode (nothing to grade).
+ */
+export const gradeQuiz = (data: QuizData, selectedIds: Set<string>): boolean | null => {
+  if (data.mode === 'choice') {
+    return null
+  }
+
+  const correctIds = data.options.filter((o) => o.isCorrect).map((o) => o.id)
+  const allCorrectSelected = correctIds.every((id) => selectedIds.has(id))
+  const noIncorrectSelected = [...selectedIds].every((id) => correctIds.includes(id))
+
+  return allCorrectSelected && noIncorrectSelected
+}
+
+/** Maps an option index to its display letter (0 → "A", 1 → "B", ...). */
+export const optionLetter = (index: number): string => String.fromCharCode(65 + index)
+
+/** Namespace prefix for quiz entries stored in a message's cache blob. */
+export const QUIZ_CACHE_PREFIX = 'quiz'
+
+/** Cache key for a single quiz instance within a message (one tag = one prompt). */
+export const quizStorageKey = (prompt: string): string => `${QUIZ_CACHE_PREFIX}/${prompt}`
+
+/**
+ * Persisted record of how the user answered one quiz. Stored under
+ * {@link quizStorageKey} in the message's `cache` column, and read back both
+ * to restore the widget UI and to report results to the model on later turns.
+ */
+export type QuizCacheEntry = {
+  prompt: string
+  mode: QuizMode
+  /** The option ids the user chose — used to restore the widget UI. */
+  selectedIds: string[]
+  /** The option texts the user chose — used to report results to the model. */
+  chosen: string[]
+  /** `true`/`false` for graded modes, `null` for `choice` mode. */
+  correct: boolean | null
+}
+
+const isQuizCacheEntry = (value: unknown): value is QuizCacheEntry =>
+  typeof value === 'object' &&
+  value !== null &&
+  'prompt' in value &&
+  'chosen' in value &&
+  Array.isArray((value as QuizCacheEntry).chosen)
+
+/** Pulls quiz answer records out of a message's flat cache blob. */
+export const collectQuizEntriesFromCache = (cache: Record<string, unknown>): QuizCacheEntry[] =>
+  Object.entries(cache)
+    .filter(([key]) => key.startsWith(`${QUIZ_CACHE_PREFIX}/`))
+    .map(([, value]) => value)
+    .filter(isQuizCacheEntry)
+
+/**
+ * Renders the user's quiz answers as a system note for the model, so it can
+ * answer "what did I score?" without asking the user to re-enter their choices.
+ * Returns `null` when there are no answered quizzes.
+ */
+export const formatQuizResultsNote = (entries: QuizCacheEntry[]): string | null => {
+  if (entries.length === 0) {
+    return null
+  }
+
+  const lines = entries.map((entry) => {
+    const chosen = entry.chosen.length > 0 ? entry.chosen.map((c) => `"${c}"`).join(', ') : '(no answer)'
+    if (entry.correct === null) {
+      return `- "${entry.prompt}" — chose ${chosen}`
+    }
+    return `- "${entry.prompt}" — chose ${chosen} — ${entry.correct ? 'correct' : 'incorrect'}`
+  })
+
+  const graded = entries.filter((e) => e.correct !== null)
+  const score =
+    graded.length > 0
+      ? `\nScore: ${graded.filter((e) => e.correct).length}/${graded.length} (${Math.round(
+          (graded.filter((e) => e.correct).length / graded.length) * 100,
+        )}%).`
+      : ''
+
+  return [
+    '## Quiz results',
+    'The user answered quiz widgets in this conversation. Use these results if they ask about their answers or score — do not ask them to re-enter their choices.',
+    ...lines,
+    score,
+  ]
+    .join('\n')
+    .trim()
+}

--- a/src/widgets/quiz/schema.ts
+++ b/src/widgets/quiz/schema.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createParser } from '@/lib/create-parser'
+import { z } from 'zod'
+import type { QuizCacheEntry } from './lib'
+
+const optionShape = z.object({
+  id: z.string().min(1),
+  text: z.string().min(1),
+  isCorrect: z.boolean().optional(),
+})
+
+/**
+ * The `options` attribute arrives as a JSON-encoded string (widget attributes
+ * are always strings). Parse it leniently, then validate the decoded shape.
+ */
+const optionsAttr = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value)
+    } catch {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'options must be valid JSON' })
+      return z.NEVER
+    }
+  })
+  .pipe(z.array(optionShape).min(2))
+
+export const schema = z.object({
+  widget: z.literal('quiz'),
+  args: z.object({
+    prompt: z.string().min(1),
+    mode: z.enum(['single', 'multiple', 'choice']),
+    options: optionsAttr,
+    explanation: z.string().optional(),
+  }),
+})
+
+export type QuizWidget = z.infer<typeof schema>
+
+/** The user's persisted answer to a single quiz, stored in the message cache. */
+export type CacheData = QuizCacheEntry
+
+export const parse = createParser(schema)

--- a/src/widgets/quiz/stories.tsx
+++ b/src/widgets/quiz/stories.tsx
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Quiz } from './display'
+import type { QuizData } from './lib'
+
+const meta = {
+  title: 'widgets/quiz',
+  component: Quiz,
+  parameters: {
+    layout: 'centered',
+    viewport: { defaultViewport: 'responsive' },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-xl px-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Quiz>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const singleAnswer: QuizData = {
+  mode: 'single',
+  prompt: 'Which protocol does Thunderbird use to send outgoing mail?',
+  explanation: 'SMTP (Simple Mail Transfer Protocol) handles sending. IMAP and POP3 are for retrieving mail.',
+  options: [
+    { id: 'imap', text: 'IMAP' },
+    { id: 'smtp', text: 'SMTP', isCorrect: true },
+    { id: 'pop3', text: 'POP3' },
+    { id: 'dav', text: 'CalDAV' },
+  ],
+}
+
+const multipleAnswers: QuizData = {
+  mode: 'multiple',
+  prompt: 'Which of these are end-to-end encryption standards supported for email?',
+  explanation: 'Both OpenPGP and S/MIME provide end-to-end encryption. TLS only secures transport.',
+  options: [
+    { id: 'pgp', text: 'OpenPGP', isCorrect: true },
+    { id: 'smime', text: 'S/MIME', isCorrect: true },
+    { id: 'tls', text: 'TLS (transport only)' },
+    { id: 'base64', text: 'Base64 encoding' },
+  ],
+}
+
+const noCorrectAnswer: QuizData = {
+  mode: 'choice',
+  prompt: 'What would you like to do next?',
+  options: [
+    { id: 'draft', text: 'Draft a reply to this thread' },
+    { id: 'summarize', text: 'Summarize the conversation so far' },
+    { id: 'schedule', text: 'Schedule a follow-up for tomorrow' },
+    { id: 'archive', text: 'Archive and move on' },
+  ],
+}
+
+/** One correct answer — radio-style, graded on "Check answer". */
+export const SingleCorrectAnswer: Story = { args: singleAnswer }
+
+/** Multiple correct answers — checkbox-style, all-or-nothing grading. */
+export const MultipleCorrectAnswers: Story = { args: multipleAnswers }
+
+/** No correct answer — an open prompt where the choice itself is the action. */
+export const NoCorrectAnswer: Story = { args: noCorrectAnswer }

--- a/src/widgets/quiz/widget.tsx
+++ b/src/widgets/quiz/widget.tsx
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useDatabase } from '@/contexts'
+import { getMessage, updateMessageCache } from '@/dal/chat-messages'
+import { useQuery } from '@tanstack/react-query'
+
+import { Quiz, type QuizSubmission } from './display'
+import { type QuizCacheEntry, type QuizData, quizStorageKey } from './lib'
+
+type QuizWidgetProps = QuizData & {
+  messageId: string
+}
+
+/**
+ * Connects the presentational {@link Quiz} to the message cache: restores a
+ * prior answer on mount and persists the user's choice on submit. Persisted
+ * entries are later surfaced to the model (see `formatQuizResultsNote`).
+ */
+export const QuizWidget = ({ prompt, mode, options, explanation, messageId }: QuizWidgetProps) => {
+  const db = useDatabase()
+  const storageKey = quizStorageKey(prompt)
+
+  const { data: saved, isPending } = useQuery({
+    queryKey: ['quizState', messageId, storageKey],
+    queryFn: async () => {
+      const message = await getMessage(db, messageId)
+      const cache = message?.cache as Record<string, unknown> | null | undefined
+      return (cache?.[storageKey] as QuizCacheEntry | undefined) ?? null
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+  })
+
+  const handleSubmit = async ({ selectedIds, correct }: QuizSubmission) => {
+    const chosen = selectedIds.map((id) => options.find((o) => o.id === id)?.text ?? id)
+    const entry: QuizCacheEntry = { prompt, mode, selectedIds, chosen, correct }
+    await updateMessageCache(db, messageId, storageKey, entry)
+  }
+
+  // Wait for the cached answer before seeding the (lazy) initial state, so a
+  // restored quiz doesn't briefly flash as unanswered.
+  if (isPending) {
+    return <div className="my-4 h-40 w-full animate-pulse rounded-2xl border border-border bg-card" />
+  }
+
+  return (
+    <Quiz
+      prompt={prompt}
+      mode={mode}
+      options={options}
+      explanation={explanation}
+      initialSelectedIds={saved?.selectedIds}
+      initialSubmitted={saved !== null}
+      onSubmit={handleSubmit}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

Adds a new in-chat **quiz** widget (THU-569, OUP demo) supporting three modes:

- **single** — exactly one correct answer (radio-style)
- **multiple** — one or more correct answers (checkbox-style, all-or-nothing grading)
- **choice** — no correct answer, an open prompt like "What do you want to do next?"

The model emits `<widget:quiz mode="..." prompt="..." options='[...]' explanation="..." />`; structured options ride in as a JSON-encoded attribute.

### Persistence + auto-report
- Answers are persisted to the assistant message's `cache` (keyed `quiz/<prompt>`), so they survive reload and restore the exact UI state (including which wrong option was picked).
- `src/ai/fetch.ts` scans the thread's assistant-message caches and prepends a system note summarizing the user's answers + score — so the model can answer "what did I get?" without asking the user to re-enter their choices.

### Files
- `src/widgets/quiz/` — `schema.ts`, `instructions.ts`, `display.tsx` (pure, Storybook-tested), `widget.tsx` (cache-backed wrapper, the registered `Component`), `lib.ts` (+ unit tests), `stories.tsx`
- `src/widgets/index.ts` — registry entry
- `src/ai/fetch.ts` — quiz-results system note

### Design
Uses existing design language throughout — semantic color tokens, responsive sizing variables, `lucide-react` icons, mobile-first layout, dark mode.

### Tests
`src/widgets/quiz/lib.test.ts` — grading (all modes), cache extraction, note formatting (9 passing). Zero TypeScript errors.

## Notes / follow-ups
- Adds one `getMessage` read per assistant message per turn — fine for normal threads; could batch with `inArray` if threads get very long.
- The results note is included every turn once a quiz is answered (small token cost); could be gated to only when the user asks about results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the AI request path in `fetch.ts` with per-assistant-message `getMessage` reads and extra system prompt tokens; widget/cache logic is otherwise self-contained.
> 
> **Overview**
> Adds an inline **quiz** chat widget (`single`, `multiple`, and ungraded `choice` modes) driven by `<widget:quiz … />` tags, registered in the widget system with model-facing instructions and JSON-validated options.
> 
> User answers are written to the assistant message **`cache`** under `quiz/<prompt>` so the UI restores selection and grading after reload; **`aiFetchStreamingResponse`** now aggregates those cache entries across assistant messages and prepends an ephemeral **quiz results** system note (choices + score) alongside existing skill system messages.
> 
> Includes presentation (`display`), cache-backed wrapper (`widget`), grading/cache helpers with unit tests, and Storybook coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d687aedd321f812ce28e32486d687d637b147299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->