### PR TITLE
fix: fix lint error

### DIFF
--- a/src/db/powersync/middleware/EncryptionMiddleware.test.ts
+++ b/src/db/powersync/middleware/EncryptionMiddleware.test.ts
@@ -10,8 +10,7 @@ type SyncEntry = SyncDataBucket['data'][number]
 const makeEntry = (object_type: string, data: Record<string, unknown>): SyncEntry =>
   ({ object_type, object_id: 'id-1', data: JSON.stringify(data), op: 'PUT' }) as SyncEntry
 
-const makeBucket = (...entries: SyncEntry[]): SyncDataBucket =>
-  ({ data: entries }) as SyncDataBucket
+const makeBucket = (...entries: SyncEntry[]): SyncDataBucket => ({ data: entries }) as SyncDataBucket
 
 // Controllable passthrough flag so individual tests can simulate a missing CK
 // without re-calling mock.module (which would bleed into subsequent tests).
@@ -20,7 +19,9 @@ let ckAvailable = true
 mock.module('@/db/encryption/codec', () => ({
   codec: {
     decode: async (val: string) => {
-      if (!ckAvailable || !val.startsWith('__enc:')) return val
+      if (!ckAvailable || !val.startsWith('__enc:')) {
+        return val
+      }
       return `decrypted(${val})`
     },
     encode: async (val: string) => `__enc:${val}`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only style changes with no production or encryption logic impact.
> 
> **Overview**
> Resolves lint/style issues in `EncryptionMiddleware.test.ts` only—no changes to `EncryptionMiddleware` or runtime behavior.
> 
> **Formatting:** `makeBucket` is written as a one-line arrow function, and the mocked `codec.decode` early-return guard uses a braced `if` block instead of a single-line `if`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f547256085a0e90fe310cd59a6358a292255e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->