### PR TITLE
fix(THU-582): prevent stale desktop clients from leaking __enc: ciphertext

### DIFF
--- a/src/db/powersync/middleware/EncryptionMiddleware.test.ts
+++ b/src/db/powersync/middleware/EncryptionMiddleware.test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import type { SyncDataBucket } from '../TransformableBucketStorage'
+
+type SyncEntry = SyncDataBucket['data'][number]
+
+const makeEntry = (object_type: string, data: Record<string, unknown>): SyncEntry =>
+  ({ object_type, object_id: 'id-1', data: JSON.stringify(data), op: 'PUT' }) as SyncEntry
+
+const makeBucket = (...entries: SyncEntry[]): SyncDataBucket =>
+  ({ data: entries }) as SyncDataBucket
+
+// Controllable passthrough flag so individual tests can simulate a missing CK
+// without re-calling mock.module (which would bleed into subsequent tests).
+let ckAvailable = true
+
+mock.module('@/db/encryption/codec', () => ({
+  codec: {
+    decode: async (val: string) => {
+      if (!ckAvailable || !val.startsWith('__enc:')) return val
+      return `decrypted(${val})`
+    },
+    encode: async (val: string) => `__enc:${val}`,
+  },
+}))
+
+const { encryptionMiddleware } = await import('./EncryptionMiddleware')
+
+afterEach(() => {
+  ckAvailable = true
+})
+
+describe('encryptionMiddleware', () => {
+  describe('data-driven decryption (no encryptedColumnsMap dependency)', () => {
+    it('decrypts __enc: values on a table not in encryptedColumnsMap', async () => {
+      // Simulates a stale desktop client that predates `skills` being added to the map.
+      // The middleware must still decrypt the values because __enc: is the authoritative signal.
+      const entry = makeEntry('skills', {
+        name: '__enc:iv1:ct1',
+        description: '__enc:iv2:ct2',
+        instruction: '__enc:iv3:ct3',
+        workspace_id: 'ws-1',
+      })
+
+      const result = await encryptionMiddleware.transform(makeBucket(entry))
+      const row = JSON.parse(result.data[0].data!)
+
+      expect(row.name).toBe('decrypted(__enc:iv1:ct1)')
+      expect(row.description).toBe('decrypted(__enc:iv2:ct2)')
+      expect(row.instruction).toBe('decrypted(__enc:iv3:ct3)')
+      expect(row.workspace_id).toBe('ws-1')
+    })
+
+    it('decrypts __enc: values on a known table', async () => {
+      const entry = makeEntry('tasks', { item: '__enc:iv:ct', order: 1 })
+
+      const result = await encryptionMiddleware.transform(makeBucket(entry))
+      const row = JSON.parse(result.data[0].data!)
+
+      expect(row.item).toBe('decrypted(__enc:iv:ct)')
+      expect(row.order).toBe(1)
+    })
+
+    it('leaves plaintext values unchanged', async () => {
+      const entry = makeEntry('tasks', { item: 'plain text', order: 2 })
+
+      const result = await encryptionMiddleware.transform(makeBucket(entry))
+      const row = JSON.parse(result.data[0].data!)
+
+      expect(row.item).toBe('plain text')
+      expect(row.order).toBe(2)
+    })
+
+    it('does not touch non-string values', async () => {
+      const entry = makeEntry('skills', {
+        name: '__enc:iv:ct',
+        count: 42,
+        active: true,
+        meta: null,
+      })
+
+      const result = await encryptionMiddleware.transform(makeBucket(entry))
+      const row = JSON.parse(result.data[0].data!)
+
+      expect(row.count).toBe(42)
+      expect(row.active).toBe(true)
+      expect(row.meta).toBeNull()
+    })
+
+    it('passes through __enc: values when codec returns them as-is (no CK)', async () => {
+      // When the CK is unavailable, codec.decode returns the raw __enc: value.
+      // The middleware writes it to SQLite; the client will retry on the next sync cycle.
+      ckAvailable = false
+
+      const entry = makeEntry('skills', { name: '__enc:iv:ct' })
+      const result = await encryptionMiddleware.transform(makeBucket(entry))
+      const row = JSON.parse(result.data[0].data!)
+
+      expect(row.name).toBe('__enc:iv:ct')
+    })
+
+    it('decrypts multiple entries in a bucket', async () => {
+      const bucket = makeBucket(
+        makeEntry('tasks', { item: '__enc:a:b' }),
+        makeEntry('skills', { name: '__enc:c:d' }),
+        makeEntry('other_table', { label: '__enc:e:f', extra: 'plain' }),
+      )
+
+      const result = await encryptionMiddleware.transform(bucket)
+
+      expect(JSON.parse(result.data[0].data!).item).toBe('decrypted(__enc:a:b)')
+      expect(JSON.parse(result.data[1].data!).name).toBe('decrypted(__enc:c:d)')
+      expect(JSON.parse(result.data[2].data!).label).toBe('decrypted(__enc:e:f)')
+      expect(JSON.parse(result.data[2].data!).extra).toBe('plain')
+    })
+
+    it('skips entries with no data', async () => {
+      const entry = { object_type: 'tasks', object_id: 'id-1', data: null, op: 'DELETE' } as unknown as SyncEntry
+      const result = await encryptionMiddleware.transform(makeBucket(entry))
+      expect(result.data[0].data).toBeNull()
+    })
+  })
+})

--- a/src/db/powersync/middleware/EncryptionMiddleware.ts
+++ b/src/db/powersync/middleware/EncryptionMiddleware.ts
@@ -3,18 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { DataTransformMiddleware, SyncDataBucket } from '../TransformableBucketStorage'
-import { encryptedColumnsMap } from '@/db/encryption/config'
 import { codec } from '@/db/encryption/codec'
 
 type SyncEntry = SyncDataBucket['data'][number]
 
-/** Decrypt encrypted columns in a single sync entry. Mutates entry.data in place. */
+/**
+ * Decrypt all __enc:-prefixed values in a single sync entry. Mutates entry.data in place.
+ *
+ * Intentionally data-driven rather than map-driven: any string value starting with __enc:
+ * is decrypted regardless of whether its column appears in encryptedColumnsMap. This means
+ * a stale desktop client (whose bundled map predates a new encrypted column) still decrypts
+ * correctly — the __enc: prefix is the authoritative signal, not the config.
+ */
 const decryptEntry = async (entry: SyncEntry) => {
-  if (!entry.object_type || !entry.data) {
-    return
-  }
-  const columns = encryptedColumnsMap[entry.object_type]
-  if (!columns) {
+  if (!entry.data) {
     return
   }
 
@@ -23,10 +25,9 @@ const decryptEntry = async (entry: SyncEntry) => {
     let changed = false
 
     await Promise.all(
-      columns.map(async (col) => {
-        const val = obj[col]
-        if (typeof val === 'string') {
-          obj[col] = await codec.decode(val)
+      Object.entries(obj).map(async ([key, val]) => {
+        if (typeof val === 'string' && val.startsWith('__enc:')) {
+          obj[key] = await codec.decode(val)
           changed = true
         }
       }),
@@ -42,9 +43,9 @@ const decryptEntry = async (entry: SyncEntry) => {
 
 /**
  * Decrypts encrypted columns in sync data before it reaches SQLite.
- * Config-driven: uses encryptedColumnsMap to determine which columns to decrypt.
- * Handles __enc: (AES-GCM) format — codec.decode passes through plaintext unchanged.
- * Passes through when no CK is available (pre-setup or CK cleared).
+ * Data-driven: scans all string values for the __enc: prefix rather than consulting
+ * encryptedColumnsMap, so stale desktop bundles handle newly-encrypted columns correctly.
+ * codec.decode passes through plaintext and returns raw ciphertext when no CK is available.
  *
  * No isEncryptionEnabled() gate: this middleware runs in the SharedWorker where
  * localStorage is unavailable. The codec safely handles both encrypted and plaintext data.


### PR DESCRIPTION
Stale Tauri desktop bundles (whose embedded `encryptedColumnsMap` predates a newly-encrypted column) were writing raw `__enc:…` ciphertext into SQLite, which then surfaced in the UI.

**Root cause:** `EncryptionMiddleware` gated decryption on `encryptedColumnsMap` — if a table/column wasn't in the map, the middleware skipped it entirely. Since desktop bundles embed the map at build time, any column added after a build shipped was invisible to the codec.

**Fix:** Make the download path data-driven. Instead of consulting the map, the middleware now scans every string value for the `__enc:` prefix and decrypts it — identical to how `codec.decode` already works. The map remains the source of truth for upload encoding (`encodeForUpload`) and documentation; it no longer gates decryption.

This eliminates the entire class of "new encrypted column breaks old client" bugs — a stale desktop will always decrypt correctly as long as the `__enc:` prefix is present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the sync-to-SQLite decryption path for E2EE data; behavior broadens (all `__enc:` strings) but aligns with codec semantics and is covered by new tests.
> 
> **Overview**
> **PowerSync download decryption** no longer depends on `encryptedColumnsMap`. `EncryptionMiddleware` now walks every field in each sync row and decrypts any string that starts with `__enc:` via `codec.decode`, instead of only columns listed for that `object_type`.
> 
> This fixes stale Tauri builds that ship an older map: newly encrypted columns still decrypt before SQLite/UI. Plaintext strings, non-strings, DELETE rows with null `data`, and `__enc:` passthrough when no content key is available behave as before. **`encryptedColumnsMap` stays in use for upload encoding** (`encodeForUpload`), not for this middleware.
> 
> Adds **`EncryptionMiddleware.test.ts`** covering unknown tables, known tables, plaintext, multi-entry buckets, and missing CK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace977b442ffb81c0eee778391d505f728ab2d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->