### PR TITLE
test(backend): make proxy WS e2e tests event-driven (load-immune)

### DIFF
--- a/backend/src/proxy/ws-e2e.test.ts
+++ b/backend/src/proxy/ws-e2e.test.ts
@@ -156,7 +156,9 @@ describe('Universal proxy WebSocket relay /v1/proxy/ws — e2e', () => {
     // The per-test timeout below is only a failsafe for a genuine hang.
     const echoed = new Promise<string>((resolve) => {
       client.onmessage = (e: MessageEvent) => {
-        if (e.data === 'echo: hello') resolve(e.data as string)
+        if (e.data === 'echo: hello') {
+          resolve(e.data as string)
+        }
       }
     })
 

--- a/backend/src/proxy/ws-e2e.test.ts
+++ b/backend/src/proxy/ws-e2e.test.ts
@@ -150,12 +150,15 @@ describe('Universal proxy WebSocket relay /v1/proxy/ws — e2e', () => {
       buildProtocols('wss://upstream.test/path', handle.bearerToken, ['acp.v1']),
     )
 
-    const messages: string[] = []
-    // Use onmessage rather than addEventListener: in Bun's same-process WS the
-    // addEventListener path has been observed to drop late-bound 'message' events.
-    client.onmessage = (e: MessageEvent) => {
-      messages.push(typeof e.data === 'string' ? e.data : '')
-    }
+    // Await the echo frame's onmessage callback directly — no fixed wait, no
+    // polling. The assertion is "the echo arrived", not "...within N ms", so
+    // event-loop scheduling latency under load can't starve it into failing.
+    // The per-test timeout below is only a failsafe for a genuine hang.
+    const echoed = new Promise<string>((resolve) => {
+      client.onmessage = (e: MessageEvent) => {
+        if (e.data === 'echo: hello') resolve(e.data as string)
+      }
+    })
 
     await new Promise<void>((resolve, reject) => {
       client.addEventListener('open', () => resolve())
@@ -163,10 +166,9 @@ describe('Universal proxy WebSocket relay /v1/proxy/ws — e2e', () => {
     })
 
     client.send('hello')
-    await new Promise((r) => setTimeout(r, 100))
-    expect(messages).toContain('echo: hello')
+    expect(await echoed).toBe('echo: hello')
     client.close()
-  })
+  }, 15_000)
 
   it('upstream close code propagates through the relay (server-side observation)', async () => {
     // We observe the close on the proxy's relay (where the upstream connection
@@ -178,12 +180,16 @@ describe('Universal proxy WebSocket relay /v1/proxy/ws — e2e', () => {
     })
     upstreams.push(upstream)
 
-    const observed: { code: number | null } = { code: null }
+    // Await the relay's upstream-facing socket onclose directly (the relay
+    // logic is the contract). Awaiting the event rather than polling a deadline
+    // makes the test immune to event-loop scheduling latency under load.
+    let resolveClose!: (code: number) => void
+    const upstreamClosed = new Promise<number>((resolve) => {
+      resolveClose = resolve
+    })
     const upstreamFactory = (_url: string, protocols?: string[]): WebSocket => {
       const ws = new WebSocket(`ws://127.0.0.1:${upstream.port}`, protocols)
-      ws.onclose = (event: CloseEvent) => {
-        observed.code = event.code
-      }
+      ws.onclose = (event: CloseEvent) => resolveClose(event.code)
       return ws
     }
 
@@ -195,21 +201,13 @@ describe('Universal proxy WebSocket relay /v1/proxy/ws — e2e', () => {
       buildProtocols('wss://upstream.test/', handle.bearerToken, ['acp.v1']),
     )
     client.onopen = () => client.send('please close')
-    // Poll for the upstream-side close — Bun's same-process WS doesn't reliably
-    // surface late-binding events on the downstream client, so we observe at
-    // the upstream connection (where the proxy's relay sits) instead.
-    let polls = 0
-    while (observed.code === null && polls < 50) {
-      await new Promise((r) => setTimeout(r, 50))
-      polls++
-    }
-    expect(observed.code).toBe(4321)
+    expect(await upstreamClosed).toBe(4321)
     try {
       client.close()
     } catch {
       /* may already be closed */
     }
-  })
+  }, 15_000)
 
   it('rejects upgrade with HTTP 400 when subprotocol is missing tbproxy.target.*', async () => {
     const upstream = await startUpstreamServer()


### PR DESCRIPTION
## Root cause

The two flaky `proxy/ws — e2e` tests asserted on a **wall-clock deadline** (fixed 100ms wait / 50-iteration poll) for an asynchronous WebSocket round-trip. Under the `--rerun-each 5 --randomize` load (~20k test executions on one Bun event loop), the frame's JS delivery callback gets *scheduled late* — so the deadline expires before the event fires. The test fails not because the relay is wrong, but because the event loop was busy. That couples a deterministic question ("did the relay forward the message?") to a non-deterministic one ("did it happen within N ms?").

## Fix

Await the **actual event** — a promise resolved from `onmessage` / the upstream socket's `onclose` — with a 15s per-test timeout as a failsafe (not a correctness signal). The test now passes the instant the event fires, however long the loop took to get there, and only fails on a genuine hang.

- `relays text messages bidirectionally`: `await echoed` instead of `sleep(100); expect(messages).toContain(...)`.
- `upstream close code propagates`: `await upstreamClosed` instead of polling `observed.code`.

No CI/config changes — the tests stay in the normal randomized 5× run, so a green here proves they're load-*immune*, not just load-*tolerant*. Verified locally at `--rerun-each 10` → 110/110.

## Not in scope
- The `haystack/ws` flake is a *separate, real server race* (frames arriving during the async `open()` get dropped) — fixed by #929's `__pendingMessages` buffering, not by a test change.
- The rate-limit cascade (multi-minute hangs) is also separate (#929's `clearExpiredByTimeout` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in ws-e2e.test.ts; no production proxy or relay logic modified.
> 
> **Overview**
> Two **proxy WebSocket e2e** tests in `ws-e2e.test.ts` no longer use fixed delays or poll loops to observe async behavior. **Bidirectional relay** now resolves a promise from `client.onmessage` when the expected `echo: hello` frame arrives, then asserts on that value. **Upstream close propagation** awaits a promise from the hooked upstream socket’s `onclose` instead of polling `observed.code` for up to ~2.5s.
> 
> Each test gets a **15s Bun timeout** as a hang failsafe only; correctness is tied to the event firing, not a millisecond budget, so heavy randomized reruns are less likely to flake on busy event loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a08469c991f8149661b90fd427621a34d3a936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->