### PR TITLE
fix(ci): isolate test files (--isolate) to deterministically fix backend/frontend flakes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "license": "MPL-2.0",
   "scripts": {
     "test": "bun test --cwd=src --timeout 5000 --randomize && bun test scripts/create-release.test.ts ./.github/scripts/post-pr-metrics.test.js --timeout 5000 --randomize",
-    "test:5x": "bun test --cwd=src --timeout 5000 --randomize --rerun-each 5 && bun test scripts/create-release.test.ts ./.github/scripts/post-pr-metrics.test.js --timeout 5000 --randomize --rerun-each 5",
+    "test:5x": "bun test --cwd=src --timeout 5000 --randomize --rerun-each 5 --isolate && bun test scripts/create-release.test.ts ./.github/scripts/post-pr-metrics.test.js --timeout 5000 --randomize --rerun-each 5 --isolate",
     "test:watch": "bun test --cwd=src --watch",
     "test:backend": "cd backend && bun test --timeout 5000 --randomize",
-    "test:backend:5x": "cd backend && bun test --timeout 5000 --randomize --rerun-each 5",
+    "test:backend:5x": "cd backend && bun test --timeout 5000 --randomize --rerun-each 5 --isolate",
     "test:backend:watch": "cd backend && bun test --watch",
     "start": "vite",
     "dev": "vite",


### PR DESCRIPTION
## Root cause (synthesis)

Backend CI went green→red when same-process WebSocket e2e tests landed (#837 May 22, #905 May 29). But the tests aren't wrong — they're the **canary** for a pre-existing condition: the entire suite runs in **one long-lived Bun process** under `--rerun-each 5` (~20k executions), accumulating pollution (a leaked rate-limit `setTimeout`, a degrading shared PGlite connection, open handles). That pollution degrades Bun's in-process WS event delivery — tipping the WS tests from "late" into "dropped" — and corrupts the shared PGlite connection (the multi-minute cascade hangs). It was green for months only because nothing was fragile enough to trip on the pollution until the WS tests existed.

## Fix

`bun test --isolate` on the two CI test commands. It runs each test file with a fresh global and **isolated handles** ("leaked handles from one file cannot affect another"), so no file inherits the prior tests' pollution — sequentially, so unlike `--parallel` it adds no CPU contention.

- **No product-source changes**, no mocking, no carving-out flaky tests, no test-logic rewrites.
- Addresses the *root* (process pollution), uniformly across the suite.
- Verified locally: the proxy WS subset **passes under `--isolate`** (the same subset that **failed under `--parallel`**); frontend happy-dom tests are `--isolate`-compatible.

## Validation
CI here is the verdict — watching the backend + typescript jobs across the 5× randomized rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only npm script flags for Bun test; no runtime, auth, or product code changes.
> 
> **Overview**
> Adds **`--isolate`** to the CI-heavy **`test:5x`** and **`test:backend:5x`** scripts in `package.json` (both `bun test` invocations in each script).
> 
> That makes Bun run **each test file in a fresh process** so timers, WebSocket state, and shared PGlite connections from earlier files cannot leak into later ones—addressing flakes seen under **`--rerun-each 5`** in a single long-lived process. **No application or test source changes**; only how CI/local 5× runs execute tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2dbe0b2eeb3c92c603961cb6854df90f1d8b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->