### PR TITLE
fix(THU-583): unstick "Reset to default" and stuck PATCH uploads

### DIFF
--- a/backend/src/api/powersync.test.ts
+++ b/backend/src/api/powersync.test.ts
@@ -1212,6 +1212,63 @@ describe('PowerSync API', () => {
       expect(rows[0]?.value).toBe('unchanged')
     })
 
+    it('returns 200 for PATCH that contains only stripped fields (e.g. only user_id)', async () => {
+      // A buggy client (such as `resetModelToDefault` pre-fix) can queue a
+      // PATCH whose only field is server-managed (e.g. `{ user_id: null }`).
+      // The handler must treat the post-strip empty patch as a no-op success
+      // so the client's CRUD queue can drain — returning 400 would loop the
+      // upload and block every subsequent write behind it.
+      const userId = 'user-patch-only-stripped'
+      const now = new Date()
+      const expiresAt = new Date(now.getTime() + 3600 * 1000)
+
+      await db.insert(userTable).values({
+        id: userId,
+        name: 'Stripped Patch User',
+        email: 'patch-stripped@example.com',
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await db.insert(sessionTable).values({
+        id: 'session-patch-stripped',
+        expiresAt,
+        token: 'bearer-patch-stripped',
+        createdAt: now,
+        updatedAt: now,
+        userId,
+      })
+      await insertTrustedDevice('test-device-id', userId)
+      await db.insert(settingsTable).values({
+        key: 'stripped_patch_setting',
+        value: 'unchanged',
+        userId,
+      })
+
+      const response = await app.handle(
+        new Request('http://localhost/powersync/upload', {
+          method: 'PUT',
+          headers: uploadHeaders('bearer-patch-stripped'),
+          body: JSON.stringify({
+            operations: [
+              {
+                op: 'PATCH' as const,
+                type: 'settings',
+                id: 'stripped_patch_setting',
+                data: { user_id: null },
+              },
+            ],
+          }),
+        }),
+      )
+      expect(response.status).toBe(200)
+
+      const rows = await db.select().from(settingsTable).where(eq(settingsTable.key, 'stripped_patch_setting'))
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.value).toBe('unchanged')
+      expect(rows[0]?.userId).toBe(userId)
+    })
+
     it('returns 400 when PATCH targets non-existent record', async () => {
       const userId = 'user-patch-nonexistent'
       const now = new Date()

--- a/backend/src/dal/powersync.ts
+++ b/backend/src/dal/powersync.ts
@@ -127,8 +127,13 @@ export const applyOperation = async (
         delete patchPayload[col]
       }
       const schemaPatch = toSchemaRecord(patchPayload, validDbNames, dbNameToKey)
+      // Empty patch after stripping server-managed and unknown columns is a
+      // harmless no-op (e.g. a buggy client that only sent `{ user_id: null }`).
+      // Accept it so the client's CRUD queue can drain instead of looping on a
+      // 400 — refusing it would block every subsequent upload behind a write
+      // that has nothing to apply anyway.
       if (Object.keys(schemaPatch).length === 0) {
-        return false
+        return true
       }
 
       const patched = await database

--- a/src/dal/models.test.ts
+++ b/src/dal/models.test.ts
@@ -15,7 +15,8 @@ import {
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
-import { defaultModelGptOss120b } from '@/defaults/models'
+import { defaultModelGptOss120b, hashModel } from '@/defaults/models'
+import { isModelModified } from '@/defaults/utils'
 import type { Model } from '@/types'
 import {
   createModel,
@@ -27,6 +28,7 @@ import {
   getSelectedModel,
   getSelectedModelQuery,
   getSystemModel,
+  resetModelToDefault,
   updateModel,
 } from './models'
 import { getAllPrompts, getPrompt } from './prompts'
@@ -925,6 +927,64 @@ describe('Models DAL', () => {
       const rawModel = await db.select().from(modelsTable).where(eq(modelsTable.id, modelId)).get()
       expect(rawModel?.defaultHash).toBe('original-hash')
       expect(rawModel?.name).toBe('Updated')
+    })
+  })
+
+  describe('resetModelToDefault', () => {
+    it('restores default fields and refreshes defaultHash', async () => {
+      const db = getDb()
+      const defaultModel = defaultModelGptOss120b
+
+      await db.insert(modelsTable).values({
+        ...defaultModel,
+        name: 'User Edited Name',
+        enabled: 0,
+        defaultHash: 'stale-from-an-older-era',
+      })
+
+      const before = (await db.select().from(modelsTable).where(eq(modelsTable.id, defaultModel.id)).get()) as Model
+      expect(isModelModified(before)).toBe(true)
+
+      await resetModelToDefault(getDb(), defaultModel.id, defaultModel)
+
+      const after = (await db.select().from(modelsTable).where(eq(modelsTable.id, defaultModel.id)).get()) as Model
+      expect(after.name).toBe(defaultModel.name)
+      expect(after.enabled).toBe(defaultModel.enabled)
+      expect(after.defaultHash).toBe(hashModel(defaultModel))
+      expect(isModelModified(after)).toBe(false)
+    })
+
+    it('clears the local-only api key on reset', async () => {
+      const db = getDb()
+      const defaultModel = defaultModelGptOss120b
+
+      await db.insert(modelsTable).values({ ...defaultModel })
+      await db.insert(modelsSecretsTable).values({ modelId: defaultModel.id, apiKey: 'sk-user-supplied' })
+
+      await resetModelToDefault(getDb(), defaultModel.id, defaultModel)
+
+      const secret = await db
+        .select()
+        .from(modelsSecretsTable)
+        .where(eq(modelsSecretsTable.modelId, defaultModel.id))
+        .get()
+      expect(secret).toBeUndefined()
+    })
+
+    it('preserves the row userId (does not overwrite with null from the default template)', async () => {
+      const db = getDb()
+      const defaultModel = defaultModelGptOss120b
+
+      // The default template carries `userId: null`. A row that has already
+      // been synced has a real user_id — reset must not overwrite it, otherwise
+      // PowerSync queues a `{ user_id: null }` PATCH that the upload handler
+      // rejects (it strips user_id, leaving an empty payload → 400).
+      await db.insert(modelsTable).values({ ...defaultModel, userId: 'real-user-id' })
+
+      await resetModelToDefault(getDb(), defaultModel.id, defaultModel)
+
+      const after = (await db.select().from(modelsTable).where(eq(modelsTable.id, defaultModel.id)).get()) as Model
+      expect(after.userId).toBe('real-user-id')
     })
   })
 

--- a/src/dal/models.ts
+++ b/src/dal/models.ts
@@ -5,6 +5,7 @@
 import { and, desc, eq, getTableColumns, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { modelsSecretsTable, modelsTable, settingsTable } from '../db/tables'
+import { hashModel } from '../defaults/models'
 import { clearNullableColumns, nowIso } from '../lib/utils'
 import type { DrizzleQueryWithPromise, Model } from '@/types'
 import { getLastMessage } from './chat-messages'
@@ -156,12 +157,20 @@ export const updateModel = async (db: AnyDrizzleDatabase, id: string, updates: P
 }
 
 /**
- * Reset a model to its default state
+ * Reset a model to its default state. Recomputes `defaultHash` so that any
+ * legacy/stale value left over from a previous `hashModel` formula is replaced
+ * with the current one — otherwise `isModelModified` would keep flagging the
+ * row as modified even right after a reset. `userId` is stripped from the
+ * default template so we never overwrite the row's real owner with `null`
+ * (which would surface as an empty PATCH and a 400 from the upload handler).
  */
 export const resetModelToDefault = async (db: AnyDrizzleDatabase, id: string, defaultModel: Model): Promise<void> => {
-  const { defaultHash, apiKey, ...defaultFields } = defaultModel
+  const { defaultHash, apiKey, userId, ...defaultFields } = defaultModel
   await db.transaction(async (tx) => {
-    await tx.update(modelsTable).set(defaultFields).where(eq(modelsTable.id, id))
+    await tx
+      .update(modelsTable)
+      .set({ ...defaultFields, defaultHash: hashModel(defaultModel) })
+      .where(eq(modelsTable.id, id))
     await tx.delete(modelsSecretsTable).where(eq(modelsSecretsTable.modelId, id))
   })
 }

--- a/src/dal/prompts.test.ts
+++ b/src/dal/prompts.test.ts
@@ -331,6 +331,47 @@ describe('Prompts DAL', () => {
         expect(currentHash).toBe(automation.defaultHash!)
       }
     })
+
+    it('refreshes a stale defaultHash (e.g. from a previous hashPrompt formula)', async () => {
+      const db = getDb()
+      const defaultAutomation = defaultAutomations[0]
+
+      // Simulate a row whose defaultHash was stamped under an older hashPrompt
+      // formula — reset must overwrite it, not preserve it.
+      await db
+        .update(promptsTable)
+        .set({ defaultHash: 'stale-from-an-older-era' })
+        .where(eq(promptsTable.id, defaultAutomation.id))
+
+      await resetAutomationToDefault(getDb(), defaultAutomation.id, defaultAutomation)
+
+      const automation = (await db
+        .select()
+        .from(promptsTable)
+        .where(eq(promptsTable.id, defaultAutomation.id))
+        .get()) as Prompt
+      expect(automation?.defaultHash).toBe(hashPrompt(defaultAutomation))
+      expect(hashPrompt(automation)).toBe(automation.defaultHash!)
+    })
+
+    it('preserves the row userId (does not overwrite with null from the default template)', async () => {
+      const db = getDb()
+      const defaultAutomation = defaultAutomations[0]
+
+      // The default template carries `userId: null`. Reset must leave the
+      // row's real user_id intact — otherwise PowerSync queues a
+      // `{ user_id: null }` PATCH that the upload handler rejects.
+      await db.update(promptsTable).set({ userId: 'real-user-id' }).where(eq(promptsTable.id, defaultAutomation.id))
+
+      await resetAutomationToDefault(getDb(), defaultAutomation.id, defaultAutomation)
+
+      const automation = (await db
+        .select()
+        .from(promptsTable)
+        .where(eq(promptsTable.id, defaultAutomation.id))
+        .get()) as Prompt
+      expect(automation?.userId).toBe('real-user-id')
+    })
   })
 
   describe('createAutomation', () => {

--- a/src/dal/prompts.ts
+++ b/src/dal/prompts.ts
@@ -6,6 +6,7 @@ import { and, asc, eq, isNull, like } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { chatMessagesTable, chatThreadsTable, promptsTable } from '../db/tables'
+import { hashPrompt } from '../defaults/automations'
 import type { AutomationRun, Prompt } from '../types'
 import { clearNullableColumns, convertUIMessageToDbChatMessage, nowIso } from '../lib/utils'
 import { getModel } from './models'
@@ -76,15 +77,24 @@ export const updateAutomation = async (db: AnyDrizzleDatabase, id: string, updat
 }
 
 /**
- * Reset an automation to its default state
+ * Reset an automation to its default state. Recomputes `defaultHash` so that
+ * any legacy/stale value left over from a previous `hashPrompt` formula is
+ * replaced with the current one — otherwise `isAutomationModified` would keep
+ * flagging the row as modified even right after a reset. `userId` is stripped
+ * from the default template so we never overwrite the row's real owner with
+ * `null` (which would surface as an empty PATCH and a 400 from the upload
+ * handler).
  */
 export const resetAutomationToDefault = async (
   db: AnyDrizzleDatabase,
   id: string,
   defaultAutomation: Prompt,
 ): Promise<void> => {
-  const { defaultHash, ...defaultFields } = defaultAutomation
-  await db.update(promptsTable).set(defaultFields).where(eq(promptsTable.id, id))
+  const { defaultHash, userId, ...defaultFields } = defaultAutomation
+  await db
+    .update(promptsTable)
+    .set({ ...defaultFields, defaultHash: hashPrompt(defaultAutomation) })
+    .where(eq(promptsTable.id, id))
 }
 
 /**


### PR DESCRIPTION
## Problem

Two coupled bugs in `resetModelToDefault` (same shape in `resetAutomationToDefault`):

1. **Stale `defaultHash`.** Reset wrote default field values but never recomputed `defaultHash`. After a `hashModel` shape change (PR #858 removed `apiKey` from the array), `isModelModified` kept returning `true` post-reset — badge never cleared, the button looked dead.
2. **`{ user_id: null }` upload 400.** The default template has `userId: null`. Reset spread it over the row's real `user_id`. PowerSync queued a PATCH the backend rejects (`user_id` is stripped → empty payload → 400 → CRUD queue stuck). Latent in prod since PR #858.

## Changes

- **Backend** (`125ebc9d`): empty `schemaPatch` returns 200 (was 400). Empty patches must drain, not loop.
- **Frontend** (`845551dd`): `resetModelToDefault` / `resetAutomationToDefault` strip `userId` and explicitly write a fresh `defaultHash`.
- Tests cover stale-hash refresh, `userId` preservation, api-key clear, and the empty-PATCH 200.

## Ship order

Backend first (or together). Once backend tolerates empty PATCHes, existing stuck `ps_crud` ops drain on next connect; frontend fix prevents new ones.

## Test plan

- [ ] `bun test src/dal/models.test.ts src/dal/prompts.test.ts` → 65 pass
- [ ] `cd backend && bun test src/api/powersync.test.ts` → 63 pass
- [ ] `make check` → 0 errors
- [ ] Manual: stale `default_hash` row → click Reset → badge clears, no `{ user_id: null }` upload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 845551ddc4b15c1138d4f39ae1c31f610fdd419e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->