### PR TITLE
fix(THU-580): cache Better Auth session so app boots offline

### DIFF
--- a/src/contexts/auth-context.test.ts
+++ b/src/contexts/auth-context.test.ts
@@ -5,6 +5,7 @@
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { powersyncCredentialsInvalid } from '@/db/powersync/connector'
 import { clearAuthToken, getAuthToken, setAuthToken } from '@/lib/auth-token'
+import { clearCachedSession, getCachedSession, setCachedSession } from '@/lib/session-cache'
 import { createMockAuthClient } from '@/test-utils/auth-client'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { cleanup, render } from '@testing-library/react'
@@ -12,6 +13,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock 
 import { buildFetchOptions } from './auth-context'
 
 const authTokenKey = 'thunderbolt_auth_token'
+const sessionCacheKey = 'thunderbolt_session_cache'
 
 const fireStorageEvent = (newValue: string | null, oldValue: string | null) => {
   window.dispatchEvent(
@@ -33,11 +35,13 @@ describe('buildFetchOptions onError', () => {
     dispatchSpy = mock(() => true)
     window.dispatchEvent = dispatchSpy as unknown as typeof window.dispatchEvent
     clearAuthToken()
+    clearCachedSession()
   })
 
   afterEach(() => {
     window.dispatchEvent = originalDispatch
     clearAuthToken()
+    clearCachedSession()
   })
 
   const trigger401 = () => {
@@ -73,6 +77,24 @@ describe('buildFetchOptions onError', () => {
 
     expect(getAuthToken()).toBe('valid-token')
     expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('clears the cached session on 401 so a future offline boot does not show stale data', () => {
+    setAuthToken('stale-token')
+    setCachedSession({ user: { id: '1' }, session: { id: 's1' } })
+
+    trigger401()
+
+    expect(localStorage.getItem(sessionCacheKey)).toBeNull()
+    expect(getCachedSession()).toBeNull()
+  })
+
+  it('clears the cached session on 401 even when no token was stored', () => {
+    setCachedSession({ user: { id: '1' } })
+
+    trigger401()
+
+    expect(getCachedSession()).toBeNull()
   })
 })
 

--- a/src/contexts/auth-context.test.ts
+++ b/src/contexts/auth-context.test.ts
@@ -10,7 +10,7 @@ import { createMockAuthClient } from '@/test-utils/auth-client'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { cleanup, render } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { buildFetchOptions, hydrateSessionFromCache } from './auth-context'
+import { buildFetchOptions, hydrateSessionFromCache, subscribeSessionCachePersist } from './auth-context'
 import type { createAuthClient } from 'better-auth/react'
 
 const authTokenKey = 'thunderbolt_auth_token'
@@ -170,6 +170,79 @@ describe('hydrateSessionFromCache', () => {
     hydrateSessionFromCache(createFakeClient(atom))
 
     expect(atom.get().data).toBeNull()
+    expect(getCachedSession()).toBeNull()
+  })
+})
+
+describe('subscribeSessionCachePersist', () => {
+  type Listener = (state: { data: unknown }) => void
+
+  const createFakeSubscribableAtom = () => {
+    const listeners = new Set<Listener>()
+    return {
+      emit: (state: { data: unknown }) => {
+        listeners.forEach((l) => l(state))
+      },
+      subscribe: (l: Listener) => {
+        listeners.add(l)
+        return () => {
+          listeners.delete(l)
+        }
+      },
+      size: () => listeners.size,
+    }
+  }
+
+  const createFakeClient = (atom: ReturnType<typeof createFakeSubscribableAtom>) =>
+    ({
+      $store: { atoms: { session: atom } },
+    }) as unknown as ReturnType<typeof createAuthClient>
+
+  beforeEach(() => {
+    clearCachedSession()
+  })
+
+  afterEach(() => {
+    clearCachedSession()
+  })
+
+  it('persists payloads that carry both user and session', () => {
+    const atom = createFakeSubscribableAtom()
+    subscribeSessionCachePersist(createFakeClient(atom))
+
+    const payload = { user: { id: 'u1' }, session: { id: 's1', expiresAt: new Date().toISOString() } }
+    atom.emit({ data: payload })
+
+    expect(getCachedSession()).toEqual(payload)
+  })
+
+  it('does not persist when data is null (initial / signed-out state)', () => {
+    const atom = createFakeSubscribableAtom()
+    subscribeSessionCachePersist(createFakeClient(atom))
+
+    atom.emit({ data: null })
+
+    expect(getCachedSession()).toBeNull()
+  })
+
+  it('does not persist when user or session are null (empty payload)', () => {
+    const atom = createFakeSubscribableAtom()
+    subscribeSessionCachePersist(createFakeClient(atom))
+
+    atom.emit({ data: { user: null, session: null } })
+
+    expect(getCachedSession()).toBeNull()
+  })
+
+  it('unsubscribe stops further writes to the cache', () => {
+    const atom = createFakeSubscribableAtom()
+    const unsubscribe = subscribeSessionCachePersist(createFakeClient(atom))
+    expect(atom.size()).toBe(1)
+
+    unsubscribe()
+    expect(atom.size()).toBe(0)
+
+    atom.emit({ data: { user: { id: 'u1' }, session: { id: 's1' } } })
     expect(getCachedSession()).toBeNull()
   })
 })

--- a/src/contexts/auth-context.test.ts
+++ b/src/contexts/auth-context.test.ts
@@ -10,7 +10,8 @@ import { createMockAuthClient } from '@/test-utils/auth-client'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { cleanup, render } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { buildFetchOptions } from './auth-context'
+import { buildFetchOptions, hydrateSessionFromCache } from './auth-context'
+import type { createAuthClient } from 'better-auth/react'
 
 const authTokenKey = 'thunderbolt_auth_token'
 const sessionCacheKey = 'thunderbolt_session_cache'
@@ -98,6 +99,81 @@ describe('buildFetchOptions onError', () => {
   })
 })
 
+describe('hydrateSessionFromCache', () => {
+  type AtomState = { data: unknown; isPending: boolean }
+
+  const createFakeAtom = (initial: AtomState = { data: null, isPending: true }) => {
+    let state: AtomState = initial
+    return {
+      get: () => state,
+      set: (next: AtomState) => {
+        state = next
+      },
+    }
+  }
+
+  const createFakeClient = (atom: ReturnType<typeof createFakeAtom>) =>
+    ({
+      $store: { atoms: { session: atom } },
+    }) as unknown as ReturnType<typeof createAuthClient>
+
+  const future = () => new Date(Date.now() + 60_000).toISOString()
+  const past = () => new Date(Date.now() - 60_000).toISOString()
+
+  beforeEach(() => {
+    clearAuthToken()
+    clearCachedSession()
+  })
+
+  afterEach(() => {
+    clearAuthToken()
+    clearCachedSession()
+  })
+
+  it('seeds the atom when token and non-expired cache are present', () => {
+    setAuthToken('t')
+    const cached = { user: { id: 'u1' }, session: { id: 's1', expiresAt: future() } }
+    setCachedSession(cached)
+    const atom = createFakeAtom()
+
+    hydrateSessionFromCache(createFakeClient(atom))
+
+    expect(atom.get().data).toEqual(cached)
+    expect(atom.get().isPending).toBe(false)
+  })
+
+  it('does not seed when no token is stored', () => {
+    setCachedSession({ user: { id: 'u1' }, session: { expiresAt: future() } })
+    const atom = createFakeAtom()
+
+    hydrateSessionFromCache(createFakeClient(atom))
+
+    expect(atom.get().data).toBeNull()
+    expect(atom.get().isPending).toBe(true)
+  })
+
+  it('does not seed when the cache is empty', () => {
+    setAuthToken('t')
+    const atom = createFakeAtom()
+
+    hydrateSessionFromCache(createFakeClient(atom))
+
+    expect(atom.get().data).toBeNull()
+    expect(atom.get().isPending).toBe(true)
+  })
+
+  it('drops and clears expired caches without seeding', () => {
+    setAuthToken('t')
+    setCachedSession({ user: { id: 'u1' }, session: { expiresAt: past() } })
+    const atom = createFakeAtom()
+
+    hydrateSessionFromCache(createFakeClient(atom))
+
+    expect(atom.get().data).toBeNull()
+    expect(getCachedSession()).toBeNull()
+  })
+})
+
 describe('AuthProvider — cross-tab auth-token listener', () => {
   beforeAll(async () => {
     await setupTestDatabase()
@@ -149,6 +225,16 @@ describe('AuthProvider — cross-tab auth-token listener', () => {
 
     expect(reloadSpy).toHaveBeenCalledTimes(1)
     expect(capturedEvents).toHaveLength(0)
+  })
+
+  it('clears the cached session before reloading on cross-tab token rotation', () => {
+    setCachedSession({ user: { id: 'u1' }, session: { expiresAt: new Date(Date.now() + 60_000).toISOString() } })
+    renderAuthProvider()
+
+    fireStorageEvent('new-token', 'old-token')
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(getCachedSession()).toBeNull()
   })
 
   it('dispatches session_expired when another tab clears the token', () => {

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -8,7 +8,7 @@ import { usePowerSyncCredentialsInvalidListener } from '@/hooks/use-powersync-cr
 import { isSsoMode } from '@/lib/auth-mode'
 import { clearAuthToken, getAuthToken, onAuthTokenChangedInOtherTab, setAuthToken } from '@/lib/auth-token'
 import { getPlatform } from '@/lib/platform'
-import { clearCachedSession, getCachedSession, setCachedSession } from '@/lib/session-cache'
+import { clearCachedSession, getCachedSession, isCachedSessionValid, setCachedSession } from '@/lib/session-cache'
 import { anonymousClient, emailOTPClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/react'
 import { consumePendingSsoAnonAlias } from '@/lib/analytics/anonymous-promotion-sso-bridge'
@@ -54,16 +54,25 @@ const createAuthClientInstance = (cloudUrl: string) => {
  * (Better Auth's online listener fires this automatically when the network
  * returns).
  *
+ * An expired cache is discarded rather than seeded: if the device has been
+ * offline past `session.expiresAt`, every subsequent API call would 401
+ * anyway, so it's safer to force a fresh `/get-session` than to flash a
+ * logged-in UI that will be torn down moments later.
+ *
  * Only the seed is synchronous (no lifecycle to clean up). Persisting future
  * updates is wired in {@link subscribeSessionCachePersist} from the provider so
  * the listener is released when the auth client is replaced.
  */
-const hydrateSessionFromCache = (client: ReturnType<typeof createAuthClient>) => {
+export const hydrateSessionFromCache = (client: ReturnType<typeof createAuthClient>) => {
   if (!getAuthToken()) {
     return
   }
   const cached = getCachedSession()
   if (!cached) {
+    return
+  }
+  if (!isCachedSessionValid(cached)) {
+    clearCachedSession()
     return
   }
   const sessionAtom = client.$store.atoms.session
@@ -216,6 +225,10 @@ export const AuthProvider = ({ children, cloudUrl, authClient: overrideClient }:
   useEffect(() => {
     return onAuthTokenChangedInOtherTab((next, prev) => {
       if (next && next !== prev) {
+        // Cross-tab rotation may swap in a different user identity; wipe the
+        // cache so the reloaded tab doesn't seed the previous user's session
+        // under the new token before /get-session lands.
+        clearCachedSession()
         window.location.reload()
         return
       }

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -98,11 +98,11 @@ export const hydrateSessionFromCache = (client: ReturnType<typeof createAuthClie
  * to avoid caching a payload that would only resurrect as a logged-out flash on
  * the next boot.
  */
-const subscribeSessionCachePersist = (client: ReturnType<typeof createAuthClient>): (() => void) => {
-  return client.$store.atoms.session.subscribe((state: { data: unknown }) => {
-    const data = state.data as { user?: unknown; session?: unknown } | null
+export const subscribeSessionCachePersist = (client: ReturnType<typeof createAuthClient>): (() => void) => {
+  return client.$store.atoms.session.subscribe((state: { data: Session | null }) => {
+    const data = state.data
     if (data?.user && data?.session) {
-      setCachedSession(data as Record<string, unknown>)
+      setCachedSession(data)
     }
   })
 }

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -180,7 +180,7 @@ export const AuthProvider = ({ children, cloudUrl, authClient: overrideClient }:
   // Skipped when the auth client is an injected test override (no `$store`).
   useEffect(() => {
     const client = value?.authClient
-    if (!client?.$store?.atoms?.session) {
+    if (!client?.$store) {
       return
     }
     return subscribeSessionCachePersist(client)

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -96,7 +96,8 @@ export const hydrateSessionFromCache = (client: ReturnType<typeof createAuthClie
  * but the initial `useAuthQuery` `onSuccess` writes the raw server payload, so
  * `{ user: null, session: null }` can transit the atom — we filter it out here
  * to avoid caching a payload that would only resurrect as a logged-out flash on
- * the next boot.
+ * the next boot. Real sign-out (atom → `null`) is a no-op here on purpose —
+ * cache clearing is owned by the 401 handler and `clearLocalData` callers.
  */
 export const subscribeSessionCachePersist = (client: ReturnType<typeof createAuthClient>): (() => void) => {
   return client.$store.atoms.session.subscribe((state: { data: Session | null }) => {

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -8,6 +8,7 @@ import { usePowerSyncCredentialsInvalidListener } from '@/hooks/use-powersync-cr
 import { isSsoMode } from '@/lib/auth-mode'
 import { clearAuthToken, getAuthToken, onAuthTokenChangedInOtherTab, setAuthToken } from '@/lib/auth-token'
 import { getPlatform } from '@/lib/platform'
+import { clearCachedSession, getCachedSession, setCachedSession } from '@/lib/session-cache'
 import { anonymousClient, emailOTPClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/react'
 import { consumePendingSsoAnonAlias } from '@/lib/analytics/anonymous-promotion-sso-bridge'
@@ -23,7 +24,7 @@ const createAuthClientInstance = (cloudUrl: string) => {
   const baseURL = cloudUrl.replace(/\/v1$/, '') // Better Auth adds /api/auth
   const platform = getPlatform()
 
-  return createAuthClient({
+  const client = createAuthClient({
     baseURL,
     basePath: '/v1/api/auth',
     plugins: [emailOTPClient(), anonymousClient()],
@@ -36,6 +37,64 @@ const createAuthClientInstance = (cloudUrl: string) => {
       refetchOnWindowFocus: false,
       refetchWhenOffline: false,
     },
+  })
+
+  hydrateSessionFromCache(client)
+  return client
+}
+
+/**
+ * Seed Better Auth's session atom from the localStorage cache so the app can
+ * boot offline for previously-authenticated users.
+ *
+ * Without this, the gate-protected routes redirect to /waitlist whenever the
+ * initial `/get-session` request fails (THU-580). Better Auth's `useAuthQuery`
+ * preserves non-null `data` on non-401 errors, so the cached value survives the
+ * failing offline fetch and is replaced as soon as a real refetch succeeds
+ * (Better Auth's online listener fires this automatically when the network
+ * returns).
+ *
+ * Only the seed is synchronous (no lifecycle to clean up). Persisting future
+ * updates is wired in {@link subscribeSessionCachePersist} from the provider so
+ * the listener is released when the auth client is replaced.
+ */
+const hydrateSessionFromCache = (client: ReturnType<typeof createAuthClient>) => {
+  if (!getAuthToken()) {
+    return
+  }
+  const cached = getCachedSession()
+  if (!cached) {
+    return
+  }
+  const sessionAtom = client.$store.atoms.session
+  sessionAtom.set({
+    ...sessionAtom.get(),
+    data: cached,
+    isPending: false,
+  })
+}
+
+/**
+ * Subscribe to the session atom and mirror every authenticated payload back to
+ * the localStorage cache so the next offline boot has fresh user data.
+ *
+ * Returns the nanostores unsubscribe so the caller can release the listener
+ * when the auth client is replaced — without this, swapping `cloudUrl` would
+ * leak the old client + its refresh manager forever.
+ *
+ * Only payloads with both `user` and `session` are persisted. Better Auth's
+ * refresh manager normalizes empty responses to `null` on its own refetch path
+ * but the initial `useAuthQuery` `onSuccess` writes the raw server payload, so
+ * `{ user: null, session: null }` can transit the atom — we filter it out here
+ * to avoid caching a payload that would only resurrect as a logged-out flash on
+ * the next boot.
+ */
+const subscribeSessionCachePersist = (client: ReturnType<typeof createAuthClient>): (() => void) => {
+  return client.$store.atoms.session.subscribe((state: { data: unknown }) => {
+    const data = state.data as { user?: unknown; session?: unknown } | null
+    if (data?.user && data?.session) {
+      setCachedSession(data as Record<string, unknown>)
+    }
   })
 }
 
@@ -60,6 +119,7 @@ export const buildFetchOptions = (platform: string) => ({
     // session expiry. A 401 from sign-in/OTP-verify (no stored token) must NOT trigger the modal.
     const hadToken = Boolean(getAuthToken())
     clearAuthToken()
+    clearCachedSession()
     if (hadToken) {
       // Event name + reason kept in sync with src/db/powersync/connector.ts. Fires on Better Auth's
       // session validation (mount + tab focus), which detects expiry well before PowerSync's
@@ -104,6 +164,18 @@ export const AuthProvider = ({ children, cloudUrl, authClient: overrideClient }:
     const client = createAuthClientInstance(cloudUrl)
     return { authClient: client }
   }, [cloudUrl, overrideClient])
+
+  // Persist session updates back to the localStorage cache (THU-580). Scoped to
+  // an effect so the listener is released when `value` is replaced — otherwise
+  // a cloudUrl change would keep the old client's refresh manager alive forever.
+  // Skipped when the auth client is an injected test override (no `$store`).
+  useEffect(() => {
+    const client = value?.authClient
+    if (!client?.$store?.atoms?.session) {
+      return
+    }
+    return subscribeSessionCachePersist(client)
+  }, [value])
 
   // Consume any pending SSO anon-id alias from sessionStorage (written before the SSO redirect
   // by persistForSso()). A ref guard prevents StrictMode's double-invocation from firing alias

--- a/src/db/powersync/middleware/EncryptionMiddleware.test.ts
+++ b/src/db/powersync/middleware/EncryptionMiddleware.test.ts
@@ -10,8 +10,7 @@ type SyncEntry = SyncDataBucket['data'][number]
 const makeEntry = (object_type: string, data: Record<string, unknown>): SyncEntry =>
   ({ object_type, object_id: 'id-1', data: JSON.stringify(data), op: 'PUT' }) as SyncEntry
 
-const makeBucket = (...entries: SyncEntry[]): SyncDataBucket =>
-  ({ data: entries }) as SyncDataBucket
+const makeBucket = (...entries: SyncEntry[]): SyncDataBucket => ({ data: entries }) as SyncDataBucket
 
 // Controllable passthrough flag so individual tests can simulate a missing CK
 // without re-calling mock.module (which would bleed into subsequent tests).
@@ -20,7 +19,9 @@ let ckAvailable = true
 mock.module('@/db/encryption/codec', () => ({
   codec: {
     decode: async (val: string) => {
-      if (!ckAvailable || !val.startsWith('__enc:')) return val
+      if (!ckAvailable || !val.startsWith('__enc:')) {
+        return val
+      }
       return `decrypted(${val})`
     },
     encode: async (val: string) => `__enc:${val}`,

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -6,6 +6,7 @@ import { disposeAllAdapters } from '@/acp/adapter-cache'
 import { setSyncEnabled } from '@/db/powersync/sync-state'
 import { clearAuthToken, clearDeviceId } from '@/lib/auth-token'
 import { resetAppDir } from '@/lib/fs'
+import { clearCachedSession } from '@/lib/session-cache'
 import { handleFullWipe } from '@/services/encryption'
 import { initialLocalSettings, useLocalSettingsStore } from '@/stores/local-settings-store'
 
@@ -68,5 +69,6 @@ export const clearLocalData = async (options?: ClearLocalDataOptions): Promise<v
   if (clearAuth) {
     clearAuthToken()
     clearDeviceId()
+    clearCachedSession()
   }
 }

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -6,6 +6,7 @@ import { disposeAllAdapters } from '@/acp/adapter-cache'
 import { setSyncEnabled } from '@/db/powersync'
 import { clearAuthToken, clearDeviceId } from '@/lib/auth-token'
 import { resetAppDir } from '@/lib/fs'
+import { clearCachedSession } from '@/lib/session-cache'
 import { handleFullWipe } from '@/services/encryption'
 import { initialLocalSettings, useLocalSettingsStore } from '@/stores/local-settings-store'
 
@@ -68,5 +69,6 @@ export const clearLocalData = async (options?: ClearLocalDataOptions): Promise<v
   if (clearAuth) {
     clearAuthToken()
     clearDeviceId()
+    clearCachedSession()
   }
 }

--- a/src/lib/session-cache.test.ts
+++ b/src/lib/session-cache.test.ts
@@ -37,6 +37,11 @@ describe('session-cache', () => {
     localStorage.setItem(sessionCacheKey, JSON.stringify('not-an-object'))
     expect(getCachedSession()).toBeNull()
   })
+
+  it('returns null when the stored value is an array', () => {
+    localStorage.setItem(sessionCacheKey, JSON.stringify([]))
+    expect(getCachedSession()).toBeNull()
+  })
 })
 
 describe('isCachedSessionValid', () => {

--- a/src/lib/session-cache.test.ts
+++ b/src/lib/session-cache.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { afterEach, describe, expect, it } from 'bun:test'
-import { clearCachedSession, getCachedSession, setCachedSession } from './session-cache'
+import { clearCachedSession, getCachedSession, isCachedSessionValid, setCachedSession } from './session-cache'
 
 const sessionCacheKey = 'thunderbolt_session_cache'
 
@@ -36,5 +36,34 @@ describe('session-cache', () => {
   it('returns null when the stored value is not an object', () => {
     localStorage.setItem(sessionCacheKey, JSON.stringify('not-an-object'))
     expect(getCachedSession()).toBeNull()
+  })
+})
+
+describe('isCachedSessionValid', () => {
+  const future = () => new Date(Date.now() + 60_000).toISOString()
+  const past = () => new Date(Date.now() - 60_000).toISOString()
+
+  it('returns true when session.expiresAt is in the future', () => {
+    expect(isCachedSessionValid({ user: { id: '1' }, session: { expiresAt: future() } })).toBe(true)
+  })
+
+  it('returns false when session.expiresAt is in the past', () => {
+    expect(isCachedSessionValid({ user: { id: '1' }, session: { expiresAt: past() } })).toBe(false)
+  })
+
+  it('returns false when session.expiresAt is missing', () => {
+    expect(isCachedSessionValid({ user: { id: '1' }, session: {} })).toBe(false)
+  })
+
+  it('returns false when session is missing', () => {
+    expect(isCachedSessionValid({ user: { id: '1' } })).toBe(false)
+  })
+
+  it('returns false when expiresAt is not parseable', () => {
+    expect(isCachedSessionValid({ user: { id: '1' }, session: { expiresAt: 'not-a-date' } })).toBe(false)
+  })
+
+  it('accepts numeric expiresAt (unix ms)', () => {
+    expect(isCachedSessionValid({ user: { id: '1' }, session: { expiresAt: Date.now() + 60_000 } })).toBe(true)
   })
 })

--- a/src/lib/session-cache.test.ts
+++ b/src/lib/session-cache.test.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { clearCachedSession, getCachedSession, setCachedSession } from './session-cache'
+
+const sessionCacheKey = 'thunderbolt_session_cache'
+
+afterEach(() => {
+  localStorage.removeItem(sessionCacheKey)
+})
+
+describe('session-cache', () => {
+  it('returns null when nothing is cached', () => {
+    expect(getCachedSession()).toBeNull()
+  })
+
+  it('round-trips through localStorage', () => {
+    const data = { user: { id: '1', email: 'u@example.com' }, session: { id: 's1' } }
+    setCachedSession(data)
+    expect(getCachedSession()).toEqual(data)
+  })
+
+  it('clearCachedSession removes the entry', () => {
+    setCachedSession({ user: { id: '1' } })
+    clearCachedSession()
+    expect(getCachedSession()).toBeNull()
+  })
+
+  it('returns null for malformed JSON without throwing', () => {
+    localStorage.setItem(sessionCacheKey, '{not-json')
+    expect(getCachedSession()).toBeNull()
+  })
+
+  it('returns null when the stored value is not an object', () => {
+    localStorage.setItem(sessionCacheKey, JSON.stringify('not-an-object'))
+    expect(getCachedSession()).toBeNull()
+  })
+})

--- a/src/lib/session-cache.ts
+++ b/src/lib/session-cache.ts
@@ -51,3 +51,20 @@ export const setCachedSession = (data: CachedSessionData): void => {
 export const clearCachedSession = (): void => {
   localStorage.removeItem(sessionCacheKey)
 }
+
+/**
+ * True when the cached payload has a `session.expiresAt` in the future.
+ *
+ * Called before seeding the atom so an offline device past the token's TTL
+ * doesn't boot as logged in (THU-580 review). A cache without a parseable
+ * `expiresAt` is treated as invalid — likely an older payload shape, and a
+ * fresh `/get-session` is safer than trusting it.
+ */
+export const isCachedSessionValid = (cached: CachedSessionData): boolean => {
+  const session = cached.session as { expiresAt?: string | number | Date } | undefined
+  if (!session?.expiresAt) {
+    return false
+  }
+  const expiresAt = new Date(session.expiresAt).getTime()
+  return Number.isFinite(expiresAt) && expiresAt > Date.now()
+}

--- a/src/lib/session-cache.ts
+++ b/src/lib/session-cache.ts
@@ -42,7 +42,7 @@ export const getCachedSession = (): CachedSessionData | null => {
       return null
     }
     const parsed = JSON.parse(raw)
-    if (parsed && typeof parsed === 'object') {
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed as CachedSessionData
     }
     return null

--- a/src/lib/session-cache.ts
+++ b/src/lib/session-cache.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Cache of the last successful Better Auth session response in localStorage.
+ *
+ * Used to seed `authClient.$store.atoms.session` on app start so the auth gate
+ * doesn't redirect to the login screen when offline (THU-580). Better Auth's
+ * `useSession` requires a network round-trip on mount; without a seed, the
+ * offline fetch fails and `data` stays null, which the gate treats as logged-out.
+ *
+ * Lifecycle:
+ *  - written from `AuthProvider` whenever the session atom receives non-null data
+ *  - cleared on 401 (token rejection) and on logout/wipe (via `clearLocalData`)
+ *
+ * Stored in localStorage to match the existing pattern in `auth-token.ts`.
+ */
+
+const sessionCacheKey = 'thunderbolt_session_cache'
+
+export type CachedSessionData = Record<string, unknown>
+
+/** Read the cached session, or null when absent / malformed. */
+export const getCachedSession = (): CachedSessionData | null => {
+  try {
+    const raw = localStorage.getItem(sessionCacheKey)
+    if (!raw) {
+      return null
+    }
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') {
+      return parsed as CachedSessionData
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/** Persist the latest session payload. Silently no-ops if localStorage rejects the write. */
+export const setCachedSession = (data: CachedSessionData): void => {
+  try {
+    localStorage.setItem(sessionCacheKey, JSON.stringify(data))
+  } catch {
+    // Quota exceeded or storage unavailable — caching is best-effort.
+  }
+}
+
+/** Remove any cached session (used on logout, 401, and full wipe). */
+export const clearCachedSession = (): void => {
+  localStorage.removeItem(sessionCacheKey)
+}

--- a/src/lib/session-cache.ts
+++ b/src/lib/session-cache.ts
@@ -16,7 +16,10 @@ import type { Session } from '@/contexts/auth-context'
  *  - written from `AuthProvider` whenever the session atom receives non-null data
  *  - cleared on 401 (token rejection) and on logout/wipe (via `clearLocalData`)
  *
- * Stored in localStorage to match the existing pattern in `auth-token.ts`.
+ * Stored in localStorage to match the existing pattern in `auth-token.ts`. Note
+ * that this widens the localStorage exfil surface from the bare bearer token to
+ * the full user profile (id, email, name, `isAnonymous`) — same exposure class
+ * as the token itself, but more identifying if an attacker gets read access.
  */
 
 const sessionCacheKey = 'thunderbolt_session_cache'

--- a/src/lib/session-cache.ts
+++ b/src/lib/session-cache.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { Session } from '@/contexts/auth-context'
+
 /**
  * Cache of the last successful Better Auth session response in localStorage.
  *
@@ -19,7 +21,18 @@
 
 const sessionCacheKey = 'thunderbolt_session_cache'
 
-export type CachedSessionData = Record<string, unknown>
+/**
+ * Shape of the payload as it exists in localStorage — a JSON-serialized subset
+ * of Better Auth's `Session`. `Date` fields (e.g. `session.expiresAt`) round-
+ * trip to ISO strings through `JSON.stringify`, so `expiresAt` is widened to
+ * `string | number | Date`. Everything else is `Partial` because the localStorage
+ * value predates our writer contract (older shapes, corruption, manual edits) —
+ * reads are validated at runtime by {@link isCachedSessionValid}.
+ */
+export type CachedSessionData = {
+  user?: Partial<Session['user']>
+  session?: Partial<Omit<Session['session'], 'expiresAt'>> & { expiresAt?: string | number | Date }
+}
 
 /** Read the cached session, or null when absent / malformed. */
 export const getCachedSession = (): CachedSessionData | null => {
@@ -61,10 +74,9 @@ export const clearCachedSession = (): void => {
  * fresh `/get-session` is safer than trusting it.
  */
 export const isCachedSessionValid = (cached: CachedSessionData): boolean => {
-  const session = cached.session as { expiresAt?: string | number | Date } | undefined
-  if (!session?.expiresAt) {
+  if (!cached.session?.expiresAt) {
     return false
   }
-  const expiresAt = new Date(session.expiresAt).getTime()
+  const expiresAt = new Date(cached.session.expiresAt).getTime()
   return Number.isFinite(expiresAt) && expiresAt > Date.now()
 }


### PR DESCRIPTION
Closes [THU-580](https://linear.app/mozilla-thunderbolt/issue/THU-580/desktop-app-fails-to-start-when-network-is-offline).

Better Auth's `useSession` needs a `/get-session` round-trip to populate `data`. Offline at boot that fetch fails, `data` stays `null`, and `useAuthGate` redirects authenticated routes to `/waitlist` — the user is stuck on the login screen until they reconnect.

Cache the last successful session payload in `localStorage` and seed `client.\$store.atoms.session` on auth-client creation. `useAuthQuery.onError` preserves non-null `data` on non-401 errors, so the cached value survives the failing offline fetch. Better Auth's own online listener replaces it with fresh server data as soon as the network returns. Cache is cleared on 401 and on `clearLocalData` (logout / wipe).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth boot path and stores richer profile data in localStorage alongside the token; invalidation on 401/logout/wipe and expiry checks limit stale-session risk.
> 
> **Overview**
> Fixes offline startup for users who already have a bearer token: the last successful session is stored in **localStorage** and used to **seed** Better Auth’s session atom before `/get-session` runs, so protected routes are not treated as logged-out when the network is down.
> 
> **`session-cache`** adds read/write/clear plus **`isCachedSessionValid`** (future `session.expiresAt` only). **`hydrateSessionFromCache`** runs when the auth client is created (token + valid cache required); **`subscribeSessionCachePersist`** mirrors atom updates that include both user and session, with unsubscribe on client swap.
> 
> The cache is cleared on **401**, **`clearLocalData`**, and **cross-tab token rotation** (before reload) so stale or wrong-user data is not reused offline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5b928bb810c695224a1efdbae7d9ac606c1ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->