### PR TITLE
feat(deploy): wire TINFOIL_API_KEY + TINFOIL_ENCLAVE_URL into preview deploy

### DIFF
--- a/.github/workflows/previews-shared-deploy.yml
+++ b/.github/workflows/previews-shared-deploy.yml
@@ -111,6 +111,7 @@ jobs:
           INPUT_MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           INPUT_THUNDERBOLT_INFERENCE_API_KEY: ${{ secrets.THUNDERBOLT_INFERENCE_API_KEY }}
           INPUT_EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
+          INPUT_TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
         run: |
           pulumi config set version "$INPUT_VERSION" -s "$INPUT_STACK_NAME" --non-interactive
           pulumi config set authHostname "$INPUT_AUTH_HOSTNAME" -s "$INPUT_STACK_NAME" --non-interactive
@@ -130,6 +131,7 @@ jobs:
           [ -n "$INPUT_MISTRAL_API_KEY" ]               && pulumi config set --secret mistralApiKey               "$INPUT_MISTRAL_API_KEY"               -s "$INPUT_STACK_NAME" --non-interactive
           [ -n "$INPUT_THUNDERBOLT_INFERENCE_API_KEY" ] && pulumi config set --secret thunderboltInferenceApiKey "$INPUT_THUNDERBOLT_INFERENCE_API_KEY" -s "$INPUT_STACK_NAME" --non-interactive
           [ -n "$INPUT_EXA_API_KEY" ]                   && pulumi config set --secret exaApiKey                   "$INPUT_EXA_API_KEY"                   -s "$INPUT_STACK_NAME" --non-interactive
+          [ -n "$INPUT_TINFOIL_API_KEY" ]               && pulumi config set --secret tinfoilApiKey              "$INPUT_TINFOIL_API_KEY"               -s "$INPUT_STACK_NAME" --non-interactive
           true
 
       - name: Deploy

--- a/.github/workflows/stack-deploy.yml
+++ b/.github/workflows/stack-deploy.yml
@@ -159,6 +159,8 @@ jobs:
           INPUT_MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           INPUT_THUNDERBOLT_INFERENCE_API_KEY: ${{ secrets.THUNDERBOLT_INFERENCE_API_KEY }}
           INPUT_EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
+          INPUT_TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
+          INPUT_TINFOIL_ENCLAVE_URL: ${{ secrets.TINFOIL_ENCLAVE_URL }}
         run: |
           pulumi config set platform "$INPUT_PLATFORM" -s "$INPUT_STACK_NAME" --non-interactive
           pulumi config set version "$INPUT_VERSION" -s "$INPUT_STACK_NAME" --non-interactive
@@ -191,11 +193,13 @@ jobs:
           # so they propagate into AWS Secrets Manager via services.ts. Only set when
           # non-empty — lets enterprise stacks skip these entirely.
           [ -n "$INPUT_THUNDERBOLT_INFERENCE_URL" ] && pulumi config set thunderboltInferenceUrl "$INPUT_THUNDERBOLT_INFERENCE_URL" -s "$INPUT_STACK_NAME" --non-interactive
+          [ -n "$INPUT_TINFOIL_ENCLAVE_URL" ] && pulumi config set tinfoilEnclaveUrl "$INPUT_TINFOIL_ENCLAVE_URL" -s "$INPUT_STACK_NAME" --non-interactive
           [ -n "$INPUT_ANTHROPIC_API_KEY" ]             && pulumi config set --secret anthropicApiKey             "$INPUT_ANTHROPIC_API_KEY"             -s "$INPUT_STACK_NAME" --non-interactive
           [ -n "$INPUT_FIREWORKS_API_KEY" ]             && pulumi config set --secret fireworksApiKey             "$INPUT_FIREWORKS_API_KEY"             -s "$INPUT_STACK_NAME" --non-interactive
           [ -n "$INPUT_MISTRAL_API_KEY" ]               && pulumi config set --secret mistralApiKey               "$INPUT_MISTRAL_API_KEY"               -s "$INPUT_STACK_NAME" --non-interactive
           [ -n "$INPUT_THUNDERBOLT_INFERENCE_API_KEY" ] && pulumi config set --secret thunderboltInferenceApiKey "$INPUT_THUNDERBOLT_INFERENCE_API_KEY" -s "$INPUT_STACK_NAME" --non-interactive
           [ -n "$INPUT_EXA_API_KEY" ]                   && pulumi config set --secret exaApiKey                   "$INPUT_EXA_API_KEY"                   -s "$INPUT_STACK_NAME" --non-interactive
+          [ -n "$INPUT_TINFOIL_API_KEY" ]               && pulumi config set --secret tinfoilApiKey              "$INPUT_TINFOIL_API_KEY"               -s "$INPUT_STACK_NAME" --non-interactive
           # Unconditional `|| true` prevents the last `[ -n ... ] && ...` from
           # masking non-zero exit when a secret is empty (which is expected).
           true

--- a/deploy/pulumi/index.ts
+++ b/deploy/pulumi/index.ts
@@ -74,6 +74,7 @@ if (isSharedStack) {
       mistralApiKey: config.getSecret('mistralApiKey') ?? pulumi.output(''),
       thunderboltInferenceApiKey: config.getSecret('thunderboltInferenceApiKey') ?? pulumi.output(''),
       exaApiKey: config.getSecret('exaApiKey') ?? pulumi.output(''),
+      tinfoilApiKey: config.getSecret('tinfoilApiKey') ?? pulumi.output(''),
     },
     postgresPassword,
     powersyncDbPassword,
@@ -128,6 +129,7 @@ if (isSharedStack) {
     shared: sharedOutputs,
     betterAuthSecret: betterAuthSecretInput,
     thunderboltInferenceUrl: config.get('thunderboltInferenceUrl'),
+    tinfoilEnclaveUrl: config.get('tinfoilEnclaveUrl'),
   })
 
   module.exports = {
@@ -237,10 +239,13 @@ if (isSharedStack) {
     mistralApiKey: config.getSecret('mistralApiKey') ?? pulumi.output(''),
     thunderboltInferenceApiKey: config.getSecret('thunderboltInferenceApiKey') ?? pulumi.output(''),
     exaApiKey: config.getSecret('exaApiKey') ?? pulumi.output(''),
+    tinfoilApiKey: config.getSecret('tinfoilApiKey') ?? pulumi.output(''),
   }
 
   // Thunderbolt inference gateway URL (not a secret; set per-stack)
   const thunderboltInferenceUrl = config.get('thunderboltInferenceUrl') ?? ''
+  // Tinfoil confidential-inference enclave URL (not a secret; set per-stack)
+  const tinfoilEnclaveUrl = config.get('tinfoilEnclaveUrl') ?? ''
 
   // Shared: VPC (both platforms need this)
   const { vpc, publicSubnets, privateSubnets, albSg, servicesSg } = createVpc(name)
@@ -325,6 +330,7 @@ if (isSharedStack) {
       ghcrToken: config.getSecret('ghcrToken'),
       publicUrls,
       thunderboltInferenceUrl,
+      tinfoilEnclaveUrl,
       behindCloudflareProxy: hasSubdomainRouting,
       albListener: listener,
       targetGroups: {

--- a/deploy/pulumi/src/per-pr-stack.ts
+++ b/deploy/pulumi/src/per-pr-stack.ts
@@ -39,6 +39,8 @@ export type PerPrStackArgs = {
   betterAuthSecret: pulumi.Output<string>
   /** Optional thunderbolt inference URL — same value across all stacks today. */
   thunderboltInferenceUrl?: pulumi.Input<string>
+  /** Optional Tinfoil enclave URL — same value across all stacks today. */
+  tinfoilEnclaveUrl?: pulumi.Input<string>
 }
 
 export type PerPrStackOutputs = {
@@ -307,6 +309,7 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
             shared.mistralApiKeySecretArn,
             shared.thunderboltInferenceApiKeySecretArn,
             shared.exaApiKeySecretArn,
+            shared.tinfoilApiKeySecretArn,
           ],
         },
       ],
@@ -358,6 +361,7 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
           { name: 'POWERSYNC_JWT_KID', value: 'enterprise-powersync' },
           { name: 'RATE_LIMIT_ENABLED', value: 'true' },
           { name: 'THUNDERBOLT_INFERENCE_URL', value: args.thunderboltInferenceUrl ?? '' },
+          { name: 'TINFOIL_ENCLAVE_URL', value: args.tinfoilEnclaveUrl ?? '' },
           { name: 'TRUSTED_PROXY', value: 'cloudflare' },
         ],
         secrets: [
@@ -371,6 +375,7 @@ export const createPerPrStack = (args: PerPrStackArgs): PerPrStackOutputs => {
           { name: 'MISTRAL_API_KEY', valueFrom: shared.mistralApiKeySecretArn },
           { name: 'THUNDERBOLT_INFERENCE_API_KEY', valueFrom: shared.thunderboltInferenceApiKeySecretArn },
           { name: 'EXA_API_KEY', valueFrom: shared.exaApiKeySecretArn },
+          { name: 'TINFOIL_API_KEY', valueFrom: shared.tinfoilApiKeySecretArn },
         ],
         portMappings: [{ containerPort: 8000 }],
         logConfiguration: logConfig('backend'),

--- a/deploy/pulumi/src/services.ts
+++ b/deploy/pulumi/src/services.ts
@@ -26,6 +26,7 @@ type Secrets = {
   mistralApiKey: pulumi.Output<string>
   thunderboltInferenceApiKey: pulumi.Output<string>
   exaApiKey: pulumi.Output<string>
+  tinfoilApiKey: pulumi.Output<string>
 }
 
 type ServiceArgs = {
@@ -60,6 +61,8 @@ type ServiceArgs = {
   }
   /** URL for the Thunderbolt inference gateway (env: THUNDERBOLT_INFERENCE_URL). Optional. */
   thunderboltInferenceUrl?: pulumi.Input<string>
+  /** URL for the Tinfoil confidential-inference enclave (env: TINFOIL_ENCLAVE_URL). Optional. */
+  tinfoilEnclaveUrl?: pulumi.Input<string>
   /**
    * When true, backend runs behind a proxy whose X-Forwarded-* headers we trust
    * for client IP extraction (Cloudflare edge for preview stacks).
@@ -389,6 +392,9 @@ export const createServices = (args: ServiceArgs) => {
     exaApiKey: new aws.secretsmanager.Secret(`${name}-exa-api-key`, {
       tags: { Name: `${name}-exa-api-key` },
     }),
+    tinfoilApiKey: new aws.secretsmanager.Secret(`${name}-tinfoil-api-key`, {
+      tags: { Name: `${name}-tinfoil-api-key` },
+    }),
   }
 
   new aws.secretsmanager.SecretVersion(`${name}-oidc-secret-version`, {
@@ -427,6 +433,10 @@ export const createServices = (args: ServiceArgs) => {
     secretId: backendSecrets.exaApiKey.id,
     secretString: args.secrets.exaApiKey,
   })
+  new aws.secretsmanager.SecretVersion(`${name}-tinfoil-api-key-version`, {
+    secretId: backendSecrets.tinfoilApiKey.id,
+    secretString: args.secrets.tinfoilApiKey,
+  })
 
   new aws.iam.RolePolicy(`${name}-exec-backend-secrets-policy`, {
     role: execRoleInstance.name,
@@ -447,6 +457,7 @@ export const createServices = (args: ServiceArgs) => {
           backendSecrets.mistralApiKey.arn,
           backendSecrets.thunderboltInferenceApiKey.arn,
           backendSecrets.exaApiKey.arn,
+          backendSecrets.tinfoilApiKey.arn,
         ],
       }],
     }),
@@ -490,6 +501,7 @@ export const createServices = (args: ServiceArgs) => {
           { name: 'POWERSYNC_JWT_KID', value: 'enterprise-powersync' },
           { name: 'RATE_LIMIT_ENABLED', value: 'true' },
           { name: 'THUNDERBOLT_INFERENCE_URL', value: args.thunderboltInferenceUrl ?? '' },
+          { name: 'TINFOIL_ENCLAVE_URL', value: args.tinfoilEnclaveUrl ?? '' },
           // Cloudflare terminates TLS for preview stacks — trust its CF-Connecting-IP
           // header for rate limiting. Enterprise stacks leave this unset (direct socket IP).
           { name: 'TRUSTED_PROXY', value: args.behindCloudflareProxy ? 'cloudflare' : '' },
@@ -504,6 +516,7 @@ export const createServices = (args: ServiceArgs) => {
           { name: 'MISTRAL_API_KEY', valueFrom: backendSecrets.mistralApiKey.arn },
           { name: 'THUNDERBOLT_INFERENCE_API_KEY', valueFrom: backendSecrets.thunderboltInferenceApiKey.arn },
           { name: 'EXA_API_KEY', valueFrom: backendSecrets.exaApiKey.arn },
+          { name: 'TINFOIL_API_KEY', valueFrom: backendSecrets.tinfoilApiKey.arn },
         ],
         portMappings: [{ containerPort: 8000 }],
         logConfiguration: logConfig('backend'),

--- a/deploy/pulumi/src/shared.ts
+++ b/deploy/pulumi/src/shared.ts
@@ -46,6 +46,7 @@ export type SharedStackArgs = {
     mistralApiKey: pulumi.Output<string>
     thunderboltInferenceApiKey: pulumi.Output<string>
     exaApiKey: pulumi.Output<string>
+    tinfoilApiKey: pulumi.Output<string>
   }
   /** Postgres admin password (random per shared-stack; persisted in Pulumi state). */
   postgresPassword: pulumi.Output<string>
@@ -133,6 +134,7 @@ export type SharedStackOutputs = {
   mistralApiKeySecretArn: pulumi.Output<string>
   thunderboltInferenceApiKeySecretArn: pulumi.Output<string>
   exaApiKeySecretArn: pulumi.Output<string>
+  tinfoilApiKeySecretArn: pulumi.Output<string>
 }
 
 const NAMESPACE_DOMAIN = 'thunderbolt.local'
@@ -370,6 +372,7 @@ export const createSharedStack = (args: SharedStackArgs): SharedStackOutputs => 
     ['mistralApiKey', `${name}-mistral-api-key`],
     ['thunderboltInferenceApiKey', `${name}-tb-inference-api-key`],
     ['exaApiKey', `${name}-exa-api-key`],
+    ['tinfoilApiKey', `${name}-tinfoil-api-key`],
   ]
   const aiSecretArns: Record<keyof SharedStackArgs['aiSecrets'], pulumi.Output<string>> = {} as ReturnType<typeof Object>
   for (const [key, secretName] of aiSecretSpecs) {
@@ -600,6 +603,7 @@ export const createSharedStack = (args: SharedStackArgs): SharedStackOutputs => 
     mistralApiKeySecretArn: aiSecretArns.mistralApiKey,
     thunderboltInferenceApiKeySecretArn: aiSecretArns.thunderboltInferenceApiKey,
     exaApiKeySecretArn: aiSecretArns.exaApiKey,
+    tinfoilApiKeySecretArn: aiSecretArns.tinfoilApiKey,
   }
 }
 
@@ -646,5 +650,6 @@ export const loadSharedStackOutputs = (ref: pulumi.StackReference): SharedStackO
     mistralApiKeySecretArn: get<string>('mistralApiKeySecretArn'),
     thunderboltInferenceApiKeySecretArn: get<string>('thunderboltInferenceApiKeySecretArn'),
     exaApiKeySecretArn: get<string>('exaApiKeySecretArn'),
+    tinfoilApiKeySecretArn: get<string>('tinfoilApiKeySecretArn'),
   }
 }


### PR DESCRIPTION
## What

Threads two new environment variables into the **preview / per-PR Fargate backend** containers so the Tinfoil confidential-inference integration has its config in preview environments:

- **`TINFOIL_API_KEY`** — sensitive → AWS Secrets Manager, mirroring the `exaApiKey` path end-to-end.
- **`TINFOIL_ENCLAVE_URL`** — non-secret → plain container env, mirroring `thunderboltInferenceUrl`.

## Files

- `.github/workflows/stack-deploy.yml` — reads `secrets.TINFOIL_API_KEY` / `secrets.TINFOIL_ENCLAVE_URL` → `pulumi config set` (`--secret` for the key).
- `deploy/pulumi/index.ts` — threads both into the shared-stack and per-PR/monolithic paths.
- `deploy/pulumi/src/shared.ts` — secret in the shared AI-secrets set + ARN output + StackReference reader.
- `deploy/pulumi/src/services.ts` — Secrets Manager secret + version + IAM + container env (key); plain env (URL).
- `deploy/pulumi/src/per-pr-stack.ts` — shared ARN in IAM + container env (key); plain env (URL).

## Notes

- **GitHub secrets** (`preview` + `production` environments) are set out-of-band: `TINFOIL_API_KEY` (both), `TINFOIL_ENCLAVE_URL` (both).
- **Backend consumption** (`settings.ts` reading `process.env.TINFOIL_*`) lands in a separate PR — this change is deploy-plumbing only.
- No production backend-deploy workflow exists in-repo; this wires the preview path. The `production`-env secret is staged for whatever deploys prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-only secret/env plumbing following existing AI provider patterns; optional when secrets are unset and no runtime auth logic changes in this PR.
> 
> **Overview**
> Adds **Tinfoil** configuration to preview/Pulumi deploy paths so Fargate backends can receive **`TINFOIL_API_KEY`** and **`TINFOIL_ENCLAVE_URL`** before application code reads them.
> 
> GitHub Actions now maps **`secrets.TINFOIL_API_KEY`** (and **`TINFOIL_ENCLAVE_URL`** on `stack-deploy`) into Pulumi config (`tinfoilApiKey` as a secret, `tinfoilEnclaveUrl` as plain config). **`previews-shared-deploy`** only wires the API key into the shared stack’s AI secrets, matching other provider keys.
> 
> Pulumi threads the key through **`previews-shared`** (Secrets Manager + `tinfoilApiKeySecretArn` on StackReference), **per-PR** backends (IAM + `TINFOIL_API_KEY` secret ref), and **monolithic** `services.ts` (new secret, version, exec IAM, container env). **`TINFOIL_ENCLAVE_URL`** is passed as a non-secret env var on per-PR and monolithic backends, parallel to `THUNDERBOLT_INFERENCE_URL`. No backend `settings.ts` changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c02ae3d5a52e41348c3cd17fbef2866a29dbf03b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->