### PR TITLE
fix(THU-559): Fix copy button overlapping tool calls

### DIFF
--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -151,6 +151,15 @@ export const AssistantMessage = memo(
       [message.parts],
     )
 
+    const lastPartIsReasoningGroup = useMemo(() => {
+      const lastPart = groupedParts[groupedParts.length - 1]
+      if (!lastPart) {
+        return false
+      }
+      const [partType] = splitPartType(lastPart.type)
+      return partType === 'reasoning_group'
+    }, [groupedParts])
+
     const showCopyOnHover = !isLastAssistantMessage
 
     return (
@@ -168,7 +177,7 @@ export const AssistantMessage = memo(
         ))}
         {!isStreaming && copyText && (
           <div
-            className={`flex items-center gap-2.5 px-4 ${hasWidgets ? 'mt-1' : '-mt-6'} ${showCopyOnHover ? 'md:opacity-0 md:group-hover:opacity-100 md:transition-opacity' : ''}`}
+            className={`flex items-center gap-2.5 px-4 ${hasWidgets || lastPartIsReasoningGroup ? 'mt-1' : '-mt-6'} ${showCopyOnHover ? 'md:opacity-0 md:group-hover:opacity-100 md:transition-opacity' : ''}`}
           >
             <CopyMessageButton text={copyText} />
           </div>

--- a/src/lib/message-utils.test.ts
+++ b/src/lib/message-utils.test.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { UIMessage } from 'ai'
+import { describe, expect, test } from 'bun:test'
+import { extractTextFromParts } from './message-utils'
+
+const textPart = (text: string): UIMessage['parts'][number] => ({ type: 'text', text }) as UIMessage['parts'][number]
+
+describe('extractTextFromParts', () => {
+  test('returns empty string when message has no text parts', () => {
+    expect(extractTextFromParts([])).toBe('')
+  })
+
+  test('returns empty string when text parts contain only widgets with URL slashes', () => {
+    const parts = [
+      textPart('<widget:link-preview url="https://reuters.com/tech/foo" />'),
+      textPart('<widget:link-preview url="https://apnews.com/article/bar" />'),
+    ]
+    expect(extractTextFromParts(parts)).toBe('')
+  })
+
+  test('returns empty string for widget with multiple attributes including slashes', () => {
+    const parts = [textPart('<widget:link-preview source="1" url="https://example.com/path/to/page" />')]
+    expect(extractTextFromParts(parts)).toBe('')
+  })
+
+  test('returns empty string for inline citations only', () => {
+    expect(extractTextFromParts([textPart('[1] [2] [3]')])).toBe('')
+  })
+
+  test('returns trimmed text for regular text parts', () => {
+    expect(extractTextFromParts([textPart('Hello world')])).toBe('Hello world')
+  })
+
+  test('strips widgets but keeps surrounding text', () => {
+    const parts = [textPart('Here is the news: <widget:link-preview url="https://x.com/a/b" /> read more.')]
+    expect(extractTextFromParts(parts)).toBe('Here is the news:  read more.')
+  })
+
+  test('joins multiple non-empty text parts with separator', () => {
+    expect(extractTextFromParts([textPart('first'), textPart('second')])).toBe('first\n\nsecond')
+  })
+})

--- a/src/lib/message-utils.ts
+++ b/src/lib/message-utils.ts
@@ -15,7 +15,7 @@ export const extractTextFromParts = (parts: UIMessage['parts'], separator = '\n\
     .filter((part): part is TextPart => part.type === 'text')
     .map((part) =>
       part.text
-        .replace(/<widget:[^/]*\/>/g, '')
+        .replace(/<widget:[a-z][a-z0-9-]*\s+(?:[^/]|\/(?!>))+\/>/gi, '')
         .replace(/\[\d+\](?!\()(?:\s*\[\d+\](?!\())*/g, '')
         .trim(),
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI spacing and copy-text sanitization only; no auth or data-path changes.
> 
> **Overview**
> Fixes the assistant message **copy** control sitting on top of **reasoning/tool-call** blocks by treating a trailing `reasoning_group` like widgets: use normal `mt-1` spacing instead of `-mt-6` when the last rendered group is reasoning.
> 
> Updates **`extractTextFromParts`** widget stripping so tags with attributes containing slashes (e.g. `url="https://…"`) are removed in full; the previous pattern stopped at the first `/` and left broken markup. Adds **`message-utils.test.ts`** coverage for widgets, citations, and joined text parts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5592b70140a0622f39d476cfae77c71621cdd7da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->