### PR TITLE
fix(THU-581): pass --repo to gh release edit in desktop publish job

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -368,7 +368,7 @@ jobs:
           PRERELEASE: ${{ inputs.nightly }}
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          gh release edit "v${RELEASE_VERSION}" --draft=false --prerelease="${PRERELEASE}"
+          gh release edit "v${RELEASE_VERSION}" --repo "${{ github.repository }}" --draft=false --prerelease="${PRERELEASE}"
 
       # Publish release on CrabNebula Cloud for auto-updates (skip for nightly to prevent unstable auto-updates)
       - name: Publish to CrabNebula Cloud


### PR DESCRIPTION
The `Publish Release` job in `.github/workflows/desktop-release.yml` was failing on every run with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `publish` job runs `gh release edit` without checking out the repo, and `gh` resolves the target repo from the local git remote — so without a checkout it can't determine which repo to operate on. Desktop releases were stuck in draft.

Passes `--repo "${{ github.repository }}"` to `gh release edit` so it doesn't need a local git context.

## Test plan

- [ ] Next nightly run completes the `Publish Release` job successfully.
- [ ] Resulting GitHub release is marked as prerelease (nightly) and not a draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow change with no application or security impact.
> 
> **Overview**
> Fixes the **Publish Release** job in `desktop-release.yml` so `gh release edit` can run without a repository checkout.
> 
> The publish job only runs `gh release edit` on a clean runner; `gh` used to infer the repo from local git and failed with *not a git repository*, leaving desktop releases stuck as drafts. The command now passes **`--repo "${{ github.repository }}"`** so the correct release is finalized (draft cleared, prerelease flag applied for nightlies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab8572359c7f4ded601887aa965da0df9bed383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->