### PR TITLE
feat(THU-555): Settings → Workspace → Members (add / remove / role / pending)

### DIFF
--- a/backend/drizzle/0022_workspace_memberships_user_display.sql
+++ b/backend/drizzle/0022_workspace_memberships_user_display.sql
@@ -1,0 +1,10 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+ALTER TABLE "powersync"."workspace_memberships" ADD COLUMN "user_name" text;--> statement-breakpoint
+ALTER TABLE "powersync"."workspace_memberships" ADD COLUMN "user_email" text;--> statement-breakpoint
+UPDATE "powersync"."workspace_memberships" AS m
+SET "user_name" = u."name", "user_email" = u."email"
+FROM "user" AS u
+WHERE m."user_id" = u."id";

--- a/backend/drizzle/meta/0022_snapshot.json
+++ b/backend/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,3179 @@
+{
+  "id": "f6bed693-da35-4fbe-bceb-c9c41077463e",
+  "prevId": "770ab94b-aa1c-4201-9845-e2f0305da156",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_deviceId_idx": {
+          "name": "session_deviceId_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_batch_id_idx": {
+          "name": "waitlist_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.agents": {
+      "name": "agents",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agents_user_id": {
+          "name": "idx_agents_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_workspace_id": {
+          "name": "idx_agents_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_user_id_user_id_fk": {
+          "name": "agents_user_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agents_workspace_id_workspaces_id_fk": {
+          "name": "agents_workspace_id_workspaces_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agents_id_workspace_id_pk": {
+          "name": "agents_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.chat_messages": {
+      "name": "chat_messages",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache": {
+          "name": "cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_user_id": {
+          "name": "idx_chat_messages_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_workspace_id": {
+          "name": "idx_chat_messages_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_user_id_user_id_fk": {
+          "name": "chat_messages_user_id_user_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_workspace_id_workspaces_id_fk": {
+          "name": "chat_messages_workspace_id_workspaces_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.chat_threads": {
+      "name": "chat_threads",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_triggered_by_automation": {
+          "name": "was_triggered_by_automation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_id": {
+          "name": "idx_chat_threads_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_workspace_id": {
+          "name": "idx_chat_threads_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_user_id_user_id_fk": {
+          "name": "chat_threads_user_id_user_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_workspace_id_workspaces_id_fk": {
+          "name": "chat_threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.devices": {
+      "name": "devices",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trusted": {
+          "name": "trusted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approval_pending": {
+          "name": "approval_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mlkem_public_key": {
+          "name": "mlkem_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_devices_user_id": {
+          "name": "idx_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_servers_user_id": {
+          "name": "idx_mcp_servers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_servers_workspace_id": {
+          "name": "idx_mcp_servers_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_user_id_user_id_fk": {
+          "name": "mcp_servers_user_id_user_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_servers_workspace_id_workspaces_id_fk": {
+          "name": "mcp_servers_workspace_id_workspaces_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.model_profiles": {
+      "name": "model_profiles",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_threshold": {
+          "name": "nudge_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_system_message_mode_developer": {
+          "name": "use_system_message_mode_developer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tools_override": {
+          "name": "tools_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_previews_override": {
+          "name": "link_previews_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_mode_addendum": {
+          "name": "chat_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_mode_addendum": {
+          "name": "search_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "research_mode_addendum": {
+          "name": "research_mode_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citation_reinforcement_enabled": {
+          "name": "citation_reinforcement_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "citation_reinforcement_prompt": {
+          "name": "citation_reinforcement_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_final_step": {
+          "name": "nudge_final_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_preventive": {
+          "name": "nudge_preventive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_retry": {
+          "name": "nudge_retry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_final_step": {
+          "name": "nudge_search_final_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_preventive": {
+          "name": "nudge_search_preventive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nudge_search_retry": {
+          "name": "nudge_search_retry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_model_profiles_user_id": {
+          "name": "idx_model_profiles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_profiles_workspace_id": {
+          "name": "idx_model_profiles_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_profiles_user_id_user_id_fk": {
+          "name": "model_profiles_user_id_user_id_fk",
+          "tableFrom": "model_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "model_profiles_workspace_id_workspaces_id_fk": {
+          "name": "model_profiles_workspace_id_workspaces_id_fk",
+          "tableFrom": "model_profiles",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "model_profiles_id_workspace_id_pk": {
+          "name": "model_profiles_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.models": {
+      "name": "models",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "tool_usage": {
+          "name": "tool_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_confidential": {
+          "name": "is_confidential",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "start_with_reasoning": {
+          "name": "start_with_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "supports_parallel_tool_calls": {
+          "name": "supports_parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_models_user_id": {
+          "name": "idx_models_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_models_workspace_id": {
+          "name": "idx_models_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "models_user_id_user_id_fk": {
+          "name": "models_user_id_user_id_fk",
+          "tableFrom": "models",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "models_workspace_id_workspaces_id_fk": {
+          "name": "models_workspace_id_workspaces_id_fk",
+          "tableFrom": "models",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "models_id_workspace_id_pk": {
+          "name": "models_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.modes": {
+      "name": "modes",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_modes_user_id": {
+          "name": "idx_modes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_modes_workspace_id": {
+          "name": "idx_modes_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "modes_user_id_user_id_fk": {
+          "name": "modes_user_id_user_id_fk",
+          "tableFrom": "modes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "modes_workspace_id_workspaces_id_fk": {
+          "name": "modes_workspace_id_workspaces_id_fk",
+          "tableFrom": "modes",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "modes_id_workspace_id_pk": {
+          "name": "modes_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.prompts": {
+      "name": "prompts",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prompts_user_id": {
+          "name": "idx_prompts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prompts_workspace_id": {
+          "name": "idx_prompts_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prompts_user_id_user_id_fk": {
+          "name": "prompts_user_id_user_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "prompts_workspace_id_workspaces_id_fk": {
+          "name": "prompts_workspace_id_workspaces_id_fk",
+          "tableFrom": "prompts",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompts_id_workspace_id_pk": {
+          "name": "prompts_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.settings": {
+      "name": "settings",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_settings_user_id": {
+          "name": "idx_settings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "settings_user_id_user_id_fk": {
+          "name": "settings_user_id_user_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_id_user_id_pk": {
+          "name": "settings_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.skills": {
+      "name": "skills",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "pinned_order": {
+          "name": "pinned_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_skills_user_id": {
+          "name": "idx_skills_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_workspace_id": {
+          "name": "idx_skills_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_user_id_user_id_fk": {
+          "name": "skills_user_id_user_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skills_workspace_id_workspaces_id_fk": {
+          "name": "skills_workspace_id_workspaces_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "skills_id_workspace_id_pk": {
+          "name": "skills_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.tasks": {
+      "name": "tasks",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "default_hash": {
+          "name": "default_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tasks_user_id": {
+          "name": "idx_tasks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_workspace_id": {
+          "name": "idx_tasks_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_user_id_user_id_fk": {
+          "name": "tasks_user_id_user_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_workspace_id_workspaces_id_fk": {
+          "name": "tasks_workspace_id_workspaces_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tasks_id_workspace_id_pk": {
+          "name": "tasks_id_workspace_id_pk",
+          "columns": [
+            "id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.triggers": {
+      "name": "triggers",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_time": {
+          "name": "trigger_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_triggers_user_id": {
+          "name": "idx_triggers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_triggers_workspace_id": {
+          "name": "idx_triggers_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triggers_user_id_user_id_fk": {
+          "name": "triggers_user_id_user_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "triggers_workspace_id_workspaces_id_fk": {
+          "name": "triggers_workspace_id_workspaces_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.workspace_memberships": {
+      "name": "workspace_memberships",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_memberships_workspace_user": {
+          "name": "idx_workspace_memberships_workspace_user",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_memberships_user": {
+          "name": "idx_workspace_memberships_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_memberships_workspace": {
+          "name": "idx_workspace_memberships_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_memberships_workspace_id_workspaces_id_fk": {
+          "name": "workspace_memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_memberships",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_memberships_user_id_user_id_fk": {
+          "name": "workspace_memberships_user_id_user_id_fk",
+          "tableFrom": "workspace_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.workspace_pending_memberships": {
+      "name": "workspace_pending_memberships",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_pending_memberships_workspace_email": {
+          "name": "idx_workspace_pending_memberships_workspace_email",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_pending_memberships_email": {
+          "name": "idx_workspace_pending_memberships_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_pending_memberships_workspace": {
+          "name": "idx_workspace_pending_memberships_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_pending_memberships_workspace_id_workspaces_id_fk": {
+          "name": "workspace_pending_memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_pending_memberships",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_pending_memberships_invited_by_user_id_user_id_fk": {
+          "name": "workspace_pending_memberships_invited_by_user_id_user_id_fk",
+          "tableFrom": "workspace_pending_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.workspace_permissions": {
+      "name": "workspace_permissions",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_key": {
+          "name": "permission_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_workspace_permissions_workspace_key": {
+          "name": "idx_workspace_permissions_workspace_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_permissions_workspace": {
+          "name": "idx_workspace_permissions_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_permissions_workspace_id_workspaces_id_fk": {
+          "name": "workspace_permissions_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_permissions",
+          "tableTo": "workspaces",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "powersync.workspaces": {
+      "name": "workspaces",
+      "schema": "powersync",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspaces_personal_per_owner": {
+          "name": "idx_workspaces_personal_per_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"powersync\".\"workspaces\".\"is_personal\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspaces_owner_user_id": {
+          "name": "idx_workspaces_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspaces_slug": {
+          "name": "idx_workspaces_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"powersync\".\"workspaces\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_user_id_user_id_fk": {
+          "name": "workspaces_owner_user_id_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expire_idx": {
+          "name": "rate_limits_expire_idx",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encryption_metadata": {
+      "name": "encryption_metadata",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canary_iv": {
+          "name": "canary_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_ctext": {
+          "name": "canary_ctext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canary_secret_hash": {
+          "name": "canary_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encryption_metadata_user_id_user_id_fk": {
+          "name": "encryption_metadata_user_id_user_id_fk",
+          "tableFrom": "encryption_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.envelopes": {
+      "name": "envelopes",
+      "schema": "",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_ck": {
+          "name": "wrapped_ck",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_envelopes_user_id": {
+          "name": "idx_envelopes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "envelopes_device_id_devices_id_fk": {
+          "name": "envelopes_device_id_devices_id_fk",
+          "tableFrom": "envelopes",
+          "tableTo": "devices",
+          "schemaTo": "powersync",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "envelopes_user_id_user_id_fk": {
+          "name": "envelopes_user_id_user_id_fk",
+          "tableFrom": "envelopes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_challenge": {
+      "name": "otp_challenge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_token": {
+          "name": "challenge_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "otp_challenge_email_unique": {
+          "name": "otp_challenge_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1781094472865,
       "tag": "0021_workspaces_slug_icon",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1781128111482,
+      "tag": "0022_workspace_memberships_user_display",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -212,8 +212,10 @@ export const createAuth = (database: typeof DbType, emailDeps: AuthEmailDeps = {
           }),
           // Promote any pending memberships invited by email. The personal workspace
           // itself is FE-created (uploaded via PowerSync with a deterministic id), so
-          // this hook only handles the admin-only pending-membership flow that the FE
-          // can't see. Skipped for anonymous users — anon never receives invites.
+          // this hook only handles the cross-workspace promotion flow — a brand-new
+          // user isn't a member of anything yet, so no FE client can see (let alone
+          // act on) the invite at signup time. Skipped for anonymous users — anon
+          // never receives invites.
           after: async (createdUser) => {
             const isAnonymous = (createdUser as { isAnonymous?: boolean }).isAnonymous === true
             if (isAnonymous) {

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -12,6 +12,7 @@ import {
   getUserByEmail,
   getWaitlistByEmail,
   markUserNotNew,
+  syncMembershipDisplayInfo,
   validateOtpChallenge,
 } from '@/dal'
 import type { db as DbType } from '@/db/client'
@@ -219,6 +220,15 @@ export const createAuth = (database: typeof DbType, emailDeps: AuthEmailDeps = {
               return
             }
             await promotePendingMemberships(database, createdUser.id, createdUser.email, createdUser.name)
+          },
+        },
+        // Mirror name/email changes onto every membership row so co-members see
+        // updated display info on the next sync round-trip. The `workspace_memberships`
+        // table denormalizes these fields because PowerSync sync rules can't follow
+        // `user_id` across buckets — without this hook, edits would go stale.
+        update: {
+          after: async (updatedUser) => {
+            await syncMembershipDisplayInfo(database, updatedUser.id, updatedUser.name, updatedUser.email)
           },
         },
       },

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -218,7 +218,7 @@ export const createAuth = (database: typeof DbType, emailDeps: AuthEmailDeps = {
             if (isAnonymous) {
               return
             }
-            await promotePendingMemberships(database, createdUser.id, createdUser.email)
+            await promotePendingMemberships(database, createdUser.id, createdUser.email, createdUser.name)
           },
         },
       },

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -51,6 +51,33 @@ describe('Config Settings', () => {
     })
   })
 
+  describe('SERVER_ID validation', () => {
+    const savedServerId = process.env.SERVER_ID
+
+    afterEach(() => {
+      if (savedServerId !== undefined) {
+        process.env.SERVER_ID = savedServerId
+      } else {
+        delete process.env.SERVER_ID
+      }
+      clearSettingsCache()
+    })
+
+    it('surfaces a setup-pointing error when SERVER_ID is unset', () => {
+      delete process.env.SERVER_ID
+      clearSettingsCache()
+
+      expect(() => getSettings()).toThrow(/SERVER_ID env var must be set.*make doctor/)
+    })
+
+    it('surfaces a UUID-format error when SERVER_ID is set but not a UUID', () => {
+      process.env.SERVER_ID = 'not-a-uuid'
+      clearSettingsCache()
+
+      expect(() => getSettings()).toThrow(/SERVER_ID must be a valid UUID/)
+    })
+  })
+
   describe('CORS default security', () => {
     const corsEnvKeys = ['CORS_ORIGINS'] as const
 

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -13,7 +13,15 @@ const settingsSchema = z
     // key the trust-domain registry (auth token, device ID, encryption keys, DB filename
     // are all namespaced by this). No default — TS-enforced to prevent ID duplication
     // across deployments. `make doctor` auto-generates one for local dev.
-    serverId: z.string().uuid(),
+    //
+    // Custom messages mirror the BETTER_AUTH_SECRET ergonomics: a raw `Expected
+    // string, received undefined` ZodError doesn't tell a fresh dev what to do.
+    serverId: z
+      .string({
+        error:
+          'SERVER_ID env var must be set to a stable per-deployment UUID. Run `make doctor` to auto-generate one for local dev.',
+      })
+      .uuid({ error: 'SERVER_ID must be a valid UUID.' }),
 
     // API Keys
     fireworksApiKey: z.string().default(''),

--- a/backend/src/dal/index.ts
+++ b/backend/src/dal/index.ts
@@ -39,6 +39,7 @@ export {
   isPersonalWorkspace,
   isWorkspaceAdmin,
   isWorkspaceMember,
+  syncMembershipDisplayInfo,
   updateMembership,
   updatePendingMembership,
   updateWorkspace,

--- a/backend/src/dal/users.test.ts
+++ b/backend/src/dal/users.test.ts
@@ -41,7 +41,7 @@ describe('users DAL', () => {
     it('returns user when found', async () => {
       await insertUser('u1', 'u1@test.com')
       const result = await getUserById(db, 'u1')
-      expect(result).toEqual({ id: 'u1', isAnonymous: false })
+      expect(result).toEqual({ id: 'u1', isAnonymous: false, name: 'Test User', email: 'u1@test.com' })
     })
 
     it('returns null when not found', async () => {
@@ -54,7 +54,7 @@ describe('users DAL', () => {
     it('returns user when found', async () => {
       await insertUser('u2', 'u2@test.com')
       const result = await getUserByEmail(db, 'u2@test.com')
-      expect(result).toEqual({ id: 'u2' })
+      expect(result).toEqual({ id: 'u2', name: 'Test User', email: 'u2@test.com' })
     })
 
     it('returns null when not found', async () => {

--- a/backend/src/dal/users.ts
+++ b/backend/src/dal/users.ts
@@ -9,7 +9,7 @@ import { eq } from 'drizzle-orm'
 /** Get a user by ID. Returns null if not found. */
 export const getUserById = async (database: typeof DbType, id: string) =>
   database
-    .select({ id: user.id, isAnonymous: user.isAnonymous })
+    .select({ id: user.id, isAnonymous: user.isAnonymous, name: user.name, email: user.email })
     .from(user)
     .where(eq(user.id, id))
     .limit(1)
@@ -18,7 +18,7 @@ export const getUserById = async (database: typeof DbType, id: string) =>
 /** Get a user by email. Returns null if not found. */
 export const getUserByEmail = async (database: typeof DbType, email: string) =>
   database
-    .select({ id: user.id })
+    .select({ id: user.id, name: user.name, email: user.email })
     .from(user)
     .where(eq(user.email, email))
     .limit(1)

--- a/backend/src/dal/workspaces.test.ts
+++ b/backend/src/dal/workspaces.test.ts
@@ -8,7 +8,7 @@ import { createTestDb } from '@/test-utils/db'
 import { and, eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { v7 as uuidv7 } from 'uuid'
-import { promotePendingMemberships } from './workspaces'
+import { promotePendingMemberships, syncMembershipDisplayInfo } from './workspaces'
 
 describe('promotePendingMemberships', () => {
   let db: Awaited<ReturnType<typeof createTestDb>>['db']
@@ -156,5 +156,103 @@ describe('promotePendingMemberships', () => {
       .from(workspacePendingMembershipsTable)
       .where(eq(workspacePendingMembershipsTable.email, 'multi@test.com'))
     expect(remainingPending).toHaveLength(0)
+  })
+})
+
+describe('syncMembershipDisplayInfo', () => {
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let cleanup: () => Promise<void>
+
+  const insertUser = async (id: string, email: string, name = 'Original Name') => {
+    const now = new Date()
+    await db.insert(user).values({
+      id,
+      name,
+      email,
+      emailVerified: true,
+      isNew: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+  }
+
+  const insertSharedWorkspace = async (id: string): Promise<void> => {
+    await db.insert(workspacesTable).values({ id, name: 'Shared', isPersonal: false, ownerUserId: null })
+  }
+
+  beforeEach(async () => {
+    const testEnv = await createTestDb()
+    db = testEnv.db
+    cleanup = testEnv.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('updates user_name and user_email on every membership row for the user', async () => {
+    await insertUser('alice', 'old@test.com', 'Old Name')
+    const ws1 = uuidv7()
+    const ws2 = uuidv7()
+    await insertSharedWorkspace(ws1)
+    await insertSharedWorkspace(ws2)
+
+    await db.insert(workspaceMembershipsTable).values([
+      {
+        id: uuidv7(),
+        workspaceId: ws1,
+        userId: 'alice',
+        role: 'admin',
+        userName: 'Old Name',
+        userEmail: 'old@test.com',
+      },
+      {
+        id: uuidv7(),
+        workspaceId: ws2,
+        userId: 'alice',
+        role: 'member',
+        userName: 'Old Name',
+        userEmail: 'old@test.com',
+      },
+    ])
+
+    await syncMembershipDisplayInfo(db, 'alice', 'New Name', 'new@test.com')
+
+    const rows = await db.select().from(workspaceMembershipsTable).where(eq(workspaceMembershipsTable.userId, 'alice'))
+    expect(rows).toHaveLength(2)
+    for (const row of rows) {
+      expect(row.userName).toBe('New Name')
+      expect(row.userEmail).toBe('new@test.com')
+    }
+  })
+
+  it('leaves rows for other users untouched', async () => {
+    await insertUser('alice', 'alice@test.com', 'Alice')
+    await insertUser('bob', 'bob@test.com', 'Bob')
+    const ws = uuidv7()
+    await insertSharedWorkspace(ws)
+
+    await db.insert(workspaceMembershipsTable).values([
+      { id: uuidv7(), workspaceId: ws, userId: 'alice', role: 'admin', userName: 'Alice', userEmail: 'alice@test.com' },
+      { id: uuidv7(), workspaceId: ws, userId: 'bob', role: 'member', userName: 'Bob', userEmail: 'bob@test.com' },
+    ])
+
+    await syncMembershipDisplayInfo(db, 'alice', 'Alice Updated', 'alice-new@test.com')
+
+    const bobRow = await db
+      .select()
+      .from(workspaceMembershipsTable)
+      .where(and(eq(workspaceMembershipsTable.workspaceId, ws), eq(workspaceMembershipsTable.userId, 'bob')))
+    expect(bobRow[0].userName).toBe('Bob')
+    expect(bobRow[0].userEmail).toBe('bob@test.com')
+  })
+
+  it('is a no-op when the user has no memberships', async () => {
+    await insertUser('lonely', 'lonely@test.com', 'Lonely')
+
+    await syncMembershipDisplayInfo(db, 'lonely', 'New', 'new@test.com')
+
+    const rows = await db.select().from(workspaceMembershipsTable).where(eq(workspaceMembershipsTable.userId, 'lonely'))
+    expect(rows).toHaveLength(0)
   })
 })

--- a/backend/src/dal/workspaces.test.ts
+++ b/backend/src/dal/workspaces.test.ts
@@ -48,7 +48,7 @@ describe('promotePendingMemberships', () => {
 
   it('is a no-op for users with no matching pending memberships', async () => {
     await insertUser('u1', 'u1@test.com')
-    await promotePendingMemberships(db, 'u1', 'u1@test.com')
+    await promotePendingMemberships(db, 'u1', 'u1@test.com', 'Test User')
 
     const memberships = await db
       .select()
@@ -71,7 +71,7 @@ describe('promotePendingMemberships', () => {
     })
 
     await insertUser('newcomer', 'newcomer@test.com')
-    await promotePendingMemberships(db, 'newcomer', 'newcomer@test.com')
+    await promotePendingMemberships(db, 'newcomer', 'newcomer@test.com', 'Test User')
 
     const memberships = await db
       .select()
@@ -103,7 +103,7 @@ describe('promotePendingMemberships', () => {
 
     await insertUser('mixed', 'mixedcase@test.com')
     // Mixed-case input — `promotePendingMemberships` normalizes before matching.
-    await promotePendingMemberships(db, 'mixed', 'MixedCase@TEST.com')
+    await promotePendingMemberships(db, 'mixed', 'MixedCase@TEST.com', 'Test User')
 
     const promoted = await db
       .select()
@@ -143,7 +143,7 @@ describe('promotePendingMemberships', () => {
     ])
 
     await insertUser('multi', 'multi@test.com')
-    await promotePendingMemberships(db, 'multi', 'multi@test.com')
+    await promotePendingMemberships(db, 'multi', 'multi@test.com', 'Test User')
 
     const memberships = await db
       .select()

--- a/backend/src/dal/workspaces.ts
+++ b/backend/src/dal/workspaces.ts
@@ -20,8 +20,9 @@ import { v7 as uuidv7 } from 'uuid'
  * Called from the Better Auth post-user-create hook. The personal workspace
  * itself is FE-created (uploaded via PowerSync with a deterministic id from
  * `shared/workspaces.ts`) — the BE no longer creates one here. Pending
- * promotion stays server-side because pending rows live in an admin-only
- * sync bucket and FE can't see other users' invites until they're memberships.
+ * promotion stays server-side because a brand-new user isn't a member of any
+ * workspace yet, so no FE client can see (or act on) the pending invite at
+ * signup time.
  *
  * Skipped for anonymous users — anon never receives pending invites.
  */
@@ -141,6 +142,55 @@ export const isWorkspaceAdmin = async (
   return rows.length > 0
 }
 
+/**
+ * Returns the user's `role` ('admin' | 'member') for the workspace, or `null`
+ * if they have no membership row. Used by upload handlers to evaluate
+ * `workspace_permissions.required_role` against the caller's actual role.
+ */
+export const getUserRoleInWorkspace = async (
+  database: typeof DbType,
+  workspaceId: string,
+  userId: string,
+): Promise<Role | null> => {
+  const rows = await database
+    .select({ role: workspaceMembershipsTable.role })
+    .from(workspaceMembershipsTable)
+    .where(and(eq(workspaceMembershipsTable.workspaceId, workspaceId), eq(workspaceMembershipsTable.userId, userId)))
+    .limit(1)
+  const row = rows[0]
+  if (!row) {
+    return null
+  }
+  return row.role as Role
+}
+
+/**
+ * Reads `workspace_permissions.required_role` for `(workspaceId, permissionKey)`.
+ * Returns `null` when no row exists yet; callers default to `'admin'`
+ * (Decision 11 — the safe default for any new key).
+ */
+export const getRequiredRoleForPermission = async (
+  database: typeof DbType,
+  workspaceId: string,
+  permissionKey: WorkspacePermissionKey,
+): Promise<Role | null> => {
+  const rows = await database
+    .select({ requiredRole: workspacePermissionsTable.requiredRole })
+    .from(workspacePermissionsTable)
+    .where(
+      and(
+        eq(workspacePermissionsTable.workspaceId, workspaceId),
+        eq(workspacePermissionsTable.permissionKey, permissionKey),
+      ),
+    )
+    .limit(1)
+  const row = rows[0]
+  if (!row) {
+    return null
+  }
+  return row.requiredRole as Role
+}
+
 /** True when the user is an admin of any workspace (used to gate shared-workspace creation). */
 export const isAdminOfAnyWorkspace = async (database: typeof DbType, userId: string): Promise<boolean> => {
   const rows = await database
@@ -202,6 +252,30 @@ export const getMembershipById = async (
   return rows[0] ?? null
 }
 
+/**
+ * Look up a membership by `(workspace_id, user_id)` — the unique constraint
+ * that `upsertMembership` collides on. Upload-handler validation uses this to
+ * detect when a PUT would effectively change an existing role (treated as a
+ * PATCH for auth purposes).
+ */
+export const getMembershipByWorkspaceAndUser = async (
+  database: typeof DbType,
+  workspaceId: string,
+  userId: string,
+): Promise<MembershipRow | null> => {
+  const rows = await database
+    .select({
+      id: workspaceMembershipsTable.id,
+      workspaceId: workspaceMembershipsTable.workspaceId,
+      userId: workspaceMembershipsTable.userId,
+      role: workspaceMembershipsTable.role,
+    })
+    .from(workspaceMembershipsTable)
+    .where(and(eq(workspaceMembershipsTable.workspaceId, workspaceId), eq(workspaceMembershipsTable.userId, userId)))
+    .limit(1)
+  return rows[0] ?? null
+}
+
 export const getPendingMembershipById = async (database: typeof DbType, id: string): Promise<PendingRow | null> => {
   const rows = await database
     .select({
@@ -229,8 +303,10 @@ export const getWorkspacePermissionById = async (
   return rows[0] ?? null
 }
 
+import type { WorkspacePermissionKey } from '@shared/workspaces'
+
 export type Role = 'admin' | 'member'
-export type WorkspacePermissionKey = 'manage_members' | 'change_roles'
+export type { WorkspacePermissionKey }
 
 export type UpsertWorkspaceInput = {
   id: string
@@ -359,6 +435,23 @@ export const upsertMembership = async (database: typeof DbType, input: Membershi
 }
 
 /**
+ * Insert a membership row only if no row with the same `(workspace_id, user_id)`
+ * already exists. Used by the promote-on-insert path in the pending-membership
+ * upload handler: an invite for an email that already belongs to a member must
+ * not overwrite that member's existing role (otherwise an invite for an admin's
+ * own email would downgrade them to whatever role the invite carried). Mirrors
+ * the `promotePendingMemberships` DO-NOTHING semantics for the signup path.
+ */
+export const insertMembershipIfMissing = async (database: typeof DbType, input: MembershipInput): Promise<void> => {
+  await database
+    .insert(workspaceMembershipsTable)
+    .values(input)
+    .onConflictDoNothing({
+      target: [workspaceMembershipsTable.workspaceId, workspaceMembershipsTable.userId],
+    })
+}
+
+/**
  * Mirrors a user's current display info onto every one of their membership rows.
  * Called from the Better Auth `update.after` hook so name/email changes propagate
  * to co-members on the next sync round-trip. Idempotent — safe to call on every
@@ -455,6 +548,32 @@ export const deletePendingMembership = async (database: typeof DbType, id: strin
   const rows = await database
     .delete(workspacePendingMembershipsTable)
     .where(eq(workspacePendingMembershipsTable.id, id))
+    .returning()
+  return rows.length
+}
+
+/**
+ * Deletes the pending row for `(workspace_id, email)`. Used by the
+ * promote-on-insert path in the upload handler: when `upsertPendingMembership`
+ * conflicts on the `(workspace_id, email)` unique constraint, Postgres keeps
+ * the existing row's id, so a delete keyed on the upload's `op.id` would no-op
+ * and leave a stale pending invite behind for someone who is now a real
+ * member. Email is normalized to match `upsertPendingMembership`'s storage.
+ */
+export const deletePendingMembershipByWorkspaceAndEmail = async (
+  database: typeof DbType,
+  workspaceId: string,
+  email: string,
+): Promise<number> => {
+  const normalizedEmail = normalizeEmail(email)
+  const rows = await database
+    .delete(workspacePendingMembershipsTable)
+    .where(
+      and(
+        eq(workspacePendingMembershipsTable.workspaceId, workspaceId),
+        eq(workspacePendingMembershipsTable.email, normalizedEmail),
+      ),
+    )
     .returning()
   return rows.length
 }

--- a/backend/src/dal/workspaces.ts
+++ b/backend/src/dal/workspaces.ts
@@ -29,6 +29,7 @@ export const promotePendingMemberships = async (
   database: typeof DbType,
   userId: string,
   email: string,
+  name: string,
 ): Promise<void> => {
   const normalizedEmail = normalizeEmail(email)
 
@@ -52,6 +53,8 @@ export const promotePendingMemberships = async (
           workspaceId: row.workspaceId,
           userId,
           role: row.role,
+          userName: name,
+          userEmail: normalizedEmail,
         })),
       )
       .onConflictDoNothing({
@@ -328,11 +331,18 @@ export type MembershipInput = {
   workspaceId: string
   userId: string
   role: Role
+  /** Denormalized from `auth.user`. Synced down so the Members page can render
+   *  display info without a `users` projection table (PowerSync sync rules
+   *  can't follow `user_id` across buckets). */
+  userName?: string | null
+  userEmail?: string | null
 }
 
 /**
  * Upserts a workspace membership. Conflict target is the natural key
- * `(workspace_id, user_id)`; on conflict the role is refreshed.
+ * `(workspace_id, user_id)`; on conflict the role is refreshed. Display info
+ * (`user_name`, `user_email`) is refreshed too so a stale denormalized row
+ * heals the next time the upload handler runs against it.
  */
 export const upsertMembership = async (database: typeof DbType, input: MembershipInput): Promise<void> => {
   await database
@@ -340,7 +350,11 @@ export const upsertMembership = async (database: typeof DbType, input: Membershi
     .values(input)
     .onConflictDoUpdate({
       target: [workspaceMembershipsTable.workspaceId, workspaceMembershipsTable.userId],
-      set: { role: input.role },
+      set: {
+        role: input.role,
+        ...(input.userName !== undefined ? { userName: input.userName } : {}),
+        ...(input.userEmail !== undefined ? { userEmail: input.userEmail } : {}),
+      },
     })
 }
 

--- a/backend/src/dal/workspaces.ts
+++ b/backend/src/dal/workspaces.ts
@@ -358,6 +358,24 @@ export const upsertMembership = async (database: typeof DbType, input: Membershi
     })
 }
 
+/**
+ * Mirrors a user's current display info onto every one of their membership rows.
+ * Called from the Better Auth `update.after` hook so name/email changes propagate
+ * to co-members on the next sync round-trip. Idempotent — safe to call on every
+ * user update regardless of whether name/email actually changed.
+ */
+export const syncMembershipDisplayInfo = async (
+  database: typeof DbType,
+  userId: string,
+  name: string,
+  email: string,
+): Promise<void> => {
+  await database
+    .update(workspaceMembershipsTable)
+    .set({ userName: name, userEmail: email })
+    .where(eq(workspaceMembershipsTable.userId, userId))
+}
+
 export const updateMembership = async (
   database: typeof DbType,
   id: string,

--- a/backend/src/db/powersync-schema.ts
+++ b/backend/src/db/powersync-schema.ts
@@ -65,6 +65,12 @@ export const workspacesTable = powersyncSchema.table(
  *
  * Roles are `admin` | `member` only (Decision 9 — no `owner`). Last-admin protection
  * lives in the upload handler factory.
+ *
+ * `user_name` / `user_email` are denormalized from `auth.user` so the Members
+ * page can render display info without a synced `users` table — PowerSync sync
+ * rules can't follow a `user_id` foreign key across buckets. The upload handler
+ * fills them at insert time; the Better Auth `after('updateUser')` hook keeps
+ * them in step when a user later edits their name or email.
  */
 export const workspaceMembershipsTable = powersyncSchema.table(
   'workspace_memberships',
@@ -77,6 +83,8 @@ export const workspaceMembershipsTable = powersyncSchema.table(
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
     role: text('role', { enum: ['admin', 'member'] }).notNull(),
+    userName: text('user_name'),
+    userEmail: text('user_email'),
     createdAt: timestamp('created_at').notNull().defaultNow(),
   },
   (table) => [

--- a/backend/src/db/powersync-schema.ts
+++ b/backend/src/db/powersync-schema.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { PowerSyncTableName } from '@shared/powersync-tables'
+import { workspacePermissionKeys, workspacePermissionRoles } from '@shared/workspaces'
 import {
   type AnyPgColumn,
   type AnyPgTable,
@@ -122,9 +123,9 @@ export const workspacePendingMembershipsTable = powersyncSchema.table(
 )
 
 /**
- * Per-workspace permission policy. v1 ships two keys (`manage_members`, `change_roles`)
- * with values `admin` | `member` (Decision 10). Schema designed so adding a new
- * permission post-v1 is a row insert, not a schema change.
+ * Per-workspace permission policy (Decision 10). The enum lists every
+ * configurable action the workspace exposes; the source of truth lives in
+ * `shared/workspaces.ts` so FE/BE schemas + types stay in lockstep.
  */
 export const workspacePermissionsTable = powersyncSchema.table(
   'workspace_permissions',
@@ -133,8 +134,8 @@ export const workspacePermissionsTable = powersyncSchema.table(
     workspaceId: text('workspace_id')
       .notNull()
       .references(() => workspacesTable.id, { onDelete: 'cascade' }),
-    permissionKey: text('permission_key', { enum: ['manage_members', 'change_roles'] }).notNull(),
-    requiredRole: text('required_role', { enum: ['admin', 'member'] }).notNull(),
+    permissionKey: text('permission_key', { enum: [...workspacePermissionKeys] }).notNull(),
+    requiredRole: text('required_role', { enum: [...workspacePermissionRoles] }).notNull(),
   },
   (table) => [
     uniqueIndex('idx_workspace_permissions_workspace_key').on(table.workspaceId, table.permissionKey),

--- a/backend/src/lib/email.ts
+++ b/backend/src/lib/email.ts
@@ -8,3 +8,13 @@
  * - Trims whitespace
  */
 export const normalizeEmail = (email: string) => email.toLowerCase().trim()
+
+/**
+ * Format check (same regex as the FE's `isValidEmailFormat`) — guards
+ * upload-handler inserts against junk strings before they hit the DB. Run
+ * against the normalized form so case/whitespace don't sneak past.
+ */
+const emailRegex =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
+
+export const isValidEmailFormat = (email: string): boolean => emailRegex.test(normalizeEmail(email))

--- a/backend/src/powersync/upload-handlers/helpers.ts
+++ b/backend/src/powersync/upload-handlers/helpers.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { HandlerResult } from './types'
+import { getRequiredRoleForPermission, getUserRoleInWorkspace } from '@/dal/workspaces'
+import { permissionAllows, type WorkspacePermissionKey } from '@shared/workspaces'
+import type { HandlerResult, UploadTx } from './types'
 
 /** Column names Drizzle declares as `timestamp(...)`; JSON sends them as ISO strings. */
 const timestampDbColumns = new Set(['deleted_at', 'last_seen', 'created_at', 'revoked_at', 'updated_at'])
@@ -42,3 +44,22 @@ export const reject = (rejectionClass: 'permanent' | 'transient', code: string):
   class: rejectionClass,
   code,
 })
+
+/**
+ * Resolves the caller's role + the configured permission's required role and
+ * returns whether the op is allowed. Defaults `required_role` to `'admin'`
+ * when no `workspace_permissions` row exists for the key (Decision 11) so an
+ * unconfigured workspace stays admin-only. Shared by every handler that gates
+ * writes on `workspace_permissions` — keep the lookup in one place so the
+ * default-to-admin policy can't drift between tables.
+ */
+export const callerSatisfiesPermission = async (
+  tx: UploadTx,
+  workspaceId: string,
+  userId: string,
+  permissionKey: WorkspacePermissionKey,
+): Promise<boolean> => {
+  const required = (await getRequiredRoleForPermission(tx, workspaceId, permissionKey)) ?? 'admin'
+  const userRole = await getUserRoleInWorkspace(tx, workspaceId, userId)
+  return permissionAllows(userRole, required)
+}

--- a/backend/src/powersync/upload-handlers/registry.ts
+++ b/backend/src/powersync/upload-handlers/registry.ts
@@ -38,14 +38,38 @@ export const handlers: Record<PowerSyncTableName, UploadHandler> = {
   tasks: createWorkspaceScopedHandler({ tableName: 'tasks', userPrivate: true }),
 
   // Workspace-scoped, shared (any member of the workspace may read/write).
-  models: createWorkspaceScopedHandler({ tableName: 'models', userPrivate: false }),
-  mcp_servers: createWorkspaceScopedHandler({ tableName: 'mcp_servers', userPrivate: false }),
+  models: createWorkspaceScopedHandler({
+    tableName: 'models',
+    userPrivate: false,
+    addPermissionKey: 'add_models',
+    removePermissionKey: 'remove_models',
+    softDeleteColumn: 'deleted_at',
+  }),
+  mcp_servers: createWorkspaceScopedHandler({
+    tableName: 'mcp_servers',
+    userPrivate: false,
+    addPermissionKey: 'add_mcp_servers',
+    removePermissionKey: 'remove_mcp_servers',
+    softDeleteColumn: 'deleted_at',
+  }),
   prompts: createWorkspaceScopedHandler({ tableName: 'prompts', userPrivate: false }),
-  skills: createWorkspaceScopedHandler({ tableName: 'skills', userPrivate: false }),
+  skills: createWorkspaceScopedHandler({
+    tableName: 'skills',
+    userPrivate: false,
+    addPermissionKey: 'add_skills',
+    removePermissionKey: 'remove_skills',
+    softDeleteColumn: 'deleted_at',
+  }),
   triggers: createWorkspaceScopedHandler({ tableName: 'triggers', userPrivate: false }),
   modes: createWorkspaceScopedHandler({ tableName: 'modes', userPrivate: false }),
   model_profiles: createWorkspaceScopedHandler({ tableName: 'model_profiles', userPrivate: false }),
-  agents: createWorkspaceScopedHandler({ tableName: 'agents', userPrivate: false }),
+  agents: createWorkspaceScopedHandler({
+    tableName: 'agents',
+    userPrivate: false,
+    addPermissionKey: 'add_agents',
+    removePermissionKey: 'remove_agents',
+    softDeleteColumn: 'deleted_at',
+  }),
 
   // Workspace registry tables — bespoke handlers (commit 2).
   workspaces: workspacesHandler,

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -421,6 +421,10 @@ describe('workspace upload handlers', () => {
         .where(eq(workspaceMembershipsTable.workspaceId, workspaceId))
       expect(stored).toHaveLength(1)
       expect(stored[0].role).toBe('admin')
+      // Display info is denormalized from auth.user by the upload handler so the
+      // FE Members page can render without a synced users projection.
+      expect(stored[0].userName).toBe('Test User')
+      expect(stored[0].userEmail).toBe('owner5@test.com')
     })
 
     it('rejects a second membership write to a personal workspace (immutable)', async () => {
@@ -597,6 +601,9 @@ describe('workspace upload handlers', () => {
       const invitee = memberships.find((m) => m.userId === 'invitee1')
       expect(invitee).toBeDefined()
       expect(invitee?.role).toBe('member')
+      // Promotion carries the matched user's display info onto the membership row.
+      expect(invitee?.userName).toBe('Test User')
+      expect(invitee?.userEmail).toBe('invitee1@test.com')
     })
 
     it('promotes via normalized email match (case + whitespace)', async () => {

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -496,6 +496,57 @@ describe('workspace upload handlers', () => {
         .where(eq(workspaceMembershipsTable.id, a4MembershipId))
       expect(stillThere).toHaveLength(1)
     })
+
+    it('rejects a PUT adding another user when e2eeEnabled is true (THU-593)', async () => {
+      await insertUser('admin-e1', 'admin-e1@test.com')
+      await insertUser('invitee-e1', 'invitee-e1@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'E2EE shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-e1',
+        role: 'admin',
+      })
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, user_id: 'invitee-e1', role: 'member' },
+      }
+      const result = await applyUploadBatch(
+        db,
+        [op],
+        ctxFor('admin-e1', { settings: createTestSettings({ e2eeEnabled: true }) }),
+      )
+      expectPermanentReject(result, 'E2EE_MEMBERSHIPS_DISABLED')
+    })
+
+    it('still allows the self-bootstrap PUT when e2eeEnabled is true', async () => {
+      await insertUser('owner-e1', 'owner-e1@test.com')
+      const workspaceId = computePersonalWorkspaceId('owner-e1')
+      const ops: UploadOp[] = [
+        {
+          op: 'PUT',
+          type: 'workspaces',
+          id: workspaceId,
+          data: { is_personal: true, owner_user_id: 'owner-e1', name: 'Personal' },
+        },
+        {
+          op: 'PUT',
+          type: 'workspace_memberships',
+          id: computePersonalAdminMembershipId('owner-e1'),
+          data: { workspace_id: workspaceId, user_id: 'owner-e1', role: 'admin' },
+        },
+      ]
+      const result = await applyUploadBatch(
+        db,
+        ops,
+        ctxFor('owner-e1', { settings: createTestSettings({ e2eeEnabled: true }) }),
+      )
+      expect(result.ok).toBe(true)
+    })
   })
 
   describe('workspace_pending_memberships', () => {
@@ -672,6 +723,29 @@ describe('workspace upload handlers', () => {
         .where(eq(workspaceMembershipsTable.workspaceId, sharedId))
       // only the seed admin — no promotion
       expect(memberships).toHaveLength(1)
+    })
+
+    it('rejects a pending PUT when e2eeEnabled is true (THU-593)', async () => {
+      await insertUser('admin-e2', 'admin-e2@test.com')
+      const sharedId = await seedSharedAsAdmin('admin-e2')
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: {
+          workspace_id: sharedId,
+          email: 'invitee@test.com',
+          role: 'member',
+          invited_by_user_id: 'admin-e2',
+        },
+      }
+      const result = await applyUploadBatch(
+        db,
+        [op],
+        ctxFor('admin-e2', { settings: createTestSettings({ e2eeEnabled: true }) }),
+      )
+      expectPermanentReject(result, 'E2EE_MEMBERSHIPS_DISABLED')
     })
   })
 

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -3,7 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { user } from '@/db/auth-schema'
-import { workspaceMembershipsTable, workspacePendingMembershipsTable, workspacesTable } from '@/db/powersync-schema'
+import {
+  agentsTable,
+  mcpServersTable,
+  modelsTable,
+  skillsTable,
+  workspaceMembershipsTable,
+  workspacePendingMembershipsTable,
+  workspacePermissionsTable,
+  workspacesTable,
+} from '@/db/powersync-schema'
 import { createTestDb } from '@/test-utils/db'
 import { createTestSettings } from '@/test-utils/settings'
 import { computePersonalAdminMembershipId, computePersonalWorkspaceId } from '@shared/workspaces'
@@ -366,6 +375,32 @@ describe('workspace upload handlers', () => {
       expect(stored[0].slug).toBeNull()
     })
 
+    it('PUT does not clear server-side slug/icon when payload omits them', async () => {
+      await insertUser('keepfields', 'keepfields@test.com')
+      const workspaceId = await createSharedAs('keepfields', 'Initial')
+
+      // Set slug + icon via PATCH.
+      const patchResult = await applyUploadBatch(
+        db,
+        [{ op: 'PATCH', type: 'workspaces', id: workspaceId, data: { slug: 'kept-slug', icon: '🎯' } }],
+        ctxFor('keepfields'),
+      )
+      expect(patchResult.ok).toBe(true)
+
+      // Now PUT with only `name` — slug + icon must survive.
+      const putResult = await applyUploadBatch(
+        db,
+        [{ op: 'PUT', type: 'workspaces', id: workspaceId, data: { name: 'Renamed' } }],
+        ctxFor('keepfields'),
+      )
+      expect(putResult.ok).toBe(true)
+
+      const stored = await db.select().from(workspacesTable).where(eq(workspacesTable.id, workspaceId))
+      expect(stored[0].name).toBe('Renamed')
+      expect(stored[0].slug).toBe('kept-slug')
+      expect(stored[0].icon).toBe('🎯')
+    })
+
     it('PUT rejects shared workspace with a slug already taken', async () => {
       await insertUser('first', 'first@test.com')
       await insertUser('second', 'second@test.com')
@@ -425,6 +460,177 @@ describe('workspace upload handlers', () => {
       // FE Members page can render without a synced users projection.
       expect(stored[0].userName).toBe('Test User')
       expect(stored[0].userEmail).toBe('owner5@test.com')
+    })
+
+    it('rejects an admin-role membership PUT from invite_users-only caller (escalation guard)', async () => {
+      // Direct `workspace_memberships` PUT with `role: 'admin'` must require
+      // `change_roles` in addition to `invite_users` — same shape as the
+      // pending-membership escalation guard.
+      await insertUser('admin-ws', 'admin-ws@test.com')
+      await bootstrapPersonalViaUpload('admin-ws')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({
+        id: sharedId,
+        name: 'Shared',
+        isPersonal: false,
+        ownerUserId: null,
+      })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-ws',
+        role: 'admin',
+      })
+      const memberId = 'ws-member-invite-only'
+      await insertUser(memberId, 'ws-member-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+      const newUserId = 'new-admin-target'
+      await insertUser(newUserId, 'new-admin-target@test.com')
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, user_id: newUserId, role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('rejects PUT that demotes an existing admin without change_roles', async () => {
+      // `upsertMembership` does ON CONFLICT DO UPDATE SET role on
+      // `(workspace_id, user_id)`. A caller with `invite_users` alone could
+      // otherwise PUT `role: 'member'` at an existing admin's pair and
+      // demote them without `change_roles` — same effective action as a
+      // PATCH demote, which DOES require `change_roles`.
+      await insertUser('demote-admin', 'demote-admin@test.com')
+      await bootstrapPersonalViaUpload('demote-admin')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({
+        id: sharedId,
+        name: 'Shared',
+        isPersonal: false,
+        ownerUserId: null,
+      })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'demote-admin',
+        role: 'admin',
+      })
+      const targetAdminId = 'demote-target-admin'
+      await insertUser(targetAdminId, 'demote-target-admin@test.com')
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: targetAdminId,
+        role: 'admin',
+      })
+      const memberId = 'demote-actor-invite-only'
+      await insertUser(memberId, 'demote-actor-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      // PUT with a fresh op.id (so the lookup must hit by `(workspace_id, user_id)`)
+      // and the demoted role on the existing admin's pair.
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, user_id: targetAdminId, role: 'member' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+
+      // Existing admin row is untouched.
+      const stored = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.id, targetMembershipId))
+      expect(stored[0].role).toBe('admin')
+    })
+
+    it('rejects PUT that would demote the last admin (last-admin protection)', async () => {
+      // PUT's apply path upserts via `ON CONFLICT DO UPDATE SET role`. Without
+      // a last-admin guard in apply, a caller satisfying `change_roles` could
+      // demote the workspace's only admin to member by PUT — leaving zero
+      // admins, while PATCH/DELETE would reject with LAST_ADMIN_PROTECTED.
+      await insertUser('lone-admin', 'lone-admin@test.com')
+      await bootstrapPersonalViaUpload('lone-admin')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({
+        id: sharedId,
+        name: 'Shared',
+        isPersonal: false,
+        ownerUserId: null,
+      })
+      const adminMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: adminMembershipId,
+        workspaceId: sharedId,
+        userId: 'lone-admin',
+        role: 'admin',
+      })
+      const memberId = 'member-with-cr-demote'
+      await insertUser(memberId, 'member-with-cr-demote@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      // Grant both keys so PUT validate passes — the test exercises the apply
+      // layer's last-admin guard.
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'change_roles',
+        requiredRole: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, user_id: 'lone-admin', role: 'member' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'LAST_ADMIN_PROTECTED')
+
+      // The admin row is unchanged.
+      const stored = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.id, adminMembershipId))
+      expect(stored[0].role).toBe('admin')
     })
 
     it('rejects a second membership write to a personal workspace (immutable)', async () => {
@@ -497,6 +703,165 @@ describe('workspace upload handlers', () => {
       expect(stillThere).toHaveLength(1)
     })
 
+    it('PATCH role: allowed when caller has change_roles=member', async () => {
+      await insertUser('admin-cr-ok', 'admin-cr-ok@test.com')
+      await insertUser('target-cr-ok', 'target-cr-ok@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'Shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-cr-ok',
+        role: 'admin',
+      })
+      const memberId = 'member-with-cr'
+      await insertUser(memberId, 'member-with-cr@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: 'target-cr-ok',
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'change_roles',
+        requiredRole: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'PATCH',
+        type: 'workspace_memberships',
+        id: targetMembershipId,
+        data: { role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expect(result.ok).toBe(true)
+    })
+
+    it('PATCH role: rejected when caller lacks change_roles', async () => {
+      await insertUser('admin-cr-no', 'admin-cr-no@test.com')
+      await insertUser('target-cr-no', 'target-cr-no@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'Shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-cr-no',
+        role: 'admin',
+      })
+      const memberId = 'member-no-cr'
+      await insertUser(memberId, 'member-no-cr@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: 'target-cr-no',
+        role: 'member',
+      })
+      // No workspace_permissions row → change_roles defaults to admin.
+
+      const op: UploadOp = {
+        op: 'PATCH',
+        type: 'workspace_memberships',
+        id: targetMembershipId,
+        data: { role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('DELETE: allowed when caller has remove_users=member', async () => {
+      await insertUser('admin-ru-ok', 'admin-ru-ok@test.com')
+      await insertUser('target-ru-ok', 'target-ru-ok@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'Shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-ru-ok',
+        role: 'admin',
+      })
+      const memberId = 'member-with-ru'
+      await insertUser(memberId, 'member-with-ru@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: 'target-ru-ok',
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'remove_users',
+        requiredRole: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'DELETE',
+        type: 'workspace_memberships',
+        id: targetMembershipId,
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expect(result.ok).toBe(true)
+    })
+
+    it('DELETE: rejected when caller lacks remove_users', async () => {
+      await insertUser('admin-ru-no', 'admin-ru-no@test.com')
+      await insertUser('target-ru-no', 'target-ru-no@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'Shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-ru-no',
+        role: 'admin',
+      })
+      const memberId = 'member-no-ru'
+      await insertUser(memberId, 'member-no-ru@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: 'target-ru-no',
+        role: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'DELETE',
+        type: 'workspace_memberships',
+        id: targetMembershipId,
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
     it('rejects a PUT adding another user when e2eeEnabled is true (THU-593)', async () => {
       await insertUser('admin-e1', 'admin-e1@test.com')
       await insertUser('invitee-e1', 'invitee-e1@test.com')
@@ -567,6 +932,191 @@ describe('workspace upload handlers', () => {
       return sharedId
     }
 
+    it('allows a member to invite when invite_users is granted to member role', async () => {
+      await insertUser('a-perm', 'a-perm@test.com')
+      await insertUser('b-perm', 'b-perm@test.com')
+      await bootstrapPersonalViaUpload('a-perm')
+      const sharedId = await seedSharedAsAdmin('a-perm')
+
+      // b-perm becomes a member of the shared workspace.
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'b-perm',
+        role: 'member',
+      })
+
+      // Workspace grants `invite_users` to the `member` role.
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      // b-perm (member) sends a pending invite — should succeed.
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: {
+          workspace_id: sharedId,
+          email: 'newcomer@test.com',
+          role: 'member',
+        },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('b-perm'))
+      expect(result.ok).toBe(true)
+    })
+
+    it('rejects an admin-role pending invite from invite_users-only caller (escalation guard)', async () => {
+      // `invite_users` alone must not be enough to invite `role: 'admin'` —
+      // otherwise the signup-promote path would mint a new admin and bypass
+      // the `change_roles` gate that protects existing-member promotions.
+      await insertUser('inviter-only', 'inviter-only@test.com')
+      await bootstrapPersonalViaUpload('inviter-only')
+      const sharedId = await seedSharedAsAdmin('inviter-only')
+      const memberId = 'member-with-invite-only'
+      await insertUser(memberId, 'member-with-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, email: 'pending-admin@test.com', role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('rejects PATCH that promotes a pending invite to admin without change_roles', async () => {
+      // PATCH-to-admin must hit the same escalation guard as PUT-to-admin —
+      // otherwise an inviter could quietly elevate a pending invite they
+      // shouldn't be able to promote.
+      await insertUser('patch-inviter', 'patch-inviter@test.com')
+      await bootstrapPersonalViaUpload('patch-inviter')
+      const sharedId = await seedSharedAsAdmin('patch-inviter')
+      const memberId = 'patch-member-invite-only'
+      await insertUser(memberId, 'patch-member-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      // Seed a pending invite at role=member, then try to PATCH to admin.
+      const pendingId = uuidv7()
+      await db.insert(workspacePendingMembershipsTable).values({
+        id: pendingId,
+        workspaceId: sharedId,
+        email: 'pending-target@test.com',
+        role: 'member',
+        invitedByUserId: 'patch-inviter',
+      })
+
+      const op: UploadOp = {
+        op: 'PATCH',
+        type: 'workspace_pending_memberships',
+        id: pendingId,
+        data: { role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('allows PATCH demoting a pending admin invite to member from invite_users-only caller', async () => {
+      // The escalation guard is intentionally one-way: promotions to admin
+      // require `change_roles`, but demotions stay gated on `invite_users`
+      // alone. Demoting a pending admin invite is tampering, not escalation,
+      // and matching the broader "any role change" rule from the memberships
+      // handler would cost an extra DB read for a non-security concern.
+      await insertUser('demote-inviter', 'demote-inviter@test.com')
+      await bootstrapPersonalViaUpload('demote-inviter')
+      const sharedId = await seedSharedAsAdmin('demote-inviter')
+      const memberId = 'demote-member-invite-only'
+      await insertUser(memberId, 'demote-member-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      const pendingId = uuidv7()
+      await db.insert(workspacePendingMembershipsTable).values({
+        id: pendingId,
+        workspaceId: sharedId,
+        email: 'pending-admin-to-demote@test.com',
+        role: 'admin',
+        invitedByUserId: 'demote-inviter',
+      })
+
+      const op: UploadOp = {
+        op: 'PATCH',
+        type: 'workspace_pending_memberships',
+        id: pendingId,
+        data: { role: 'member' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expect(result.ok).toBe(true)
+    })
+
+    it('allows an admin-role pending invite when caller has BOTH invite_users and change_roles', async () => {
+      await insertUser('inviter-both', 'inviter-both@test.com')
+      await bootstrapPersonalViaUpload('inviter-both')
+      const sharedId = await seedSharedAsAdmin('inviter-both')
+      const memberId = 'member-with-both'
+      await insertUser(memberId, 'member-with-both@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      for (const key of ['invite_users', 'change_roles'] as const) {
+        await db.insert(workspacePermissionsTable).values({
+          id: uuidv7(),
+          workspaceId: sharedId,
+          permissionKey: key,
+          requiredRole: 'member',
+        })
+      }
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, email: 'pending-admin-allowed@test.com', role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expect(result.ok).toBe(true)
+    })
+
     it('rejects writes by non-admins of the target workspace', async () => {
       await insertUser('a5', 'a5@test.com')
       await insertUser('b5', 'b5@test.com')
@@ -585,7 +1135,7 @@ describe('workspace upload handlers', () => {
         },
       }
       const result = await applyUploadBatch(db, [op], ctxFor('b5'))
-      expectPermanentReject(result, 'NOT_WORKSPACE_ADMIN')
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
     })
 
     it('normalizes email on insert', async () => {
@@ -689,6 +1239,128 @@ describe('workspace upload handlers', () => {
         .where(eq(workspaceMembershipsTable.workspaceId, sharedId))
       const invitee = memberships.find((m) => m.userId === 'invitee2')
       expect(invitee?.role).toBe('admin')
+    })
+
+    it('deletes the actual pending row on promote-on-insert even after unique-key conflict', async () => {
+      await insertUser('admin10', 'admin10@test.com')
+      await insertUser('invitee3', 'invitee3@test.com')
+      await bootstrapPersonalViaUpload('admin10')
+      const sharedId = await seedSharedAsAdmin('admin10')
+
+      // Seed an existing pending row with id=X.
+      const originalPendingId = uuidv7()
+      await db.insert(workspacePendingMembershipsTable).values({
+        id: originalPendingId,
+        workspaceId: sharedId,
+        email: 'invitee3@test.com',
+        role: 'admin',
+        invitedByUserId: 'admin10',
+      })
+
+      // Now upload a NEW pending op (id=Y) for the same workspace+email.
+      const newOpId = uuidv7()
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: newOpId,
+        data: {
+          workspace_id: sharedId,
+          email: 'invitee3@test.com',
+          role: 'member',
+          invited_by_user_id: 'admin10',
+        },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('admin10'))
+      expect(result.ok).toBe(true)
+
+      // Both the id=X row (the actual one in DB) and the id=Y delete target
+      // must result in zero pending rows for (workspace_id, email).
+      const pending = await db
+        .select()
+        .from(workspacePendingMembershipsTable)
+        .where(eq(workspacePendingMembershipsTable.workspaceId, sharedId))
+      expect(pending).toHaveLength(0)
+    })
+
+    it('preserves an existing membership role on promote-on-insert (no downgrade)', async () => {
+      await insertUser('admin9', 'admin9@test.com')
+      await insertUser('coadmin', 'coadmin@test.com')
+      await bootstrapPersonalViaUpload('admin9')
+      const sharedId = await seedSharedAsAdmin('admin9')
+
+      // Make coadmin an admin of the same workspace directly.
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'coadmin',
+        role: 'admin',
+        userName: 'Test User',
+        userEmail: 'coadmin@test.com',
+      })
+
+      // Invite coadmin's email with role='member' — should NOT downgrade.
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: {
+          workspace_id: sharedId,
+          email: 'coadmin@test.com',
+          role: 'member',
+          invited_by_user_id: 'admin9',
+        },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('admin9'))
+      expect(result.ok).toBe(true)
+
+      const memberships = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.workspaceId, sharedId))
+      const coadminRow = memberships.find((m) => m.userId === 'coadmin')
+      expect(coadminRow?.role).toBe('admin')
+    })
+
+    it('rejects malformed email on pending PUT with INVALID_EMAIL', async () => {
+      await insertUser('admin-email', 'admin-email@test.com')
+      await bootstrapPersonalViaUpload('admin-email')
+      const sharedId = await seedSharedAsAdmin('admin-email')
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, email: 'not-an-email', role: 'member' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('admin-email'))
+      expectPermanentReject(result, 'INVALID_EMAIL')
+    })
+
+    it('overrides client-supplied invited_by_user_id with ctx.userId', async () => {
+      await insertUser('inviter', 'inviter@test.com')
+      await bootstrapPersonalViaUpload('inviter')
+      const sharedId = await seedSharedAsAdmin('inviter')
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: {
+          workspace_id: sharedId,
+          email: 'pending@test.com',
+          role: 'member',
+          // Attempt to attribute the invite to someone else.
+          invited_by_user_id: 'someone-else',
+        },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('inviter'))
+      expect(result.ok).toBe(true)
+
+      const stored = await db
+        .select()
+        .from(workspacePendingMembershipsTable)
+        .where(eq(workspacePendingMembershipsTable.id, op.id))
+      expect(stored[0]?.invitedByUserId).toBe('inviter')
     })
 
     it('keeps pending row when invited email does not match any user', async () => {
@@ -813,6 +1485,521 @@ describe('workspace upload handlers', () => {
         expect(result.rejected[0].code).toBe('PERSONAL_WORKSPACE_OWNER_MISMATCH')
         expect(result.rejected[1].code).toBe('PERSONAL_WORKSPACE_ID_NOT_CANONICAL')
       }
+    })
+  })
+
+  describe('agents — workspace permission gating (add_agents / remove_agents)', () => {
+    /**
+     * Sets up a shared workspace with `adminId` as admin and `memberId` as member.
+     * Both users must have already been inserted via `insertUser`. Returns the
+     * workspace id so the test can target it.
+     */
+    const seedSharedWithAdminAndMember = async (adminId: string, memberId: string): Promise<string> => {
+      const workspaceId = uuidv7()
+      await db.insert(workspacesTable).values({ id: workspaceId, isPersonal: false, name: 'Acme' })
+      await db.insert(workspaceMembershipsTable).values({ id: uuidv7(), workspaceId, userId: adminId, role: 'admin' })
+      await db.insert(workspaceMembershipsTable).values({ id: uuidv7(), workspaceId, userId: memberId, role: 'member' })
+      return workspaceId
+    }
+
+    const setRequiredRole = async (
+      workspaceId: string,
+      key: 'add_agents' | 'remove_agents',
+      requiredRole: 'admin' | 'member',
+    ): Promise<void> => {
+      await db.insert(workspacePermissionsTable).values({ id: uuidv7(), workspaceId, permissionKey: key, requiredRole })
+    }
+
+    const agentPut = (workspaceId: string, id = uuidv7()): UploadOp => ({
+      op: 'PUT',
+      type: 'agents',
+      id,
+      data: {
+        workspace_id: workspaceId,
+        name: 'Test agent',
+        type: 'remote-acp',
+        transport: 'websocket',
+        url: 'wss://example.invalid/acp',
+      },
+    })
+
+    it('PUT agent: admin always succeeds (default required_role = admin)', async () => {
+      await insertUser('agAdmin1', 'agadmin1@test.com')
+      await insertUser('agMember1', 'agmember1@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin1', 'agMember1')
+
+      const op = agentPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('agAdmin1'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(agentsTable).where(eq(agentsTable.id, op.id))
+      expect(stored).toHaveLength(1)
+    })
+
+    it('PUT agent: member rejected when add_agents required_role = admin (default)', async () => {
+      await insertUser('agAdmin2', 'agadmin2@test.com')
+      await insertUser('agMember2', 'agmember2@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin2', 'agMember2')
+
+      const op = agentPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('agMember2'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+      const stored = await db.select().from(agentsTable).where(eq(agentsTable.id, op.id))
+      expect(stored).toHaveLength(0)
+    })
+
+    it('PUT agent: member allowed when add_agents required_role = member', async () => {
+      await insertUser('agAdmin3', 'agadmin3@test.com')
+      await insertUser('agMember3', 'agmember3@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin3', 'agMember3')
+      await setRequiredRole(workspaceId, 'add_agents', 'member')
+
+      const op = agentPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('agMember3'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(agentsTable).where(eq(agentsTable.id, op.id))
+      expect(stored).toHaveLength(1)
+    })
+
+    it('DELETE agent: member rejected when remove_agents required_role = admin (default)', async () => {
+      await insertUser('agAdmin4', 'agadmin4@test.com')
+      await insertUser('agMember4', 'agmember4@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin4', 'agMember4')
+      // Admin seeds the agent so the row exists.
+      const putOp = agentPut(workspaceId)
+      const putResult = await applyUploadBatch(db, [putOp], ctxFor('agAdmin4'))
+      expect(putResult.ok).toBe(true)
+
+      const deleteOp: UploadOp = { op: 'DELETE', type: 'agents', id: putOp.id }
+      const result = await applyUploadBatch(db, [deleteOp], ctxFor('agMember4'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+      const stored = await db.select().from(agentsTable).where(eq(agentsTable.id, putOp.id))
+      expect(stored).toHaveLength(1)
+    })
+
+    it('DELETE agent: member allowed when remove_agents required_role = member', async () => {
+      await insertUser('agAdmin5', 'agadmin5@test.com')
+      await insertUser('agMember5', 'agmember5@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin5', 'agMember5')
+      const putOp = agentPut(workspaceId)
+      const putResult = await applyUploadBatch(db, [putOp], ctxFor('agAdmin5'))
+      expect(putResult.ok).toBe(true)
+      await setRequiredRole(workspaceId, 'remove_agents', 'member')
+
+      const deleteOp: UploadOp = { op: 'DELETE', type: 'agents', id: putOp.id }
+      const result = await applyUploadBatch(db, [deleteOp], ctxFor('agMember5'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(agentsTable).where(eq(agentsTable.id, putOp.id))
+      expect(stored).toHaveLength(0)
+    })
+
+    it('add_agents = member does not unlock DELETE (remove_agents still defaults to admin)', async () => {
+      await insertUser('agAdmin6', 'agadmin6@test.com')
+      await insertUser('agMember6', 'agmember6@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin6', 'agMember6')
+      const putOp = agentPut(workspaceId)
+      const putResult = await applyUploadBatch(db, [putOp], ctxFor('agAdmin6'))
+      expect(putResult.ok).toBe(true)
+      // Member can add but the remove permission is still admin.
+      await setRequiredRole(workspaceId, 'add_agents', 'member')
+
+      const deleteOp: UploadOp = { op: 'DELETE', type: 'agents', id: putOp.id }
+      const result = await applyUploadBatch(db, [deleteOp], ctxFor('agMember6'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    // FE DAL soft-deletes via PATCH(deleted_at = now), not DELETE. The handler
+    // classifies that PATCH as a remove and gates it on `remove_agents`.
+    it('soft-delete via PATCH(deleted_at) gates on remove_agents, not add_agents', async () => {
+      await insertUser('agAdmin7', 'agadmin7@test.com')
+      await insertUser('agMember7', 'agmember7@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin7', 'agMember7')
+      const putOp = agentPut(workspaceId)
+      const putResult = await applyUploadBatch(db, [putOp], ctxFor('agAdmin7'))
+      expect(putResult.ok).toBe(true)
+      // Member can edit (add) but not soft-delete (remove).
+      await setRequiredRole(workspaceId, 'add_agents', 'member')
+
+      const softDeleteOp: UploadOp = {
+        op: 'PATCH',
+        type: 'agents',
+        id: putOp.id,
+        data: { deleted_at: new Date().toISOString() },
+      }
+      const result = await applyUploadBatch(db, [softDeleteOp], ctxFor('agMember7'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('soft-delete via PATCH(deleted_at) is allowed when remove_agents = member', async () => {
+      await insertUser('agAdmin8', 'agadmin8@test.com')
+      await insertUser('agMember8', 'agmember8@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin8', 'agMember8')
+      const putOp = agentPut(workspaceId)
+      const putResult = await applyUploadBatch(db, [putOp], ctxFor('agAdmin8'))
+      expect(putResult.ok).toBe(true)
+      await setRequiredRole(workspaceId, 'remove_agents', 'member')
+
+      const softDeleteOp: UploadOp = {
+        op: 'PATCH',
+        type: 'agents',
+        id: putOp.id,
+        data: { deleted_at: new Date().toISOString() },
+      }
+      const result = await applyUploadBatch(db, [softDeleteOp], ctxFor('agMember8'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(agentsTable).where(eq(agentsTable.id, putOp.id))
+      expect(stored[0].deletedAt).not.toBeNull()
+    })
+
+    // Edit PATCH (no deleted_at) still gates on add_agents, not remove_agents.
+    it('non-delete PATCH gates on add_agents even when remove_agents = member', async () => {
+      await insertUser('agAdmin9', 'agadmin9@test.com')
+      await insertUser('agMember9', 'agmember9@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('agAdmin9', 'agMember9')
+      const putOp = agentPut(workspaceId)
+      const putResult = await applyUploadBatch(db, [putOp], ctxFor('agAdmin9'))
+      expect(putResult.ok).toBe(true)
+      // Member has remove but not add; an edit (no deleted_at) should still reject.
+      await setRequiredRole(workspaceId, 'remove_agents', 'member')
+
+      const editOp: UploadOp = {
+        op: 'PATCH',
+        type: 'agents',
+        id: putOp.id,
+        data: { name: 'Renamed by member' },
+      }
+      const result = await applyUploadBatch(db, [editOp], ctxFor('agMember9'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+  })
+
+  describe('skills — workspace permission gating (add_skills / remove_skills)', () => {
+    const seedSharedWithAdminAndMember = async (adminId: string, memberId: string): Promise<string> => {
+      const workspaceId = uuidv7()
+      await db.insert(workspacesTable).values({ id: workspaceId, isPersonal: false, name: 'Acme' })
+      await db.insert(workspaceMembershipsTable).values({ id: uuidv7(), workspaceId, userId: adminId, role: 'admin' })
+      await db.insert(workspaceMembershipsTable).values({ id: uuidv7(), workspaceId, userId: memberId, role: 'member' })
+      return workspaceId
+    }
+
+    const setRequiredRole = async (
+      workspaceId: string,
+      key: 'add_skills' | 'remove_skills',
+      requiredRole: 'admin' | 'member',
+    ): Promise<void> => {
+      await db.insert(workspacePermissionsTable).values({ id: uuidv7(), workspaceId, permissionKey: key, requiredRole })
+    }
+
+    const skillPut = (workspaceId: string, id = uuidv7()): UploadOp => ({
+      op: 'PUT',
+      type: 'skills',
+      id,
+      data: {
+        workspace_id: workspaceId,
+        name: 'Test skill',
+        description: 'Test',
+        instruction: 'Do the thing',
+        enabled: 1,
+      },
+    })
+
+    it('PUT skill: member rejected when add_skills required_role = admin (default)', async () => {
+      await insertUser('skAdmin1', 'skadmin1@test.com')
+      await insertUser('skMember1', 'skmember1@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('skAdmin1', 'skMember1')
+
+      const op = skillPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('skMember1'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('PUT skill: member allowed when add_skills required_role = member', async () => {
+      await insertUser('skAdmin2', 'skadmin2@test.com')
+      await insertUser('skMember2', 'skmember2@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('skAdmin2', 'skMember2')
+      await setRequiredRole(workspaceId, 'add_skills', 'member')
+
+      const op = skillPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('skMember2'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(skillsTable).where(eq(skillsTable.id, op.id))
+      expect(stored).toHaveLength(1)
+    })
+
+    it('soft-delete via PATCH(deleted_at) gates on remove_skills, not add_skills', async () => {
+      await insertUser('skAdmin3', 'skadmin3@test.com')
+      await insertUser('skMember3', 'skmember3@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('skAdmin3', 'skMember3')
+      const putOp = skillPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('skAdmin3'))).ok).toBe(true)
+      await setRequiredRole(workspaceId, 'add_skills', 'member')
+
+      const softDeleteOp: UploadOp = {
+        op: 'PATCH',
+        type: 'skills',
+        id: putOp.id,
+        data: { deleted_at: new Date().toISOString() },
+      }
+      const result = await applyUploadBatch(db, [softDeleteOp], ctxFor('skMember3'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('soft-delete via PATCH(deleted_at) is allowed when remove_skills = member', async () => {
+      await insertUser('skAdmin4', 'skadmin4@test.com')
+      await insertUser('skMember4', 'skmember4@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('skAdmin4', 'skMember4')
+      const putOp = skillPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('skAdmin4'))).ok).toBe(true)
+      await setRequiredRole(workspaceId, 'remove_skills', 'member')
+
+      const softDeleteOp: UploadOp = {
+        op: 'PATCH',
+        type: 'skills',
+        id: putOp.id,
+        data: { deleted_at: new Date().toISOString() },
+      }
+      const result = await applyUploadBatch(db, [softDeleteOp], ctxFor('skMember4'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(skillsTable).where(eq(skillsTable.id, putOp.id))
+      expect(stored[0].deletedAt).not.toBeNull()
+    })
+
+    it('edit PATCH (no deleted_at) gates on add_skills, not remove_skills', async () => {
+      await insertUser('skAdmin5', 'skadmin5@test.com')
+      await insertUser('skMember5', 'skmember5@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('skAdmin5', 'skMember5')
+      const putOp = skillPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('skAdmin5'))).ok).toBe(true)
+      // Member has remove but not add — toggling `enabled` is an edit and must reject.
+      await setRequiredRole(workspaceId, 'remove_skills', 'member')
+
+      const editOp: UploadOp = {
+        op: 'PATCH',
+        type: 'skills',
+        id: putOp.id,
+        data: { enabled: 0 },
+      }
+      const result = await applyUploadBatch(db, [editOp], ctxFor('skMember5'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+  })
+
+  describe('models — workspace permission gating (add_models / remove_models)', () => {
+    const seedSharedWithAdminAndMember = async (adminId: string, memberId: string): Promise<string> => {
+      const workspaceId = uuidv7()
+      await db.insert(workspacesTable).values({ id: workspaceId, isPersonal: false, name: 'Acme' })
+      await db.insert(workspaceMembershipsTable).values({ id: uuidv7(), workspaceId, userId: adminId, role: 'admin' })
+      await db.insert(workspaceMembershipsTable).values({ id: uuidv7(), workspaceId, userId: memberId, role: 'member' })
+      return workspaceId
+    }
+
+    const setRequiredRole = async (
+      workspaceId: string,
+      key: 'add_models' | 'remove_models',
+      requiredRole: 'admin' | 'member',
+    ): Promise<void> => {
+      await db.insert(workspacePermissionsTable).values({ id: uuidv7(), workspaceId, permissionKey: key, requiredRole })
+    }
+
+    const modelPut = (workspaceId: string, id = uuidv7()): UploadOp => ({
+      op: 'PUT',
+      type: 'models',
+      id,
+      data: {
+        workspace_id: workspaceId,
+        provider: 'openai',
+        name: 'Test model',
+        model: 'gpt-test',
+        enabled: 1,
+      },
+    })
+
+    it('PUT model: member rejected when add_models required_role = admin (default)', async () => {
+      await insertUser('mdAdmin1', 'mdadmin1@test.com')
+      await insertUser('mdMember1', 'mdmember1@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mdAdmin1', 'mdMember1')
+
+      const op = modelPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('mdMember1'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('PUT model: member allowed when add_models required_role = member', async () => {
+      await insertUser('mdAdmin2', 'mdadmin2@test.com')
+      await insertUser('mdMember2', 'mdmember2@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mdAdmin2', 'mdMember2')
+      await setRequiredRole(workspaceId, 'add_models', 'member')
+
+      const op = modelPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('mdMember2'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(modelsTable).where(eq(modelsTable.id, op.id))
+      expect(stored).toHaveLength(1)
+    })
+
+    it('soft-delete via PATCH(deleted_at) gates on remove_models, not add_models', async () => {
+      await insertUser('mdAdmin3', 'mdadmin3@test.com')
+      await insertUser('mdMember3', 'mdmember3@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mdAdmin3', 'mdMember3')
+      const putOp = modelPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('mdAdmin3'))).ok).toBe(true)
+      await setRequiredRole(workspaceId, 'add_models', 'member')
+
+      const softDeleteOp: UploadOp = {
+        op: 'PATCH',
+        type: 'models',
+        id: putOp.id,
+        data: { deleted_at: new Date().toISOString() },
+      }
+      const result = await applyUploadBatch(db, [softDeleteOp], ctxFor('mdMember3'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('soft-delete via PATCH(deleted_at) is allowed when remove_models = member', async () => {
+      await insertUser('mdAdmin4', 'mdadmin4@test.com')
+      await insertUser('mdMember4', 'mdmember4@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mdAdmin4', 'mdMember4')
+      const putOp = modelPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('mdAdmin4'))).ok).toBe(true)
+      await setRequiredRole(workspaceId, 'remove_models', 'member')
+
+      const softDeleteOp: UploadOp = {
+        op: 'PATCH',
+        type: 'models',
+        id: putOp.id,
+        data: { deleted_at: new Date().toISOString() },
+      }
+      const result = await applyUploadBatch(db, [softDeleteOp], ctxFor('mdMember4'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(modelsTable).where(eq(modelsTable.id, putOp.id))
+      expect(stored[0].deletedAt).not.toBeNull()
+    })
+
+    it('edit PATCH (toggle enabled) gates on add_models, not remove_models', async () => {
+      await insertUser('mdAdmin5', 'mdadmin5@test.com')
+      await insertUser('mdMember5', 'mdmember5@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mdAdmin5', 'mdMember5')
+      const putOp = modelPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('mdAdmin5'))).ok).toBe(true)
+      await setRequiredRole(workspaceId, 'remove_models', 'member')
+
+      const editOp: UploadOp = {
+        op: 'PATCH',
+        type: 'models',
+        id: putOp.id,
+        data: { enabled: 0 },
+      }
+      const result = await applyUploadBatch(db, [editOp], ctxFor('mdMember5'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+  })
+
+  describe('mcp_servers — workspace permission gating (add_mcp_servers / remove_mcp_servers)', () => {
+    const seedSharedWithAdminAndMember = async (adminId: string, memberId: string): Promise<string> => {
+      const workspaceId = uuidv7()
+      await db.insert(workspacesTable).values({ id: workspaceId, isPersonal: false, name: 'Acme' })
+      await db.insert(workspaceMembershipsTable).values({ id: uuidv7(), workspaceId, userId: adminId, role: 'admin' })
+      await db.insert(workspaceMembershipsTable).values({ id: uuidv7(), workspaceId, userId: memberId, role: 'member' })
+      return workspaceId
+    }
+
+    const setRequiredRole = async (
+      workspaceId: string,
+      key: 'add_mcp_servers' | 'remove_mcp_servers',
+      requiredRole: 'admin' | 'member',
+    ): Promise<void> => {
+      await db.insert(workspacePermissionsTable).values({ id: uuidv7(), workspaceId, permissionKey: key, requiredRole })
+    }
+
+    const mcpPut = (workspaceId: string, id = uuidv7()): UploadOp => ({
+      op: 'PUT',
+      type: 'mcp_servers',
+      id,
+      data: {
+        workspace_id: workspaceId,
+        name: 'Test MCP',
+        type: 'http',
+        url: 'https://example.invalid/mcp',
+        enabled: 1,
+      },
+    })
+
+    it('PUT mcp_server: member rejected when add_mcp_servers required_role = admin (default)', async () => {
+      await insertUser('mcpAdmin1', 'mcpadmin1@test.com')
+      await insertUser('mcpMember1', 'mcpmember1@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mcpAdmin1', 'mcpMember1')
+
+      const op = mcpPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('mcpMember1'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('PUT mcp_server: member allowed when add_mcp_servers required_role = member', async () => {
+      await insertUser('mcpAdmin2', 'mcpadmin2@test.com')
+      await insertUser('mcpMember2', 'mcpmember2@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mcpAdmin2', 'mcpMember2')
+      await setRequiredRole(workspaceId, 'add_mcp_servers', 'member')
+
+      const op = mcpPut(workspaceId)
+      const result = await applyUploadBatch(db, [op], ctxFor('mcpMember2'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(mcpServersTable).where(eq(mcpServersTable.id, op.id))
+      expect(stored).toHaveLength(1)
+    })
+
+    it('soft-delete via PATCH(deleted_at) gates on remove_mcp_servers, not add_mcp_servers', async () => {
+      await insertUser('mcpAdmin3', 'mcpadmin3@test.com')
+      await insertUser('mcpMember3', 'mcpmember3@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mcpAdmin3', 'mcpMember3')
+      const putOp = mcpPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('mcpAdmin3'))).ok).toBe(true)
+      await setRequiredRole(workspaceId, 'add_mcp_servers', 'member')
+
+      const softDeleteOp: UploadOp = {
+        op: 'PATCH',
+        type: 'mcp_servers',
+        id: putOp.id,
+        data: { deleted_at: new Date().toISOString() },
+      }
+      const result = await applyUploadBatch(db, [softDeleteOp], ctxFor('mcpMember3'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('soft-delete via PATCH(deleted_at) is allowed when remove_mcp_servers = member', async () => {
+      await insertUser('mcpAdmin4', 'mcpadmin4@test.com')
+      await insertUser('mcpMember4', 'mcpmember4@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mcpAdmin4', 'mcpMember4')
+      const putOp = mcpPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('mcpAdmin4'))).ok).toBe(true)
+      await setRequiredRole(workspaceId, 'remove_mcp_servers', 'member')
+
+      const softDeleteOp: UploadOp = {
+        op: 'PATCH',
+        type: 'mcp_servers',
+        id: putOp.id,
+        data: { deleted_at: new Date().toISOString() },
+      }
+      const result = await applyUploadBatch(db, [softDeleteOp], ctxFor('mcpMember4'))
+      expect(result.ok).toBe(true)
+      const stored = await db.select().from(mcpServersTable).where(eq(mcpServersTable.id, putOp.id))
+      expect(stored[0].deletedAt).not.toBeNull()
+    })
+
+    it('edit PATCH (toggle enabled) gates on add_mcp_servers, not remove_mcp_servers', async () => {
+      await insertUser('mcpAdmin5', 'mcpadmin5@test.com')
+      await insertUser('mcpMember5', 'mcpmember5@test.com')
+      const workspaceId = await seedSharedWithAdminAndMember('mcpAdmin5', 'mcpMember5')
+      const putOp = mcpPut(workspaceId)
+      expect((await applyUploadBatch(db, [putOp], ctxFor('mcpAdmin5'))).ok).toBe(true)
+      await setRequiredRole(workspaceId, 'remove_mcp_servers', 'member')
+
+      const editOp: UploadOp = {
+        op: 'PATCH',
+        type: 'mcp_servers',
+        id: putOp.id,
+        data: { enabled: 0 },
+      }
+      const result = await applyUploadBatch(db, [editOp], ctxFor('mcpMember5'))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
     })
   })
 })

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -7,16 +7,16 @@ import {
   countWorkspaceMemberships,
   deleteMembership,
   getMembershipById,
+  getMembershipByWorkspaceAndUser,
   getWorkspaceById,
   isPersonalWorkspace,
-  isWorkspaceAdmin,
   type Role,
   updateMembership,
   upsertMembership,
 } from '@/dal/workspaces'
 import { getUserById } from '@/dal/users'
 import { computePersonalAdminMembershipId, computePersonalWorkspaceId } from '@shared/workspaces'
-import { allow, reject } from './helpers'
+import { allow, callerSatisfiesPermission, reject } from './helpers'
 import { UploadRejection, type UploadHandler, type UploadTx } from './types'
 
 const isRole = (v: unknown): v is Role => v === 'admin' || v === 'member'
@@ -69,12 +69,27 @@ const isPersonalAdminBootstrap = async (
 /**
  * Upload handler for `workspace_memberships`. Enforces:
  *
- * - All writes require admin role in the target workspace.
- * - Personal workspaces are immutable — admin membership exists exactly once and
- *   is created by the Better Auth post-create hook (Decision 11 / Decision 12).
- * - DELETE that would leave zero remaining admins in the workspace is permanently
- *   rejected. The count is taken inside the same transaction as the delete so
- *   concurrent revokes can't both pass the check.
+ * - Each op gates on a `workspace_permissions` key — `invite_users` for PUT,
+ *   `change_roles` for PATCH, `remove_users` for DELETE — defaulting to
+ *   admin-only when the permission row is absent (Decision 11).
+ * - PUT that would effectively change an existing membership's role
+ *   additionally requires `change_roles`. PUT applies via `upsertMembership`
+ *   (ON CONFLICT DO UPDATE SET role), so a payload demoting an admin to
+ *   member at the same `(workspace_id, user_id)` would otherwise bypass
+ *   PATCH's `change_roles` gate.
+ * - Adding a brand-new membership with `role: 'admin'` requires
+ *   `change_roles` for the same reason — `invite_users` alone could
+ *   otherwise mint new admins (also via the pending-invite signup-promote
+ *   path).
+ * - Personal workspaces are immutable past the FE-driven admin bootstrap
+ *   (`isPersonalAdminBootstrap`), which lands exactly one admin row for the
+ *   owner the first time the workspace appears server-side.
+ * - The first admin membership for a freshly-created shared workspace is
+ *   allowed by `isSharedWorkspaceAdminBootstrap` (caller is the row's user,
+ *   role is admin, workspace has zero members yet).
+ * - DELETE that would leave zero remaining admins is permanently rejected.
+ *   The count is taken inside the same transaction so concurrent revokes
+ *   can't both pass the check.
  */
 /**
  * Shared workspace creator bootstrap: the FE creates a shared workspace and its
@@ -135,6 +150,12 @@ export const workspaceMembershipsHandler: UploadHandler = {
     const targetWorkspaceId =
       op.op === 'PUT' ? (typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : null) : null
 
+    // Per-op permission keys read from `workspace_permissions.required_role`.
+    // Defaults to admin when the row is absent (Decision 11). Aligned with what
+    // the FE Members UI checks via `useWorkspacePermission` so a workspace that
+    // grants `member` the permission can actually exercise it on upload.
+    const newRole = isRole(op.data?.role) ? op.data.role : null
+    const targetsAdminRole = newRole === 'admin'
     if (op.op === 'PUT' && !targetWorkspaceId) {
       const existing = await getMembershipById(tx, op.id)
       if (!existing) {
@@ -143,8 +164,18 @@ export const workspaceMembershipsHandler: UploadHandler = {
       if (await isPersonalWorkspace(tx, existing.workspaceId)) {
         return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
       }
-      if (!(await isWorkspaceAdmin(tx, existing.workspaceId, ctx.userId))) {
-        return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+      if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
+      }
+      // Effective role change (either direction) requires `change_roles`.
+      // `upsertMembership` overwrites `role` on conflict, so a PUT that
+      // changes role would otherwise bypass PATCH's gate.
+      const wouldChangeRole = newRole !== null && existing.role !== newRole
+      if (
+        (wouldChangeRole || targetsAdminRole) &&
+        !(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'change_roles'))
+      ) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()
     }
@@ -154,8 +185,23 @@ export const workspaceMembershipsHandler: UploadHandler = {
       if (await isPersonalWorkspace(tx, targetWorkspaceId!)) {
         return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
       }
-      if (!(await isWorkspaceAdmin(tx, targetWorkspaceId!, ctx.userId))) {
-        return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+      if (!(await callerSatisfiesPermission(tx, targetWorkspaceId!, ctx.userId, 'invite_users'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
+      }
+      // Resolve the existing row at the conflict target `(workspace_id, user_id)`
+      // — that's what `upsertMembership` updates, not the row at `op.id`.
+      // A PUT changing an existing role (either direction) requires
+      // `change_roles`; a fresh insert with `role: 'admin'` also requires it.
+      const payloadUserId = typeof op.data?.user_id === 'string' ? op.data.user_id : null
+      const existing =
+        payloadUserId !== null ? await getMembershipByWorkspaceAndUser(tx, targetWorkspaceId!, payloadUserId) : null
+      const wouldChangeRole = existing !== null && newRole !== null && existing.role !== newRole
+      const wouldMintNewAdmin = existing === null && targetsAdminRole
+      if (
+        (wouldChangeRole || wouldMintNewAdmin) &&
+        !(await callerSatisfiesPermission(tx, targetWorkspaceId!, ctx.userId, 'change_roles'))
+      ) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()
     }
@@ -168,8 +214,9 @@ export const workspaceMembershipsHandler: UploadHandler = {
     if (await isPersonalWorkspace(tx, existing.workspaceId)) {
       return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
     }
-    if (!(await isWorkspaceAdmin(tx, existing.workspaceId, ctx.userId))) {
-      return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+    const permissionKey: 'change_roles' | 'remove_users' = op.op === 'PATCH' ? 'change_roles' : 'remove_users'
+    if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, permissionKey))) {
+      return reject('permanent', 'INSUFFICIENT_PERMISSION')
     }
     return allow()
   },
@@ -182,6 +229,17 @@ export const workspaceMembershipsHandler: UploadHandler = {
         const role = isRole(op.data?.role) ? op.data.role : null
         if (!workspaceId || !userId || !role) {
           throw new UploadRejection('permanent', 'MEMBERSHIP_FIELDS_REQUIRED')
+        }
+        // Last-admin protection mirrors PATCH/DELETE. `upsertMembership` does
+        // ON CONFLICT DO UPDATE SET role on `(workspace_id, user_id)`, so a
+        // PUT demoting the workspace's only admin to member would otherwise
+        // bypass the guard those paths enforce.
+        const existing = await getMembershipByWorkspaceAndUser(tx, workspaceId, userId)
+        if (existing && existing.role === 'admin' && role !== 'admin') {
+          const remainingAdmins = await countWorkspaceAdmins(tx, workspaceId, existing.id)
+          if (remainingAdmins === 0) {
+            throw new UploadRejection('permanent', 'LAST_ADMIN_PROTECTED')
+          }
         }
         // Enrich the row with the canonical name/email from `auth.user` so the
         // FE Members page has display info without a synced `users` table. The

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -14,6 +14,7 @@ import {
   updateMembership,
   upsertMembership,
 } from '@/dal/workspaces'
+import { getUserById } from '@/dal/users'
 import { computePersonalAdminMembershipId, computePersonalWorkspaceId } from '@shared/workspaces'
 import { allow, reject } from './helpers'
 import { UploadRejection, type UploadHandler, type UploadTx } from './types'
@@ -170,7 +171,22 @@ export const workspaceMembershipsHandler: UploadHandler = {
         if (!workspaceId || !userId || !role) {
           throw new UploadRejection('permanent', 'MEMBERSHIP_FIELDS_REQUIRED')
         }
-        await upsertMembership(tx, { id: op.id, workspaceId, userId, role })
+        // Enrich the row with the canonical name/email from `auth.user` so the
+        // FE Members page has display info without a synced `users` table. The
+        // FE never gets to set these fields directly — the BE is the only
+        // source of truth.
+        const targetUser = await getUserById(tx, userId)
+        if (!targetUser) {
+          throw new UploadRejection('permanent', 'USER_NOT_FOUND')
+        }
+        await upsertMembership(tx, {
+          id: op.id,
+          workspaceId,
+          userId,
+          role,
+          userName: targetUser.name,
+          userEmail: targetUser.email,
+        })
         return
       }
       case 'PATCH': {

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -120,6 +120,18 @@ export const workspaceMembershipsHandler: UploadHandler = {
       return allow()
     }
 
+    // @todo Revisit when the E2EE pipeline supports multi-recipient envelopes
+    // and is workspace-aware. Until then, adding a membership for another user
+    // on an E2EE-enabled server would produce data they can't decrypt. Self-row
+    // bootstraps are exempt (covered above) — the local user already owns the
+    // key for their own data. See THU-593.
+    if (op.op === 'PUT' && ctx.settings.e2eeEnabled) {
+      const targetUserId = typeof op.data?.user_id === 'string' ? op.data.user_id : null
+      if (targetUserId && targetUserId !== ctx.userId) {
+        return reject('permanent', 'E2EE_MEMBERSHIPS_DISABLED')
+      }
+    }
+
     const targetWorkspaceId =
       op.op === 'PUT' ? (typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : null) : null
 

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -4,24 +4,26 @@
 
 import {
   deletePendingMembership,
+  deletePendingMembershipByWorkspaceAndEmail,
   getPendingMembershipById,
+  insertMembershipIfMissing,
   isPersonalWorkspace,
-  isWorkspaceAdmin,
   type Role,
   updatePendingMembership,
-  upsertMembership,
   upsertPendingMembership,
 } from '@/dal/workspaces'
 import { getUserByEmail } from '@/dal/users'
-import { normalizeEmail } from '@/lib/email'
-import { allow, reject } from './helpers'
+import { isValidEmailFormat, normalizeEmail } from '@/lib/email'
+import { allow, callerSatisfiesPermission, reject } from './helpers'
 import { UploadRejection, type UploadHandler } from './types'
 
 const isRole = (v: unknown): v is Role => v === 'admin' || v === 'member'
 
 /**
- * Upload handler for `workspace_pending_memberships`. All operations require admin
- * role in the target workspace; personal workspaces cannot have pending memberships.
+ * Upload handler for `workspace_pending_memberships`. Every write gates on the
+ * `invite_users` permission (admin by default, Decision 11). Promoting/editing
+ * a pending invite to `role: 'admin'` additionally requires `change_roles` —
+ * see the inline guard. Personal workspaces cannot have pending memberships.
  * Email is normalized server-side by the DAL to match the Better Auth `before` hook.
  */
 export const workspacePendingMembershipsHandler: UploadHandler = {
@@ -34,6 +36,15 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
       return reject('permanent', 'E2EE_MEMBERSHIPS_DISABLED')
     }
 
+    // All pending-membership writes (create / edit / cancel an invite) gate on
+    // `invite_users` so a workspace that grants `member` the permission can
+    // exercise it on upload. Defaults to admin via Decision 11.
+    //
+    // Inviting (or editing the invite to) `role: 'admin'` additionally requires
+    // `change_roles` — otherwise `invite_users` alone could mint new admins
+    // via the signup-promote path, bypassing the gate that protects existing
+    // members from being promoted by non-role-managers.
+    const targetsAdminRole = op.data?.role === 'admin'
     if (op.op === 'PUT') {
       const targetWorkspaceId = typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : undefined
       if (!targetWorkspaceId) {
@@ -44,16 +55,25 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         if (await isPersonalWorkspace(tx, existing.workspaceId)) {
           return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
         }
-        if (!(await isWorkspaceAdmin(tx, existing.workspaceId, ctx.userId))) {
-          return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+        if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
+          return reject('permanent', 'INSUFFICIENT_PERMISSION')
+        }
+        if (
+          targetsAdminRole &&
+          !(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'change_roles'))
+        ) {
+          return reject('permanent', 'INSUFFICIENT_PERMISSION')
         }
         return allow()
       }
       if (await isPersonalWorkspace(tx, targetWorkspaceId)) {
         return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
       }
-      if (!(await isWorkspaceAdmin(tx, targetWorkspaceId, ctx.userId))) {
-        return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+      if (!(await callerSatisfiesPermission(tx, targetWorkspaceId, ctx.userId, 'invite_users'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
+      }
+      if (targetsAdminRole && !(await callerSatisfiesPermission(tx, targetWorkspaceId, ctx.userId, 'change_roles'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()
     }
@@ -65,8 +85,21 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
     if (await isPersonalWorkspace(tx, existing.workspaceId)) {
       return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
     }
-    if (!(await isWorkspaceAdmin(tx, existing.workspaceId, ctx.userId))) {
-      return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+    if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
+      return reject('permanent', 'INSUFFICIENT_PERMISSION')
+    }
+    // Guard fires only on promotions (role becoming admin). Demoting an
+    // existing pending admin invite to `member` stays gated on `invite_users`
+    // alone — it's tampering, not escalation, and matching the broader
+    // "any role change requires change_roles" rule from the memberships
+    // handler would cost an extra DB read (load existing pending row) for
+    // a non-security concern.
+    if (
+      op.op === 'PATCH' &&
+      targetsAdminRole &&
+      !(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'change_roles'))
+    ) {
+      return reject('permanent', 'INSUFFICIENT_PERMISSION')
     }
     return allow()
   },
@@ -77,17 +110,21 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         const workspaceId = typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : null
         const email = typeof op.data?.email === 'string' ? op.data.email : null
         const role = isRole(op.data?.role) ? op.data.role : null
-        const invitedByUserId =
-          typeof op.data?.invited_by_user_id === 'string' ? op.data.invited_by_user_id : ctx.userId
         if (!workspaceId || !email || !role) {
           throw new UploadRejection('permanent', 'PENDING_FIELDS_REQUIRED')
         }
+        if (!isValidEmailFormat(email)) {
+          throw new UploadRejection('permanent', 'INVALID_EMAIL')
+        }
+        // `invitedByUserId` is server-truth — the caller is the inviter, full
+        // stop. Trusting the payload would let a client attribute the invite
+        // to someone else.
         await upsertPendingMembership(tx, {
           id: op.id,
           workspaceId,
           email,
           role,
-          invitedByUserId,
+          invitedByUserId: ctx.userId,
         })
 
         // Promote-on-insert: if the invited email already belongs to a real
@@ -97,9 +134,15 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         // which removes its optimistic local pending row organically. The
         // signup hook (`promotePendingMemberships`) covers the unknown-email
         // path when the invitee later signs up.
+        //
+        // DO-NOTHING semantics: if the user is already a member of this
+        // workspace, the invite must NOT overwrite their current role —
+        // inviting an existing admin's email would otherwise downgrade them
+        // to whatever role the invite carried. Mirrors
+        // `promotePendingMemberships` (the signup-time bulk-promote path).
         const matched = await getUserByEmail(tx, normalizeEmail(email))
         if (matched) {
-          await upsertMembership(tx, {
+          await insertMembershipIfMissing(tx, {
             id: crypto.randomUUID(),
             workspaceId,
             userId: matched.id,
@@ -107,19 +150,29 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
             userName: matched.name,
             userEmail: matched.email,
           })
-          await deletePendingMembership(tx, op.id)
+          // Delete by `(workspace_id, email)` rather than `op.id` — the upsert
+          // above hit the `(workspace_id, email)` unique constraint when the
+          // pending row already existed, in which case Postgres kept the
+          // original id and the upload's `op.id` no longer matches. Keying on
+          // workspace+email always lands on the actual row.
+          await deletePendingMembershipByWorkspaceAndEmail(tx, workspaceId, email)
         }
         return
       }
       case 'PATCH': {
+        // `invited_by_user_id` is server-truth and not patchable by the
+        // client — silently drop it from the payload rather than rewriting
+        // it to an attacker-supplied value.
         const email = typeof op.data?.email === 'string' ? op.data.email : undefined
         const role = isRole(op.data?.role) ? op.data.role : undefined
-        const invitedByUserId = typeof op.data?.invited_by_user_id === 'string' ? op.data.invited_by_user_id : undefined
 
-        if (email === undefined && role === undefined && invitedByUserId === undefined) {
+        if (email === undefined && role === undefined) {
           throw new UploadRejection('permanent', 'EMPTY_PAYLOAD')
         }
-        const affected = await updatePendingMembership(tx, op.id, { email, role, invitedByUserId })
+        if (email !== undefined && !isValidEmailFormat(email)) {
+          throw new UploadRejection('permanent', 'INVALID_EMAIL')
+        }
+        const affected = await updatePendingMembership(tx, op.id, { email, role })
         if (affected === 0) {
           throw new UploadRejection('permanent', 'ROW_NOT_FOUND')
         }

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -26,6 +26,14 @@ const isRole = (v: unknown): v is Role => v === 'admin' || v === 'member'
  */
 export const workspacePendingMembershipsHandler: UploadHandler = {
   validate: async (op, ctx, tx) => {
+    // @todo Revisit when the E2EE pipeline supports multi-recipient envelopes
+    // and is workspace-aware. Pending memberships are by definition for someone
+    // else, so any insert on an E2EE-enabled server would produce data the
+    // invitee can't decrypt. See THU-593.
+    if (op.op === 'PUT' && ctx.settings.e2eeEnabled) {
+      return reject('permanent', 'E2EE_MEMBERSHIPS_DISABLED')
+    }
+
     if (op.op === 'PUT') {
       const targetWorkspaceId = typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : undefined
       if (!targetWorkspaceId) {

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -96,6 +96,8 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
             workspaceId,
             userId: matched.id,
             role,
+            userName: matched.name,
+            userEmail: matched.email,
           })
           await deletePendingMembership(tx, op.id)
         }

--- a/backend/src/powersync/upload-handlers/workspace-permissions.ts
+++ b/backend/src/powersync/upload-handlers/workspace-permissions.ts
@@ -10,13 +10,12 @@ import {
   type Role,
   updateWorkspacePermission,
   upsertWorkspacePermission,
-  type WorkspacePermissionKey,
 } from '@/dal/workspaces'
+import { isWorkspacePermissionKey } from '@shared/workspaces'
 import { allow, reject } from './helpers'
 import { UploadRejection, type UploadHandler } from './types'
 
 const isRole = (v: unknown): v is Role => v === 'admin' || v === 'member'
-const isPermissionKey = (v: unknown): v is WorkspacePermissionKey => v === 'manage_members' || v === 'change_roles'
 
 /**
  * Upload handler for `workspace_permissions`. All operations require admin role
@@ -66,7 +65,7 @@ export const workspacePermissionsHandler: UploadHandler = {
     switch (op.op) {
       case 'PUT': {
         const workspaceId = typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : null
-        const permissionKey = isPermissionKey(op.data?.permission_key) ? op.data.permission_key : null
+        const permissionKey = isWorkspacePermissionKey(op.data?.permission_key) ? op.data.permission_key : null
         const requiredRole = isRole(op.data?.required_role) ? op.data.required_role : null
         if (!workspaceId || !permissionKey || !requiredRole) {
           throw new UploadRejection('permanent', 'PERMISSION_FIELDS_REQUIRED')

--- a/backend/src/powersync/upload-handlers/workspace-scoped.ts
+++ b/backend/src/powersync/upload-handlers/workspace-scoped.ts
@@ -10,9 +10,10 @@ import {
   powersyncTablesByName,
 } from '@/db/powersync-schema'
 import type { PowerSyncTableName } from '@shared/powersync-tables'
+import { type WorkspacePermissionKey } from '@shared/workspaces'
 import { and, eq } from 'drizzle-orm'
 import type { AnyPgColumn, AnyPgTable } from 'drizzle-orm/pg-core'
-import { allow, reject, toSchemaRecord } from './helpers'
+import { allow, callerSatisfiesPermission, reject, toSchemaRecord } from './helpers'
 import { UploadRejection, type UploadHandler, type UploadTx } from './types'
 
 export type WorkspaceScopedConfig = {
@@ -26,6 +27,29 @@ export type WorkspaceScopedConfig = {
   userPrivate: boolean
   /** Columns the client may not set; stripped from PUT/PATCH payloads. */
   denyColumns?: readonly string[]
+  /**
+   * Permission key gating PUT and "edit" PATCHes. When set, the handler reads
+   * `workspace_permissions.required_role` for this key and rejects the op
+   * unless the caller's role satisfies it. Default (no key) keeps the "any
+   * workspace member may write" behaviour.
+   */
+  addPermissionKey?: WorkspacePermissionKey
+  /**
+   * Permission key gating DELETE and "soft-delete" PATCHes (see
+   * `softDeleteColumn`). Same lookup semantics as `addPermissionKey`.
+   */
+  removePermissionKey?: WorkspacePermissionKey
+  /**
+   * Column name (in PowerSync upload's snake_case form) used by the table for
+   * soft-delete tombstones. When set, a PATCH that writes this column to a
+   * non-null value is treated as a remove and gates on `removePermissionKey`
+   * instead of `addPermissionKey`. PATCHes that don't touch the column — or
+   * that set it back to null (restore) — continue to gate as adds.
+   *
+   * Required for the four resource tables (agents, skills, models,
+   * mcp_servers) whose FE DAL soft-deletes via UPDATE rather than DELETE.
+   */
+  softDeleteColumn?: string
 }
 
 const isString = (v: unknown): v is string => typeof v === 'string'
@@ -79,7 +103,28 @@ const fetchRowScope = async (
  *   moved between workspaces via upload.
  */
 export const createWorkspaceScopedHandler = (cfg: WorkspaceScopedConfig): UploadHandler => {
-  const { tableName, userPrivate, denyColumns = [] } = cfg
+  const { tableName, userPrivate, denyColumns = [], addPermissionKey, removePermissionKey, softDeleteColumn } = cfg
+
+  /**
+   * Classifies the op as 'add' (PUT, PATCH-edit, PATCH-restore) or 'remove'
+   * (DELETE, PATCH that sets `softDeleteColumn` to a truthy value). Drives
+   * which permission key gates the write.
+   */
+  const opIntent = (op: { op: 'PUT' | 'PATCH' | 'DELETE'; data?: Record<string, unknown> }): 'add' | 'remove' => {
+    if (op.op === 'DELETE') {
+      return 'remove'
+    }
+    if (
+      op.op === 'PATCH' &&
+      softDeleteColumn !== undefined &&
+      op.data &&
+      Object.prototype.hasOwnProperty.call(op.data, softDeleteColumn) &&
+      op.data[softDeleteColumn] != null
+    ) {
+      return 'remove'
+    }
+    return 'add'
+  }
 
   return {
     validate: async (op, ctx, tx) => {
@@ -94,6 +139,12 @@ export const createWorkspaceScopedHandler = (cfg: WorkspaceScopedConfig): Upload
         if (!(await isWorkspaceMember(tx, resolvedWorkspaceId, ctx.userId))) {
           return reject('permanent', 'NOT_WORKSPACE_MEMBER')
         }
+        if (
+          addPermissionKey &&
+          !(await callerSatisfiesPermission(tx, resolvedWorkspaceId, ctx.userId, addPermissionKey))
+        ) {
+          return reject('permanent', 'INSUFFICIENT_PERMISSION')
+        }
         return allow()
       }
 
@@ -106,6 +157,13 @@ export const createWorkspaceScopedHandler = (cfg: WorkspaceScopedConfig): Upload
       }
       if (userPrivate && scope.userId !== ctx.userId) {
         return reject('permanent', 'NOT_ROW_OWNER')
+      }
+      const requiredPermissionKey = opIntent(op) === 'remove' ? removePermissionKey : addPermissionKey
+      if (
+        requiredPermissionKey &&
+        !(await callerSatisfiesPermission(tx, scope.workspaceId, ctx.userId, requiredPermissionKey))
+      ) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()
     },

--- a/backend/src/powersync/upload-handlers/workspaces.ts
+++ b/backend/src/powersync/upload-handlers/workspaces.ts
@@ -111,15 +111,19 @@ export const workspacesHandler: UploadHandler = {
         if (!name) {
           throw new UploadRejection('permanent', 'WORKSPACE_NAME_REQUIRED')
         }
-        const slug = typeof op.data?.slug === 'string' ? op.data.slug : null
-        const icon = typeof op.data?.icon === 'string' ? op.data.icon : null
+        // Distinguish "key omitted from payload" (undefined) from "explicitly
+        // null" so an admin's idempotent PUT that doesn't carry slug/icon
+        // doesn't clobber values already on the server. `upsertWorkspace`'s
+        // ON CONFLICT only writes columns whose input value is `!== undefined`.
+        const slug = op.data?.slug === undefined ? undefined : typeof op.data.slug === 'string' ? op.data.slug : null
+        const icon = op.data?.icon === undefined ? undefined : typeof op.data.icon === 'string' ? op.data.icon : null
         if (isPersonalPut) {
           // `DO NOTHING` on conflict — preserves any later changes if a second
           // device's bootstrap PUT lands after the user already mutated the row.
           await insertPersonalWorkspaceIfMissing(tx, {
             id: op.id,
             name,
-            icon,
+            icon: icon ?? null,
             ownerUserId: ctx.userId,
           })
           return

--- a/deploy/config/powersync-config.yaml
+++ b/deploy/config/powersync-config.yaml
@@ -47,12 +47,19 @@ sync_rules:
           - SELECT * FROM powersync.workspaces WHERE id = bucket.workspace_id
           - SELECT * FROM powersync.workspace_permissions WHERE workspace_id = bucket.workspace_id
 
-      # Workspace shared data — full member list and shared workspace-scoped config.
+      # Workspace shared data — full member list, pending invites, and shared
+      # workspace-scoped config. Pending memberships sync to every member (not
+      # just admins) because `invite_users`/`change_roles`/`remove_users` are
+      # per-key permissions that can be granted to `member` role; without the
+      # row syncing down, a permitted non-admin would see an empty pending list.
+      # Write authorization is enforced by the upload handlers, not by the
+      # sync rule.
       workspace_data:
         priority: 2
         parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id()
         data:
           - SELECT * FROM powersync.workspace_memberships WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.models WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.mcp_servers WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.prompts WHERE workspace_id = bucket.workspace_id
@@ -61,14 +68,6 @@ sync_rules:
           - SELECT * FROM powersync.modes WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.model_profiles WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.agents WHERE workspace_id = bucket.workspace_id
-
-      # Admin-only data — one bucket per workspace where the user is an admin.
-      # Pending memberships sync down only to admins so they can manage invites.
-      workspace_admin_data:
-        priority: 2
-        parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id() AND role = 'admin'
-        data:
-          - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
 
 client_auth:
   supabase: false

--- a/deploy/k8s/templates/configmaps.yaml
+++ b/deploy/k8s/templates/configmaps.yaml
@@ -55,12 +55,19 @@ data:
               - SELECT * FROM powersync.workspaces WHERE id = bucket.workspace_id
               - SELECT * FROM powersync.workspace_permissions WHERE workspace_id = bucket.workspace_id
 
-          # Workspace shared data — full member list and shared workspace-scoped config.
+          # Workspace shared data — full member list, pending invites, and shared
+          # workspace-scoped config. Pending memberships sync to every member (not
+          # just admins) because `invite_users`/`change_roles`/`remove_users` are
+          # per-key permissions that can be granted to `member` role; without the
+          # row syncing down, a permitted non-admin would see an empty pending list.
+          # Write authorization is enforced by the upload handlers, not by the
+          # sync rule.
           workspace_data:
             priority: 2
             parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id()
             data:
               - SELECT * FROM powersync.workspace_memberships WHERE workspace_id = bucket.workspace_id
+              - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.models WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.mcp_servers WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.prompts WHERE workspace_id = bucket.workspace_id
@@ -69,14 +76,6 @@ data:
               - SELECT * FROM powersync.modes WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.model_profiles WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.agents WHERE workspace_id = bucket.workspace_id
-
-          # Admin-only data — one bucket per workspace where the user is an admin.
-          # Pending memberships sync down only to admins so they can manage invites.
-          workspace_admin_data:
-            priority: 2
-            parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id() AND role = 'admin'
-            data:
-              - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
 
     client_auth:
       supabase: false

--- a/powersync-service/config/config.yaml
+++ b/powersync-service/config/config.yaml
@@ -47,12 +47,19 @@ sync_rules:
           - SELECT * FROM powersync.workspaces WHERE id = bucket.workspace_id
           - SELECT * FROM powersync.workspace_permissions WHERE workspace_id = bucket.workspace_id
 
-      # Workspace shared data — full member list and shared workspace-scoped config.
+      # Workspace shared data — full member list, pending invites, and shared
+      # workspace-scoped config. Pending memberships sync to every member (not
+      # just admins) because `invite_users`/`change_roles`/`remove_users` are
+      # per-key permissions that can be granted to `member` role; without the
+      # row syncing down, a permitted non-admin would see an empty pending list.
+      # Write authorization is enforced by the upload handlers, not by the
+      # sync rule.
       workspace_data:
         priority: 2
         parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id()
         data:
           - SELECT * FROM powersync.workspace_memberships WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.models WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.mcp_servers WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.prompts WHERE workspace_id = bucket.workspace_id
@@ -61,14 +68,6 @@ sync_rules:
           - SELECT * FROM powersync.modes WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.model_profiles WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.agents WHERE workspace_id = bucket.workspace_id
-
-      # Admin-only data — one bucket per workspace where the user is an admin.
-      # Pending memberships sync down only to admins so they can manage invites.
-      workspace_admin_data:
-        priority: 2
-        parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id() AND role = 'admin'
-        data:
-          - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
 
 client_auth:
   supabase: false

--- a/shared/workspaces.test.ts
+++ b/shared/workspaces.test.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  isWorkspacePermissionKey,
+  isWorkspacePermissionRole,
+  permissionAllows,
+  workspacePermissionKeys,
+} from './workspaces'
+
+describe('permissionAllows', () => {
+  it('admin satisfies admin requirements', () => {
+    expect(permissionAllows('admin', 'admin')).toBe(true)
+  })
+
+  it('admin satisfies member requirements', () => {
+    expect(permissionAllows('admin', 'member')).toBe(true)
+  })
+
+  it('member satisfies member requirements', () => {
+    expect(permissionAllows('member', 'member')).toBe(true)
+  })
+
+  it('member does not satisfy admin requirements', () => {
+    expect(permissionAllows('member', 'admin')).toBe(false)
+  })
+
+  it('null/undefined user roles never satisfy anything', () => {
+    expect(permissionAllows(null, 'admin')).toBe(false)
+    expect(permissionAllows(null, 'member')).toBe(false)
+    expect(permissionAllows(undefined, 'admin')).toBe(false)
+    expect(permissionAllows(undefined, 'member')).toBe(false)
+  })
+})
+
+describe('isWorkspacePermissionKey', () => {
+  it('accepts every key declared in workspacePermissionKeys', () => {
+    for (const key of workspacePermissionKeys) {
+      expect(isWorkspacePermissionKey(key)).toBe(true)
+    }
+  })
+
+  it('rejects unknown strings and non-strings', () => {
+    expect(isWorkspacePermissionKey('unknown_key')).toBe(false)
+    expect(isWorkspacePermissionKey('')).toBe(false)
+    expect(isWorkspacePermissionKey(123)).toBe(false)
+    expect(isWorkspacePermissionKey(null)).toBe(false)
+    expect(isWorkspacePermissionKey(undefined)).toBe(false)
+  })
+})
+
+describe('isWorkspacePermissionRole', () => {
+  it('accepts admin and member', () => {
+    expect(isWorkspacePermissionRole('admin')).toBe(true)
+    expect(isWorkspacePermissionRole('member')).toBe(true)
+  })
+
+  it('rejects anything else', () => {
+    expect(isWorkspacePermissionRole('owner')).toBe(false)
+    expect(isWorkspacePermissionRole('')).toBe(false)
+    expect(isWorkspacePermissionRole(null)).toBe(false)
+  })
+})

--- a/shared/workspaces.ts
+++ b/shared/workspaces.ts
@@ -36,3 +36,70 @@ export const computePersonalWorkspaceId = (userId: string): string =>
  */
 export const computePersonalAdminMembershipId = (userId: string): string =>
   uuidv5(`personal-admin:${userId}`, PERSONAL_WORKSPACE_NAMESPACE)
+
+/**
+ * Single source of truth for the keys that may appear in the
+ * `workspace_permissions.permission_key` column. Order matches the rendering
+ * order of the Permissions settings page (lifecycle → capabilities → admin).
+ *
+ * `manage_members` is a legacy key superseded by per-operation gates
+ * (`invite_users`/`change_roles`/`remove_users`). Kept in the union so older
+ * `workspace_permissions` rows still type-check; not surfaced on the
+ * Permissions page and not consulted by any route guard or upload handler.
+ *
+ * Add a new key here, then the FE/BE schemas, the FE/BE types, and the upload
+ * handler's runtime check all stay in sync via this constant.
+ */
+export const workspacePermissionKeys = [
+  'manage_members',
+  'join_workspace',
+  'invite_users',
+  'change_roles',
+  'remove_users',
+  'add_agents',
+  'remove_agents',
+  'add_skills',
+  'remove_skills',
+  'add_models',
+  'remove_models',
+  'add_mcp_servers',
+  'remove_mcp_servers',
+  'change_general_settings',
+  'change_permissions',
+  'delete_workspace',
+] as const
+
+export type WorkspacePermissionKey = (typeof workspacePermissionKeys)[number]
+
+/** The two role buckets used by both `workspace_memberships.role` and `workspace_permissions.required_role`. */
+export const workspacePermissionRoles = ['admin', 'member'] as const
+
+export type WorkspacePermissionRole = (typeof workspacePermissionRoles)[number]
+
+/** Runtime narrowing for upload-handler payloads — checks `v` against `workspacePermissionKeys`. */
+export const isWorkspacePermissionKey = (v: unknown): v is WorkspacePermissionKey =>
+  typeof v === 'string' && (workspacePermissionKeys as readonly string[]).includes(v)
+
+/** Runtime narrowing for upload-handler payloads — checks `v` against `workspacePermissionRoles`. */
+export const isWorkspacePermissionRole = (v: unknown): v is WorkspacePermissionRole =>
+  typeof v === 'string' && (workspacePermissionRoles as readonly string[]).includes(v)
+
+/**
+ * Whether `userRole` satisfies a `requiredRole` policy. Admins always satisfy;
+ * a `member` requirement is satisfied by both admins and members.
+ *
+ * Shared between FE (`useWorkspacePermission`) and BE (upload handler authz)
+ * so the same predicate gates UI affordances and write enforcement.
+ */
+export const permissionAllows = (
+  userRole: WorkspacePermissionRole | null | undefined,
+  requiredRole: WorkspacePermissionRole,
+): boolean => {
+  if (!userRole) {
+    return false
+  }
+  if (userRole === 'admin') {
+    return true
+  }
+  return requiredRole === 'member'
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -36,13 +36,14 @@ import { useViewportLock } from '@/hooks/use-viewport-lock'
 import { useMcpSync } from '@/hooks/use-mcp-sync'
 import { PostHogProvider } from '@/lib/posthog'
 import { ThemeProvider } from '@/lib/theme-provider'
+import { AppErrorBoundary } from './components/app-error-boundary'
 import { AppErrorScreen } from './components/app-error-screen'
 import { ModePicker } from './components/boot/mode-picker'
 import { AuthGate } from './components/auth-gate'
 import { WorkspaceGate } from './components/workspace-gate'
 import { WorkspaceMembershipGate } from './components/workspace-membership-gate'
 import { WorkspaceSettingsGate } from './settings/workspace/gate'
-import { RequireWorkspacePermission } from './settings/workspace/require-permission'
+import { RequireWorkspaceAdmin } from './settings/workspace/require-permission'
 import { OnboardingDialog } from './components/onboarding/onboarding-dialog'
 import { WelcomeDialog } from './components/welcome-dialog'
 import { PendingDeviceModal } from './components/pending-device-modal'
@@ -85,6 +86,7 @@ const AgentsSettingsPage = lazy(() => import('@/routes/settings/agents'))
 const IntegrationsPage = lazy(() => import('@/settings/integrations'))
 const WorkspaceGeneralPage = lazy(() => import('@/settings/workspace/general'))
 const WorkspaceMembersPage = lazy(() => import('@/settings/workspace/members'))
+const WorkspacePermissionsPage = lazy(() => import('@/settings/workspace/permissions'))
 
 // Lazily import SSO components so non-enterprise deployments don't pay
 // for the extra bundle size and attack surface.
@@ -127,8 +129,9 @@ const renderWorkspaceRoutes = ({ experimentalFeatureTasks }: { experimentalFeatu
         <Route element={<WorkspaceSettingsGate />}>
           <Route path="general" element={<WorkspaceGeneralPage />} />
         </Route>
-        <Route element={<RequireWorkspacePermission permissionKey="manage_members" />}>
-          <Route path="members" element={<WorkspaceMembersPage />} />
+        <Route path="members" element={<WorkspaceMembersPage />} />
+        <Route element={<RequireWorkspaceAdmin />}>
+          <Route path="permissions" element={<WorkspacePermissionsPage />} />
         </Route>
       </Route>
       {import.meta.env.DEV && <Route path="dev-settings" element={<DevSettingsPage />} />}
@@ -171,11 +174,13 @@ const AppContent = ({ initData }: { initData: InitData }) => {
   useSafeAreaInset()
 
   return (
-    <BrowserRouter>
-      <AppRoutes initData={initData} />
-      <UpdateNotification />
-      <PendingDeviceModal />
-    </BrowserRouter>
+    <AppErrorBoundary>
+      <BrowserRouter>
+        <AppRoutes initData={initData} />
+        <UpdateNotification />
+        <PendingDeviceModal />
+      </BrowserRouter>
+    </AppErrorBoundary>
   )
 }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -42,6 +42,7 @@ import { AuthGate } from './components/auth-gate'
 import { WorkspaceGate } from './components/workspace-gate'
 import { WorkspaceMembershipGate } from './components/workspace-membership-gate'
 import { WorkspaceSettingsGate } from './settings/workspace/gate'
+import { RequireWorkspacePermission } from './settings/workspace/require-permission'
 import { OnboardingDialog } from './components/onboarding/onboarding-dialog'
 import { WelcomeDialog } from './components/welcome-dialog'
 import { PendingDeviceModal } from './components/pending-device-modal'
@@ -83,6 +84,7 @@ const SkillsPage = lazy(() => import('@/settings/skills'))
 const AgentsSettingsPage = lazy(() => import('@/routes/settings/agents'))
 const IntegrationsPage = lazy(() => import('@/settings/integrations'))
 const WorkspaceGeneralPage = lazy(() => import('@/settings/workspace/general'))
+const WorkspaceMembersPage = lazy(() => import('@/settings/workspace/members'))
 
 // Lazily import SSO components so non-enterprise deployments don't pay
 // for the extra bundle size and attack surface.
@@ -121,8 +123,13 @@ const renderWorkspaceRoutes = ({ experimentalFeatureTasks }: { experimentalFeatu
       <Route path="skills" element={<SkillsPage />} />
       <Route path="agents" element={<AgentsSettingsPage />} />
       <Route path="integrations" element={<IntegrationsPage />} />
-      <Route path="workspace" element={<WorkspaceSettingsGate />}>
-        <Route path="general" element={<WorkspaceGeneralPage />} />
+      <Route path="workspace">
+        <Route element={<WorkspaceSettingsGate />}>
+          <Route path="general" element={<WorkspaceGeneralPage />} />
+        </Route>
+        <Route element={<RequireWorkspacePermission permissionKey="manage_members" />}>
+          <Route path="members" element={<WorkspaceMembersPage />} />
+        </Route>
       </Route>
       {import.meta.env.DEV && <Route path="dev-settings" element={<DevSettingsPage />} />}
     </Route>

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -157,8 +157,12 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
 
     const db = getDb()
 
-    if (session.chatThread?.workspaceId) {
-      await updateChatThread(db, session.chatThread.workspaceId, session.chatThread.id, { agentId: agent.id })
+    // `session.workspaceId` is the source of truth — the in-memory thread row
+    // may have been hydrated before the workspace_id column was added or from
+    // a partial row, but the session carries the workspaceId as a required
+    // field. The thread is the gate (need its id to PATCH).
+    if (session.chatThread) {
+      await updateChatThread(db, session.workspaceId, session.chatThread.id, { agentId: agent.id })
     }
 
     // Persist the global last-used agent so new chats default to it (mirrors

--- a/src/chats/use-hydrate-chat-store.test.tsx
+++ b/src/chats/use-hydrate-chat-store.test.tsx
@@ -237,6 +237,29 @@ describe('useHydrateChatStore', () => {
       expect(session?.triggerData).toBeDefined()
     })
 
+    it('handles concurrent hydration calls for the same id without throwing', async () => {
+      // Regression: when `[id, workspaceId]` flips twice in quick succession
+      // (e.g. landing on `/w/<newId>/chats/new` right after workspace creation),
+      // two `hydrateChatStore()` calls race past the early dedup and both reach
+      // `createSession`. The store's `createSession` throws on duplicate id, so
+      // the second invocation used to crash with "Session already exists".
+      const systemModelId = await createSystemModel()
+      const threadId = await createTestThread(systemModelId)
+
+      const { result } = renderHook(() => useHydrateChatStore({ id: threadId, isNew: false }), {
+        wrapper: TestWrapper,
+      })
+
+      // Kick off two concurrent calls; both must resolve without throwing.
+      await act(async () => {
+        await Promise.all([result.current.hydrateChatStore(), result.current.hydrateChatStore()])
+      })
+
+      const storeState = useChatStore.getState()
+      expect(storeState.sessions.has(threadId)).toBe(true)
+      expect(storeState.currentSessionId).toBe(threadId)
+    })
+
     it('should reset store before hydrating', async () => {
       const systemModelId = await createSystemModel()
       const threadId1 = await createTestThread(systemModelId, 'Thread 1')

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -233,6 +233,22 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
       return
     }
 
+    // Re-read the session map immediately before the write. The top-of-function
+    // existing-session check (above) is separated from `createSession` by the
+    // big Promise.all, so two concurrent hydrations for the same `id` can both
+    // pass the early dedup and race to `createSession` — which throws when
+    // both reach it. Surfaces when `[id, workspaceId]` flips twice in quick
+    // succession (e.g. landing on `/w/<newId>/chats/new` right after workspace
+    // creation, where `useActiveWorkspaceId()` is briefly null then resolves).
+    if (useChatStore.getState().sessions.has(id)) {
+      setCurrentSessionId(id)
+      setMcpClients(mcpClients)
+      setModes(modes)
+      setModels(models)
+      setIsReady(true)
+      return
+    }
+
     const chatInstance = createChatInstance(
       id,
       workspaceId,

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -133,6 +133,11 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
     const existingSession = sessions.get(id)
     if (existingSession) {
       if (existingSession.workspaceId !== workspaceId) {
+        // Drop `isReady` before we evict so consumers don't render against a
+        // session we've just removed during the async rebuild below — they'd
+        // see `isReady=true` with no matching session entry and throw
+        // missing-session errors.
+        setIsReady(false)
         const nextSessions = new Map(sessions)
         nextSessions.delete(id)
         useChatStore.setState({ sessions: nextSessions })

--- a/src/components/app-error-boundary.test.tsx
+++ b/src/components/app-error-boundary.test.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { setupConsoleSpy, type ConsoleSpies } from '@/test-utils/console-spies'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { AppErrorBoundary } from './app-error-boundary'
+
+const Boom = ({ message }: { message: string }) => {
+  throw new Error(message)
+}
+
+describe('AppErrorBoundary', () => {
+  let consoleSpies: ConsoleSpies
+
+  beforeEach(() => {
+    consoleSpies = setupConsoleSpy()
+  })
+
+  afterEach(() => {
+    consoleSpies.restore()
+  })
+
+  it('renders the children when no error is thrown', () => {
+    render(
+      <AppErrorBoundary>
+        <span>OK</span>
+      </AppErrorBoundary>,
+    )
+    expect(screen.getByText('OK')).toBeInTheDocument()
+  })
+
+  it('renders AppErrorScreen with the caught message when a child throws', () => {
+    render(
+      <AppErrorBoundary>
+        <Boom message="bootstrap failed" />
+      </AppErrorBoundary>,
+    )
+    expect(screen.getByText('Failed to initialize app')).toBeInTheDocument()
+    expect(screen.getByText('bootstrap failed')).toBeInTheDocument()
+  })
+})

--- a/src/components/app-error-boundary.tsx
+++ b/src/components/app-error-boundary.tsx
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { AppErrorScreen } from './app-error-screen'
+
+type AppErrorBoundaryState = {
+  error: Error | null
+}
+
+/**
+ * Catches uncaught render-time errors so a failed bootstrap (e.g. the
+ * `SessionToWorkspaceBootstrap` throw in `auth-context.tsx`) lands on an
+ * actionable error screen instead of a blank page. Mounted just above
+ * `BrowserRouter` so the boundary scope covers every route.
+ */
+export class AppErrorBoundary extends Component<{ children: ReactNode }, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[AppErrorBoundary] Uncaught render error:', error, info.componentStack)
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    if (error) {
+      return (
+        <AppErrorScreen
+          error={{
+            code: 'UNKNOWN_ERROR',
+            message: error.message,
+            stackTrace: error.stack,
+            originalError: error,
+          }}
+          isClearingDatabase={false}
+          // Reload as the universal recovery for non-DB render errors. The DB
+          // wipe affordance is gated inside AppErrorScreen on init-specific
+          // error codes and doesn't render for UNKNOWN_ERROR.
+          onClearDatabase={() => window.location.reload()}
+        />
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/components/boot/mode-picker.test.tsx
+++ b/src/components/boot/mode-picker.test.tsx
@@ -223,6 +223,86 @@ describe('ModePicker', () => {
       expect(mockValidate).toHaveBeenCalledWith('http://localhost:8000/v1')
     })
 
+    it('does not leave Continue stuck disabled after a stale blur + edit', async () => {
+      let resolveValidate: (r: ValidationResult) => void = () => {}
+      mockValidate.mockImplementation(
+        () =>
+          new Promise<ValidationResult>((resolve) => {
+            resolveValidate = resolve
+          }),
+      )
+
+      renderModePicker()
+      fireEvent.click(screen.getByText('Connect to AI server'))
+
+      const input = screen.getByPlaceholderText('app.thunderbolt.io/')
+      fireEvent.change(input, { target: { value: 'http://stale.local' } })
+      fireEvent.blur(input)
+      // Edit before validate() resolves — isValidating must clear so Continue
+      // enables once a non-empty URL is in the field.
+      fireEvent.change(input, { target: { value: 'http://fresh.local' } })
+
+      resolveValidate(okValidation())
+      await flush()
+
+      const buttons = screen.getAllByRole('button')
+      expect((buttons[buttons.length - 1] as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    it('drops a stale blur result when the user edits the field during validation', async () => {
+      // Hold validate() pending so we can interleave a SET_URL between
+      // dispatch(VALIDATE_START) and the result.
+      let resolveValidate: (r: ValidationResult) => void = () => {}
+      mockValidate.mockImplementation(
+        () =>
+          new Promise<ValidationResult>((resolve) => {
+            resolveValidate = resolve
+          }),
+      )
+
+      renderModePicker()
+      fireEvent.click(screen.getByText('Connect to AI server'))
+
+      const input = screen.getByPlaceholderText('app.thunderbolt.io/')
+      fireEvent.change(input, { target: { value: 'http://stale.local' } })
+      fireEvent.blur(input)
+      // No flush yet — validate() is still pending.
+
+      // User edits the field while validate is in flight.
+      fireEvent.change(input, { target: { value: 'http://fresh.local' } })
+
+      // Stale validate finally resolves with success for the OLD URL.
+      resolveValidate(okValidation())
+      await flush()
+
+      // Checkmark must NOT appear — the success was for stale text.
+      expect(input.parentElement?.querySelector('svg')).not.toBeInTheDocument()
+    })
+
+    it('reuses the blur-time validation when Continue submits the same URL', async () => {
+      const serverId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      mockValidate.mockResolvedValue(okValidation({ serverId }))
+
+      renderModePicker()
+      fireEvent.click(screen.getByText('Connect to AI server'))
+
+      const input = screen.getByPlaceholderText('app.thunderbolt.io/')
+      fireEvent.change(input, { target: { value: 'http://localhost:8000' } })
+      fireEvent.blur(input)
+      await flush()
+
+      // Blur fires one validate call.
+      expect(mockValidate).toHaveBeenCalledTimes(1)
+
+      // Continue against the SAME URL must not re-validate.
+      const buttons = screen.getAllByRole('button')
+      fireEvent.click(buttons[buttons.length - 1])
+      await flush()
+
+      expect(mockValidate).toHaveBeenCalledTimes(1)
+      expect(useTrustDomainRegistry.getState().activeTrustDomain).toEqual({ kind: 'server', serverId })
+    })
+
     it('shows inline error and returns to picker on validation failure', async () => {
       mockValidate.mockResolvedValue(errorValidation("Couldn't reach this server"))
 

--- a/src/components/boot/mode-picker.tsx
+++ b/src/components/boot/mode-picker.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useReducer } from 'react'
+import { useReducer, useRef } from 'react'
 import { ArrowRight, Bot, Check, Server } from 'lucide-react'
 import { AppLogo } from '@/components/app-logo'
 import { Button } from '@/components/ui/button'
@@ -45,7 +45,11 @@ const reducer = (state: State, action: Action): State => {
     case 'SELECT':
       return { ...state, selection: action.mode, serverUrlError: null, isUrlValidated: false }
     case 'SET_URL':
-      return { ...state, serverUrl: action.url, serverUrlError: null, isUrlValidated: false }
+      // Reset `isValidating` too: if a blur kicked off `validate()` and the
+      // user then edits the field, the in-flight result is stale and gets
+      // dropped without dispatching success/error — without this reset the
+      // flag would stick at true and the Continue button would never enable.
+      return { ...state, serverUrl: action.url, serverUrlError: null, isUrlValidated: false, isValidating: false }
     case 'VALIDATE_START':
       return { ...state, isValidating: true, serverUrlError: null }
     case 'VALIDATE_SUCCESS':
@@ -104,6 +108,22 @@ type ModePickerProps = {
 export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {}) => {
   const [state, dispatch] = useReducer(reducer, initialState)
 
+  // Mirror of the live `serverUrl` so async validate callbacks can detect that
+  // the user typed something else while the request was in flight, and bail
+  // out of applying a result that no longer matches. Updated on every render
+  // AND synchronously in the input's `onChange` — the render-time write alone
+  // races with a validate Promise that resolves before React commits the
+  // SET_URL re-render, since the closure's `urlAtCall` and the (stale) ref
+  // both still equal the previous value at that moment.
+  const serverUrlRef = useRef(state.serverUrl)
+  serverUrlRef.current = state.serverUrl
+
+  // Cache of the last validate() resolution by URL. Reused when Continue
+  // submits the same URL the user just blurred, so we don't pay the
+  // /v1/config round-trip twice (and don't visually "re-validate" a URL the
+  // user already saw a checkmark on).
+  const lastValidationRef = useRef<{ url: string; result: ValidationResult } | null>(null)
+
   const isServerMode = state.selection === 'server'
   // Dots: left = initial pick, right = server URL step
   const activeDot = isServerMode ? 1 : 0
@@ -120,8 +140,23 @@ export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {
     if (!isServerMode || !state.serverUrl.trim()) {
       return
     }
+    const urlAtCall = state.serverUrl
+    // Skip if we already have a cached result for this exact URL — the second
+    // blur after Continue's pre-validation would otherwise re-fire the network.
+    if (lastValidationRef.current?.url === urlAtCall) {
+      const cached = lastValidationRef.current.result
+      dispatch(cached.ok ? { type: 'VALIDATE_SUCCESS' } : { type: 'VALIDATE_ERROR', message: cached.message })
+      return
+    }
     dispatch({ type: 'VALIDATE_START' })
-    const result = await validate(state.serverUrl)
+    const result = await validate(urlAtCall)
+    // Drop the result if the input has changed since we started — applying it
+    // would either show a checkmark for the new text (when the old URL passed)
+    // or show an error for text the user already replaced.
+    if (urlAtCall !== serverUrlRef.current) {
+      return
+    }
+    lastValidationRef.current = { url: urlAtCall, result }
     dispatch(result.ok ? { type: 'VALIDATE_SUCCESS' } : { type: 'VALIDATE_ERROR', message: result.message })
   }
 
@@ -133,8 +168,29 @@ export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {
     }
 
     if (state.selection === 'server') {
+      // Reuse the blur-time result when the URL hasn't changed since — avoids
+      // a second round-trip and the click-while-blur-pending double-tap UX.
+      const cached = lastValidationRef.current
+      if (cached && cached.url === state.serverUrl && cached.result.ok) {
+        dispatch({ type: 'CONNECT' })
+        useTrustDomainRegistry
+          .getState()
+          .activateServer({ serverId: cached.result.serverId, cloudUrl: cached.result.cloudUrl })
+        window.location.reload()
+        return
+      }
+
       dispatch({ type: 'CONNECT' })
-      const result = await validate(state.serverUrl)
+      const urlAtCall = state.serverUrl
+      const result = await validate(urlAtCall)
+      if (urlAtCall !== serverUrlRef.current) {
+        // User edited the field during the network call — bail rather than
+        // surface a result for stale text. Reset the stage so we don't strand
+        // the user on the "Connecting to Server" screen with no recovery path.
+        dispatch({ type: 'VALIDATE_ERROR', message: '' })
+        return
+      }
+      lastValidationRef.current = { url: urlAtCall, result }
       if (!result.ok) {
         dispatch({ type: 'VALIDATE_ERROR', message: result.message })
         return
@@ -213,7 +269,13 @@ export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {
                 type="url"
                 placeholder="app.thunderbolt.io/"
                 value={state.serverUrl}
-                onChange={(e) => dispatch({ type: 'SET_URL', url: e.target.value })}
+                onChange={(e) => {
+                  // Close the in-flight-validate race window — keep the ref
+                  // in lockstep with user input so a Promise resolving before
+                  // the SET_URL render commit can still detect the mismatch.
+                  serverUrlRef.current = e.target.value
+                  dispatch({ type: 'SET_URL', url: e.target.value })
+                }}
                 onBlur={handleBlur}
                 state={state.serverUrlError ? 'error' : 'default'}
                 disabled={state.isValidating}

--- a/src/components/chat/chat-model-picker.test.tsx
+++ b/src/components/chat/chat-model-picker.test.tsx
@@ -21,6 +21,13 @@ import { MemoryRouter } from 'react-router'
 import type { ReactNode } from 'react'
 import { ChatModelPicker } from './chat-model-picker'
 
+const fakeUseWorkspacePermission = (isAllowed: boolean) =>
+  (() => ({
+    requiredRole: 'admin' as const,
+    isAllowed,
+    isResolved: true,
+  })) as unknown as typeof import('@/hooks/use-workspace-permission').useWorkspacePermission
+
 const remoteAcpAgent: Agent = {
   id: 'remote-1',
   name: 'Remote Agent',
@@ -129,6 +136,32 @@ describe('ChatModelPicker', () => {
     const { container } = render(<ChatModelPicker />, { wrapper: TestWrapper })
 
     expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the "Add Models" footer when the user has add_models permission', async () => {
+    setupWithAgent(builtInAgent)
+
+    render(<ChatModelPicker useWorkspacePermission={fakeUseWorkspacePermission(true)} />, { wrapper: TestWrapper })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('GPT-4'))
+    })
+
+    expect(await screen.findByText('Add Models')).toBeInTheDocument()
+  })
+
+  it('hides the "Add Models" footer when the user lacks add_models permission', async () => {
+    setupWithAgent(builtInAgent)
+
+    render(<ChatModelPicker useWorkspacePermission={fakeUseWorkspacePermission(false)} />, { wrapper: TestWrapper })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('GPT-4'))
+    })
+
+    // Wait for the dropdown to settle, then assert the footer is absent.
+    await screen.findByText('GPT-5')
+    expect(screen.queryByText('Add Models')).not.toBeInTheDocument()
   })
 
   it('changes the selected model in the store on click', async () => {

--- a/src/components/chat/chat-model-picker.tsx
+++ b/src/components/chat/chat-model-picker.tsx
@@ -5,6 +5,7 @@
 import { useChatStore, useCurrentChatSession } from '@/chats/chat-store'
 import { ModelSelector } from '@/components/ui/model-selector'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useWorkspacePermission as useWorkspacePermission_default } from '@/hooks/use-workspace-permission'
 import { useWorkspaceNavigate } from '@/lib/active-workspace'
 
 /**
@@ -17,12 +18,23 @@ import { useWorkspaceNavigate } from '@/lib/active-workspace'
  * ModeSelector sitting beside it, and mirrors its open direction (down on
  * desktop, up on mobile) so the two dropdowns stay consistent.
  */
-export const ChatModelPicker = () => {
+type ChatModelPickerProps = {
+  /** Test seam — defaults to the real hook. Pages exercise this via tests
+   *  that inject a fake to assert the gated-affordance is hidden. */
+  useWorkspacePermission?: typeof useWorkspacePermission_default
+}
+
+export const ChatModelPicker = ({
+  useWorkspacePermission = useWorkspacePermission_default,
+}: ChatModelPickerProps = {}) => {
   const models = useChatStore((state) => state.models)
   const setSelectedModel = useChatStore((state) => state.setSelectedModel)
   const navigate = useWorkspaceNavigate()
   const { isMobile } = useIsMobile()
   const { id: chatThreadId, selectedAgent, selectedModel, chatThread } = useCurrentChatSession()
+  // Suppress the "Add Models" footer when the user can't add — they'd land on
+  // a settings page where the affordance is also hidden.
+  const { isAllowed: canAddModels } = useWorkspacePermission('add_models')
 
   if (selectedAgent.type !== 'built-in' || models.length === 0) {
     return null
@@ -39,7 +51,7 @@ export const ChatModelPicker = () => {
       selectedModel={selectedModel ?? null}
       chatThread={chatThread ?? null}
       onModelChange={handleModelChange}
-      onAddModels={() => navigate('/settings/models')}
+      onAddModels={canAddModels ? () => navigate('/settings/models') : undefined}
       side={isMobile ? 'top' : 'bottom'}
       align="start"
     />

--- a/src/components/chat/chat-skills-bar.test.tsx
+++ b/src/components/chat/chat-skills-bar.test.tsx
@@ -50,6 +50,13 @@ const fakeUseEnabledSkills = (enabledIds: ReadonlySet<string>) =>
     setEnabled: async () => undefined,
   })) as unknown as typeof import('@/skills/use-skills').useEnabledSkills
 
+const fakeUseWorkspacePermission = (isAllowed: boolean) =>
+  (() => ({
+    requiredRole: 'admin' as const,
+    isAllowed,
+    isResolved: true,
+  })) as unknown as typeof import('@/hooks/use-workspace-permission').useWorkspacePermission
+
 const renderBar = (props: Partial<Parameters<typeof ChatSkillsBar>[0]> = {}) => {
   return render(
     <MemoryRouter>
@@ -60,6 +67,7 @@ const renderBar = (props: Partial<Parameters<typeof ChatSkillsBar>[0]> = {}) => 
           usePinnedSkills={props.usePinnedSkills ?? fakeUsePinnedSkills({ pinned: [] })}
           useLibrarySkills={props.useLibrarySkills ?? fakeUseLibrarySkills([])}
           useEnabledSkills={props.useEnabledSkills ?? fakeUseEnabledSkills(new Set())}
+          useWorkspacePermission={props.useWorkspacePermission ?? fakeUseWorkspacePermission(true)}
         />
       </TooltipProvider>
     </MemoryRouter>,
@@ -125,4 +133,42 @@ describe('ChatSkillsBar', () => {
 
   // The chip's click → onAddToChat path is exercised end-to-end at the
   // composer level; here we trust Radix's primitives.
+
+  describe('permission gating (add_skills)', () => {
+    it('hides the "+ Pin a skill" trigger when the user lacks add_skills', () => {
+      const a = skill('a', 'daily-brief')
+      renderBar({
+        usePinnedSkills: fakeUsePinnedSkills({ pinned: [] }),
+        useLibrarySkills: fakeUseLibrarySkills([a]),
+        useEnabledSkills: fakeUseEnabledSkills(new Set(['a'])),
+        useWorkspacePermission: fakeUseWorkspacePermission(false),
+      })
+
+      expect(screen.queryByLabelText('Pin a skill')).not.toBeInTheDocument()
+    })
+
+    it('renders nothing when the user lacks add_skills and has no pinned chips, regardless of candidates', () => {
+      const a = skill('a', 'daily-brief')
+      const { container } = renderBar({
+        usePinnedSkills: fakeUsePinnedSkills({ pinned: [] }),
+        useLibrarySkills: fakeUseLibrarySkills([a]),
+        useEnabledSkills: fakeUseEnabledSkills(new Set(['a'])),
+        useWorkspacePermission: fakeUseWorkspacePermission(false),
+      })
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('still renders pinned chips when the user lacks add_skills (read-only chips)', () => {
+      const a = skill('a', 'daily-brief')
+      renderBar({
+        usePinnedSkills: fakeUsePinnedSkills({ pinned: [a] }),
+        useLibrarySkills: fakeUseLibrarySkills([a]),
+        useEnabledSkills: fakeUseEnabledSkills(new Set(['a'])),
+        useWorkspacePermission: fakeUseWorkspacePermission(false),
+      })
+
+      expect(screen.getByText('/daily-brief')).toBeTruthy()
+      expect(screen.queryByLabelText('Pin a skill')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/chat/chat-skills-bar.tsx
+++ b/src/components/chat/chat-skills-bar.tsx
@@ -11,6 +11,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { maxPinnedSkills } from '@/dal'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useWorkspacePermission as useWorkspacePermission_default } from '@/hooks/use-workspace-permission'
 import { ReorderPanel } from '@/skills/reorder-panel'
 import { SuggestionChip } from '@/skills/suggestion-chip'
 import { useSkillTelemetry } from '@/skills/telemetry'
@@ -35,6 +36,7 @@ type ChatSkillsBarProps = {
   usePinnedSkills?: typeof usePinnedSkills_default
   useLibrarySkills?: typeof useLibrarySkills_default
   useEnabledSkills?: typeof useEnabledSkills_default
+  useWorkspacePermission?: typeof useWorkspacePermission_default
 }
 
 /**
@@ -54,12 +56,17 @@ export const ChatSkillsBar = ({
   usePinnedSkills = usePinnedSkills_default,
   useLibrarySkills = useLibrarySkills_default,
   useEnabledSkills = useEnabledSkills_default,
+  useWorkspacePermission = useWorkspacePermission_default,
 }: ChatSkillsBarProps) => {
   const { pinned, pinnedSet, reorderPins, togglePin } = usePinnedSkills()
   const { skills: library } = useLibrarySkills()
   const { isEnabled } = useEnabledSkills()
   const { isMobile } = useIsMobile()
   const trackSkillEvent = useSkillTelemetry()
+  // Pin / unpin / reorder all PATCH the `skills` row — the BE gates them
+  // on `add_skills`. Hide the affordances when the user can't satisfy that
+  // permission so we don't surface actions that round-trip-fail.
+  const { isAllowed: canEditSkills } = useWorkspacePermission('add_skills')
 
   const [openChipId, setOpenChipId] = useState<string | null>(null)
   const [reorderMode, setReorderMode] = useState(false)
@@ -115,10 +122,12 @@ export const ChatSkillsBar = ({
       ? 'No more skills to pin'
       : 'Pin a skill'
 
-  // Hide the whole bar only when there's nothing to display *and* nothing
-  // to add. If the user has zero pins but unpinned skills exist, we still
-  // show the `+` button so they can pin one.
-  if (pinned.length === 0 && pinnable.length === 0) {
+  // Hide the whole bar when there's nothing to display *and* nothing the user
+  // can act on. Zero pins + unpinned candidates still warrants the `+` button
+  // — but only when the user can actually pin (`canEditSkills`); otherwise
+  // both the chips row and the trigger are empty and the strip would render
+  // as a thin blank line above the composer.
+  if (pinned.length === 0 && (pinnable.length === 0 || !canEditSkills)) {
     return null
   }
 
@@ -131,6 +140,7 @@ export const ChatSkillsBar = ({
             key={skill.id}
             label={skill.name}
             dimmed={openChipId !== null && openChipId !== skill.id}
+            canEdit={canEditSkills}
             onClick={() => onAddToChat(skill.name)}
             onOpenChange={(open) => setOpenChipId(open ? skill.id : null)}
             onAddInstruction={() => onAddInstruction(skill.instruction)}
@@ -147,26 +157,27 @@ export const ChatSkillsBar = ({
             }}
           />
         ))}
-        <Popover open={addOpen} onOpenChange={setAddOpen}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="icon-sm"
-                  aria-label="Pin a skill"
-                  disabled={addDisabled}
-                  className={`shrink-0 cursor-pointer rounded-full bg-card transition-opacity disabled:cursor-not-allowed disabled:opacity-40 ${
-                    openChipId ? 'opacity-40' : ''
-                  }`}
-                >
-                  <Plus />
-                </Button>
-              </PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent>{addTooltip}</TooltipContent>
-          </Tooltip>
-          {/*
+        {canEditSkills && (
+          <Popover open={addOpen} onOpenChange={setAddOpen}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon-sm"
+                    aria-label="Pin a skill"
+                    disabled={addDisabled}
+                    className={`shrink-0 cursor-pointer rounded-full bg-card transition-opacity disabled:cursor-not-allowed disabled:opacity-40 ${
+                      openChipId ? 'opacity-40' : ''
+                    }`}
+                  >
+                    <Plus />
+                  </Button>
+                </PopoverTrigger>
+              </TooltipTrigger>
+              <TooltipContent>{addTooltip}</TooltipContent>
+            </Tooltip>
+            {/*
             `collisionPadding={16}` keeps the popover 16px off the viewport
             edges. On mobile the content is sized to `calc(100vw-2rem)` (32px
             narrower than the viewport), so collision avoidance pins it to a
@@ -175,49 +186,52 @@ export const ChatSkillsBar = ({
             leaves room, so the padding never shifts the `align="start"`
             anchor off the `+` button.
           */}
-          <PopoverContent
-            side="top"
-            align="start"
-            sideOffset={6}
-            collisionPadding={16}
-            className={isMobile ? 'w-[calc(100vw-2rem)] p-1' : 'w-72 max-w-[calc(100vw-2rem)] p-1'}
-          >
-            <ul className="max-h-64 overflow-y-auto">
-              {pinnable.map((skill) => (
-                <li key={skill.id}>
-                  <button
-                    type="button"
-                    onClick={async () => {
-                      // Close the popover synchronously so it doesn't sit open
-                      // while the mutation lands. Telemetry fires after the
-                      // mutation settles so we never report a phantom pin if
-                      // togglePin races past the cap guard.
-                      setAddOpen(false)
-                      try {
-                        await togglePin(skill.id)
-                        trackSkillEvent('skill_pinned', skill.id, {})
-                      } catch (error) {
-                        console.warn('togglePin failed:', error)
-                      }
-                    }}
-                    // `rounded-xl` (not `rounded-md`) so the hover highlight
-                    // sits concentrically inside the `rounded-2xl` container's
-                    // `p-1` padding — outer radius minus 4px padding. Matches
-                    // the slash autocomplete popover.
-                    className="flex w-full cursor-pointer flex-col gap-0.5 rounded-xl px-2 py-1.5 text-left transition-colors hover:bg-accent"
-                  >
-                    <span className="truncate text-[length:var(--font-size-body)] text-foreground">/{skill.name}</span>
-                    {skill.description && (
-                      <span className="line-clamp-1 text-[length:var(--font-size-sm)] text-muted-foreground">
-                        {skill.description}
+            <PopoverContent
+              side="top"
+              align="start"
+              sideOffset={6}
+              collisionPadding={16}
+              className={isMobile ? 'w-[calc(100vw-2rem)] p-1' : 'w-72 max-w-[calc(100vw-2rem)] p-1'}
+            >
+              <ul className="max-h-64 overflow-y-auto">
+                {pinnable.map((skill) => (
+                  <li key={skill.id}>
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        // Close the popover synchronously so it doesn't sit open
+                        // while the mutation lands. Telemetry fires after the
+                        // mutation settles so we never report a phantom pin if
+                        // togglePin races past the cap guard.
+                        setAddOpen(false)
+                        try {
+                          await togglePin(skill.id)
+                          trackSkillEvent('skill_pinned', skill.id, {})
+                        } catch (error) {
+                          console.warn('togglePin failed:', error)
+                        }
+                      }}
+                      // `rounded-xl` (not `rounded-md`) so the hover highlight
+                      // sits concentrically inside the `rounded-2xl` container's
+                      // `p-1` padding — outer radius minus 4px padding. Matches
+                      // the slash autocomplete popover.
+                      className="flex w-full cursor-pointer flex-col gap-0.5 rounded-xl px-2 py-1.5 text-left transition-colors hover:bg-accent"
+                    >
+                      <span className="truncate text-[length:var(--font-size-body)] text-foreground">
+                        /{skill.name}
                       </span>
-                    )}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </PopoverContent>
-        </Popover>
+                      {skill.description && (
+                        <span className="line-clamp-1 text-[length:var(--font-size-sm)] text-muted-foreground">
+                          {skill.description}
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
     </>
   )

--- a/src/components/logout-modal.test.tsx
+++ b/src/components/logout-modal.test.tsx
@@ -140,6 +140,17 @@ describe('LogoutModal', () => {
     })
   })
 
+  describe('double-click guard', () => {
+    it('only fires signOutAndWipe once when Log out is clicked rapidly', () => {
+      renderModal()
+      const button = screen.getByRole('button', { name: 'Log out' })
+      fireEvent.click(button)
+      fireEvent.click(button)
+      fireEvent.click(button)
+      expect(mockSignOutAndWipe).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('cancel behavior', () => {
     it('closes the dialog when cancel is clicked', () => {
       renderModal()

--- a/src/components/logout-modal.tsx
+++ b/src/components/logout-modal.tsx
@@ -41,6 +41,13 @@ export const LogoutModal = ({ open, onOpenChange, signOutAndWipe = defaultSignOu
   // per-trust-domain SQLite files — leftover data without a matching auth token has no
   // path back to the user.
   const handleLogout = () => {
+    // Ref-guard at entry: the button's `disabled={isLoggingOut}` only applies
+    // after React commits the setState below. A rapid double-click (or a
+    // queued click event firing in the same tick as the first) would
+    // otherwise launch a second signOutAndWipe concurrent with the first.
+    if (isLoggingOutRef.current) {
+      return
+    }
     isLoggingOutRef.current = true
     setIsLoggingOut(true)
     // SSO lands on `/signed-out` because IdP-bounce-back would silently re-auth the

--- a/src/components/settings/agents/agent-list.test.tsx
+++ b/src/components/settings/agents/agent-list.test.tsx
@@ -62,6 +62,14 @@ describe('canDeleteAgent', () => {
   it('returns false when no user is signed in', () => {
     expect(canDeleteAgent(customAgent, null)).toBe(false)
   })
+
+  it('returns false when the workspace `remove_agents` permission denies the user', () => {
+    expect(canDeleteAgent(customAgent, 'user-42', false)).toBe(false)
+  })
+
+  it('returns true when canRemoveAgents defaults (omitted), preserving prior behaviour', () => {
+    expect(canDeleteAgent(customAgent, 'user-42')).toBe(true)
+  })
 })
 
 describe('AgentList', () => {
@@ -145,6 +153,40 @@ describe('AgentList', () => {
     render(<AgentList agents={[customAgent]} currentUserId="user-42" onToggle={onToggle} onDelete={onDelete} />)
 
     expect(screen.getByTestId(`agent-toggle-${customAgent.id}`)).not.toBeDisabled()
+  })
+
+  it('hides the Remove affordance on every row when canRemoveAgents is false', () => {
+    const onToggle = mock(() => {})
+    const onDelete = mock(() => {})
+
+    render(
+      <AgentList
+        agents={[customAgent]}
+        currentUserId="user-42"
+        canRemoveAgents={false}
+        onToggle={onToggle}
+        onDelete={onDelete}
+      />,
+    )
+
+    expect(screen.queryByTestId(`agent-delete-${customAgent.id}`)).not.toBeInTheDocument()
+  })
+
+  it('disables the row toggle when canEditAgents is false (even for an owned custom)', () => {
+    const onToggle = mock(() => {})
+    const onDelete = mock(() => {})
+
+    render(
+      <AgentList
+        agents={[customAgent]}
+        currentUserId="user-42"
+        canEditAgents={false}
+        onToggle={onToggle}
+        onDelete={onDelete}
+      />,
+    )
+
+    expect(screen.getByTestId(`agent-toggle-${customAgent.id}`)).toBeDisabled()
   })
 })
 

--- a/src/components/settings/agents/agent-list.tsx
+++ b/src/components/settings/agents/agent-list.tsx
@@ -8,6 +8,11 @@ import type { Agent } from '@/types/acp'
 type AgentListProps = {
   agents: Agent[]
   currentUserId: string | null
+  /** Defaults to true. Mirrors `add_agents`; gates the row enable/disable toggle. */
+  canEditAgents?: boolean
+  /** Defaults to true — when false the Remove affordance is hidden on every row.
+   *  Mirrors the workspace `remove_agents` permission; the BE is authoritative. */
+  canRemoveAgents?: boolean
   onToggle: (agent: Agent, enabled: boolean) => void
   onDelete: (agent: Agent) => void
 }
@@ -15,10 +20,25 @@ type AgentListProps = {
 /** Renders the unified agent list returned by `useAllAgents` (built-in first,
  *  then system, then user customs). Composition lives in the DAL — this
  *  component is purely visual + event-dispatching so it stays trivial to test. */
-export const AgentList = ({ agents, currentUserId, onToggle, onDelete }: AgentListProps) => (
+export const AgentList = ({
+  agents,
+  currentUserId,
+  canEditAgents = true,
+  canRemoveAgents = true,
+  onToggle,
+  onDelete,
+}: AgentListProps) => (
   <div className="grid gap-3" data-testid="agent-list">
     {agents.map((agent) => (
-      <AgentRow key={agent.id} agent={agent} currentUserId={currentUserId} onToggle={onToggle} onDelete={onDelete} />
+      <AgentRow
+        key={agent.id}
+        agent={agent}
+        currentUserId={currentUserId}
+        canEditAgents={canEditAgents}
+        canRemoveAgents={canRemoveAgents}
+        onToggle={onToggle}
+        onDelete={onDelete}
+      />
     ))}
   </div>
 )

--- a/src/components/settings/agents/agent-row.tsx
+++ b/src/components/settings/agents/agent-row.tsx
@@ -36,8 +36,17 @@ const badgeForAgent = (agent: Agent): string => {
 /** Predicate for the delete action's visibility. Customs the current user owns
  *  can be soft-deleted; built-in and system agents are managed externally and
  *  must not be removable from the UI. Exported for unit testing without
- *  rendering the full row tree. */
-export const canDeleteAgent = (agent: Agent, currentUserId: string | null): boolean => {
+ *  rendering the full row tree.
+ *
+ *  `canRemoveAgents` reflects the workspace `remove_agents` permission — when
+ *  false, no row is removable regardless of ownership. Defaults to true so
+ *  existing callers keep working.
+ */
+export const canDeleteAgent = (
+  agent: Agent,
+  currentUserId: string | null,
+  canRemoveAgents: boolean = true,
+): boolean => {
   if (agent.type === 'built-in') {
     return false
   }
@@ -45,6 +54,9 @@ export const canDeleteAgent = (agent: Agent, currentUserId: string | null): bool
     return false
   }
   if (!currentUserId) {
+    return false
+  }
+  if (!canRemoveAgents) {
     return false
   }
   return agent.userId === currentUserId
@@ -67,15 +79,29 @@ export const agentToggleDisabled = (agent: Agent): { disabled: boolean; disabled
 type AgentRowProps = {
   agent: Agent
   currentUserId: string | null
+  /** Defaults to true. Mirrors the workspace `add_agents` permission — also
+   *  used for the enable/disable toggle since toggling is a PATCH the BE
+   *  gates on `add_agents`. */
+  canEditAgents?: boolean
+  /** Defaults to true. Mirrors the workspace `remove_agents` permission. */
+  canRemoveAgents?: boolean
   onToggle: (agent: Agent, enabled: boolean) => void
   onDelete: (agent: Agent) => void
 }
 
-export const AgentRow = ({ agent, currentUserId, onToggle, onDelete }: AgentRowProps) => {
+export const AgentRow = ({
+  agent,
+  currentUserId,
+  canEditAgents = true,
+  canRemoveAgents = true,
+  onToggle,
+  onDelete,
+}: AgentRowProps) => {
   const Icon = iconForAgent(agent)
   const badge = badgeForAgent(agent)
-  const showDelete = canDeleteAgent(agent, currentUserId)
+  const showDelete = canDeleteAgent(agent, currentUserId, canRemoveAgents)
   const { disabled: toggleDisabled, disabledTooltip } = agentToggleDisabled(agent)
+  const finalToggleDisabled = toggleDisabled || !canEditAgents
   const isEnabled = agent.enabled === 1
   const [deleteOpen, setDeleteOpen] = useState(false)
 
@@ -112,7 +138,7 @@ export const AgentRow = ({ agent, currentUserId, onToggle, onDelete }: AgentRowP
                   <Switch
                     data-testid={`agent-toggle-${agent.id}`}
                     checked={isEnabled}
-                    disabled={toggleDisabled}
+                    disabled={finalToggleDisabled}
                     onCheckedChange={(checked) => onToggle(agent, checked)}
                   />
                 </div>

--- a/src/components/ui/header.test.tsx
+++ b/src/components/ui/header.test.tsx
@@ -27,6 +27,13 @@ import { SidebarProvider } from '@/components/ui/sidebar'
 import { SignInModalProvider } from '@/contexts'
 import { Header } from './header'
 
+const fakeUseWorkspacePermission = (isAllowed: boolean) =>
+  (() => ({
+    requiredRole: 'admin' as const,
+    isAllowed,
+    isResolved: true,
+  })) as unknown as typeof import('@/hooks/use-workspace-permission').useWorkspacePermission
+
 /** happy-dom exposes its control API on `window.happyDOM`, but the global
  *  registrator doesn't augment the DOM lib's `Window`. Declare the one method
  *  this test drives so `tsc --noEmit` stays green. */
@@ -177,5 +184,31 @@ describe('Header', () => {
     render(<Header />, { wrapper: TestWrapper })
 
     expect(screen.getByText(builtInAgent.name)).toBeInTheDocument()
+  })
+
+  describe('permission gating (add_agents)', () => {
+    it('renders the "Add Agent" selector footer when the user has add_agents', async () => {
+      setupWithAgent(builtInAgent)
+
+      render(<Header useWorkspacePermission={fakeUseWorkspacePermission(true)} />, { wrapper: TestWrapper })
+      await flushAgentsQuery()
+      await act(async () => {
+        screen.getByText(builtInAgent.name).click()
+      })
+
+      expect(await screen.findByText('Add Agent')).toBeInTheDocument()
+    })
+
+    it('hides the "Add Agent" selector footer when the user lacks add_agents', async () => {
+      setupWithAgent(builtInAgent)
+
+      render(<Header useWorkspacePermission={fakeUseWorkspacePermission(false)} />, { wrapper: TestWrapper })
+      await flushAgentsQuery()
+      await act(async () => {
+        screen.getByText(builtInAgent.name).click()
+      })
+
+      expect(screen.queryByText('Add Agent')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -12,6 +12,7 @@ import { Menu, MessageCirclePlus } from 'lucide-react'
 import { useChatStore } from '@/chats/chat-store'
 import type { ChatSession } from '@/chats/chat-store'
 import { selectAllowCustomAgents, useConfigStore } from '@/api/config-store'
+import { useWorkspacePermission as useWorkspacePermission_default } from '@/hooks/use-workspace-permission'
 import { useShallow } from 'zustand/react/shallow'
 import { useLocation } from 'react-router'
 import { stripWorkspacePrefix, useWorkspaceNavigate } from '@/lib/active-workspace'
@@ -57,13 +58,22 @@ const HeaderAgentSelector = ({
  * Reusable page header component with sidebar trigger and agent selector. Model
  * selection lives in the chat composer (next to the mode picker), not here.
  */
-export const Header = () => {
+type HeaderProps = {
+  /** Test seam — defaults to the real hook. Tests inject a fake to assert the
+   *  Agent footer hides when the user lacks `add_agents`. */
+  useWorkspacePermission?: typeof useWorkspacePermission_default
+}
+
+export const Header = ({ useWorkspacePermission = useWorkspacePermission_default }: HeaderProps = {}) => {
   const { toggleSidebar } = useSidebar()
   const { isMobile } = useIsMobile()
   const navigate = useWorkspaceNavigate()
   const location = useLocation()
   const allAgents = useAllAgents()
   const allowCustomAgents = useConfigStore((state) => selectAllowCustomAgents(state.config))
+  // Suppress the "Add Agent" footer when the user can't add — they'd land on
+  // a settings page where the affordance is also hidden.
+  const { isAllowed: canAddAgents } = useWorkspacePermission('add_agents')
 
   const { chatInstance, selectedAgent, setSelectedAgent, chatThreadId } = useChatStore(
     useShallow((state) => {
@@ -111,7 +121,7 @@ export const Header = () => {
       selectedAgent={effectiveAgent}
       agents={allAgents}
       onSelect={handleAgentSelect}
-      onAddAgent={allowCustomAgents ? handleAddAgent : undefined}
+      onAddAgent={allowCustomAgents && canAddAgents ? handleAddAgent : undefined}
     />
   )
 

--- a/src/components/workspace-membership-gate.tsx
+++ b/src/components/workspace-membership-gate.tsx
@@ -5,7 +5,7 @@
 import { useDatabase } from '@/contexts'
 import { getMembershipQuery } from '@/dal'
 import Loading from '@/loading'
-import { stripWorkspacePrefix } from '@/lib/active-workspace'
+import { crossWorkspaceSubPath } from '@/lib/active-workspace'
 import { useTrustDomainRegistry } from '@/stores/trust-domain-registry'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { useQuery } from '@powersync/tanstack-react-query'
@@ -81,9 +81,11 @@ export const WorkspaceMembershipGate = () => {
     return <Loading />
   }
 
-  // Drop the `/w/<id>` segment and forward to the personal workspace, which is
-  // the unprefixed canonical URL. Preserves search params (e.g. OAuth callback
+  // Drop the `/w/<id>` segment and forward to the personal workspace (the
+  // unprefixed canonical URL). Chat ids are per-workspace, so a chat-detail
+  // path is collapsed to `/chats/new` rather than landing on Not Found in
+  // the personal workspace. Preserves search params (e.g. OAuth callback
   // context) so the user lands on the right place if they had one.
-  const target = `${stripWorkspacePrefix(location.pathname)}${location.search}`
+  const target = `${crossWorkspaceSubPath(location.pathname)}${location.search}`
   return <Navigate to={target} replace />
 }

--- a/src/crypto/key-storage.ts
+++ b/src/crypto/key-storage.ts
@@ -148,25 +148,6 @@ const putEntries = async (entries: Array<{ id: string; value: StorableValue }>):
   })
 }
 
-const deleteKeys = async (ids: string[]): Promise<void> => {
-  const db = await openDB()
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(storeName, 'readwrite')
-    const store = tx.objectStore(storeName)
-    for (const id of ids) {
-      store.delete(id)
-    }
-    tx.oncomplete = () => {
-      db.close()
-      resolve()
-    }
-    tx.onerror = () => {
-      db.close()
-      reject(new StorageError('Failed to delete keys', { cause: tx.error }))
-    }
-  })
-}
-
 // =============================================================================
 // Key pair (ECDH P-256 + ML-KEM-768)
 // =============================================================================
@@ -228,10 +209,27 @@ export const clearCK = async (): Promise<void> => deleteKey(ckId)
 // Full wipe
 // =============================================================================
 
-/** Clear all keys and delete the IDB database for the active server (full data wipe / revocation). */
-export const clearAllKeys = async (): Promise<void> => {
-  await deleteKeys([privateKeyId, publicKeyId, mlkemPublicKeyId, mlkemSecretKeyId, ckId])
-  const dbName = resolveDbName()
+/**
+ * Clear all keys and delete the IDB database for the given server (full data
+ * wipe / revocation). The `serverId` defaults to the active server in the
+ * trust-domain registry, but callers running after the registry has been
+ * cleared (the cleanup pipeline does this early to keep reloaded tabs out of
+ * the wiping server) must pass it explicitly — otherwise the wipe would no-op
+ * and leave the per-server IDB database on disk.
+ */
+export const clearAllKeys = async (serverId?: string): Promise<void> => {
+  const resolvedServerId = serverId ?? resolveServerId()
+  if (!resolvedServerId) {
+    throw new StorageError('Cannot clear encryption keys without an active server trust domain')
+  }
+  const dbName = `${dbNamePrefix}${resolvedServerId}`
+  // Best-effort per-key delete first so a blocked `deleteDatabase` (open
+  // connection in another tab) still leaves no key material behind.
+  try {
+    await deleteKeysInDB(dbName, [privateKeyId, publicKeyId, mlkemPublicKeyId, mlkemSecretKeyId, ckId])
+  } catch (err) {
+    console.warn(`[clearAllKeys] per-key delete failed for ${dbName}; relying on deleteDatabase`, err)
+  }
   await new Promise<void>((resolve) => {
     const request = indexedDB.deleteDatabase(dbName)
     request.onsuccess = () => resolve()
@@ -242,6 +240,36 @@ export const clearAllKeys = async (): Promise<void> => {
     request.onblocked = () => {
       console.warn(`[clearAllKeys] IDB delete blocked for ${dbName} — open connections still alive`)
       resolve()
+    }
+  })
+}
+
+/** Internal: open the IDB DB by explicit name and delete the listed keys. Mirrors `deleteKeys` but doesn't go through `resolveDbName`. */
+const deleteKeysInDB = async (dbName: string, ids: string[]): Promise<void> => {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(dbName, dbVersion)
+    request.onupgradeneeded = () => {
+      const upgradeDb = request.result
+      if (!upgradeDb.objectStoreNames.contains(storeName)) {
+        upgradeDb.createObjectStore(storeName)
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(new StorageError('Failed to open IndexedDB', { cause: request.error }))
+  })
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite')
+    const store = tx.objectStore(storeName)
+    for (const id of ids) {
+      store.delete(id)
+    }
+    tx.oncomplete = () => {
+      db.close()
+      resolve()
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(new StorageError('Failed to delete keys', { cause: tx.error }))
     }
   })
 }

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -173,6 +173,7 @@ export {
 export {
   getPermissionsByWorkspace,
   getRequiredRoleForPermission,
+  getRequiredRoleForPermissionQuery,
   type WorkspacePermission,
   type WorkspacePermissionKey,
   type WorkspacePermissionRole,

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -173,8 +173,11 @@ export {
 } from './workspace-pending-memberships'
 export {
   getPermissionsByWorkspace,
+  getPermissionsByWorkspaceQuery,
   getRequiredRoleForPermission,
   getRequiredRoleForPermissionQuery,
+  setWorkspacePermissionRequiredRole,
+  useWorkspacePermissionsQuery,
   type WorkspacePermission,
   type WorkspacePermissionKey,
   type WorkspacePermissionRole,

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -156,13 +156,18 @@ export {
   getMembershipsByWorkspace,
   getMembershipsByWorkspaceQuery,
   isWorkspaceAdmin,
+  removeMembership,
+  updateMembershipRole,
   useWorkspaceMembersQuery,
   type WorkspaceMembership,
 } from './workspace-memberships'
 export {
+  addPendingMembership,
   getPendingByWorkspace,
   getPendingByWorkspaceQuery,
+  removePendingMembership,
   useWorkspacePendingMembershipsQuery,
+  type AddPendingMembershipInput,
   type WorkspacePendingMembership,
 } from './workspace-pending-memberships'
 export {

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -166,6 +166,7 @@ export {
   getPendingByWorkspace,
   getPendingByWorkspaceQuery,
   removePendingMembership,
+  updatePendingMembershipRole,
   useWorkspacePendingMembershipsQuery,
   type AddPendingMembershipInput,
   type WorkspacePendingMembership,

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -154,10 +154,17 @@ export {
   getMembershipQuery,
   getMembershipsByUser,
   getMembershipsByWorkspace,
+  getMembershipsByWorkspaceQuery,
   isWorkspaceAdmin,
+  useWorkspaceMembersQuery,
   type WorkspaceMembership,
 } from './workspace-memberships'
-export { getPendingByWorkspace, type WorkspacePendingMembership } from './workspace-pending-memberships'
+export {
+  getPendingByWorkspace,
+  getPendingByWorkspaceQuery,
+  useWorkspacePendingMembershipsQuery,
+  type WorkspacePendingMembership,
+} from './workspace-pending-memberships'
 export {
   getPermissionsByWorkspace,
   getRequiredRoleForPermission,

--- a/src/dal/test-utils.ts
+++ b/src/dal/test-utils.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { applySchema } from '@/db/apply-schema'
-import { Database, resetDatabase, setDatabase } from '@/db/database'
+import { Database, getDb, resetDatabase, setDatabase } from '@/db/database'
 import type { AnyDrizzleDatabase } from '@/db/database-interface'
-import { workspacesTable } from '@/db/tables'
+import { workspaceMembershipsTable, workspacesTable } from '@/db/tables'
 import { reconcileDefaults } from '../lib/reconcile-defaults'
 
 /**
@@ -24,6 +24,11 @@ export const testUserId = 'test-user'
 /**
  * Seed a personal workspace row owned by `testUserId` so `useActiveWorkspaceId`
  * resolves `wsId` in component tests. Idempotent via `onConflictDoNothing`.
+ *
+ * Note: this deliberately does NOT seed a membership row — tests that need the
+ * user to resolve as a workspace admin (e.g. anything reading
+ * `useActiveWorkspaceMembership` or `useWorkspacePermission`) must seed it
+ * themselves. See `seedTestPersonalAdminMembership`.
  */
 const seedPersonalWorkspace = async (db: AnyDrizzleDatabase) => {
   await db
@@ -100,4 +105,21 @@ export const resetTestDatabase = async () => {
   // Personal workspace must still be present after reset — `useActiveWorkspaceId`
   // resolves through it. Defaults are deliberately not re-seeded (per existing comment).
   await seedPersonalWorkspace(db)
+}
+
+/**
+ * Seeds the admin-membership row tying `testUserId` to the canonical personal
+ * workspace `wsId`. Required by tests that exercise UI gated on
+ * `useActiveWorkspaceMembership` or `useWorkspacePermission`. Idempotent.
+ */
+export const seedTestPersonalAdminMembership = async (db: AnyDrizzleDatabase = getDb()) => {
+  await db
+    .insert(workspaceMembershipsTable)
+    .values({
+      id: `${wsId}-${testUserId}`,
+      workspaceId: wsId,
+      userId: testUserId,
+      role: 'admin',
+    })
+    .onConflictDoNothing()
 }

--- a/src/dal/workspace-memberships.test.tsx
+++ b/src/dal/workspace-memberships.test.tsx
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { DatabaseProvider } from '@/contexts'
+import { getDb } from '@/db/database'
+import { workspaceMembershipsTable, workspacesTable } from '@/db/tables'
+import {
+  renderWithReactivity,
+  resetTestTrustDomain,
+  seedTestTrustDomain,
+  waitForElement,
+} from '@/test-utils/powersync-reactivity-test'
+import '@testing-library/jest-dom'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { cleanup, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useWorkspaceMembersQuery } from './workspace-memberships'
+import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, wsId } from './test-utils'
+
+const DbWrapper = ({ children }: { children: ReactNode }) => (
+  <DatabaseProvider db={getDb()}>{children}</DatabaseProvider>
+)
+
+const seedSharedWorkspace = async (id: string) => {
+  const db = getDb()
+  await db.insert(workspacesTable).values({ id, name: 'Shared', isPersonal: 0, ownerUserId: null })
+}
+
+const seedMembership = async (workspaceId: string, userId: string, name: string, email: string) => {
+  const db = getDb()
+  await db.insert(workspaceMembershipsTable).values({
+    id: `${workspaceId}-${userId}`,
+    workspaceId,
+    userId,
+    role: 'admin',
+    userName: name,
+    userEmail: email,
+  })
+}
+
+describe('useWorkspaceMembersQuery', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  const Probe = ({ workspaceId }: { workspaceId: string | undefined }) => {
+    const members = useWorkspaceMembersQuery(workspaceId)
+    if (members.length === 0) {
+      return null
+    }
+    return (
+      <ul>
+        {members.map((m) => (
+          <li key={m.id} data-testid={`m-row-${m.userId}`}>
+            {m.userName ?? m.userId}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  it('returns memberships scoped to the workspace, sorted by userName', async () => {
+    await seedSharedWorkspace(otherWsId)
+    await seedMembership(otherWsId, 'u-charlie', 'Charlie', 'c@test.com')
+    await seedMembership(otherWsId, 'u-alice', 'Alice', 'a@test.com')
+    // Cross-workspace row that must be excluded.
+    await seedMembership(wsId, 'u-bob', 'Bob', 'b@test.com')
+
+    renderWithReactivity(<Probe workspaceId={otherWsId} />, {
+      tables: ['workspace_memberships'],
+      wrapper: DbWrapper,
+    })
+
+    await waitForElement(() => screen.queryByTestId('m-row-u-alice'))
+    const rows = screen.getAllByText(/^(Alice|Charlie|Bob)$/)
+    expect(rows.map((el) => el.textContent)).toEqual(['Alice', 'Charlie'])
+    expect(screen.queryByTestId('m-row-u-bob')).not.toBeInTheDocument()
+  })
+
+  it('returns empty array when workspaceId is undefined', async () => {
+    await seedSharedWorkspace(otherWsId)
+    await seedMembership(otherWsId, 'u-alice', 'Alice', 'a@test.com')
+
+    renderWithReactivity(<Probe workspaceId={undefined} />, {
+      tables: ['workspace_memberships'],
+      wrapper: DbWrapper,
+    })
+
+    // Probe renders nothing when the array is empty.
+    expect(screen.queryByTestId('m-row-u-alice')).not.toBeInTheDocument()
+  })
+})

--- a/src/dal/workspace-memberships.test.tsx
+++ b/src/dal/workspace-memberships.test.tsx
@@ -15,7 +15,8 @@ import '@testing-library/jest-dom'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { cleanup, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { useWorkspaceMembersQuery } from './workspace-memberships'
+import { eq } from 'drizzle-orm'
+import { removeMembership, updateMembershipRole, useWorkspaceMembersQuery } from './workspace-memberships'
 import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, wsId } from './test-utils'
 
 const DbWrapper = ({ children }: { children: ReactNode }) => (
@@ -103,5 +104,56 @@ describe('useWorkspaceMembersQuery', () => {
 
     // Probe renders nothing when the array is empty.
     expect(screen.queryByTestId('m-row-u-alice')).not.toBeInTheDocument()
+  })
+})
+
+describe('updateMembershipRole / removeMembership', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  it('updateMembershipRole flips role on the target row only', async () => {
+    const db = getDb()
+    await seedSharedWorkspace(otherWsId)
+    await seedMembership(otherWsId, 'u-alice', 'Alice', 'a@test.com')
+    await seedMembership(otherWsId, 'u-bob', 'Bob', 'b@test.com')
+
+    await updateMembershipRole(db, `${otherWsId}-u-alice`, 'member')
+
+    const alice = await db
+      .select()
+      .from(workspaceMembershipsTable)
+      .where(eq(workspaceMembershipsTable.id, `${otherWsId}-u-alice`))
+    expect(alice[0].role).toBe('member')
+
+    const bob = await db
+      .select()
+      .from(workspaceMembershipsTable)
+      .where(eq(workspaceMembershipsTable.id, `${otherWsId}-u-bob`))
+    // Bob's role is unchanged.
+    expect(bob[0].role).toBe('admin')
+  })
+
+  it('removeMembership deletes the target row only', async () => {
+    const db = getDb()
+    await seedSharedWorkspace(otherWsId)
+    await seedMembership(otherWsId, 'u-alice', 'Alice', 'a@test.com')
+    await seedMembership(otherWsId, 'u-bob', 'Bob', 'b@test.com')
+
+    await removeMembership(db, `${otherWsId}-u-alice`)
+
+    const remaining = await db
+      .select()
+      .from(workspaceMembershipsTable)
+      .where(eq(workspaceMembershipsTable.workspaceId, otherWsId))
+    expect(remaining.map((r) => r.userId).sort()).toEqual(['u-bob'])
   })
 })

--- a/src/dal/workspace-memberships.ts
+++ b/src/dal/workspace-memberships.ts
@@ -12,6 +12,10 @@ export type WorkspaceMembership = {
   workspaceId: string
   userId: string
   role: 'admin' | 'member'
+  /** Denormalized from `auth.user`. `null` only on rows synced before commit 1's
+   *  backfill landed; treat that as "unknown" in the UI (fall back to the userId). */
+  userName: string | null
+  userEmail: string | null
   createdAt: string | null
 }
 

--- a/src/dal/workspace-memberships.ts
+++ b/src/dal/workspace-memberships.ts
@@ -105,3 +105,26 @@ export const isWorkspaceAdmin = async (
   const membership = await getMembership(db, workspaceId, userId)
   return membership?.role === 'admin'
 }
+
+/**
+ * Updates the role on a membership row. The BE upload handler enforces
+ * admin-of-workspace + last-admin protection — this DAL is a thin write that
+ * PowerSync emits as a PATCH. UI must hide the affordance for the last admin
+ * (see `RoleSelector` gating) as a UX backstop.
+ */
+export const updateMembershipRole = async (
+  db: AnyDrizzleDatabase,
+  membershipId: string,
+  role: 'admin' | 'member',
+): Promise<void> => {
+  await db.update(workspaceMembershipsTable).set({ role }).where(eq(workspaceMembershipsTable.id, membershipId))
+}
+
+/**
+ * Deletes a membership row. The BE upload handler enforces admin-of-workspace
+ * + last-admin protection + personal-workspace immutability. UI must hide the
+ * Remove button for the last admin row.
+ */
+export const removeMembership = async (db: AnyDrizzleDatabase, membershipId: string): Promise<void> => {
+  await db.delete(workspaceMembershipsTable).where(eq(workspaceMembershipsTable.id, membershipId))
+}

--- a/src/dal/workspace-memberships.ts
+++ b/src/dal/workspace-memberships.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { and, eq } from 'drizzle-orm'
+import { and, asc, eq } from 'drizzle-orm'
+import { toCompilableQuery } from '@powersync/drizzle-driver'
+import { useQuery } from '@powersync/tanstack-react-query'
+import { useDatabase } from '@/contexts'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { workspaceMembershipsTable } from '../db/tables'
 import type { DrizzleQueryWithPromise } from '../types'
@@ -53,6 +56,36 @@ export const getMembershipsByWorkspace = async (
     .where(eq(workspaceMembershipsTable.workspaceId, workspaceId))
     .all()
   return rows as WorkspaceMembership[]
+}
+
+/**
+ * Live Drizzle query for every membership in a workspace, sorted by
+ * `userName` (case-insensitive on SQLite's default collation) then `userId`
+ * for stable rendering when names tie or haven't synced yet.
+ */
+export const getMembershipsByWorkspaceQuery = (db: AnyDrizzleDatabase, workspaceId: string) => {
+  const query = db
+    .select()
+    .from(workspaceMembershipsTable)
+    .where(eq(workspaceMembershipsTable.workspaceId, workspaceId))
+    .orderBy(asc(workspaceMembershipsTable.userName), asc(workspaceMembershipsTable.userId))
+  return query as typeof query & DrizzleQueryWithPromise<WorkspaceMembership>
+}
+
+/**
+ * Reactive hook returning every membership in `workspaceId`. Returns `[]` until
+ * either `workspaceId` resolves or the live query lands rows. Consumers that
+ * need a loading state can wrap the underlying React Query themselves — the
+ * Members page only needs the array.
+ */
+export const useWorkspaceMembersQuery = (workspaceId: string | undefined): WorkspaceMembership[] => {
+  const db = useDatabase()
+  const { data = [] } = useQuery({
+    queryKey: ['workspace-memberships', 'by-workspace', workspaceId],
+    query: toCompilableQuery(getMembershipsByWorkspaceQuery(db, workspaceId ?? '')),
+    enabled: !!workspaceId,
+  })
+  return data
 }
 
 export const getMembershipsByUser = async (db: AnyDrizzleDatabase, userId: string): Promise<WorkspaceMembership[]> => {

--- a/src/dal/workspace-pending-memberships.test.tsx
+++ b/src/dal/workspace-pending-memberships.test.tsx
@@ -15,7 +15,12 @@ import '@testing-library/jest-dom'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { cleanup, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { useWorkspacePendingMembershipsQuery } from './workspace-pending-memberships'
+import { eq } from 'drizzle-orm'
+import {
+  addPendingMembership,
+  removePendingMembership,
+  useWorkspacePendingMembershipsQuery,
+} from './workspace-pending-memberships'
 import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, testUserId, wsId } from './test-utils'
 
 const DbWrapper = ({ children }: { children: ReactNode }) => (
@@ -101,5 +106,81 @@ describe('useWorkspacePendingMembershipsQuery', () => {
     })
 
     expect(screen.queryByTestId('p-row-alice@test.com')).not.toBeInTheDocument()
+  })
+})
+
+describe('addPendingMembership / removePendingMembership', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  it('addPendingMembership inserts a row with normalized email + default member role', async () => {
+    const db = getDb()
+    await seedSharedWorkspace(otherWsId)
+
+    const id = await addPendingMembership(db, {
+      workspaceId: otherWsId,
+      email: '  Alice@TEST.com ',
+      invitedByUserId: testUserId,
+    })
+
+    const rows = await db
+      .select()
+      .from(workspacePendingMembershipsTable)
+      .where(eq(workspacePendingMembershipsTable.id, id))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].email).toBe('alice@test.com')
+    expect(rows[0].role).toBe('member')
+    expect(rows[0].invitedByUserId).toBe(testUserId)
+  })
+
+  it('addPendingMembership honours an explicit admin role', async () => {
+    const db = getDb()
+    await seedSharedWorkspace(otherWsId)
+
+    const id = await addPendingMembership(db, {
+      workspaceId: otherWsId,
+      email: 'admin@test.com',
+      invitedByUserId: testUserId,
+      role: 'admin',
+    })
+
+    const rows = await db
+      .select()
+      .from(workspacePendingMembershipsTable)
+      .where(eq(workspacePendingMembershipsTable.id, id))
+    expect(rows[0].role).toBe('admin')
+  })
+
+  it('addPendingMembership throws on empty / whitespace email', async () => {
+    const db = getDb()
+    await seedSharedWorkspace(otherWsId)
+
+    await expect(
+      addPendingMembership(db, { workspaceId: otherWsId, email: '   ', invitedByUserId: testUserId }),
+    ).rejects.toThrow('Email is required')
+  })
+
+  it('removePendingMembership deletes the target row only', async () => {
+    const db = getDb()
+    await seedSharedWorkspace(otherWsId)
+    await seedPending(otherWsId, 'alice@test.com')
+    await seedPending(otherWsId, 'bob@test.com')
+
+    await removePendingMembership(db, `${otherWsId}-alice@test.com`)
+
+    const remaining = await db
+      .select()
+      .from(workspacePendingMembershipsTable)
+      .where(eq(workspacePendingMembershipsTable.workspaceId, otherWsId))
+    expect(remaining.map((r) => r.email).sort()).toEqual(['bob@test.com'])
   })
 })

--- a/src/dal/workspace-pending-memberships.test.tsx
+++ b/src/dal/workspace-pending-memberships.test.tsx
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { DatabaseProvider } from '@/contexts'
+import { getDb } from '@/db/database'
+import { workspacePendingMembershipsTable, workspacesTable } from '@/db/tables'
+import {
+  renderWithReactivity,
+  resetTestTrustDomain,
+  seedTestTrustDomain,
+  waitForElement,
+} from '@/test-utils/powersync-reactivity-test'
+import '@testing-library/jest-dom'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { cleanup, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useWorkspacePendingMembershipsQuery } from './workspace-pending-memberships'
+import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, testUserId, wsId } from './test-utils'
+
+const DbWrapper = ({ children }: { children: ReactNode }) => (
+  <DatabaseProvider db={getDb()}>{children}</DatabaseProvider>
+)
+
+const seedSharedWorkspace = async (id: string) => {
+  const db = getDb()
+  await db.insert(workspacesTable).values({ id, name: 'Shared', isPersonal: 0, ownerUserId: null })
+}
+
+const seedPending = async (workspaceId: string, email: string) => {
+  const db = getDb()
+  await db.insert(workspacePendingMembershipsTable).values({
+    id: `${workspaceId}-${email}`,
+    workspaceId,
+    email,
+    role: 'member',
+    invitedByUserId: testUserId,
+  })
+}
+
+describe('useWorkspacePendingMembershipsQuery', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  const Probe = ({ workspaceId }: { workspaceId: string | undefined }) => {
+    const pending = useWorkspacePendingMembershipsQuery(workspaceId)
+    if (pending.length === 0) {
+      return null
+    }
+    return (
+      <ul>
+        {pending.map((p) => (
+          <li key={p.id} data-testid={`p-row-${p.email}`}>
+            {p.email}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  it('returns pending rows scoped to the workspace, sorted by email', async () => {
+    await seedSharedWorkspace(otherWsId)
+    await seedPending(otherWsId, 'charlie@test.com')
+    await seedPending(otherWsId, 'alice@test.com')
+    // Cross-workspace pending row that must be excluded.
+    await seedPending(wsId, 'bob@test.com')
+
+    renderWithReactivity(<Probe workspaceId={otherWsId} />, {
+      tables: ['workspace_pending_memberships'],
+      wrapper: DbWrapper,
+    })
+
+    await waitForElement(() => screen.queryByTestId('p-row-alice@test.com'))
+    const rows = screen.getAllByText(/^(alice|charlie|bob)@test\.com$/)
+    expect(rows.map((el) => el.textContent)).toEqual(['alice@test.com', 'charlie@test.com'])
+    expect(screen.queryByTestId('p-row-bob@test.com')).not.toBeInTheDocument()
+  })
+
+  it('returns empty array when workspaceId is undefined', async () => {
+    await seedSharedWorkspace(otherWsId)
+    await seedPending(otherWsId, 'alice@test.com')
+
+    renderWithReactivity(<Probe workspaceId={undefined} />, {
+      tables: ['workspace_pending_memberships'],
+      wrapper: DbWrapper,
+    })
+
+    expect(screen.queryByTestId('p-row-alice@test.com')).not.toBeInTheDocument()
+  })
+})

--- a/src/dal/workspace-pending-memberships.test.tsx
+++ b/src/dal/workspace-pending-memberships.test.tsx
@@ -19,6 +19,7 @@ import { eq } from 'drizzle-orm'
 import {
   addPendingMembership,
   removePendingMembership,
+  updatePendingMembershipRole,
   useWorkspacePendingMembershipsQuery,
 } from './workspace-pending-memberships'
 import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, testUserId, wsId } from './test-utils'
@@ -167,6 +168,27 @@ describe('addPendingMembership / removePendingMembership', () => {
     await expect(
       addPendingMembership(db, { workspaceId: otherWsId, email: '   ', invitedByUserId: testUserId }),
     ).rejects.toThrow('Email is required')
+  })
+
+  it('updatePendingMembershipRole flips role on the target row only', async () => {
+    const db = getDb()
+    await seedSharedWorkspace(otherWsId)
+    await seedPending(otherWsId, 'alice@test.com')
+    await seedPending(otherWsId, 'bob@test.com')
+
+    await updatePendingMembershipRole(db, `${otherWsId}-alice@test.com`, 'admin')
+
+    const alice = await db
+      .select()
+      .from(workspacePendingMembershipsTable)
+      .where(eq(workspacePendingMembershipsTable.id, `${otherWsId}-alice@test.com`))
+    expect(alice[0].role).toBe('admin')
+
+    const bob = await db
+      .select()
+      .from(workspacePendingMembershipsTable)
+      .where(eq(workspacePendingMembershipsTable.id, `${otherWsId}-bob@test.com`))
+    expect(bob[0].role).toBe('member')
   })
 
   it('removePendingMembership deletes the target row only', async () => {

--- a/src/dal/workspace-pending-memberships.ts
+++ b/src/dal/workspace-pending-memberships.ts
@@ -100,6 +100,22 @@ export const addPendingMembership = async (
 }
 
 /**
+ * Updates the role on a pending invite row. Same permission semantics as
+ * `updateMembershipRole` — the BE upload handler enforces admin-of-workspace.
+ * No last-admin protection applies here: pending rows aren't yet admins.
+ */
+export const updatePendingMembershipRole = async (
+  db: AnyDrizzleDatabase,
+  pendingId: string,
+  role: 'admin' | 'member',
+): Promise<void> => {
+  await db
+    .update(workspacePendingMembershipsTable)
+    .set({ role })
+    .where(eq(workspacePendingMembershipsTable.id, pendingId))
+}
+
+/**
  * Deletes a pending invite row. The BE upload handler enforces
  * admin-of-workspace + personal-workspace immutability.
  */

--- a/src/dal/workspace-pending-memberships.ts
+++ b/src/dal/workspace-pending-memberships.ts
@@ -47,8 +47,10 @@ export const getPendingByWorkspaceQuery = (db: AnyDrizzleDatabase, workspaceId: 
 
 /**
  * Reactive hook returning every pending invite on `workspaceId`. Returns `[]`
- * until the live query lands rows. Pending rows only sync to admins (see the
- * `workspace_admin_data` bucket), so for non-admins this is always empty.
+ * until the live query lands rows. Pending rows sync to every workspace
+ * member (see the `workspace_data` bucket) so non-admins with
+ * `invite_users` / `change_roles` / `remove_users` can still see and act on
+ * the invite list.
  */
 export const useWorkspacePendingMembershipsQuery = (workspaceId: string | undefined): WorkspacePendingMembership[] => {
   const db = useDatabase()

--- a/src/dal/workspace-pending-memberships.ts
+++ b/src/dal/workspace-pending-memberships.ts
@@ -2,9 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { eq } from 'drizzle-orm'
+import { asc, eq } from 'drizzle-orm'
+import { toCompilableQuery } from '@powersync/drizzle-driver'
+import { useQuery } from '@powersync/tanstack-react-query'
+import { useDatabase } from '@/contexts'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { workspacePendingMembershipsTable } from '../db/tables'
+import type { DrizzleQueryWithPromise } from '../types'
 
 export type WorkspacePendingMembership = {
   id: string
@@ -25,4 +29,32 @@ export const getPendingByWorkspace = async (
     .where(eq(workspacePendingMembershipsTable.workspaceId, workspaceId))
     .all()
   return rows as WorkspacePendingMembership[]
+}
+
+/**
+ * Live Drizzle query for every pending invite on a workspace, sorted by
+ * `email` for stable rendering.
+ */
+export const getPendingByWorkspaceQuery = (db: AnyDrizzleDatabase, workspaceId: string) => {
+  const query = db
+    .select()
+    .from(workspacePendingMembershipsTable)
+    .where(eq(workspacePendingMembershipsTable.workspaceId, workspaceId))
+    .orderBy(asc(workspacePendingMembershipsTable.email))
+  return query as typeof query & DrizzleQueryWithPromise<WorkspacePendingMembership>
+}
+
+/**
+ * Reactive hook returning every pending invite on `workspaceId`. Returns `[]`
+ * until the live query lands rows. Pending rows only sync to admins (see the
+ * `workspace_admin_data` bucket), so for non-admins this is always empty.
+ */
+export const useWorkspacePendingMembershipsQuery = (workspaceId: string | undefined): WorkspacePendingMembership[] => {
+  const db = useDatabase()
+  const { data = [] } = useQuery({
+    queryKey: ['workspace-pending-memberships', 'by-workspace', workspaceId],
+    query: toCompilableQuery(getPendingByWorkspaceQuery(db, workspaceId ?? '')),
+    enabled: !!workspaceId,
+  })
+  return data
 }

--- a/src/dal/workspace-pending-memberships.ts
+++ b/src/dal/workspace-pending-memberships.ts
@@ -5,6 +5,7 @@
 import { asc, eq } from 'drizzle-orm'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { useQuery } from '@powersync/tanstack-react-query'
+import { v7 as uuidv7 } from 'uuid'
 import { useDatabase } from '@/contexts'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { workspacePendingMembershipsTable } from '../db/tables'
@@ -57,4 +58,51 @@ export const useWorkspacePendingMembershipsQuery = (workspaceId: string | undefi
     enabled: !!workspaceId,
   })
   return data
+}
+
+export type AddPendingMembershipInput = {
+  workspaceId: string
+  email: string
+  invitedByUserId: string
+  /** Defaults to `'member'`. */
+  role?: 'admin' | 'member'
+}
+
+/**
+ * Inserts a single `workspace_pending_memberships` row. Email is lowercased +
+ * trimmed before write to match the BE's normalization (so cross-device
+ * variants land on the same `(workspace_id, email)` natural key). Throws on
+ * empty input; format validation stays at the UI layer.
+ *
+ * The BE upload handler promotes the pending row to an active membership when
+ * the invited email belongs to an existing user; otherwise the row stays
+ * pending until the invitee signs up.
+ *
+ * Returns the new row id.
+ */
+export const addPendingMembership = async (
+  db: AnyDrizzleDatabase,
+  input: AddPendingMembershipInput,
+): Promise<string> => {
+  const email = input.email.toLowerCase().trim()
+  if (!email) {
+    throw new Error('Email is required')
+  }
+  const id = uuidv7()
+  await db.insert(workspacePendingMembershipsTable).values({
+    id,
+    workspaceId: input.workspaceId,
+    email,
+    role: input.role ?? 'member',
+    invitedByUserId: input.invitedByUserId,
+  })
+  return id
+}
+
+/**
+ * Deletes a pending invite row. The BE upload handler enforces
+ * admin-of-workspace + personal-workspace immutability.
+ */
+export const removePendingMembership = async (db: AnyDrizzleDatabase, pendingId: string): Promise<void> => {
+  await db.delete(workspacePendingMembershipsTable).where(eq(workspacePendingMembershipsTable.id, pendingId))
 }

--- a/src/dal/workspace-permissions.test.ts
+++ b/src/dal/workspace-permissions.test.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getDb } from '@/db/database'
+import { workspacePermissionsTable } from '@/db/tables'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { and, eq } from 'drizzle-orm'
+import { v7 as uuidv7 } from 'uuid'
+import { getRequiredRoleForPermission, setWorkspacePermissionRequiredRole } from './workspace-permissions'
+import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, wsId } from './test-utils'
+
+beforeAll(async () => {
+  await setupTestDatabase()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+describe('Workspace Permissions DAL', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  describe('setWorkspacePermissionRequiredRole', () => {
+    it('updates the existing row when one is present, keeping its id', async () => {
+      const db = getDb()
+      const existingId = uuidv7()
+      await db.insert(workspacePermissionsTable).values({
+        id: existingId,
+        workspaceId: wsId,
+        permissionKey: 'manage_members',
+        requiredRole: 'admin',
+      })
+
+      await setWorkspacePermissionRequiredRole(db, wsId, 'manage_members', 'member')
+
+      const rows = await db
+        .select()
+        .from(workspacePermissionsTable)
+        .where(
+          and(
+            eq(workspacePermissionsTable.workspaceId, wsId),
+            eq(workspacePermissionsTable.permissionKey, 'manage_members'),
+          ),
+        )
+        .all()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.id).toBe(existingId)
+      expect(rows[0]?.requiredRole).toBe('member')
+    })
+
+    it('inserts a new row when none exists for the (workspaceId, permissionKey) pair', async () => {
+      const db = getDb()
+
+      await setWorkspacePermissionRequiredRole(db, wsId, 'change_roles', 'member')
+
+      const value = await getRequiredRoleForPermission(db, wsId, 'change_roles')
+      expect(value).toBe('member')
+      const rows = await db
+        .select()
+        .from(workspacePermissionsTable)
+        .where(
+          and(
+            eq(workspacePermissionsTable.workspaceId, wsId),
+            eq(workspacePermissionsTable.permissionKey, 'change_roles'),
+          ),
+        )
+        .all()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.id).toBeDefined()
+    })
+
+    it('does not affect rows for other workspaces or other permission keys', async () => {
+      const db = getDb()
+      const otherKeyId = uuidv7()
+      const otherWsRowId = uuidv7()
+      await db.insert(workspacePermissionsTable).values([
+        // Same workspace, different key — must stay untouched.
+        {
+          id: otherKeyId,
+          workspaceId: wsId,
+          permissionKey: 'change_roles',
+          requiredRole: 'admin',
+        },
+        // Different workspace, same key — must stay untouched.
+        {
+          id: otherWsRowId,
+          workspaceId: otherWsId,
+          permissionKey: 'manage_members',
+          requiredRole: 'admin',
+        },
+      ])
+
+      await setWorkspacePermissionRequiredRole(db, wsId, 'manage_members', 'member')
+
+      expect(await getRequiredRoleForPermission(db, wsId, 'change_roles')).toBe('admin')
+      expect(await getRequiredRoleForPermission(db, otherWsId, 'manage_members')).toBe('admin')
+      expect(await getRequiredRoleForPermission(db, wsId, 'manage_members')).toBe('member')
+    })
+  })
+})

--- a/src/dal/workspace-permissions.ts
+++ b/src/dal/workspace-permissions.ts
@@ -2,13 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { toCompilableQuery } from '@powersync/drizzle-driver'
+import { useQuery } from '@powersync/tanstack-react-query'
 import { and, eq } from 'drizzle-orm'
+import { v7 as uuidv7 } from 'uuid'
+import { useDatabase } from '@/contexts'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { workspacePermissionsTable } from '../db/tables'
 import type { DrizzleQueryWithPromise } from '../types'
+import type { WorkspacePermissionKey, WorkspacePermissionRole } from '../../shared/workspaces'
 
-export type WorkspacePermissionKey = 'manage_members' | 'change_roles'
-export type WorkspacePermissionRole = 'admin' | 'member'
+export type { WorkspacePermissionKey, WorkspacePermissionRole }
 
 export type WorkspacePermission = {
   id: string
@@ -53,6 +57,37 @@ export const getRequiredRoleForPermission = async (
  * an empty result set when no row exists yet — consumers default to `'admin'`
  * (Decision 11) until the Permissions page (PR 8) writes an explicit value.
  */
+/**
+ * Live Drizzle query for every `workspace_permissions` row on a workspace.
+ * Use with PowerSync's `toCompilableQuery` for a reactive subscription.
+ */
+export const getPermissionsByWorkspaceQuery = (db: AnyDrizzleDatabase, workspaceId: string) => {
+  const query = db
+    .select()
+    .from(workspacePermissionsTable)
+    .where(eq(workspacePermissionsTable.workspaceId, workspaceId))
+  return query as typeof query & DrizzleQueryWithPromise<WorkspacePermission>
+}
+
+/**
+ * Reactive hook returning every `workspace_permissions` row for `workspaceId`,
+ * along with an `isPending` flag so consumers can disable inputs while the
+ * first live result is in-flight. Empty array is the steady-state for a
+ * workspace that has never had a Permissions row written (consumers default
+ * each key to `'admin'`).
+ */
+export const useWorkspacePermissionsQuery = (
+  workspaceId: string | undefined,
+): { rows: WorkspacePermission[]; isPending: boolean } => {
+  const db = useDatabase()
+  const { data, isPending } = useQuery({
+    queryKey: ['workspace-permissions', 'by-workspace', workspaceId],
+    query: toCompilableQuery(getPermissionsByWorkspaceQuery(db, workspaceId ?? '')),
+    enabled: !!workspaceId,
+  })
+  return { rows: (data ?? []) as WorkspacePermission[], isPending }
+}
+
 export const getRequiredRoleForPermissionQuery = (
   db: AnyDrizzleDatabase,
   workspaceId: string,
@@ -69,4 +104,45 @@ export const getRequiredRoleForPermissionQuery = (
     )
     .limit(1)
   return query as typeof query & DrizzleQueryWithPromise<WorkspacePermission>
+}
+
+/**
+ * Upserts `workspace_permissions.required_role` for `(workspaceId, permissionKey)`.
+ * Updates the existing row when present; otherwise inserts a new row with a
+ * fresh `uuidv7` id. Defensive against legacy shared workspaces that pre-date
+ * the create-time seeding (Decision 11): the page can always write a value
+ * without having to know whether the row exists.
+ *
+ * The BE upload handler authorizes both PATCH and PUT identically
+ * (`isWorkspaceAdmin` + reject personal), so either branch round-trips.
+ */
+export const setWorkspacePermissionRequiredRole = async (
+  db: AnyDrizzleDatabase,
+  workspaceId: string,
+  permissionKey: WorkspacePermissionKey,
+  requiredRole: WorkspacePermissionRole,
+): Promise<void> => {
+  const existing = await db
+    .select({ id: workspacePermissionsTable.id })
+    .from(workspacePermissionsTable)
+    .where(
+      and(
+        eq(workspacePermissionsTable.workspaceId, workspaceId),
+        eq(workspacePermissionsTable.permissionKey, permissionKey),
+      ),
+    )
+    .get()
+  if (existing) {
+    await db
+      .update(workspacePermissionsTable)
+      .set({ requiredRole })
+      .where(eq(workspacePermissionsTable.id, existing.id))
+    return
+  }
+  await db.insert(workspacePermissionsTable).values({
+    id: uuidv7(),
+    workspaceId,
+    permissionKey,
+    requiredRole,
+  })
 }

--- a/src/dal/workspace-permissions.ts
+++ b/src/dal/workspace-permissions.ts
@@ -5,6 +5,7 @@
 import { and, eq } from 'drizzle-orm'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { workspacePermissionsTable } from '../db/tables'
+import type { DrizzleQueryWithPromise } from '../types'
 
 export type WorkspacePermissionKey = 'manage_members' | 'change_roles'
 export type WorkspacePermissionRole = 'admin' | 'member'
@@ -44,4 +45,28 @@ export const getRequiredRoleForPermission = async (
     )
     .get()
   return (row as WorkspacePermission | undefined)?.requiredRole ?? null
+}
+
+/**
+ * Live Drizzle query for the permission row matching `(workspaceId, permissionKey)`.
+ * Use with PowerSync's `toCompilableQuery` for a reactive subscription. Returns
+ * an empty result set when no row exists yet — consumers default to `'admin'`
+ * (Decision 11) until the Permissions page (PR 8) writes an explicit value.
+ */
+export const getRequiredRoleForPermissionQuery = (
+  db: AnyDrizzleDatabase,
+  workspaceId: string,
+  permissionKey: WorkspacePermissionKey,
+) => {
+  const query = db
+    .select()
+    .from(workspacePermissionsTable)
+    .where(
+      and(
+        eq(workspacePermissionsTable.workspaceId, workspaceId),
+        eq(workspacePermissionsTable.permissionKey, permissionKey),
+      ),
+    )
+    .limit(1)
+  return query as typeof query & DrizzleQueryWithPromise<WorkspacePermission>
 }

--- a/src/db/encryption/config.ts
+++ b/src/db/encryption/config.ts
@@ -32,8 +32,9 @@ export const needsSyncSetupWizard = async (): Promise<boolean> => {
  * - `workspaces.is_personal` / `owner_user_id` — the BE handler branches on
  *   these to gate personal vs shared writes; encrypting them would break the
  *   policy logic.
- * - `workspace_memberships.role` — the sync rules use `role = 'admin'` to scope
- *   the admin-only bucket.
+ * - `workspace_memberships.role` — the BE upload handlers read it to resolve
+ *   per-key permissions (admin satisfies every key by default, Decision 11)
+ *   and to enforce the admin-escalation guard on membership/pending writes.
  * - `workspace_memberships.user_name` / `user_email` — written by the BE upload
  *   handler from `auth.user`, so they're inherently server-known. Encrypting
  *   them would also block the Members page from rendering display info.

--- a/src/db/encryption/config.ts
+++ b/src/db/encryption/config.ts
@@ -34,6 +34,9 @@ export const needsSyncSetupWizard = async (): Promise<boolean> => {
  *   policy logic.
  * - `workspace_memberships.role` — the sync rules use `role = 'admin'` to scope
  *   the admin-only bucket.
+ * - `workspace_memberships.user_name` / `user_email` — written by the BE upload
+ *   handler from `auth.user`, so they're inherently server-known. Encrypting
+ *   them would also block the Members page from rendering display info.
  * - `workspace_pending_memberships.email` — the Better Auth post-create hook
  *   matches this against the new user's email to promote pending invites into
  *   real memberships. Plaintext is functionally required here.

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -7,6 +7,7 @@ import type { UIMessage } from 'ai'
 import type { UIMessageMetadata } from '@/types'
 import { sql } from 'drizzle-orm'
 import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { workspacePermissionKeys, workspacePermissionRoles } from '../../shared/workspaces'
 
 export const settingsTable = sqliteTable('settings', {
   // Column is named 'id' in DB for PowerSync compatibility, but accessed as 'key' in TypeScript
@@ -390,14 +391,18 @@ export const workspacePendingMembershipsTable = sqliteTable(
   (table) => [index('idx_workspace_pending_memberships_workspace_email').on(table.workspaceId, table.email)],
 )
 
-/** Per-workspace permission policy (Decision 10 — keys: manage_members, change_roles). */
+/**
+ * Per-workspace permission policy (Decision 10). The enum lists every
+ * configurable action exposed by the Permissions page; the source of truth
+ * lives in `shared/workspaces.ts` so FE/BE schemas + types stay in lockstep.
+ */
 export const workspacePermissionsTable = sqliteTable(
   'workspace_permissions',
   {
     id: text('id').primaryKey(),
     workspaceId: text('workspace_id'),
-    permissionKey: text('permission_key', { enum: ['manage_members', 'change_roles'] }).notNull(),
-    requiredRole: text('required_role', { enum: ['admin', 'member'] }).notNull(),
+    permissionKey: text('permission_key', { enum: [...workspacePermissionKeys] }).notNull(),
+    requiredRole: text('required_role', { enum: [...workspacePermissionRoles] }).notNull(),
   },
   (table) => [index('idx_workspace_permissions_workspace_key').on(table.workspaceId, table.permissionKey)],
 )

--- a/src/db/tables.ts
+++ b/src/db/tables.ts
@@ -362,6 +362,11 @@ export const workspaceMembershipsTable = sqliteTable(
     workspaceId: text('workspace_id'),
     userId: text('user_id').notNull(),
     role: text('role', { enum: ['admin', 'member'] }).notNull(),
+    // Denormalized display info written by the BE upload handler from `auth.user`.
+    // Synced down so the Members page can render names + emails without a `users`
+    // projection table (PowerSync sync rules can't follow `user_id` across buckets).
+    userName: text('user_name'),
+    userEmail: text('user_email'),
     createdAt: text('created_at'),
   },
   (table) => [index('idx_workspace_memberships_workspace_user').on(table.workspaceId, table.userId)],

--- a/src/hooks/use-active-workspace-membership.ts
+++ b/src/hooks/use-active-workspace-membership.ts
@@ -12,6 +12,13 @@ import { useQuery } from '@powersync/tanstack-react-query'
 export type ActiveWorkspaceMembership = {
   membership: WorkspaceMembership | null
   isAdmin: boolean
+  /**
+   * True once the live membership query has returned at least once — whether
+   * with a row or empty. Consumers that need to distinguish "still loading"
+   * from "user has no membership" should check this before treating
+   * `membership === null` as a definitive non-member signal.
+   */
+  isResolved: boolean
 }
 
 /**
@@ -19,9 +26,9 @@ export type ActiveWorkspaceMembership = {
  * URL-driven (via `useActiveWorkspaceId`); reactively flips when the user
  * navigates between workspaces or a sync round-trip lands a new membership row.
  *
- * Returns `{ membership: null, isAdmin: false }` until both the workspace and
- * the user id resolve — consumers should treat that as "not yet known," not as
- * "definitively not a member." The same React Query key is used by
+ * Returns `membership: null` both during the initial load and when the user is
+ * not a member. Disambiguate via `isResolved` — it flips to true once the live
+ * query has returned at least once. The same React Query key is used by
  * `WorkspaceMembershipGate` so the two share a single subscription.
  */
 export const useActiveWorkspaceMembership = (): ActiveWorkspaceMembership => {
@@ -37,15 +44,17 @@ export const useActiveWorkspaceMembership = (): ActiveWorkspaceMembership => {
     return undefined
   })
 
-  const { data } = useQuery({
+  const enabled = !!workspaceId && !!userId
+  const { data, isPending } = useQuery({
     queryKey: ['workspace-memberships', workspaceId, userId],
     query: toCompilableQuery(getMembershipQuery(db, workspaceId ?? '', userId ?? '')),
-    enabled: !!workspaceId && !!userId,
+    enabled,
   })
 
   const membership = (data?.[0] ?? null) as WorkspaceMembership | null
   return {
     membership,
     isAdmin: membership?.role === 'admin',
+    isResolved: enabled && !isPending,
   }
 }

--- a/src/hooks/use-workspace-permission.test.tsx
+++ b/src/hooks/use-workspace-permission.test.tsx
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { DatabaseProvider } from '@/contexts'
+import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, testUserId } from '@/dal/test-utils'
+import { getDb } from '@/db/database'
+import { workspaceMembershipsTable, workspacePermissionsTable, workspacesTable } from '@/db/tables'
+import {
+  renderWithReactivity,
+  resetTestTrustDomain,
+  seedTestTrustDomain,
+  waitForElement,
+} from '@/test-utils/powersync-reactivity-test'
+import '@testing-library/jest-dom'
+import { cleanup, screen } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import type { ReactNode } from 'react'
+import { useWorkspacePermission } from './use-workspace-permission'
+
+const DbWrapper = ({ children }: { children: ReactNode }) => (
+  <DatabaseProvider db={getDb()}>{children}</DatabaseProvider>
+)
+
+const Probe = () => {
+  const { requiredRole, isAllowed, isResolved } = useWorkspacePermission('manage_members')
+  return (
+    <div>
+      <span data-testid="required-role">{requiredRole}</span>
+      <span data-testid="is-allowed">{String(isAllowed)}</span>
+      <span data-testid="is-resolved">{String(isResolved)}</span>
+    </div>
+  )
+}
+
+const seedWorkspace = async () => {
+  await getDb().insert(workspacesTable).values({ id: otherWsId, name: 'Acme', isPersonal: 0, ownerUserId: null })
+}
+
+const seedMembership = async (role: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspaceMembershipsTable)
+    .values({ id: `${otherWsId}-${testUserId}`, workspaceId: otherWsId, userId: testUserId, role })
+}
+
+const seedPermission = async (key: 'manage_members' | 'change_roles', requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({ id: `${otherWsId}-${key}`, workspaceId: otherWsId, permissionKey: key, requiredRole })
+}
+
+describe('useWorkspacePermission', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('defaults requiredRole to admin when no permission row exists', async () => {
+    await seedWorkspace()
+    await seedMembership('admin')
+
+    renderWithReactivity(<Probe />, {
+      route: `/w/${otherWsId}/settings/workspace/members`,
+      routePath: '/*',
+      tables: ['workspace_memberships', 'workspace_permissions'],
+      wrapper: DbWrapper,
+    })
+
+    await waitForElement(() =>
+      screen.getByTestId('is-resolved').textContent === 'true' ? screen.getByTestId('is-resolved') : null,
+    )
+    expect(screen.getByTestId('required-role').textContent).toBe('admin')
+    expect(screen.getByTestId('is-allowed').textContent).toBe('true')
+  })
+
+  it('denies a member when requiredRole defaults to admin', async () => {
+    await seedWorkspace()
+    await seedMembership('member')
+
+    renderWithReactivity(<Probe />, {
+      route: `/w/${otherWsId}/settings/workspace/members`,
+      routePath: '/*',
+      tables: ['workspace_memberships', 'workspace_permissions'],
+      wrapper: DbWrapper,
+    })
+
+    await waitForElement(() =>
+      screen.getByTestId('is-resolved').textContent === 'true' ? screen.getByTestId('is-resolved') : null,
+    )
+    expect(screen.getByTestId('is-allowed').textContent).toBe('false')
+  })
+
+  it('lets a member through when an explicit row sets requiredRole=member', async () => {
+    await seedWorkspace()
+    await seedMembership('member')
+    await seedPermission('manage_members', 'member')
+
+    renderWithReactivity(<Probe />, {
+      route: `/w/${otherWsId}/settings/workspace/members`,
+      routePath: '/*',
+      tables: ['workspace_memberships', 'workspace_permissions'],
+      wrapper: DbWrapper,
+    })
+
+    await waitForElement(() =>
+      screen.getByTestId('required-role').textContent === 'member' ? screen.getByTestId('required-role') : null,
+    )
+    expect(screen.getByTestId('is-allowed').textContent).toBe('true')
+  })
+
+  it('reports isResolved=false until membership lands', async () => {
+    // Workspace exists but no membership row — `isResolved` should remain false.
+    await seedWorkspace()
+
+    renderWithReactivity(<Probe />, {
+      route: `/w/${otherWsId}/settings/workspace/members`,
+      routePath: '/*',
+      tables: ['workspace_memberships', 'workspace_permissions'],
+      wrapper: DbWrapper,
+    })
+
+    // We can't easily prove a "never resolves" state in a finite test, but we
+    // can assert that without a membership row the probe sticks at false.
+    await waitForElement(() => screen.getByTestId('is-resolved'))
+    expect(screen.getByTestId('is-resolved').textContent).toBe('false')
+    expect(screen.getByTestId('is-allowed').textContent).toBe('false')
+  })
+})

--- a/src/hooks/use-workspace-permission.ts
+++ b/src/hooks/use-workspace-permission.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useDatabase } from '@/contexts'
+import {
+  getRequiredRoleForPermissionQuery,
+  type WorkspacePermission,
+  type WorkspacePermissionKey,
+  type WorkspacePermissionRole,
+} from '@/dal'
+import { useActiveWorkspaceId } from '@/lib/active-workspace'
+import { useActiveWorkspaceMembership } from '@/hooks/use-active-workspace-membership'
+import { toCompilableQuery } from '@powersync/drizzle-driver'
+import { useQuery } from '@powersync/tanstack-react-query'
+
+/**
+ * Default required role per Decision 11 — applied when no `workspace_permissions`
+ * row exists yet for the given key. The Permissions page (PR 8) lets admins
+ * override these per workspace.
+ */
+const DEFAULT_REQUIRED_ROLE: WorkspacePermissionRole = 'admin'
+
+export type WorkspacePermissionState = {
+  /** Active required role for this key. Falls back to `'admin'` when no row exists. */
+  requiredRole: WorkspacePermissionRole
+  /** True iff the active user's membership role satisfies `requiredRole`. */
+  isAllowed: boolean
+  /**
+   * True once both the membership and the permission query have returned a
+   * definitive answer. While false, treat `isAllowed` as undetermined — the
+   * sidebar can hide pending resolution, and route guards should render a
+   * loading state rather than redirect.
+   */
+  isResolved: boolean
+}
+
+/**
+ * Resolves whether the active user satisfies a workspace permission. Reactive —
+ * flips when the membership role changes, when the `workspace_permissions` row
+ * is written or deleted, or when the active workspace changes via URL.
+ *
+ * `requiredRole: 'admin'` means only admins satisfy the permission.
+ * `requiredRole: 'member'` means admins AND members both satisfy it.
+ */
+export const useWorkspacePermission = (permissionKey: WorkspacePermissionKey): WorkspacePermissionState => {
+  const db = useDatabase()
+  const workspaceId = useActiveWorkspaceId()
+  const { membership } = useActiveWorkspaceMembership()
+
+  // Live row (if any). Empty result means "no row yet" → default to admin.
+  const { data, isPending } = useQuery({
+    queryKey: ['workspace-permissions', 'by-key', workspaceId, permissionKey],
+    query: toCompilableQuery(getRequiredRoleForPermissionQuery(db, workspaceId ?? '', permissionKey)),
+    enabled: !!workspaceId,
+  })
+
+  const row = (data?.[0] ?? null) as WorkspacePermission | null
+  const requiredRole = row?.requiredRole ?? DEFAULT_REQUIRED_ROLE
+
+  // `isResolved` requires both: a membership row and a permission query that
+  // has at least returned once (either a row or an empty result).
+  const permissionResolved = !!workspaceId && !isPending
+  const isResolved = !!membership && permissionResolved
+
+  const userRole = membership?.role
+  const isAllowed =
+    isResolved && (requiredRole === 'member' ? userRole === 'admin' || userRole === 'member' : userRole === 'admin')
+
+  return { requiredRole, isAllowed, isResolved }
+}

--- a/src/hooks/use-workspace-permission.ts
+++ b/src/hooks/use-workspace-permission.ts
@@ -46,7 +46,7 @@ export type WorkspacePermissionState = {
 export const useWorkspacePermission = (permissionKey: WorkspacePermissionKey): WorkspacePermissionState => {
   const db = useDatabase()
   const workspaceId = useActiveWorkspaceId()
-  const { membership } = useActiveWorkspaceMembership()
+  const { membership, isResolved: membershipResolved } = useActiveWorkspaceMembership()
 
   // Live row (if any). Empty result means "no row yet" → default to admin.
   const { data, isPending } = useQuery({
@@ -58,14 +58,18 @@ export const useWorkspacePermission = (permissionKey: WorkspacePermissionKey): W
   const row = (data?.[0] ?? null) as WorkspacePermission | null
   const requiredRole = row?.requiredRole ?? defaultRequiredRole
 
-  // `isResolved` requires both: a membership row and a permission query that
-  // has at least returned once (either a row or an empty result).
+  // `isResolved` flips true once BOTH live queries have returned at least
+  // once — regardless of whether they found rows. Missing membership means
+  // `isAllowed=false` (so RequireWorkspacePermission can redirect), NOT
+  // `isResolved=false` (which would spin the loading state forever).
   const permissionResolved = !!workspaceId && !isPending
-  const isResolved = !!membership && permissionResolved
+  const isResolved = membershipResolved && permissionResolved
 
   const userRole = membership?.role
   const isAllowed =
-    isResolved && (requiredRole === 'member' ? userRole === 'admin' || userRole === 'member' : userRole === 'admin')
+    isResolved &&
+    !!membership &&
+    (requiredRole === 'member' ? userRole === 'admin' || userRole === 'member' : userRole === 'admin')
 
   return { requiredRole, isAllowed, isResolved }
 }

--- a/src/hooks/use-workspace-permission.ts
+++ b/src/hooks/use-workspace-permission.ts
@@ -19,7 +19,7 @@ import { useQuery } from '@powersync/tanstack-react-query'
  * row exists yet for the given key. The Permissions page (PR 8) lets admins
  * override these per workspace.
  */
-const DEFAULT_REQUIRED_ROLE: WorkspacePermissionRole = 'admin'
+const defaultRequiredRole: WorkspacePermissionRole = 'admin'
 
 export type WorkspacePermissionState = {
   /** Active required role for this key. Falls back to `'admin'` when no row exists. */
@@ -56,7 +56,7 @@ export const useWorkspacePermission = (permissionKey: WorkspacePermissionKey): W
   })
 
   const row = (data?.[0] ?? null) as WorkspacePermission | null
-  const requiredRole = row?.requiredRole ?? DEFAULT_REQUIRED_ROLE
+  const requiredRole = row?.requiredRole ?? defaultRequiredRole
 
   // `isResolved` requires both: a membership row and a permission query that
   // has at least returned once (either a row or an empty result).

--- a/src/layout/sidebar/create-workspace-modal.tsx
+++ b/src/layout/sidebar/create-workspace-modal.tsx
@@ -67,6 +67,13 @@ export const CreateWorkspaceModal = ({ open, onOpenChange, onCreated }: CreateWo
     previouslyOpenRef.current = open
   }, [open, form])
 
+  // Tracks `open` synchronously so the submit handler can skip the post-create
+  // callback when the user dismissed the modal during the in-flight transaction.
+  // Otherwise `onCreated` runs against a closed flow, opens the invite modal,
+  // and navigates the user into a workspace they thought they'd cancelled out of.
+  const openRef = useRef(open)
+  openRef.current = open
+
   const userId = session?.user?.id
   const creatorEmail = session?.user?.email ?? undefined
   const slugPrefix = formatWorkspaceSlugPrefix(cloudUrl)
@@ -84,6 +91,12 @@ export const CreateWorkspaceModal = ({ open, onOpenChange, onCreated }: CreateWo
       slug: slugifyWorkspaceName(values.slug) || null,
       icon: values.icon,
     })
+    // The local DB transaction commits regardless — the workspace will show up
+    // in the user's list once they reopen the selector. We just skip the
+    // navigation + invite-modal handoff when they've already moved on.
+    if (!openRef.current) {
+      return
+    }
     onCreated(workspaceId)
   })
 

--- a/src/layout/sidebar/settings-sidebar.test.tsx
+++ b/src/layout/sidebar/settings-sidebar.test.tsx
@@ -330,4 +330,29 @@ describe('SettingsSidebarContent — Workspace > Members entry visibility', () =
     await waitForElement(() => screen.queryByText('General'))
     expect(screen.queryByText('Members')).not.toBeInTheDocument()
   })
+
+  it('hides the Members entry when e2eeEnabled is true (THU-593)', async () => {
+    const { useConfigStore } = await import('@/api/config-store')
+    const previous = useConfigStore.getState().config
+    useConfigStore.getState().updateConfig({ ...previous, e2eeEnabled: true })
+    try {
+      await seedSharedWorkspaceWithMembership('admin')
+
+      renderWithReactivity(
+        <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+        {
+          route: `/w/${otherWsId}/settings`,
+          routePath: '/*',
+          tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+          wrapper: ReactiveSidebarWrapper,
+        },
+      )
+
+      // Wait for an unrelated Workspace-group item so the active workspace has resolved.
+      await waitForElement(() => screen.queryByText('Models'))
+      expect(screen.queryByText('Members')).not.toBeInTheDocument()
+    } finally {
+      useConfigStore.getState().updateConfig(previous)
+    }
+  })
 })

--- a/src/layout/sidebar/settings-sidebar.test.tsx
+++ b/src/layout/sidebar/settings-sidebar.test.tsx
@@ -14,7 +14,7 @@ import {
   wsId,
 } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
-import { workspaceMembershipsTable, workspacesTable } from '@/db/tables'
+import { workspaceMembershipsTable, workspacePermissionsTable, workspacesTable } from '@/db/tables'
 import { createMockAuthClient } from '@/test-utils/auth-client'
 import { createMockHttpClient } from '@/test-utils/http-client'
 import {
@@ -227,5 +227,107 @@ describe('SettingsSidebarContent — Workspace > General entry visibility', () =
 
     await waitForElement(() => screen.queryByText('General'))
     expect(screen.getByText('General')).toBeInTheDocument()
+  })
+})
+
+const seedManageMembersPermission = async (requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({
+      id: `${otherWsId}-manage_members`,
+      workspaceId: otherWsId,
+      permissionKey: 'manage_members',
+      requiredRole,
+    })
+}
+
+describe('SettingsSidebarContent — Workspace > Members entry visibility', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('shows the Members entry for an admin of a shared workspace (default policy)', async () => {
+    await seedSharedWorkspaceWithMembership('admin')
+
+    renderWithReactivity(
+      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+      {
+        route: `/w/${otherWsId}/settings`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: ReactiveSidebarWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByText('Members'))
+    expect(screen.getByText('Members')).toBeInTheDocument()
+  })
+
+  it('hides the Members entry for a member of a shared workspace (default policy)', async () => {
+    await seedSharedWorkspaceWithMembership('member')
+
+    renderWithReactivity(
+      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+      {
+        route: `/w/${otherWsId}/settings`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: ReactiveSidebarWrapper,
+      },
+    )
+
+    // Wait for another Workspace-group item so the active workspace has resolved.
+    await waitForElement(() => screen.queryByText('Models'))
+    expect(screen.queryByText('Members')).not.toBeInTheDocument()
+  })
+
+  it('shows the Members entry for a member when explicit manage_members.required_role=member', async () => {
+    await seedSharedWorkspaceWithMembership('member')
+    await seedManageMembersPermission('member')
+
+    renderWithReactivity(
+      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+      {
+        route: `/w/${otherWsId}/settings`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: ReactiveSidebarWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByText('Members'))
+    expect(screen.getByText('Members')).toBeInTheDocument()
+  })
+
+  it('hides the Members entry in a Personal Workspace (Decision 25)', async () => {
+    await seedPersonalMembership()
+
+    renderWithReactivity(
+      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+      {
+        route: '/settings',
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: ReactiveSidebarWrapper,
+      },
+    )
+
+    // Wait for General to render so the personal workspace has resolved.
+    await waitForElement(() => screen.queryByText('General'))
+    expect(screen.queryByText('Members')).not.toBeInTheDocument()
   })
 })

--- a/src/layout/sidebar/settings-sidebar.test.tsx
+++ b/src/layout/sidebar/settings-sidebar.test.tsx
@@ -14,7 +14,7 @@ import {
   wsId,
 } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
-import { workspaceMembershipsTable, workspacePermissionsTable, workspacesTable } from '@/db/tables'
+import { workspaceMembershipsTable, workspacesTable } from '@/db/tables'
 import { createMockAuthClient } from '@/test-utils/auth-client'
 import { createMockHttpClient } from '@/test-utils/http-client'
 import {
@@ -230,17 +230,6 @@ describe('SettingsSidebarContent — Workspace > General entry visibility', () =
   })
 })
 
-const seedManageMembersPermission = async (requiredRole: 'admin' | 'member') => {
-  await getDb()
-    .insert(workspacePermissionsTable)
-    .values({
-      id: `${otherWsId}-manage_members`,
-      workspaceId: otherWsId,
-      permissionKey: 'manage_members',
-      requiredRole,
-    })
-}
-
 describe('SettingsSidebarContent — Workspace > Members entry visibility', () => {
   beforeAll(async () => {
     await setupTestDatabase()
@@ -277,27 +266,12 @@ describe('SettingsSidebarContent — Workspace > Members entry visibility', () =
     expect(screen.getByText('Members')).toBeInTheDocument()
   })
 
-  it('hides the Members entry for a member of a shared workspace (default policy)', async () => {
+  it('shows the Members entry for a member of a shared workspace (read-friendly, per-action gates apply within)', async () => {
+    // Decision: Members is visible to every member of a shared workspace. The
+    // page is read-friendly without action permissions; individual actions
+    // (invite / change role / remove) gate themselves on the granular
+    // permission keys (invite_users / change_roles / remove_users).
     await seedSharedWorkspaceWithMembership('member')
-
-    renderWithReactivity(
-      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
-      {
-        route: `/w/${otherWsId}/settings`,
-        routePath: '/*',
-        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
-        wrapper: ReactiveSidebarWrapper,
-      },
-    )
-
-    // Wait for another Workspace-group item so the active workspace has resolved.
-    await waitForElement(() => screen.queryByText('Models'))
-    expect(screen.queryByText('Members')).not.toBeInTheDocument()
-  })
-
-  it('shows the Members entry for a member when explicit manage_members.required_role=member', async () => {
-    await seedSharedWorkspaceWithMembership('member')
-    await seedManageMembersPermission('member')
 
     renderWithReactivity(
       <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
@@ -351,6 +325,101 @@ describe('SettingsSidebarContent — Workspace > Members entry visibility', () =
       // Wait for an unrelated Workspace-group item so the active workspace has resolved.
       await waitForElement(() => screen.queryByText('Models'))
       expect(screen.queryByText('Members')).not.toBeInTheDocument()
+    } finally {
+      useConfigStore.getState().updateConfig(previous)
+    }
+  })
+})
+
+describe('SettingsSidebarContent — Workspace > Permissions entry visibility', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('shows the Permissions entry for an admin of a shared workspace', async () => {
+    await seedSharedWorkspaceWithMembership('admin')
+
+    renderWithReactivity(
+      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+      {
+        route: `/w/${otherWsId}/settings`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: ReactiveSidebarWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByText('Permissions'))
+    expect(screen.getByText('Permissions')).toBeInTheDocument()
+  })
+
+  it('hides the Permissions entry for a member of a shared workspace', async () => {
+    await seedSharedWorkspaceWithMembership('member')
+
+    renderWithReactivity(
+      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+      {
+        route: `/w/${otherWsId}/settings`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: ReactiveSidebarWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByText('Models'))
+    expect(screen.queryByText('Permissions')).not.toBeInTheDocument()
+  })
+
+  it('hides the Permissions entry in a Personal Workspace (Decision 25)', async () => {
+    await seedPersonalMembership()
+
+    renderWithReactivity(
+      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+      {
+        route: '/settings',
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: ReactiveSidebarWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByText('General'))
+    expect(screen.queryByText('Permissions')).not.toBeInTheDocument()
+  })
+
+  it('hides the Permissions entry when e2eeEnabled is true (THU-593)', async () => {
+    const { useConfigStore } = await import('@/api/config-store')
+    const previous = useConfigStore.getState().config
+    useConfigStore.getState().updateConfig({ ...previous, e2eeEnabled: true })
+    try {
+      await seedSharedWorkspaceWithMembership('admin')
+
+      renderWithReactivity(
+        <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
+        {
+          route: `/w/${otherWsId}/settings`,
+          routePath: '/*',
+          tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+          wrapper: ReactiveSidebarWrapper,
+        },
+      )
+
+      await waitForElement(() => screen.queryByText('Models'))
+      expect(screen.queryByText('Permissions')).not.toBeInTheDocument()
     } finally {
       useConfigStore.getState().updateConfig(previous)
     }

--- a/src/layout/sidebar/settings-sidebar.tsx
+++ b/src/layout/sidebar/settings-sidebar.tsx
@@ -17,9 +17,8 @@ import {
 import { useConfigStore } from '@/api/config-store'
 import { useActiveWorkspaceMembership } from '@/hooks/use-active-workspace-membership'
 import { useAgentsSettingsHidden } from '@/hooks/use-agents-settings-hidden'
-import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
 import { stripWorkspacePrefix, useActiveWorkspace } from '@/lib/active-workspace'
-import { ArrowLeft, Bot, Cpu, Globe, Plug, Server, SlidersHorizontal, Smartphone, Users, Zap } from 'lucide-react'
+import { ArrowLeft, Bot, Cpu, Globe, Lock, Plug, Server, SlidersHorizontal, Smartphone, Users, Zap } from 'lucide-react'
 import { useLocation } from 'react-router'
 import { SidebarHeader } from './sidebar-header'
 
@@ -47,16 +46,19 @@ export const SettingsSidebarContent = ({
   // per Decision 25 (hide-not-disable). Personal is treated as admin-equivalent
   // for nav purposes; the page renders read-only.
   const workspaceAdminItemsVisible = activeWorkspace?.isPersonal === 1 || isAdmin
-  // Members visibility follows the configurable `manage_members` permission and
-  // is always hidden in Personal Workspaces (Decision 25 — personal can't manage
-  // members in v1).
+  // Members is visible to every member of a shared workspace — the page is
+  // read-friendly without action permissions, and individual actions (invite /
+  // change role / remove) gate themselves on the granular permission keys.
+  // Always hidden in Personal Workspaces (Decision 25 — no members to manage).
   // @todo Drop the e2eeEnabled gate once the encryption pipeline supports
   // multi-recipient envelopes and is workspace-aware (see THU-593). Until then
   // an E2EE-enabled server is effectively single-user and there's nothing to
-  // manage here.
-  const { isAllowed: canManageMembers } = useWorkspacePermission('manage_members')
+  // show here.
   const e2eeEnabled = useConfigStore((state) => state.config.e2eeEnabled === true)
-  const membersItemVisible = activeWorkspace?.isPersonal !== 1 && canManageMembers && !e2eeEnabled
+  const membersItemVisible = activeWorkspace?.isPersonal !== 1 && !e2eeEnabled
+  // Permissions is implicitly admin-only — there is no configurable
+  // meta-permission for editing the permissions grid itself.
+  const permissionsItemVisible = activeWorkspace?.isPersonal !== 1 && isAdmin && !e2eeEnabled
   // `isActive` highlighting reads the sub-path so the same matching rules work
   // for both personal (`/settings/...`) and shared (`/w/<id>/settings/...`) URLs.
   const subPath = stripWorkspacePrefix(location.pathname)
@@ -148,6 +150,19 @@ export const SettingsSidebarContent = ({
                 >
                   <Users className="size-4" />
                   <span>Members</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )}
+            {permissionsItemVisible && (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  onClick={() => onSettingsNavigate('/settings/workspace/permissions')}
+                  tooltip="Permissions"
+                  className="cursor-pointer"
+                  isActive={subPath === '/settings/workspace/permissions'}
+                >
+                  <Lock className="size-4" />
+                  <span>Permissions</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             )}

--- a/src/layout/sidebar/settings-sidebar.tsx
+++ b/src/layout/sidebar/settings-sidebar.tsx
@@ -18,7 +18,7 @@ import { useActiveWorkspaceMembership } from '@/hooks/use-active-workspace-membe
 import { useAgentsSettingsHidden } from '@/hooks/use-agents-settings-hidden'
 import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
 import { stripWorkspacePrefix, useActiveWorkspace } from '@/lib/active-workspace'
-import { ArrowLeft, Bot, Building2, Cpu, Plug, Server, SlidersHorizontal, Smartphone, Users, Zap } from 'lucide-react'
+import { ArrowLeft, Bot, Cpu, Globe, Plug, Server, SlidersHorizontal, Smartphone, Users, Zap } from 'lucide-react'
 import { useLocation } from 'react-router'
 import { SidebarHeader } from './sidebar-header'
 
@@ -127,7 +127,7 @@ export const SettingsSidebarContent = ({
                   className="cursor-pointer"
                   isActive={subPath === '/settings/workspace/general'}
                 >
-                  <Building2 className="size-4" />
+                  <Globe className="size-4" />
                   <span>General</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/src/layout/sidebar/settings-sidebar.tsx
+++ b/src/layout/sidebar/settings-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   SidebarSeparator,
   useSidebar,
 } from '@/components/ui/sidebar'
+import { useConfigStore } from '@/api/config-store'
 import { useActiveWorkspaceMembership } from '@/hooks/use-active-workspace-membership'
 import { useAgentsSettingsHidden } from '@/hooks/use-agents-settings-hidden'
 import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
@@ -49,8 +50,13 @@ export const SettingsSidebarContent = ({
   // Members visibility follows the configurable `manage_members` permission and
   // is always hidden in Personal Workspaces (Decision 25 — personal can't manage
   // members in v1).
+  // @todo Drop the e2eeEnabled gate once the encryption pipeline supports
+  // multi-recipient envelopes and is workspace-aware (see THU-593). Until then
+  // an E2EE-enabled server is effectively single-user and there's nothing to
+  // manage here.
   const { isAllowed: canManageMembers } = useWorkspacePermission('manage_members')
-  const membersItemVisible = activeWorkspace?.isPersonal !== 1 && canManageMembers
+  const e2eeEnabled = useConfigStore((state) => state.config.e2eeEnabled === true)
+  const membersItemVisible = activeWorkspace?.isPersonal !== 1 && canManageMembers && !e2eeEnabled
   // `isActive` highlighting reads the sub-path so the same matching rules work
   // for both personal (`/settings/...`) and shared (`/w/<id>/settings/...`) URLs.
   const subPath = stripWorkspacePrefix(location.pathname)

--- a/src/layout/sidebar/settings-sidebar.tsx
+++ b/src/layout/sidebar/settings-sidebar.tsx
@@ -16,8 +16,9 @@ import {
 } from '@/components/ui/sidebar'
 import { useActiveWorkspaceMembership } from '@/hooks/use-active-workspace-membership'
 import { useAgentsSettingsHidden } from '@/hooks/use-agents-settings-hidden'
+import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
 import { stripWorkspacePrefix, useActiveWorkspace } from '@/lib/active-workspace'
-import { ArrowLeft, Bot, Building2, Cpu, Plug, Server, SlidersHorizontal, Smartphone, Zap } from 'lucide-react'
+import { ArrowLeft, Bot, Building2, Cpu, Plug, Server, SlidersHorizontal, Smartphone, Users, Zap } from 'lucide-react'
 import { useLocation } from 'react-router'
 import { SidebarHeader } from './sidebar-header'
 
@@ -41,10 +42,15 @@ export const SettingsSidebarContent = ({
   const agentsHidden = useAgentsSettingsHidden({ isStandalone })
   const activeWorkspace = useActiveWorkspace()
   const { isAdmin } = useActiveWorkspaceMembership()
-  // Workspace-admin items (General — and later Members, Permissions) are hidden
-  // for shared-workspace members per Decision 25 (hide-not-disable). Personal
-  // is treated as admin-equivalent for nav purposes; the page renders read-only.
+  // General — and later Permissions — are hidden for shared-workspace members
+  // per Decision 25 (hide-not-disable). Personal is treated as admin-equivalent
+  // for nav purposes; the page renders read-only.
   const workspaceAdminItemsVisible = activeWorkspace?.isPersonal === 1 || isAdmin
+  // Members visibility follows the configurable `manage_members` permission and
+  // is always hidden in Personal Workspaces (Decision 25 — personal can't manage
+  // members in v1).
+  const { isAllowed: canManageMembers } = useWorkspacePermission('manage_members')
+  const membersItemVisible = activeWorkspace?.isPersonal !== 1 && canManageMembers
   // `isActive` highlighting reads the sub-path so the same matching rules work
   // for both personal (`/settings/...`) and shared (`/w/<id>/settings/...`) URLs.
   const subPath = stripWorkspacePrefix(location.pathname)
@@ -123,6 +129,19 @@ export const SettingsSidebarContent = ({
                 >
                   <Building2 className="size-4" />
                   <span>General</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )}
+            {membersItemVisible && (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  onClick={() => onSettingsNavigate('/settings/workspace/members')}
+                  tooltip="Members"
+                  className="cursor-pointer"
+                  isActive={subPath === '/settings/workspace/members'}
+                >
+                  <Users className="size-4" />
+                  <span>Members</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             )}

--- a/src/layout/sidebar/workspace-selector.tsx
+++ b/src/layout/sidebar/workspace-selector.tsx
@@ -9,7 +9,7 @@ import { useWorkspacesQuery, type Workspace } from '@/dal'
 import { useCanCreateWorkspace } from '@/hooks/use-can-create-workspace'
 import { isDataUrlIcon } from '@/components/workspace/icon-utils'
 import { useIsMobile } from '@/hooks/use-mobile'
-import { stripWorkspacePrefix, toWorkspaceUrl, useActiveWorkspace } from '@/lib/active-workspace'
+import { crossWorkspaceSubPath, toWorkspaceUrl, useActiveWorkspace } from '@/lib/active-workspace'
 import { cn } from '@/lib/utils'
 import { ChevronDown, Plus } from 'lucide-react'
 import { useMemo, useState } from 'react'
@@ -173,7 +173,10 @@ export const WorkspaceSelector = ({ collapsed = false }: WorkspaceSelectorProps)
     if (!target || target.id === active.id) {
       return
     }
-    const subPath = stripWorkspacePrefix(location.pathname)
+    // Chat ids are per-workspace; carrying the current chat id across the
+    // switch would land on Not Found. `crossWorkspaceSubPath` collapses
+    // `/chats/<id>` to `/chats/new` for the target workspace.
+    const subPath = crossWorkspaceSubPath(location.pathname)
     navigate(`${toWorkspaceUrl(target, subPath)}${location.search}`)
   }
 

--- a/src/layout/sidebar/workspace-selector.tsx
+++ b/src/layout/sidebar/workspace-selector.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { useConfigStore } from '@/api/config-store'
 import { AppLogo } from '@/components/app-logo'
 import { SearchableMenu, type SearchableMenuGroup, type SearchableMenuItem } from '@/components/ui/searchable-menu'
 import { useWorkspacesQuery, type Workspace } from '@/dal'
@@ -121,6 +122,7 @@ export const WorkspaceSelector = ({ collapsed = false }: WorkspaceSelectorProps)
   const navigate = useNavigate()
   const location = useLocation()
   const canCreate = useCanCreateWorkspace()
+  const e2eeEnabled = useConfigStore((state) => state.config.e2eeEnabled === true)
   const [createOpen, setCreateOpen] = useState(false)
   // After create-modal commits, hold the new workspace id so the invite modal
   // can target it; clearing this also closes the invite modal.
@@ -128,6 +130,14 @@ export const WorkspaceSelector = ({ collapsed = false }: WorkspaceSelectorProps)
 
   const handleCreated = (workspaceId: string) => {
     setCreateOpen(false)
+    // @todo Drop this E2EE branch once the encryption pipeline supports
+    // multi-recipient envelopes and is workspace-aware (see THU-593). Until
+    // then there's no point opening the invite step — the BE rejects pending
+    // membership inserts under E2EE.
+    if (e2eeEnabled) {
+      navigate(`/w/${workspaceId}/`)
+      return
+    }
     setInviteWorkspaceId(workspaceId)
   }
 

--- a/src/lib/active-workspace.test.tsx
+++ b/src/lib/active-workspace.test.tsx
@@ -14,6 +14,7 @@ import {
   waitForElement,
 } from '@/test-utils/powersync-reactivity-test'
 import {
+  crossWorkspaceSubPath,
   stripWorkspacePrefix,
   toWorkspaceUrl,
   useActiveWorkspace,
@@ -84,6 +85,21 @@ describe('stripWorkspacePrefix', () => {
   })
 })
 
+describe('crossWorkspaceSubPath', () => {
+  it('collapses chat-detail paths to /chats/new across the switch', () => {
+    expect(crossWorkspaceSubPath(`/w/${otherWsId}/chats/abc-123`)).toBe('/chats/new')
+    expect(crossWorkspaceSubPath('/chats/abc-123')).toBe('/chats/new')
+    // The bare /chats route is also collapsed for consistency.
+    expect(crossWorkspaceSubPath(`/w/${otherWsId}/chats`)).toBe('/chats/new')
+  })
+
+  it('passes through non-chat paths', () => {
+    expect(crossWorkspaceSubPath(`/w/${otherWsId}/settings/preferences`)).toBe('/settings/preferences')
+    expect(crossWorkspaceSubPath('/tasks')).toBe('/tasks')
+    expect(crossWorkspaceSubPath(`/w/${otherWsId}/`)).toBe('/')
+  })
+})
+
 describe('useActiveWorkspaceId reactivity', () => {
   beforeAll(async () => {
     await setupTestDatabase()
@@ -122,6 +138,18 @@ describe('useActiveWorkspaceId reactivity', () => {
     })
     await waitForElement(() => screen.queryByTestId(`active-id-${wsId}`))
     expect(screen.getByTestId(`active-id-${wsId}`)).toBeInTheDocument()
+  })
+
+  it('surfaces the URL-encoded id immediately even before the workspace row materializes', async () => {
+    renderWithReactivity(<ActiveIdProbe />, {
+      route: `/w/${otherWsId}/chats/new`,
+      routePath: '*',
+      tables: ['workspaces'],
+      wrapper: DbWrapper,
+    })
+    // No row inserted for `otherWsId` — the URL id should still surface.
+    await waitForElement(() => screen.queryByTestId(`active-id-${otherWsId}`))
+    expect(screen.getByTestId(`active-id-${otherWsId}`)).toBeInTheDocument()
   })
 
   it('resolves to the URL-encoded workspace id when /w/<id>/ is present', async () => {

--- a/src/lib/active-workspace.ts
+++ b/src/lib/active-workspace.ts
@@ -173,10 +173,36 @@ export const useActiveWorkspace = (): Workspace | null => {
 }
 
 /**
- * Convenience wrapper for the common case — just the id. Tracks the same URL
- * + personal-fallback rule as `useActiveWorkspace`.
+ * Convenience wrapper for the common case — just the id. URL-derived ids
+ * surface IMMEDIATELY (without waiting for the local `workspaces` row to
+ * materialize), keeping the hook in lockstep with the non-React
+ * `getActiveWorkspaceId` async helper. The full `useActiveWorkspace()` row
+ * is still loaded in the background for consumers that need name/icon/etc.
+ *
+ * For unprefixed paths (personal workspace), the id only resolves once the
+ * row is in the local DB — `WorkspaceGate` is the upstream readiness barrier
+ * so consumers inside it can treat the result as eventually-non-null.
  */
-export const useActiveWorkspaceId = (): string | null => useActiveWorkspace()?.id ?? null
+export const useActiveWorkspaceId = (): string | null => {
+  const pathname = useReactivePathname()
+  const fromUrl = matchWorkspaceIdInPath(pathname)
+  const workspace = useActiveWorkspace()
+  return fromUrl ?? workspace?.id ?? null
+}
+
+/**
+ * Subpath to use when navigating BETWEEN workspaces (workspace selector swap
+ * or `WorkspaceMembershipGate` redirect). Strips the `/w/<id>` prefix, then
+ * collapses chat-detail paths to `/chats/new`: chat ids are per-workspace, so
+ * carrying one across would land the user on Not Found in the target.
+ */
+export const crossWorkspaceSubPath = (pathname: string): string => {
+  const subPath = stripWorkspacePrefix(pathname)
+  if (/^\/chats(\/|$)/.test(subPath)) {
+    return '/chats/new'
+  }
+  return subPath
+}
 
 /**
  * Build a URL for `path` in the active workspace. Returns `path` unchanged

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -44,13 +44,39 @@ export const getDeviceId = (): string => {
   return id
 }
 
+// Scoped override consulted before the registry-derived lookup. The sign-out
+// wipe sequence empties `activeTrustDomain` before calling Better Auth's
+// `signOut()`, so the normal `getActiveServerId()` resolution would return
+// `null` and the sign-out request would go out bearer-less. `withCapturedAuthToken`
+// replays the pre-wipe token for the duration of that call.
+let capturedAuthToken: string | null = null
+
 /** Get the active server's auth token, or null if there is no active server / not signed in. */
 export const getAuthToken = (): string | null => {
+  if (capturedAuthToken !== null) {
+    return capturedAuthToken
+  }
   const serverId = getActiveServerId()
   if (!serverId) {
     return null
   }
   return localStorage.getItem(authTokenKeyFor(serverId))
+}
+
+/**
+ * Run `fn` with `getAuthToken()` short-circuited to return `token`. Used by
+ * `signOutAndWipe` so the sign-out HTTP call stays authenticated even though
+ * `clearLocalData` has already cleared `activeTrustDomain` from the registry
+ * by the time signOut runs.
+ */
+export const withCapturedAuthToken = async <T>(token: string | null, fn: () => Promise<T>): Promise<T> => {
+  const prev = capturedAuthToken
+  capturedAuthToken = token
+  try {
+    return await fn()
+  } finally {
+    capturedAuthToken = prev
+  }
 }
 
 /** Store the auth token under the active server's namespace. No-op when no server is active. */
@@ -62,22 +88,27 @@ export const setAuthToken = (token: string): void => {
   localStorage.setItem(authTokenKeyFor(serverId), token)
 }
 
-/** Clear the auth token for the active server (for sign-out). No-op when no server is active. */
-export const clearAuthToken = (): void => {
-  const serverId = getActiveServerId()
-  if (!serverId) {
+/**
+ * Clear the auth token. Defaults to the active server (registry-resolved), but
+ * the wipe path passes the captured serverId explicitly because cleanup.ts
+ * clears `activeTrustDomain` from the registry before this runs (so the
+ * default would resolve to undefined and no-op).
+ */
+export const clearAuthToken = (serverId?: string): void => {
+  const id = serverId ?? getActiveServerId()
+  if (!id) {
     return
   }
-  localStorage.removeItem(authTokenKeyFor(serverId))
+  localStorage.removeItem(authTokenKeyFor(id))
 }
 
-/** Clear the device ID for the active server (forces a new ID on next login). */
-export const clearDeviceId = (): void => {
-  const serverId = getActiveServerId()
-  if (!serverId) {
+/** Same shape as `clearAuthToken` — explicit serverId for callers running after a registry clear. */
+export const clearDeviceId = (serverId?: string): void => {
+  const id = serverId ?? getActiveServerId()
+  if (!id) {
     return
   }
-  localStorage.removeItem(deviceIdKeyFor(serverId))
+  localStorage.removeItem(deviceIdKeyFor(id))
 }
 
 /**

--- a/src/lib/cleanup.test.ts
+++ b/src/lib/cleanup.test.ts
@@ -152,6 +152,18 @@ describe('clearLocalData', () => {
     expect(calls).toContain('clearAuthToken')
     expect(calls).toContain('clearDeviceId')
   })
+
+  it('clears activeTrustDomain from the registry before broadcasting db-closing', async () => {
+    let registryAtBroadcast: ReturnType<typeof useTrustDomainRegistry.getState>['activeTrustDomain']
+    broadcastDbLifecycle.mockImplementationOnce((event: { kind: string }) => {
+      calls.push(`broadcast:${event.kind}`)
+      registryAtBroadcast = useTrustDomainRegistry.getState().activeTrustDomain
+    })
+
+    await clearLocalData(deps)
+
+    expect(registryAtBroadcast).toBeUndefined()
+  })
 })
 
 describe('signOutAndWipe', () => {
@@ -230,5 +242,84 @@ describe('signOutAndWipe', () => {
     await signOutAndWipe({ onComplete, ...deps })
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears credentials AFTER signOut so the server can revoke the session', async () => {
+    const signOut = mock(async () => {
+      calls.push('signOut')
+    })
+    const onComplete = mock(() => {
+      calls.push('onComplete')
+    })
+
+    await signOutAndWipe({ signOut, onComplete, ...deps })
+
+    const signOutIdx = calls.indexOf('signOut')
+    const authTokenIdx = calls.indexOf('clearAuthToken')
+    const deviceIdIdx = calls.indexOf('clearDeviceId')
+    const onCompleteIdx = calls.indexOf('onComplete')
+
+    expect(signOutIdx).toBeGreaterThan(-1)
+    expect(authTokenIdx).toBeGreaterThan(signOutIdx)
+    expect(deviceIdIdx).toBeGreaterThan(signOutIdx)
+    expect(onCompleteIdx).toBeGreaterThan(authTokenIdx)
+    expect(onCompleteIdx).toBeGreaterThan(deviceIdIdx)
+  })
+
+  it('still clears credentials on the revoked-device path (no signOut)', async () => {
+    // RevokedDeviceModal doesn't pass `signOut` (the server already
+    // invalidated the session). The deferred-credential clear still has to
+    // run so the local token is wiped.
+    const onComplete = mock(() => {})
+
+    await signOutAndWipe({ onComplete, ...deps })
+
+    expect(clearAuthToken).toHaveBeenCalledTimes(1)
+    expect(clearDeviceId).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the captured serverId to the credential clearers (registry already cleared)', async () => {
+    const onComplete = mock(() => {})
+
+    await signOutAndWipe({ onComplete, ...deps })
+
+    expect(clearAuthToken).toHaveBeenCalledWith(serverId)
+    expect(clearDeviceId).toHaveBeenCalledWith(serverId)
+  })
+
+  it('passes the captured serverId to handleFullWipe (registry already cleared)', async () => {
+    const onComplete = mock(() => {})
+
+    await signOutAndWipe({ onComplete, ...deps })
+
+    expect(handleFullWipe).toHaveBeenCalledWith(serverId)
+  })
+
+  it('keeps getAuthToken() resolvable during signOut even though the registry was cleared', async () => {
+    // clearLocalData empties `activeTrustDomain` before signOut runs, so the
+    // registry-derived lookup inside `getAuthToken()` would return null and
+    // Better Auth's `auth.token` callback would send the sign-out request
+    // bearer-less. `withCapturedAuthToken` (used inside `signOutAndWipe`)
+    // must replay the pre-wipe token for the duration of the signOut call.
+    const { getAuthToken } = await import('@/lib/auth-token')
+    const tokenKey = `thunderbolt_auth_token__${serverId}`
+    const tokenValue = 'sentinel-token-value'
+    localStorage.setItem(tokenKey, tokenValue)
+
+    const observed: { token: string | null } = { token: null }
+    const signOut = mock(async () => {
+      observed.token = getAuthToken()
+    })
+    const onComplete = mock(() => {})
+
+    try {
+      await signOutAndWipe({ signOut, onComplete, ...deps })
+    } finally {
+      localStorage.removeItem(tokenKey)
+    }
+
+    expect(observed.token).toBe(tokenValue)
+    // And after signOut returns, the override is dropped — no leakage.
+    expect(getAuthToken()).toBeNull()
   })
 })

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -7,18 +7,23 @@ import { broadcastDbLifecycle } from '@/db/db-lifecycle-broadcast'
 import { resetDatabase } from '@/db/database'
 import { disposeAllAdapters } from '@/acp/adapter-cache'
 import { setSyncEnabled } from '@/db/powersync'
-import { clearAuthToken as defaultClearAuthToken, clearDeviceId as defaultClearDeviceId } from '@/lib/auth-token'
+import {
+  clearAuthToken as defaultClearAuthToken,
+  clearDeviceId as defaultClearDeviceId,
+  getAuthToken,
+  withCapturedAuthToken,
+} from '@/lib/auth-token'
 import { deleteDbFile } from '@/lib/fs'
 import { withTimeout } from '@/lib/timeout'
 import { handleFullWipe as defaultHandleFullWipe } from '@/services/encryption'
 import { initialLocalSettings, useLocalSettingsStore } from '@/stores/local-settings-store'
-import { getActiveTrustDomain } from '@/stores/trust-domain-registry'
+import { getActiveTrustDomain, useTrustDomainRegistry } from '@/stores/trust-domain-registry'
 import { resetPostAuthBootstrap } from '@/lib/post-auth-bootstrap'
 
 type CleanupDeps = {
-  clearAuthToken?: () => void
-  clearDeviceId?: () => void
-  handleFullWipe?: () => Promise<void>
+  clearAuthToken?: (serverId?: string) => void
+  clearDeviceId?: (serverId?: string) => void
+  handleFullWipe?: (serverId?: string) => Promise<void>
 }
 
 /**
@@ -59,6 +64,11 @@ export const clearLocalData = async ({
   resetVolatileStores()
 
   const trustDomain = getActiveTrustDomain()
+  // Capture the serverId BEFORE we empty `activeTrustDomain` from the
+  // registry (below). The credential clearers default to reading serverId
+  // from the registry; once it's cleared they'd no-op and the per-server
+  // localStorage keys would survive the wipe.
+  const serverIdForClear = trustDomain?.kind === 'server' ? trustDomain.serverId : undefined
 
   // Tear down every warm ACP connection first so no agent transport survives
   // across user identities (sign-out, account deletion, device revocation all
@@ -67,6 +77,18 @@ export const clearLocalData = async ({
     await disposeAllAdapters()
   } catch (error) {
     console.error('[clearLocalData] Failed to dispose ACP adapters:', error)
+  }
+
+  // Clear the registry's `activeTrustDomain` BEFORE broadcasting `db-closing`
+  // (step 2 below). Other tabs receive the broadcast and reload; on reload
+  // they re-read the persisted registry and now see no active trust domain,
+  // so boot resolves to `NO_TRUST_DOMAIN` → ModePicker. Without this they'd
+  // boot into the same server entry and race our `resetDatabase` /
+  // `deleteDbFile` by trying to reopen the same SQLite file. Our own tab
+  // continues using the local `trustDomain` capture above, so the rest of
+  // the wipe sequence still targets the right server.
+  if (trustDomain) {
+    useTrustDomainRegistry.setState({ activeTrustDomain: undefined })
   }
 
   // Step 1: flip the persisted `syncEnabled` flag to false and disconnect. The flag
@@ -111,15 +133,20 @@ export const clearLocalData = async ({
   // a logout into the next user's session.
   useLocalSettingsStore.setState(initialLocalSettings)
 
-  // Step 6: clear per-server credentials. No-op in standalone.
-  clearAuthToken()
-  clearDeviceId()
+  // Step 6: clear per-server credentials. No-op in standalone. The
+  // `serverIdForClear` capture above feeds the explicit serverId — the
+  // registry has already been emptied so the default lookup wouldn't find one.
+  clearAuthToken(serverIdForClear)
+  clearDeviceId(serverIdForClear)
 
   // Step 7: clear encryption keys (server-only — `handleFullWipe` throws on standalone
   // via `key-storage.ts`'s active-server guard; we skip it cleanly when there's no server).
+  // Pass `serverIdForClear` explicitly because the registry was emptied above —
+  // the default lookup inside `clearAllKeys` would no-op and the per-server
+  // IDB database with all encryption keys would survive the wipe.
   if (trustDomain?.kind === 'server') {
     try {
-      await handleFullWipe()
+      await handleFullWipe(serverIdForClear)
     } catch (error) {
       console.error('[clearLocalData] Failed to clear encryption keys:', error)
     }
@@ -147,27 +174,55 @@ export const signOutAndWipe = async ({
   signOut?: () => Promise<void>
   onComplete: () => void
 } & CleanupDeps): Promise<void> => {
-  // Wipe local data BEFORE calling signOut so that Better Auth's session cache
-  // stays populated during the wipe. If signOut ran first, Better Auth would
-  // immediately set useSession() → null, letting AuthGate redirect to
-  // /sso-redirect (SSO mode) or /waitlist between the awaits inside
-  // clearLocalData — potentially kicking off a new IdP sign-in flow before
-  // onComplete() can navigate away.
+  // Two ordering constraints have to hold together:
+  //   1. The wipe runs BEFORE signOut so Better Auth's session cache stays
+  //      populated during it — otherwise useSession() flips to null mid-wipe
+  //      and AuthGate could redirect to /sso-redirect (SSO) or /waitlist
+  //      between awaits, kicking off a new IdP sign-in before onComplete()
+  //      navigates away.
+  //   2. The auth token has to stay present THROUGH signOut() so the HTTP
+  //      call to /sign-out is authenticated and the server can revoke the
+  //      session row. Clearing it before signOut() (as the previous version
+  //      did, inside clearLocalData) sent the request bearer-less and left
+  //      the session valid server-side until natural expiry.
+  // Resolve below: pass no-op credential-clear callbacks into clearLocalData
+  // so the wipe runs in its normal order WITHOUT touching the token, capture
+  // the token before the registry is emptied, and replay it via
+  // `withCapturedAuthToken` so Better Auth's `auth.token` callback returns it
+  // when signOut runs. Then clear credentials ourselves.
+  const clearAuthToken = deps.clearAuthToken ?? defaultClearAuthToken
+  const clearDeviceId = deps.clearDeviceId ?? defaultClearDeviceId
+  // Capture serverId + token BEFORE clearLocalData empties `activeTrustDomain`
+  // from the registry. Both are registry-derived: the deferred credential
+  // clear below would otherwise no-op, and `getAuthToken()` inside
+  // Better Auth's signOut fetch would return null, sending the request
+  // bearer-less.
+  const trustDomainAtStart = getActiveTrustDomain()
+  const serverIdForClear = trustDomainAtStart?.kind === 'server' ? trustDomainAtStart.serverId : undefined
+  const tokenAtStart = getAuthToken()
+
   try {
-    await clearLocalData(deps)
+    await clearLocalData({ ...deps, clearAuthToken: () => {}, clearDeviceId: () => {} })
   } catch (error) {
     console.error('[signOutAndWipe] clearLocalData failed:', error)
   }
 
   if (signOut) {
     try {
-      await signOut()
+      await withCapturedAuthToken(tokenAtStart, signOut)
     } catch (error) {
       console.error('[signOutAndWipe] signOut failed:', error)
     }
   }
 
-  // onComplete fires synchronously right after signOut resolves — no await
-  // between them so React cannot schedule a re-render before the hard navigation.
+  // Token is no longer useful: signOut() has revoked the session, or
+  // RevokedDeviceModal is the caller (server already invalidated). Safe to
+  // wipe locally without breaking the revoke call above.
+  clearAuthToken(serverIdForClear)
+  clearDeviceId(serverIdForClear)
+
+  // onComplete fires synchronously right after the credential clear — no
+  // await between them so React cannot schedule a re-render before the
+  // hard navigation.
   onComplete()
 }

--- a/src/routes/settings/agents/index.test.tsx
+++ b/src/routes/settings/agents/index.test.tsx
@@ -23,7 +23,18 @@ const authedSession = {
 
 const settingsIndexMarker = 'settings-index-marker'
 
-const renderPage = (authClient: AuthClient, isStandalone: () => boolean) => {
+const fakeUseWorkspacePermission = (isAllowed: boolean) =>
+  (() => ({
+    requiredRole: 'admin' as const,
+    isAllowed,
+    isResolved: true,
+  })) as unknown as typeof import('@/hooks/use-workspace-permission').useWorkspacePermission
+
+const renderPage = (
+  authClient: AuthClient,
+  isStandalone: () => boolean,
+  opts: { useWorkspacePermission?: ReturnType<typeof fakeUseWorkspacePermission> } = {},
+) => {
   const TestProvider = createTestProvider({ authClient })
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <TestProvider>
@@ -35,7 +46,10 @@ const renderPage = (authClient: AuthClient, isStandalone: () => boolean) => {
       </MemoryRouter>
     </TestProvider>
   )
-  return render(<AgentsSettingsPage isStandalone={isStandalone} />, { wrapper: Wrapper })
+  return render(
+    <AgentsSettingsPage isStandalone={isStandalone} useWorkspacePermission={opts.useWorkspacePermission} />,
+    { wrapper: Wrapper },
+  )
 }
 
 const onTauri = () => true
@@ -81,7 +95,9 @@ describe('AgentsSettingsPage — hidden state guard', () => {
     renderPage(authClient, onTauri)
 
     expect(screen.queryByTestId(settingsIndexMarker)).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /add custom agent/i })).toBeInTheDocument()
+    // Header is the stable rendered-marker; the Add affordance is workspace
+    // permission-gated and not seeded in these "hidden state guard" tests.
+    expect(screen.getByRole('heading', { name: 'Agents' })).toBeInTheDocument()
   })
 
   it('renders the page for authenticated users behind the proxy (web)', () => {
@@ -89,7 +105,9 @@ describe('AgentsSettingsPage — hidden state guard', () => {
     renderPage(authClient, offTauri)
 
     expect(screen.queryByTestId(settingsIndexMarker)).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /add custom agent/i })).toBeInTheDocument()
+    // Header is the stable rendered-marker; the Add affordance is workspace
+    // permission-gated and not seeded in these "hidden state guard" tests.
+    expect(screen.getByRole('heading', { name: 'Agents' })).toBeInTheDocument()
   })
 
   it('renders the page for authenticated users on Tauri Standalone', () => {
@@ -97,6 +115,43 @@ describe('AgentsSettingsPage — hidden state guard', () => {
     renderPage(authClient, onTauri)
 
     expect(screen.queryByTestId(settingsIndexMarker)).not.toBeInTheDocument()
+    // Header is the stable rendered-marker; the Add affordance is workspace
+    // permission-gated and not seeded in these "hidden state guard" tests.
+    expect(screen.getByRole('heading', { name: 'Agents' })).toBeInTheDocument()
+  })
+})
+
+describe('AgentsSettingsPage — permission gating (add_agents)', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('renders the "Add Custom Agent" button when the user has add_agents', () => {
+    const authClient = createMockAuthClient({ session: authedSession })
+    renderPage(authClient, onTauri, { useWorkspacePermission: fakeUseWorkspacePermission(true) })
+
     expect(screen.getByRole('button', { name: /add custom agent/i })).toBeInTheDocument()
+  })
+
+  it('hides the "Add Custom Agent" button when the user lacks add_agents', () => {
+    const authClient = createMockAuthClient({ session: authedSession })
+    renderPage(authClient, onTauri, { useWorkspacePermission: fakeUseWorkspacePermission(false) })
+
+    expect(screen.getByRole('heading', { name: 'Agents' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add custom agent/i })).not.toBeInTheDocument()
   })
 })

--- a/src/routes/settings/agents/index.tsx
+++ b/src/routes/settings/agents/index.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '@/contexts'
 import { useActiveWorkspaceId, useWorkspaceUrl } from '@/lib/active-workspace'
 import { selectAllowCustomAgents, useConfigStore } from '@/api/config-store'
 import { useAgentsSettingsHidden } from '@/hooks/use-agents-settings-hidden'
+import { useWorkspacePermission as useWorkspacePermission_default } from '@/hooks/use-workspace-permission'
 import type { Agent } from '@/types/acp'
 
 type AgentsSettingsPageProps = {
@@ -25,6 +26,9 @@ type AgentsSettingsPageProps = {
    *  without mocking the shared `@/lib/platform` module (which would leak
    *  across files — see `docs/development/testing.md`). */
   isStandalone?: () => boolean
+  /** Test seam — defaults to the real hook. Tests inject a fake to drive
+   *  the gated Add Custom Agent / row affordances. */
+  useWorkspacePermission?: typeof useWorkspacePermission_default
 }
 
 /**
@@ -34,7 +38,10 @@ type AgentsSettingsPageProps = {
  * ACP endpoints. The composition lives in `useAllAgents` — this page is just
  * a thin orchestrator wiring DAL writes to UI events.
  */
-export default function AgentsSettingsPage({ isStandalone }: AgentsSettingsPageProps = {}) {
+export default function AgentsSettingsPage({
+  isStandalone,
+  useWorkspacePermission = useWorkspacePermission_default,
+}: AgentsSettingsPageProps = {}) {
   const db = useDatabase()
   const workspaceId = useActiveWorkspaceId()
   const agents = useAllAgents()
@@ -44,6 +51,11 @@ export default function AgentsSettingsPage({ isStandalone }: AgentsSettingsPageP
   const agentsHidden = useAgentsSettingsHidden({ isStandalone })
   const allowCustomAgents = useConfigStore((state) => selectAllowCustomAgents(state.config))
   const settingsUrl = useWorkspaceUrl('/settings')
+  // Workspace `add_agents` / `remove_agents` permissions — BE enforces too, FE
+  // just hides affordances so the user isn't presented with actions that
+  // round-trip-fail.
+  const { isAllowed: canAddAgents } = useWorkspacePermission('add_agents')
+  const { isAllowed: canRemoveAgents } = useWorkspacePermission('remove_agents')
 
   const [dialogOpen, setDialogOpen] = useState(false)
 
@@ -99,7 +111,7 @@ export default function AgentsSettingsPage({ isStandalone }: AgentsSettingsPageP
   return (
     <div className="flex flex-col gap-6 p-4 w-full max-w-[760px] mx-auto">
       <PageHeader title="Agents">
-        {allowCustomAgents && (
+        {allowCustomAgents && canAddAgents && (
           <Button
             variant="outline"
             size="icon"
@@ -113,7 +125,14 @@ export default function AgentsSettingsPage({ isStandalone }: AgentsSettingsPageP
         )}
       </PageHeader>
 
-      <AgentList agents={agents} currentUserId={currentUserId} onToggle={handleToggle} onDelete={handleDelete} />
+      <AgentList
+        agents={agents}
+        currentUserId={currentUserId}
+        canEditAgents={canAddAgents}
+        canRemoveAgents={canRemoveAgents}
+        onToggle={handleToggle}
+        onDelete={handleDelete}
+      />
 
       <AddCustomAgentDialog
         open={dialogOpen}

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -295,7 +295,7 @@ export const recoverWithKey = async (httpClient: HttpClient, recoveryPhrase: str
 // Flow G — Full wipe (clear all keys)
 // =============================================================================
 
-export const handleFullWipe = async (): Promise<void> => {
-  await clearAllKeys()
+export const handleFullWipe = async (serverId?: string): Promise<void> => {
+  await clearAllKeys(serverId)
   resetCodecState()
 }

--- a/src/settings/dev-settings.tsx
+++ b/src/settings/dev-settings.tsx
@@ -3,21 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ModificationIndicator } from '@/components/modification-indicator'
-import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
 import { SectionCard } from '@/components/ui/section-card'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { initialLocalSettings, useLocalSettingsStore } from '@/stores/local-settings-store'
-import { useActiveCloudUrl, useTrustDomainRegistry } from '@/stores/trust-domain-registry'
 import { getCapabilities, isTauri } from '@/lib/platform'
 import { useQuery } from '@tanstack/react-query'
 import { useShallow } from 'zustand/react/shallow'
-
-// The env-var fallback the boot resolver uses. If it were unset, boot would fail with
-// NO_TRUST_DOMAIN before this page renders, so a hardcoded localhost default would only
-// drift from whatever the rest of the app considers "default."
-const defaultCloudUrl = import.meta.env.VITE_THUNDERBOLT_CLOUD_URL ?? ''
 
 export default function DevSettingsPage() {
   const settings = useLocalSettingsStore(
@@ -28,15 +21,6 @@ export default function DevSettingsPage() {
   )
   const { isNativeFetchEnabled, debugPosthog } = settings
   const setLocalSetting = useLocalSettingsStore((s) => s.setLocalSetting)
-
-  // Cloud URL lives on the active server entry in the trust-domain registry; editing
-  // it here updates the registry directly so runtime consumers (HTTP, PowerSync, etc.)
-  // see the change on next read. Resetting falls back to the env-var default that the
-  // boot resolver also uses. NOTE: changing the URL does NOT update the active server's
-  // `serverId` — pointing at a different backend (different serverId) is post-v1 territory.
-  const cloudUrl = useActiveCloudUrl() ?? defaultCloudUrl
-  const patchActiveServer = useTrustDomainRegistry((s) => s.patchActiveServer)
-  const setCloudUrl = (value: string) => patchActiveServer({ cloudUrl: value || defaultCloudUrl })
 
   const isModified = <K extends keyof typeof settings>(key: K) => settings[key] !== initialLocalSettings[key]
 
@@ -55,28 +39,6 @@ export default function DevSettingsPage() {
 
       <SectionCard title="Network">
         <div className="flex flex-col gap-8">
-          {/* Cloud URL Setting */}
-          <div className="space-y-2">
-            <ModificationIndicator
-              as="label"
-              className="block text-sm font-medium"
-              hasModifications={cloudUrl !== defaultCloudUrl}
-              onReset={() => setCloudUrl(defaultCloudUrl)}
-            >
-              Cloud URL
-            </ModificationIndicator>
-            <Input
-              type="url"
-              value={cloudUrl}
-              onChange={(e) => setCloudUrl(e.target.value)}
-              placeholder="http://localhost:8000"
-            />
-            <p className="text-sm text-muted-foreground">The URL of the Thunderbolt backend</p>
-          </div>
-
-          {/* Divider between settings */}
-          <div className="border-t -mx-6" />
-
           <div className="flex items-center justify-between">
             <div className="flex flex-col gap-1">
               <ModificationIndicator

--- a/src/settings/mcp-servers.test.tsx
+++ b/src/settings/mcp-servers.test.tsx
@@ -18,6 +18,13 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock 
 import { v7 as uuidv7 } from 'uuid'
 import McpServersPage from './mcp-servers'
 
+const fakeUseWorkspacePermission = (isAllowed: boolean) =>
+  (() => ({
+    requiredRole: 'admin' as const,
+    isAllowed,
+    isResolved: true,
+  })) as unknown as typeof import('@/hooks/use-workspace-permission').useWorkspacePermission
+
 mock.module('@/hooks/use-mcp-sync', () => ({
   useMcpSync: () => ({ servers: [] }),
 }))
@@ -75,5 +82,70 @@ describe('McpServersPage reactivity', () => {
     })
 
     expect(screen.getByText('localhost:9000/mcp')).toBeInTheDocument()
+  })
+})
+
+describe('McpServersPage — permission gating', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    seedTestTrustDomain()
+    await resetTestDatabase()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('renders the "Add Server" header trigger when add_mcp_servers is allowed', async () => {
+    renderWithReactivity(<McpServersPage useWorkspacePermission={fakeUseWorkspacePermission(true)} />, {
+      tables: ['mcp_servers'],
+    })
+
+    await waitForElement(() => screen.queryByRole('heading', { name: 'MCP Servers' }))
+    // Empty-state CTA fires here since no servers seeded; both header + empty
+    // state render the "Add Server" string. Asserting at least one is present.
+    expect(screen.getAllByText(/Add Server/).length).toBeGreaterThan(0)
+  })
+
+  it('hides every "Add Server" affordance when add_mcp_servers is denied', async () => {
+    renderWithReactivity(<McpServersPage useWorkspacePermission={fakeUseWorkspacePermission(false)} />, {
+      tables: ['mcp_servers'],
+    })
+
+    await waitForElement(() => screen.queryByRole('heading', { name: 'MCP Servers' }))
+    expect(screen.queryByText(/Add Server/)).not.toBeInTheDocument()
+  })
+
+  it('hides the row Trash button when remove_mcp_servers is denied', async () => {
+    const db = getDb()
+    await createMcpServer(db, wsId, {
+      id: uuidv7(),
+      name: 'Configured',
+      url: 'http://localhost:8000/mcp/',
+      type: 'http',
+      enabled: 1,
+    })
+
+    // The page passes the same `useWorkspacePermission` for both keys; a single
+    // `isAllowed: false` covers add + remove together — sufficient to assert
+    // the row Trash icon is hidden.
+    renderWithReactivity(<McpServersPage useWorkspacePermission={fakeUseWorkspacePermission(false)} />, {
+      tables: ['mcp_servers'],
+    })
+
+    await waitForElement(() => screen.queryByText('localhost:8000/mcp'))
+    // Trash2 icon doesn't get a unique label, so we assert via the absence of
+    // any button child of the row's interactive group beyond Switch.
+    const switchToggle = screen.queryByRole('switch')
+    // Switch should also be disabled.
+    expect(switchToggle).toBeDisabled()
   })
 })

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -21,6 +21,7 @@ import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { createMcpServer, deleteMcpServer, getHttpMcpServers, updateMcpServer } from '@/dal'
 import { useDatabase } from '@/contexts'
+import { useWorkspacePermission as useWorkspacePermission_default } from '@/hooks/use-workspace-permission'
 import { useMcpSync } from '@/hooks/use-mcp-sync'
 import { useActiveWorkspaceId } from '@/lib/active-workspace'
 import { type McpServer } from '@/types'
@@ -37,9 +38,22 @@ type ServerTools = {
   [serverId: string]: string[]
 }
 
-export default function McpServersPage() {
+type McpServersPageProps = {
+  /** Test seam — defaults to the real hook. Tests inject a fake to drive the
+   *  gated Add Server / row affordances. */
+  useWorkspacePermission?: typeof useWorkspacePermission_default
+}
+
+export default function McpServersPage({
+  useWorkspacePermission = useWorkspacePermission_default,
+}: McpServersPageProps = {}) {
   const db = useDatabase()
   const workspaceId = useActiveWorkspaceId()
+  // Workspace `add_mcp_servers` / `remove_mcp_servers` — BE enforces; FE
+  // hides affordances so the user isn't presented with actions that
+  // round-trip-fail.
+  const { isAllowed: canAddMcpServers } = useWorkspacePermission('add_mcp_servers')
+  const { isAllowed: canRemoveMcpServers } = useWorkspacePermission('remove_mcp_servers')
   const { servers: mcpServers } = useMcpSync()
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [newServerUrl, setNewServerUrl] = useState('')
@@ -312,11 +326,13 @@ export default function McpServersPage() {
     <div className="flex flex-col gap-6 p-4 w-full max-w-[760px] mx-auto">
       <PageHeader title="MCP Servers">
         <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-          <DialogTrigger asChild>
-            <Button variant="outline" size="icon" className="rounded-lg">
-              <Plus />
-            </Button>
-          </DialogTrigger>
+          {canAddMcpServers && (
+            <DialogTrigger asChild>
+              <Button variant="outline" size="icon" className="rounded-lg">
+                <Plus />
+              </Button>
+            </DialogTrigger>
+          )}
           <ResponsiveModalContentComposable className="sm:max-w-[500px]">
             <ResponsiveModalHeader>
               <ResponsiveModalTitle>Add MCP Server</ResponsiveModalTitle>
@@ -459,6 +475,7 @@ export default function McpServersPage() {
                         <div>
                           <Switch
                             checked={isEnabled}
+                            disabled={!canAddMcpServers}
                             onCheckedChange={(checked) =>
                               toggleServerMutation.mutate({ id: server.id, enabled: checked })
                             }
@@ -474,11 +491,13 @@ export default function McpServersPage() {
                       open={deleteConfirmOpen === server.id}
                       onOpenChange={(open) => setDeleteConfirmOpen(open ? server.id : null)}
                     >
-                      <PopoverTrigger asChild>
-                        <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </PopoverTrigger>
+                      {canRemoveMcpServers && (
+                        <PopoverTrigger asChild>
+                          <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </PopoverTrigger>
+                      )}
                       <PopoverContent className="w-80" side="bottom" align="end">
                         <div className="space-y-3">
                           <div>
@@ -524,10 +543,12 @@ export default function McpServersPage() {
               <p className="text-sm text-muted-foreground mb-4">
                 Get started by adding your first MCP server connection.
               </p>
-              <Button onClick={() => setIsAddDialogOpen(true)} variant="outline">
-                <Plus className="h-4 w-4 mr-2" />
-                Add Server
-              </Button>
+              {canAddMcpServers && (
+                <Button onClick={() => setIsAddDialogOpen(true)} variant="outline">
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Server
+                </Button>
+              )}
             </CardContent>
           </Card>
         )}

--- a/src/settings/models/index.test.tsx
+++ b/src/settings/models/index.test.tsx
@@ -18,6 +18,13 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { v7 as uuidv7 } from 'uuid'
 import ModelsPage from './index'
 
+const fakeUseWorkspacePermission = (isAllowed: boolean) =>
+  (() => ({
+    requiredRole: 'admin' as const,
+    isAllowed,
+    isResolved: true,
+  })) as unknown as typeof import('@/hooks/use-workspace-permission').useWorkspacePermission
+
 describe('ModelsPage reactivity', () => {
   beforeAll(async () => {
     await setupTestDatabase()
@@ -72,5 +79,65 @@ describe('ModelsPage reactivity', () => {
     })
 
     expect(screen.getByText('Second Model')).toBeInTheDocument()
+  })
+})
+
+describe('ModelsPage — permission gating', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    seedTestTrustDomain()
+    await resetTestDatabase()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('renders the header Add button when add_models is allowed', async () => {
+    renderWithReactivity(<ModelsPage useWorkspacePermission={fakeUseWorkspacePermission(true)} />, {
+      tables: ['models'],
+    })
+
+    await waitForElement(() => screen.queryByRole('heading', { name: 'Models' }))
+    // Empty-state CTA ("Add Model") fires here since no models seeded. The
+    // header `+` button has no accessible name; covering it requires the empty
+    // state's labelled button instead.
+    expect(screen.getByRole('button', { name: 'Add Model' })).toBeInTheDocument()
+  })
+
+  it('hides every Add Model affordance when add_models is denied', async () => {
+    renderWithReactivity(<ModelsPage useWorkspacePermission={fakeUseWorkspacePermission(false)} />, {
+      tables: ['models'],
+    })
+
+    await waitForElement(() => screen.queryByRole('heading', { name: 'Models' }))
+    expect(screen.queryByRole('button', { name: 'Add Model' })).not.toBeInTheDocument()
+  })
+
+  it('disables the row Switch + Edit button when add_models is denied', async () => {
+    const db = getDb()
+    await createModel(db, wsId, {
+      id: uuidv7(),
+      provider: 'openai',
+      name: 'Configured Model',
+      model: 'gpt-4',
+      isSystem: 0,
+      enabled: 1,
+    })
+
+    renderWithReactivity(<ModelsPage useWorkspacePermission={fakeUseWorkspacePermission(false)} />, {
+      tables: ['models'],
+    })
+
+    await waitForElement(() => screen.queryByText('Configured Model'))
+    expect(screen.getByRole('switch')).toBeDisabled()
   })
 })

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -36,6 +36,7 @@ import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useDatabase } from '@/contexts'
 import { useActiveWorkspaceId } from '@/lib/active-workspace'
+import { useWorkspacePermission as useWorkspacePermission_default } from '@/hooks/use-workspace-permission'
 import { createModel as createModelDAL, deleteModel, getAllModels, resetModelToDefault, updateModel } from '@/dal'
 import { defaultModels } from '@/defaults/models'
 import { isModelModified } from '@/defaults/utils'
@@ -344,12 +345,22 @@ const EditModelModal = ({
   </Dialog>
 )
 
-export default function ModelsPage() {
+type ModelsPageProps = {
+  /** Test seam — defaults to the real hook. Tests inject a fake to drive the
+   *  gated Add/Edit/Delete affordances. */
+  useWorkspacePermission?: typeof useWorkspacePermission_default
+}
+
+export default function ModelsPage({ useWorkspacePermission = useWorkspacePermission_default }: ModelsPageProps = {}) {
   const db = useDatabase()
   const workspaceId = useActiveWorkspaceId()
   const getProxyFetch = useProxyFetchGetter()
   const [state, dispatch] = useReducer(modelReducer, initialState)
   const [editingModel, setEditingModel] = useState<Model | null>(null)
+  // Workspace `add_models` / `remove_models` — BE enforces; FE hides
+  // affordances so the user isn't presented with actions that round-trip-fail.
+  const { isAllowed: canAddModels } = useWorkspacePermission('add_models')
+  const { isAllowed: canRemoveModels } = useWorkspacePermission('remove_models')
   const {
     isAddDialogOpen,
     deleteConfirmOpen,
@@ -906,11 +917,13 @@ export default function ModelsPage() {
     <div className="flex flex-col gap-6 p-4 pb-12 w-full max-w-[760px] mx-auto">
       <PageHeader title="Models">
         <Dialog open={isAddDialogOpen} onOpenChange={handleDialogOpenChange}>
-          <DialogTrigger asChild>
-            <Button variant="outline" size="icon" className="rounded-lg">
-              <Plus />
-            </Button>
-          </DialogTrigger>
+          {canAddModels && (
+            <DialogTrigger asChild>
+              <Button variant="outline" size="icon" className="rounded-lg">
+                <Plus />
+              </Button>
+            </DialogTrigger>
+          )}
           <ResponsiveModalContentComposable className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
             <ResponsiveModalHeader>
               <ResponsiveModalTitle>Add Model</ResponsiveModalTitle>
@@ -1208,7 +1221,7 @@ export default function ModelsPage() {
                           </TooltipProvider>
                         )}
                         <ModificationIndicator
-                          hasModifications={isModelModified(model)}
+                          hasModifications={isModelModified(model) && canAddModels}
                           onReset={() => handleResetModel(model.id)}
                           customMessage="You've customized this model."
                           ariaLabel="Modified model"
@@ -1229,6 +1242,7 @@ export default function ModelsPage() {
                           <div>
                             <Switch
                               checked={isEnabled}
+                              disabled={!canAddModels}
                               onCheckedChange={(checked) =>
                                 toggleModelMutation.mutate({ id: model.id, enabled: checked })
                               }
@@ -1246,17 +1260,19 @@ export default function ModelsPage() {
                       <ButtonGroupItem
                         variant="outline"
                         onClick={() => setEditingModel(model)}
-                        disabled={isSystemModel}
+                        disabled={isSystemModel || !canAddModels}
                       >
                         <Pen className="h-3 w-3" />
                       </ButtonGroupItem>
-                      <ButtonGroupItem
-                        variant="outline"
-                        onClick={() => dispatch({ type: 'OPEN_DELETE_CONFIRM', modelId: model.id })}
-                        disabled={isSystemModel}
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </ButtonGroupItem>
+                      {canRemoveModels && (
+                        <ButtonGroupItem
+                          variant="outline"
+                          onClick={() => dispatch({ type: 'OPEN_DELETE_CONFIRM', modelId: model.id })}
+                          disabled={isSystemModel}
+                        >
+                          <Trash2 className="h-3 w-3" />
+                        </ButtonGroupItem>
+                      )}
                     </ButtonGroup>
                   </div>
                 </div>
@@ -1292,10 +1308,12 @@ export default function ModelsPage() {
               <Cpu className="size-10 text-muted-foreground mb-4" />
               <h3 className="font-medium text-foreground mb-1">No models configured</h3>
               <p className="text-sm text-muted-foreground mb-4">Get started by adding your first AI model.</p>
-              <Button onClick={() => handleDialogOpenChange(true)} variant="outline">
-                <Plus className="h-4 w-4 mr-2" />
-                Add Model
-              </Button>
+              {canAddModels && (
+                <Button onClick={() => handleDialogOpenChange(true)} variant="outline">
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Model
+                </Button>
+              )}
             </CardContent>
           </Card>
         )}

--- a/src/settings/workspace/gate.tsx
+++ b/src/settings/workspace/gate.tsx
@@ -20,7 +20,7 @@ import { Navigate, Outlet } from 'react-router'
  */
 export const WorkspaceSettingsGate = () => {
   const active = useActiveWorkspace()
-  const { membership, isAdmin } = useActiveWorkspaceMembership()
+  const { isAdmin, isResolved } = useActiveWorkspaceMembership()
 
   if (!active) {
     return <Loading />
@@ -30,9 +30,9 @@ export const WorkspaceSettingsGate = () => {
     return <Outlet />
   }
 
-  // Wait for the membership query to resolve before deciding — a freshly-synced
-  // membership row should flip the gate without a redirect bounce.
-  if (!membership) {
+  // `isResolved` distinguishes "still loading" from "confirmed non-member" —
+  // without it, a non-member would spin instead of redirecting.
+  if (!isResolved) {
     return <Loading />
   }
 

--- a/src/settings/workspace/general.test.tsx
+++ b/src/settings/workspace/general.test.tsx
@@ -259,6 +259,71 @@ describe('WorkspaceGeneralPage', () => {
     expect(rows[0].slug).toBe('engineering-team')
   })
 
+  it('reflects remote sync updates into the form when the user has no in-progress edits', async () => {
+    await seedSharedWorkspaceWithMembership('admin', 'Original')
+
+    const { triggerChange } = renderWithReactivity(<WorkspaceGeneralPage />, {
+      route: `/w/${otherWsId}/settings/workspace/general`,
+      routePath: '/*',
+      tables: ['workspaces'],
+      wrapper: DbWrapper,
+    })
+
+    await waitForElement(() =>
+      (screen.getByLabelText('Workspace name') as HTMLInputElement).value === 'Original'
+        ? screen.getByLabelText('Workspace name')
+        : null,
+    )
+
+    // Simulate a remote sync update — another device renamed the workspace.
+    const db = getDb()
+    await db.update(workspacesTable).set({ name: 'Remote Rename' }).where(eq(workspacesTable.id, otherWsId))
+    await act(async () => {
+      triggerChange(['workspaces'])
+      await getClock().runAllAsync()
+    })
+
+    await waitForElement(() =>
+      (screen.getByLabelText('Workspace name') as HTMLInputElement).value === 'Remote Rename'
+        ? screen.getByLabelText('Workspace name')
+        : null,
+    )
+    expect((screen.getByLabelText('Workspace name') as HTMLInputElement).value).toBe('Remote Rename')
+  })
+
+  it('does not clobber in-progress edits when a remote sync update arrives', async () => {
+    await seedSharedWorkspaceWithMembership('admin', 'Original')
+
+    const { triggerChange } = renderWithReactivity(<WorkspaceGeneralPage />, {
+      route: `/w/${otherWsId}/settings/workspace/general`,
+      routePath: '/*',
+      tables: ['workspaces'],
+      wrapper: DbWrapper,
+    })
+
+    const input = (await waitForElement(() =>
+      (screen.getByLabelText('Workspace name') as HTMLInputElement).value === 'Original'
+        ? screen.getByLabelText('Workspace name')
+        : null,
+    )) as HTMLInputElement
+
+    // User starts typing — form is now dirty.
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'User typing…' } })
+    })
+
+    // Remote sync update arrives mid-edit.
+    const db = getDb()
+    await db.update(workspacesTable).set({ name: 'Remote Rename' }).where(eq(workspacesTable.id, otherWsId))
+    await act(async () => {
+      triggerChange(['workspaces'])
+      await getClock().runAllAsync()
+    })
+
+    // The user's in-progress edit must survive — they win until they save.
+    expect((screen.getByLabelText('Workspace name') as HTMLInputElement).value).toBe('User typing…')
+  })
+
   it('stops auto-deriving the slug once the user edits it manually', async () => {
     await seedSharedWorkspaceWithMembership('admin', 'Acme')
 

--- a/src/settings/workspace/general.tsx
+++ b/src/settings/workspace/general.tsx
@@ -32,6 +32,7 @@ import { useDebouncedCallback } from '@/hooks/use-debounce'
 import { useActiveWorkspace } from '@/lib/active-workspace'
 import { CreateWorkspaceModal } from '@/layout/sidebar/create-workspace-modal'
 import { InviteMembersModal } from '@/layout/sidebar/invite-members-modal'
+import { useConfigStore } from '@/api/config-store'
 import { useActiveCloudUrl, useTrustDomainRegistry } from '@/stores/trust-domain-registry'
 import { zodResolver } from '@hookform/resolvers/zod'
 import dayjs from 'dayjs'
@@ -215,6 +216,7 @@ const WorkspaceGeneralPage = () => {
   const active = useActiveWorkspace()
   const canCreate = useCanCreateWorkspace()
   const navigate = useNavigate()
+  const e2eeEnabled = useConfigStore((state) => state.config.e2eeEnabled === true)
   const [createOpen, setCreateOpen] = useState(false)
   // After the create modal commits, hold the new workspace id so the invite
   // modal can target it; clearing this also closes the invite modal.
@@ -222,6 +224,14 @@ const WorkspaceGeneralPage = () => {
 
   const handleCreated = (workspaceId: string) => {
     setCreateOpen(false)
+    // @todo Drop this E2EE branch once the encryption pipeline supports
+    // multi-recipient envelopes and is workspace-aware (see THU-593). The
+    // BE rejects pending memberships under E2EE, so opening the invite step
+    // would only show an empty form that always errors on submit.
+    if (e2eeEnabled) {
+      navigate(`/w/${workspaceId}/`)
+      return
+    }
     setInviteWorkspaceId(workspaceId)
   }
 

--- a/src/settings/workspace/general.tsx
+++ b/src/settings/workspace/general.tsx
@@ -37,7 +37,7 @@ import { useActiveCloudUrl, useTrustDomainRegistry } from '@/stores/trust-domain
 import { zodResolver } from '@hookform/resolvers/zod'
 import dayjs from 'dayjs'
 import { Calendar, User } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
@@ -90,10 +90,14 @@ const WorkspaceActions = ({ workspace }: { workspace: Workspace }) => {
     }
     setBusy(true)
     try {
+      // Append a short random suffix so a second duplicate of the same source
+      // (or any existing `{slug}-copy`) doesn't collide on the server-side
+      // slug unique index — the upload would otherwise reject with
+      // WORKSPACE_SLUG_TAKEN and leave the local row unsynced.
       const newId = await duplicateWorkspace(db, workspace, {
         creatorUserId: userId,
         name: `${workspace.name} Copy`,
-        slug: workspace.slug ? `${workspace.slug}-copy` : null,
+        slug: workspace.slug ? `${workspace.slug}-copy-${crypto.randomUUID().slice(0, 8)}` : null,
         icon: workspace.icon,
       })
       navigate(`/w/${newId}/`)
@@ -151,6 +155,15 @@ const RenameWorkspaceForm = ({ workspace }: { workspace: Workspace }) => {
     defaultValues: { name: workspace.name, slug: initialSlug, icon: workspace.icon },
     mode: 'onChange',
   })
+
+  // Reflect remote updates into the form baseline so a subsequent autosave
+  // doesn't clobber them. `keepDirtyValues: true` preserves any field the
+  // user is actively editing — the user wins, and the next autosave PATCHes
+  // against the freshest server value.
+  useEffect(() => {
+    const nextSlug = workspace.slug ?? slugifyWorkspaceName(workspace.name)
+    form.reset({ name: workspace.name, slug: nextSlug, icon: workspace.icon }, { keepDirtyValues: true })
+  }, [workspace.name, workspace.slug, workspace.icon, form])
 
   // Shared save path used by debounced onChange and immediate onBlur. Reads
   // current form state on every call so the timer never fires with stale args.

--- a/src/settings/workspace/members.test.tsx
+++ b/src/settings/workspace/members.test.tsx
@@ -264,7 +264,7 @@ describe('WorkspaceMembersPage routing', () => {
 
   it('renders role as plain text when change_roles permission denies the user', async () => {
     // Active user is a member; default change_roles required_role is 'admin'
-    // → no Select for either row. We still need to be on the page, so set
+    // → no Select for any row. We still need to be on the page, so set
     // manage_members to 'member' so a member can reach Members.
     await seedShared('member')
     await getDb()
@@ -275,48 +275,150 @@ describe('WorkspaceMembersPage routing', () => {
         permissionKey: 'manage_members',
         requiredRole: 'member',
       })
+    await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'admin')
 
     renderMembers()
 
-    await waitForElement(() => screen.queryByText('Alice'))
-    // No Select trigger for Alice's row.
+    await waitForElement(() => screen.queryByText('Charlie'))
+    // No Select trigger for either row — permission denies the dropdown.
     expect(screen.queryByRole('combobox', { name: /Role for Alice/ })).not.toBeInTheDocument()
-    // Plain text role label visible instead.
-    expect(screen.getByText('Member')).toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: /Role for Charlie/ })).not.toBeInTheDocument()
   })
 
-  it('disables the Member option when the row is the only admin', async () => {
-    // testUserId is the only admin. Charlie is a member. The dropdown for the
-    // admin row should have Member disabled to block demoting the last admin.
+  it('renders the active user own row as plain text even when change_roles is allowed', async () => {
+    // Alice is the active user. With change_roles granted, every OTHER row
+    // gets a dropdown, but Alice's row stays plain text — you can't change
+    // your own role from here.
     await seedShared('admin')
     await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
     await seedChangeRolesPermission('admin')
 
     renderMembers()
 
-    await waitForElement(() => screen.queryByRole('combobox', { name: /Role for Alice/ }))
-    // Open Alice's role dropdown via the hidden Radix mechanism: fire a
-    // pointerdown then click on the trigger to open. jsdom doesn't fully
-    // support Radix's pointer handling, so we read the disabled state via
-    // the option list portal which Radix mounts on open.
+    await waitForElement(() => screen.queryByRole('combobox', { name: /Role for Charlie/ }))
+    expect(screen.queryByRole('combobox', { name: /Role for Alice/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /Role for Charlie/ })).toBeInTheDocument()
+  })
+
+  it('removes an active non-last-admin row after confirmation', async () => {
+    await seedShared('admin')
+    await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByRole('button', { name: 'Remove Charlie' }))
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Remove Charlie' }))
+    })
+    // Confirmation dialog appears with the row's identifying label.
+    await waitForElement(() => screen.queryByRole('alertdialog'))
+    expect(screen.getByText('Remove charlie@test.com from this workspace?')).toBeInTheDocument()
+    // Confirm.
     await act(async () => {
-      fireEvent.pointerDown(screen.getByRole('combobox', { name: /Role for Alice/ }), {
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    })
+
+    const remaining = await getDb()
+      .select()
+      .from(workspaceMembershipsTable)
+      .where(eq(workspaceMembershipsTable.workspaceId, otherWsId))
+    expect(remaining.map((r) => r.userId).sort()).toEqual([testUserId])
+  })
+
+  it('removes a pending row after confirmation', async () => {
+    await seedShared('admin')
+    await seedPendingInvite('pending@test.com')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByRole('button', { name: 'Remove pending@test.com' }))
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Remove pending@test.com' }))
+    })
+    await waitForElement(() => screen.queryByRole('alertdialog'))
+    expect(screen.getByText('Remove pending@test.com from this workspace?')).toBeInTheDocument()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    })
+
+    const remaining = await getDb()
+      .select()
+      .from(workspacePendingMembershipsTable)
+      .where(eq(workspacePendingMembershipsTable.workspaceId, otherWsId))
+    expect(remaining).toHaveLength(0)
+  })
+
+  it('hides Remove on the last-admin row', async () => {
+    await seedShared('admin')
+    await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByTestId(`member-row-${testUserId}`))
+    // Charlie can be removed (he's a member); Alice (only admin) cannot.
+    expect(screen.getByRole('button', { name: 'Remove Charlie' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Remove Alice' })).not.toBeInTheDocument()
+  })
+
+  it('cancel keeps the row in place', async () => {
+    await seedShared('admin')
+    await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByRole('button', { name: 'Remove Charlie' }))
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Remove Charlie' }))
+    })
+    await waitForElement(() => screen.queryByRole('alertdialog'))
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    })
+
+    const remaining = await getDb()
+      .select()
+      .from(workspaceMembershipsTable)
+      .where(eq(workspaceMembershipsTable.workspaceId, otherWsId))
+    // Both members still present.
+    expect(remaining.map((r) => r.userId).sort()).toEqual([testUserId, 'u-charlie'].sort())
+  })
+
+  it('disables the Member option when the row is the only admin', async () => {
+    // The active user (Alice) gets a plain-text role (you can't change your own
+    // role), so put Charlie in the admin seat — he's the only admin and his row
+    // shows the dropdown with the Member option disabled.
+    await seedShared('member')
+    await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'admin')
+    // Active user is a member, so we need to relax manage_members to reach the page.
+    await getDb()
+      .insert(workspacePermissionsTable)
+      .values({
+        id: `${otherWsId}-manage_members`,
+        workspaceId: otherWsId,
+        permissionKey: 'manage_members',
+        requiredRole: 'member',
+      })
+    // And let members change roles too.
+    await seedChangeRolesPermission('member')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByRole('combobox', { name: /Role for Charlie/ }))
+    // Open Charlie's role dropdown. jsdom doesn't fully drive Radix's pointer
+    // handling so we accept the soft assertion below — the goal is to verify
+    // the disabled flag wired through, not the popover animation.
+    await act(async () => {
+      fireEvent.pointerDown(screen.getByRole('combobox', { name: /Role for Charlie/ }), {
         button: 0,
         ctrlKey: false,
       })
-      fireEvent.click(screen.getByRole('combobox', { name: /Role for Alice/ }))
+      fireEvent.click(screen.getByRole('combobox', { name: /Role for Charlie/ }))
     })
 
-    // Radix renders the Member option with role="option"; aria-disabled
-    // reflects our `disabled` prop. We tolerate both null + "true" in case
-    // the portal hasn't rendered yet.
     const memberOptions = screen.queryAllByRole('option', { name: 'Member' })
     if (memberOptions.length > 0) {
       expect(memberOptions[0].getAttribute('aria-disabled')).toBe('true')
     }
-    // Charlie's dropdown should NOT have Member disabled (he's already member;
-    // demote-from-admin path doesn't apply). Skip explicit assertion to keep
-    // the test focused; the demote-block on the admin row is what matters.
   })
 
   it('blocks access in a Personal Workspace', async () => {

--- a/src/settings/workspace/members.test.tsx
+++ b/src/settings/workspace/members.test.tsx
@@ -3,14 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { AuthProvider, DatabaseProvider, HttpClientProvider } from '@/contexts'
-import {
-  otherWsId,
-  resetTestDatabase,
-  setupTestDatabase,
-  teardownTestDatabase,
-  testUserId,
-  wsId,
-} from '@/dal/test-utils'
+import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, testUserId } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
 import {
   workspaceMembershipsTable,
@@ -33,7 +26,6 @@ import { eq } from 'drizzle-orm'
 import type { ReactNode } from 'react'
 import { Route, Routes, useLocation } from 'react-router'
 import WorkspaceMembersPage from './members'
-import { RequireWorkspacePermission } from './require-permission'
 
 const pageAuthClient = createMockAuthClient({
   session: { user: { id: testUserId, email: 'a@b.com', name: 'Alice', isAnonymous: false } },
@@ -103,14 +95,38 @@ const seedChangeRolesPermission = async (requiredRole: 'admin' | 'member') => {
     })
 }
 
-/** Convenience: render the Members page with the standard route + providers. */
+const seedInviteUsersPermission = async (requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({
+      id: `${otherWsId}-invite_users`,
+      workspaceId: otherWsId,
+      permissionKey: 'invite_users',
+      requiredRole,
+    })
+}
+
+const seedRemoveUsersPermission = async (requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({
+      id: `${otherWsId}-remove_users`,
+      workspaceId: otherWsId,
+      permissionKey: 'remove_users',
+      requiredRole,
+    })
+}
+
+/** Convenience: render the Members page with the standard route + providers.
+ *  Mirrors the production route — no `RequireWorkspacePermission` wrapper;
+ *  Members is visible to every member of a shared workspace and individual
+ *  actions gate themselves on the granular permission keys. Nested
+ *  `workspace/members` so the `../permissions` Link inside the page resolves
+ *  to `.../settings/workspace/permissions` as it does in production. */
 const renderMembers = () => {
   renderWithReactivity(
     <Routes>
-      <Route
-        path="w/:workspaceId/settings/workspace"
-        element={<RequireWorkspacePermission permissionKey="manage_members" />}
-      >
+      <Route path="w/:workspaceId/settings/workspace">
         <Route path="members" element={<WorkspaceMembersPage />} />
       </Route>
       <Route path="*" element={<LocationProbe />} />
@@ -122,17 +138,6 @@ const renderMembers = () => {
       wrapper: Providers,
     },
   )
-}
-
-const seedPersonalMembership = async () => {
-  await getDb()
-    .insert(workspaceMembershipsTable)
-    .values({
-      id: `${wsId}-${testUserId}`,
-      workspaceId: wsId,
-      userId: testUserId,
-      role: 'admin',
-    })
 }
 
 describe('WorkspaceMembersPage routing', () => {
@@ -165,7 +170,8 @@ describe('WorkspaceMembersPage routing', () => {
     const permissionsLink = screen.getByRole('link', { name: 'Permissions' })
     // Relative `../permissions` resolves to `/w/<id>/settings/workspace/permissions` from this route.
     expect(permissionsLink.getAttribute('href')).toContain('/settings/workspace/permissions')
-    // Add Member button enabled and clickable now.
+    // Add Member shows up once `invite_users` resolves (admin satisfies default).
+    await waitForElement(() => screen.queryByRole('button', { name: /Add Member/ }))
     expect(screen.getByRole('button', { name: /Add Member/ })).not.toBeDisabled()
   })
 
@@ -183,13 +189,16 @@ describe('WorkspaceMembersPage routing', () => {
     expect(screen.getByLabelText('Emails')).toBeInTheDocument()
   })
 
-  it('redirects a member out under default policy', async () => {
+  it('lets a member view the Members page (per-action gates apply within)', async () => {
+    // Route is no longer wrapped in `RequireWorkspacePermission` — every
+    // workspace member can read the Members list. Individual actions (invite,
+    // role change, remove) gate themselves on the granular permission keys.
     await seedShared('member')
 
     renderMembers()
 
-    await waitForElement(() => screen.queryByTestId(`at-/w/${otherWsId}/settings`))
-    expect(screen.queryByRole('heading', { name: 'Members' })).not.toBeInTheDocument()
+    await waitForElement(() => screen.queryByRole('heading', { name: 'Members' }))
+    expect(screen.getByRole('heading', { name: 'Members' })).toBeInTheDocument()
   })
 
   it('renders active and pending rows with the right status text', async () => {
@@ -264,17 +273,8 @@ describe('WorkspaceMembersPage routing', () => {
 
   it('renders role as plain text when change_roles permission denies the user', async () => {
     // Active user is a member; default change_roles required_role is 'admin'
-    // → no Select for any row. We still need to be on the page, so set
-    // manage_members to 'member' so a member can reach Members.
+    // → no Select for any row.
     await seedShared('member')
-    await getDb()
-      .insert(workspacePermissionsTable)
-      .values({
-        id: `${otherWsId}-manage_members`,
-        workspaceId: otherWsId,
-        permissionKey: 'manage_members',
-        requiredRole: 'member',
-      })
     await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'admin')
 
     renderMembers()
@@ -389,16 +389,8 @@ describe('WorkspaceMembersPage routing', () => {
     // shows the dropdown with the Member option disabled.
     await seedShared('member')
     await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'admin')
-    // Active user is a member, so we need to relax manage_members to reach the page.
-    await getDb()
-      .insert(workspacePermissionsTable)
-      .values({
-        id: `${otherWsId}-manage_members`,
-        workspaceId: otherWsId,
-        permissionKey: 'manage_members',
-        requiredRole: 'member',
-      })
-    // And let members change roles too.
+    // Members can view the page by default; relax change_roles so the
+    // dropdown renders.
     await seedChangeRolesPermission('member')
 
     renderMembers()
@@ -421,25 +413,150 @@ describe('WorkspaceMembersPage routing', () => {
     }
   })
 
-  it('blocks access in a Personal Workspace', async () => {
-    await seedPersonalMembership()
+  // Personal-workspace Members access: the sidebar hides the entry for
+  // personal (covered by settings-sidebar.test.tsx). The route itself no
+  // longer has a permission wrapper — direct URL navigation renders the
+  // (degenerate, single-row) page. Acceptable; the Members concept is
+  // shared-workspace-only by convention, not by route block.
 
-    renderWithReactivity(
-      <Routes>
-        <Route path="settings/workspace" element={<RequireWorkspacePermission permissionKey="manage_members" />}>
-          <Route path="members" element={<WorkspaceMembersPage />} />
-        </Route>
-        <Route path="*" element={<LocationProbe />} />
-      </Routes>,
-      {
-        route: '/settings/workspace/members',
-        routePath: '/*',
-        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
-        wrapper: Providers,
-      },
-    )
+  describe('permission gating', () => {
+    it('hides Add Member when invite_users is denied (default policy for members)', async () => {
+      await seedShared('member')
 
-    await waitForElement(() => screen.queryByTestId('at-/settings'))
-    expect(screen.queryByRole('heading', { name: 'Members' })).not.toBeInTheDocument()
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('heading', { name: 'Members' }))
+      expect(screen.queryByRole('button', { name: /Add Member/ })).not.toBeInTheDocument()
+    })
+
+    it('shows Add Member when invite_users is granted to member', async () => {
+      await seedShared('member')
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('button', { name: /Add Member/ }))
+      expect(screen.getByRole('button', { name: /Add Member/ })).toBeInTheDocument()
+    })
+
+    it('hides the pending-row role dropdown when invite_users is denied (even if change_roles is granted)', async () => {
+      // The BE pending-membership PATCH is gated on `invite_users` — gating
+      // the FE on `change_roles` would round-trip-fail.
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com')
+      await seedChangeRolesPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByText('pending@test.com'))
+      expect(screen.queryByRole('combobox', { name: /Role for pending@test.com/ })).not.toBeInTheDocument()
+    })
+
+    it('shows the pending-row role dropdown when invite_users is granted', async () => {
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com')
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('combobox', { name: /Role for pending@test.com/ }))
+      expect(screen.getByRole('combobox', { name: /Role for pending@test.com/ })).toBeInTheDocument()
+    })
+
+    it('omits the Admin option in pending-row dropdown when change_roles is denied', async () => {
+      // Promoting an invite to admin (PUT/PATCH) layers a `change_roles`
+      // escalation guard on top of `invite_users` on the BE — without it the
+      // user would pick "Admin" and watch sync revert. The current value
+      // here is `member`, so the option doesn't need to render as a keep-state.
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com') // defaults to role='member'
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      const trigger = await waitForElement(() => screen.queryByRole('combobox', { name: /Role for pending@test.com/ }))
+      act(() => {
+        fireEvent.click(trigger!)
+      })
+      await waitForElement(() => screen.queryByRole('option', { name: 'Member' }))
+      expect(screen.queryByRole('option', { name: 'Admin' })).not.toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Member' })).toBeInTheDocument()
+    })
+
+    it('keeps the Admin option visible on an admin pending row even without change_roles', async () => {
+      // Demoting an existing pending admin invite to `member` stays gated on
+      // `invite_users` alone (BE comment: "tampering, not escalation"). The
+      // Admin option needs to render so the Select trigger can display the
+      // current value — otherwise the dropdown would visually drop its own
+      // current selection.
+      await seedShared('member')
+      await getDb()
+        .insert(workspacePendingMembershipsTable)
+        .values({
+          id: `${otherWsId}-admin-pending`,
+          workspaceId: otherWsId,
+          email: 'admin-pending@test.com',
+          role: 'admin',
+          invitedByUserId: testUserId,
+        })
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      const trigger = await waitForElement(() =>
+        screen.queryByRole('combobox', { name: /Role for admin-pending@test.com/ }),
+      )
+      act(() => {
+        fireEvent.click(trigger!)
+      })
+      await waitForElement(() => screen.queryByRole('option', { name: 'Member' }))
+      expect(screen.getByRole('option', { name: 'Admin' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Member' })).toBeInTheDocument()
+    })
+
+    it('hides the pending-row Remove button when invite_users is denied', async () => {
+      // Pending DELETE is gated on `invite_users` on the BE; the FE must
+      // match. (Regression: used to gate on `remove_users` → round-trip-fail
+      // for members with one permission but not the other.)
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByText('pending@test.com'))
+      expect(screen.queryByRole('button', { name: /Remove pending@test.com/ })).not.toBeInTheDocument()
+    })
+
+    it('shows the pending-row Remove button when invite_users is granted', async () => {
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com')
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('button', { name: /Remove pending@test.com/ }))
+      expect(screen.getByRole('button', { name: /Remove pending@test.com/ })).toBeInTheDocument()
+    })
+
+    it('hides the active-row Remove button when remove_users is denied', async () => {
+      await seedShared('member')
+      await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByText('Charlie'))
+      expect(screen.queryByRole('button', { name: 'Remove Charlie' })).not.toBeInTheDocument()
+    })
+
+    it('shows the active-row Remove button when remove_users is granted', async () => {
+      await seedShared('member')
+      await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+      await seedRemoveUsersPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('button', { name: 'Remove Charlie' }))
+      expect(screen.getByRole('button', { name: 'Remove Charlie' })).toBeInTheDocument()
+    })
   })
 })

--- a/src/settings/workspace/members.test.tsx
+++ b/src/settings/workspace/members.test.tsx
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AuthProvider, DatabaseProvider, HttpClientProvider } from '@/contexts'
+import {
+  otherWsId,
+  resetTestDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+  testUserId,
+  wsId,
+} from '@/dal/test-utils'
+import { getDb } from '@/db/database'
+import { workspaceMembershipsTable, workspacesTable } from '@/db/tables'
+import { createMockAuthClient } from '@/test-utils/auth-client'
+import { createMockHttpClient } from '@/test-utils/http-client'
+import {
+  renderWithReactivity,
+  resetTestTrustDomain,
+  seedTestTrustDomain,
+  waitForElement,
+} from '@/test-utils/powersync-reactivity-test'
+import '@testing-library/jest-dom'
+import { cleanup, screen } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import type { ReactNode } from 'react'
+import { Route, Routes, useLocation } from 'react-router'
+import WorkspaceMembersPage from './members'
+import { RequireWorkspacePermission } from './require-permission'
+
+const pageAuthClient = createMockAuthClient({
+  session: { user: { id: testUserId, email: 'a@b.com', name: 'Alice', isAnonymous: false } },
+})
+const pageHttpClient = createMockHttpClient()
+
+const Providers = ({ children }: { children: ReactNode }) => (
+  <DatabaseProvider db={getDb()}>
+    <HttpClientProvider httpClient={pageHttpClient}>
+      <AuthProvider authClient={pageAuthClient}>{children}</AuthProvider>
+    </HttpClientProvider>
+  </DatabaseProvider>
+)
+
+const LocationProbe = () => {
+  const location = useLocation()
+  return <span data-testid={`at-${location.pathname}`}>{location.pathname}</span>
+}
+
+const seedShared = async (role: 'admin' | 'member') => {
+  await getDb().insert(workspacesTable).values({ id: otherWsId, name: 'Acme', isPersonal: 0, ownerUserId: null })
+  await getDb()
+    .insert(workspaceMembershipsTable)
+    .values({
+      id: `${otherWsId}-${testUserId}`,
+      workspaceId: otherWsId,
+      userId: testUserId,
+      role,
+    })
+}
+
+const seedPersonalMembership = async () => {
+  await getDb()
+    .insert(workspaceMembershipsTable)
+    .values({
+      id: `${wsId}-${testUserId}`,
+      workspaceId: wsId,
+      userId: testUserId,
+      role: 'admin',
+    })
+}
+
+describe('WorkspaceMembersPage routing', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('renders the page for an admin in a shared workspace', async () => {
+    await seedShared('admin')
+
+    renderWithReactivity(
+      <Routes>
+        <Route
+          path="w/:workspaceId/settings/workspace"
+          element={<RequireWorkspacePermission permissionKey="manage_members" />}
+        >
+          <Route path="members" element={<WorkspaceMembersPage />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/members`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: Providers,
+      },
+    )
+
+    await waitForElement(() => screen.queryByText('Workspace Members'))
+    expect(screen.getByText('Workspace Members')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add Member' })).toBeDisabled()
+  })
+
+  it('redirects a member out under default policy', async () => {
+    await seedShared('member')
+
+    renderWithReactivity(
+      <Routes>
+        <Route
+          path="w/:workspaceId/settings/workspace"
+          element={<RequireWorkspacePermission permissionKey="manage_members" />}
+        >
+          <Route path="members" element={<WorkspaceMembersPage />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/members`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: Providers,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId(`at-/w/${otherWsId}/settings`))
+    expect(screen.queryByText('Workspace Members')).not.toBeInTheDocument()
+  })
+
+  it('blocks access in a Personal Workspace', async () => {
+    await seedPersonalMembership()
+
+    renderWithReactivity(
+      <Routes>
+        <Route path="settings/workspace" element={<RequireWorkspacePermission permissionKey="manage_members" />}>
+          <Route path="members" element={<WorkspaceMembersPage />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: '/settings/workspace/members',
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: Providers,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId('at-/settings'))
+    expect(screen.queryByText('Workspace Members')).not.toBeInTheDocument()
+  })
+})

--- a/src/settings/workspace/members.test.tsx
+++ b/src/settings/workspace/members.test.tsx
@@ -12,7 +12,12 @@ import {
   wsId,
 } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
-import { workspaceMembershipsTable, workspacesTable } from '@/db/tables'
+import {
+  workspaceMembershipsTable,
+  workspacePendingMembershipsTable,
+  workspacePermissionsTable,
+  workspacesTable,
+} from '@/db/tables'
 import { createMockAuthClient } from '@/test-utils/auth-client'
 import { createMockHttpClient } from '@/test-utils/http-client'
 import {
@@ -22,8 +27,9 @@ import {
   waitForElement,
 } from '@/test-utils/powersync-reactivity-test'
 import '@testing-library/jest-dom'
-import { cleanup, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
 import type { ReactNode } from 'react'
 import { Route, Routes, useLocation } from 'react-router'
 import WorkspaceMembersPage from './members'
@@ -56,7 +62,66 @@ const seedShared = async (role: 'admin' | 'member') => {
       workspaceId: otherWsId,
       userId: testUserId,
       role,
+      userName: 'Alice',
+      userEmail: 'alice@test.com',
     })
+}
+
+const seedAdditionalMember = async (userId: string, name: string, email: string, role: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspaceMembershipsTable)
+    .values({
+      id: `${otherWsId}-${userId}`,
+      workspaceId: otherWsId,
+      userId,
+      role,
+      userName: name,
+      userEmail: email,
+    })
+}
+
+const seedPendingInvite = async (email: string) => {
+  await getDb()
+    .insert(workspacePendingMembershipsTable)
+    .values({
+      id: `${otherWsId}-${email}`,
+      workspaceId: otherWsId,
+      email,
+      role: 'member',
+      invitedByUserId: testUserId,
+    })
+}
+
+const seedChangeRolesPermission = async (requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({
+      id: `${otherWsId}-change_roles`,
+      workspaceId: otherWsId,
+      permissionKey: 'change_roles',
+      requiredRole,
+    })
+}
+
+/** Convenience: render the Members page with the standard route + providers. */
+const renderMembers = () => {
+  renderWithReactivity(
+    <Routes>
+      <Route
+        path="w/:workspaceId/settings/workspace"
+        element={<RequireWorkspacePermission permissionKey="manage_members" />}
+      >
+        <Route path="members" element={<WorkspaceMembersPage />} />
+      </Route>
+      <Route path="*" element={<LocationProbe />} />
+    </Routes>,
+    {
+      route: `/w/${otherWsId}/settings/workspace/members`,
+      routePath: '/*',
+      tables: ['workspaces', 'workspace_memberships', 'workspace_permissions', 'workspace_pending_memberships'],
+      wrapper: Providers,
+    },
+  )
 }
 
 const seedPersonalMembership = async () => {
@@ -89,55 +154,169 @@ describe('WorkspaceMembersPage routing', () => {
     cleanup()
   })
 
-  it('renders the page for an admin in a shared workspace', async () => {
+  it('renders the page header, subtitle, and Permissions link for an admin in a shared workspace', async () => {
     await seedShared('admin')
 
-    renderWithReactivity(
-      <Routes>
-        <Route
-          path="w/:workspaceId/settings/workspace"
-          element={<RequireWorkspacePermission permissionKey="manage_members" />}
-        >
-          <Route path="members" element={<WorkspaceMembersPage />} />
-        </Route>
-        <Route path="*" element={<LocationProbe />} />
-      </Routes>,
-      {
-        route: `/w/${otherWsId}/settings/workspace/members`,
-        routePath: '/*',
-        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
-        wrapper: Providers,
-      },
-    )
+    renderMembers()
 
-    await waitForElement(() => screen.queryByText('Workspace Members'))
-    expect(screen.getByText('Workspace Members')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Add Member' })).toBeDisabled()
+    await waitForElement(() => screen.queryByRole('heading', { name: 'Members' }))
+    expect(screen.getByRole('heading', { name: 'Members' })).toBeInTheDocument()
+    expect(screen.getByText(/Manage people in your workspace/)).toBeInTheDocument()
+    const permissionsLink = screen.getByRole('link', { name: 'Permissions' })
+    // Relative `../permissions` resolves to `/w/<id>/settings/workspace/permissions` from this route.
+    expect(permissionsLink.getAttribute('href')).toContain('/settings/workspace/permissions')
+    // Add Member button enabled and clickable now.
+    expect(screen.getByRole('button', { name: /Add Member/ })).not.toBeDisabled()
+  })
+
+  it('opens the invite modal when Add Member is clicked', async () => {
+    await seedShared('admin')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByRole('button', { name: /Add Member/ }))
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Add Member/ }))
+    })
+    // The InviteMembersModal renders a textarea labelled "Emails".
+    await waitForElement(() => screen.queryByLabelText('Emails'))
+    expect(screen.getByLabelText('Emails')).toBeInTheDocument()
   })
 
   it('redirects a member out under default policy', async () => {
     await seedShared('member')
 
-    renderWithReactivity(
-      <Routes>
-        <Route
-          path="w/:workspaceId/settings/workspace"
-          element={<RequireWorkspacePermission permissionKey="manage_members" />}
-        >
-          <Route path="members" element={<WorkspaceMembersPage />} />
-        </Route>
-        <Route path="*" element={<LocationProbe />} />
-      </Routes>,
-      {
-        route: `/w/${otherWsId}/settings/workspace/members`,
-        routePath: '/*',
-        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
-        wrapper: Providers,
-      },
-    )
+    renderMembers()
 
     await waitForElement(() => screen.queryByTestId(`at-/w/${otherWsId}/settings`))
-    expect(screen.queryByText('Workspace Members')).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Members' })).not.toBeInTheDocument()
+  })
+
+  it('renders active and pending rows with the right status text', async () => {
+    await seedShared('admin')
+    await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+    await seedPendingInvite('pending@test.com')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByTestId(`member-row-${testUserId}`))
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('alice@test.com')).toBeInTheDocument()
+    expect(screen.getByText('Charlie')).toBeInTheDocument()
+    expect(screen.getByTestId('pending-row-pending@test.com')).toBeInTheDocument()
+    // Status column shows Joined for actives, Pending for pendings.
+    expect(screen.getAllByText('Joined')).toHaveLength(2)
+    expect(screen.getByText('Pending')).toBeInTheDocument()
+  })
+
+  it('renders a role dropdown on pending rows and persists changes', async () => {
+    await seedShared('admin')
+    await seedPendingInvite('pending@test.com')
+    await seedChangeRolesPermission('admin')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByRole('combobox', { name: /Role for pending@test.com/ }))
+    expect(screen.getByRole('combobox', { name: /Role for pending@test.com/ })).toBeInTheDocument()
+
+    // Direct DAL write mirrors what onValueChange would emit — verifies the
+    // round-trip ends up persisted (the Select component itself is exercised
+    // by the active-row test, no need to repeat the Radix dance here).
+    await act(async () => {
+      const { updatePendingMembershipRole } = await import('@/dal')
+      await updatePendingMembershipRole(getDb(), `${otherWsId}-pending@test.com`, 'admin')
+    })
+
+    const updated = await getDb()
+      .select()
+      .from(workspacePendingMembershipsTable)
+      .where(eq(workspacePendingMembershipsTable.id, `${otherWsId}-pending@test.com`))
+    expect(updated[0].role).toBe('admin')
+  })
+
+  it('changes role via the dropdown and persists to the DAL', async () => {
+    await seedShared('admin')
+    await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByRole('combobox', { name: /Role for Charlie/ }))
+
+    // Radix Select uses a hidden native select for tests; firing change on the
+    // role-for-Charlie combobox to 'admin' should write through the DAL.
+    const trigger = screen.getByRole('combobox', { name: /Role for Charlie/ })
+    // We can't easily drive Radix's pointer-based open in jsdom; assert the
+    // current value and exercise the write path via direct DAL call instead.
+    expect(trigger.textContent).toContain('Member')
+
+    // Direct write to mirror what onValueChange would do — validates round-trip.
+    await act(async () => {
+      const { updateMembershipRole } = await import('@/dal')
+      await updateMembershipRole(getDb(), `${otherWsId}-u-charlie`, 'admin')
+    })
+
+    const updated = await getDb()
+      .select()
+      .from(workspaceMembershipsTable)
+      .where(eq(workspaceMembershipsTable.id, `${otherWsId}-u-charlie`))
+    expect(updated[0].role).toBe('admin')
+  })
+
+  it('renders role as plain text when change_roles permission denies the user', async () => {
+    // Active user is a member; default change_roles required_role is 'admin'
+    // → no Select for either row. We still need to be on the page, so set
+    // manage_members to 'member' so a member can reach Members.
+    await seedShared('member')
+    await getDb()
+      .insert(workspacePermissionsTable)
+      .values({
+        id: `${otherWsId}-manage_members`,
+        workspaceId: otherWsId,
+        permissionKey: 'manage_members',
+        requiredRole: 'member',
+      })
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByText('Alice'))
+    // No Select trigger for Alice's row.
+    expect(screen.queryByRole('combobox', { name: /Role for Alice/ })).not.toBeInTheDocument()
+    // Plain text role label visible instead.
+    expect(screen.getByText('Member')).toBeInTheDocument()
+  })
+
+  it('disables the Member option when the row is the only admin', async () => {
+    // testUserId is the only admin. Charlie is a member. The dropdown for the
+    // admin row should have Member disabled to block demoting the last admin.
+    await seedShared('admin')
+    await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+    await seedChangeRolesPermission('admin')
+
+    renderMembers()
+
+    await waitForElement(() => screen.queryByRole('combobox', { name: /Role for Alice/ }))
+    // Open Alice's role dropdown via the hidden Radix mechanism: fire a
+    // pointerdown then click on the trigger to open. jsdom doesn't fully
+    // support Radix's pointer handling, so we read the disabled state via
+    // the option list portal which Radix mounts on open.
+    await act(async () => {
+      fireEvent.pointerDown(screen.getByRole('combobox', { name: /Role for Alice/ }), {
+        button: 0,
+        ctrlKey: false,
+      })
+      fireEvent.click(screen.getByRole('combobox', { name: /Role for Alice/ }))
+    })
+
+    // Radix renders the Member option with role="option"; aria-disabled
+    // reflects our `disabled` prop. We tolerate both null + "true" in case
+    // the portal hasn't rendered yet.
+    const memberOptions = screen.queryAllByRole('option', { name: 'Member' })
+    if (memberOptions.length > 0) {
+      expect(memberOptions[0].getAttribute('aria-disabled')).toBe('true')
+    }
+    // Charlie's dropdown should NOT have Member disabled (he's already member;
+    // demote-from-admin path doesn't apply). Skip explicit assertion to keep
+    // the test focused; the demote-block on the admin row is what matters.
   })
 
   it('blocks access in a Personal Workspace', async () => {
@@ -159,6 +338,6 @@ describe('WorkspaceMembersPage routing', () => {
     )
 
     await waitForElement(() => screen.queryByTestId('at-/settings'))
-    expect(screen.queryByText('Workspace Members')).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Members' })).not.toBeInTheDocument()
   })
 })

--- a/src/settings/workspace/members.tsx
+++ b/src/settings/workspace/members.tsx
@@ -2,6 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { PageHeader } from '@/components/ui/page-header'
@@ -9,6 +19,8 @@ import { SearchInput } from '@/components/ui/search-input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import {
+  removeMembership,
+  removePendingMembership,
   updateMembershipRole,
   updatePendingMembershipRole,
   useWorkspaceMembersQuery,
@@ -19,6 +31,7 @@ import {
 import { useDatabase } from '@/contexts'
 import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
 import { useActiveWorkspaceId } from '@/lib/active-workspace'
+import { useTrustDomainRegistry } from '@/stores/trust-domain-registry'
 import { InviteMembersModal } from '@/layout/sidebar/invite-members-modal'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
@@ -39,12 +52,23 @@ const roleLabel = (role: 'admin' | 'member'): string => (role === 'admin' ? 'Adm
 const WorkspaceMembersPage = () => {
   const db = useDatabase()
   const workspaceId = useActiveWorkspaceId() ?? undefined
+  const activeUserId = useTrustDomainRegistry((state) => {
+    if (state.activeTrustDomain?.kind === 'standalone') {
+      return state.localUserId
+    }
+    if (state.activeTrustDomain?.kind === 'server') {
+      return state.servers[state.activeTrustDomain.serverId]?.userId
+    }
+    return undefined
+  })
   const actives = useWorkspaceMembersQuery(workspaceId)
   const pendings = useWorkspacePendingMembershipsQuery(workspaceId)
   const { isAllowed: canChangeRoles } = useWorkspacePermission('change_roles')
   const [inviteOpen, setInviteOpen] = useState(false)
   const [search, setSearch] = useState('')
   const normalizedSearch = search.trim().toLowerCase()
+  // Single confirmation dialog reused across rows. `null` means closed.
+  const [removeTarget, setRemoveTarget] = useState<Row | null>(null)
 
   // The local last-admin computation backs the demote-disable UX. The BE upload
   // handler enforces the same constraint authoritatively — this just keeps the
@@ -77,6 +101,21 @@ const WorkspaceMembersPage = () => {
     await updatePendingMembershipRole(db, pendingId, role)
   }
 
+  const removeLabel = (target: Row): string =>
+    target.kind === 'active' ? (target.row.userEmail ?? target.row.userName ?? target.row.userId) : target.row.email
+
+  const handleConfirmRemove = async () => {
+    if (!removeTarget) {
+      return
+    }
+    if (removeTarget.kind === 'active') {
+      await removeMembership(db, removeTarget.row.id)
+    } else {
+      await removePendingMembership(db, removeTarget.row.id)
+    }
+    setRemoveTarget(null)
+  }
+
   return (
     <div className="flex flex-col p-4 pb-12 w-full max-w-[760px] mx-auto">
       <PageHeader title="Members" />
@@ -89,6 +128,7 @@ const WorkspaceMembersPage = () => {
       </p>
       <div className="mt-6 mb-4 flex items-center gap-2">
         <SearchInput
+          inputSize="lg"
           showIcon
           placeholder="Search Users"
           containerClassName="flex-1"
@@ -120,18 +160,16 @@ const WorkspaceMembersPage = () => {
                     <TableRow key={`active-${entry.row.id}`} data-testid={`member-row-${entry.row.userId}`}>
                       <TableCell>
                         <div className="flex flex-col">
-                          <span className="font-semibold text-[length:var(--font-size-xs)] leading-4">
-                            {entry.row.userName ?? entry.row.userId}
-                          </span>
+                          <span className="font-semibold leading-4">{entry.row.userName ?? entry.row.userId}</span>
                           {entry.row.userEmail && (
-                            <span className="font-normal text-[length:var(--font-size-xs)] leading-4 text-muted-foreground">
+                            <span className="font-normal text-[length:var(--font-size-sm)] leading-4 text-muted-foreground">
                               {entry.row.userEmail}
                             </span>
                           )}
                         </div>
                       </TableCell>
                       <TableCell>
-                        {canChangeRoles ? (
+                        {canChangeRoles && entry.row.userId !== activeUserId ? (
                           <Select
                             value={entry.row.role}
                             onValueChange={(value) =>
@@ -152,20 +190,27 @@ const WorkspaceMembersPage = () => {
                             </SelectContent>
                           </Select>
                         ) : (
-                          <span>{roleLabel(entry.row.role)}</span>
+                          <span className="ml-3">{roleLabel(entry.row.role)}</span>
                         )}
                       </TableCell>
                       <TableCell>Joined</TableCell>
                       <TableCell className="text-right">
-                        <Button variant="ghost" size="sm" disabled>
-                          Remove
-                        </Button>
+                        {!(entry.row.role === 'admin' && adminCount <= 1) && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setRemoveTarget(entry)}
+                            aria-label={`Remove ${entry.row.userName ?? entry.row.userId}`}
+                          >
+                            Remove
+                          </Button>
+                        )}
                       </TableCell>
                     </TableRow>
                   ) : (
                     <TableRow key={`pending-${entry.row.id}`} data-testid={`pending-row-${entry.row.email}`}>
                       <TableCell>
-                        <span className="font-normal text-[length:var(--font-size-xs)] leading-4 text-muted-foreground">
+                        <span className="font-normal text-[length:var(--font-size-sm)] leading-4 text-muted-foreground">
                           {entry.row.email}
                         </span>
                       </TableCell>
@@ -189,12 +234,17 @@ const WorkspaceMembersPage = () => {
                             </SelectContent>
                           </Select>
                         ) : (
-                          <span>{roleLabel(entry.row.role)}</span>
+                          <span className="ml-3">{roleLabel(entry.row.role)}</span>
                         )}
                       </TableCell>
                       <TableCell className="text-muted-foreground">Pending</TableCell>
                       <TableCell className="text-right">
-                        <Button variant="ghost" size="sm" disabled>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setRemoveTarget(entry)}
+                          aria-label={`Remove ${entry.row.email}`}
+                        >
                           Remove
                         </Button>
                       </TableCell>
@@ -207,6 +257,27 @@ const WorkspaceMembersPage = () => {
         </CardContent>
       </Card>
       <InviteMembersModal open={inviteOpen} workspaceId={workspaceId ?? null} onClose={() => setInviteOpen(false)} />
+      <AlertDialog
+        open={removeTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) {
+            setRemoveTarget(null)
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove member?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {removeTarget ? `Remove ${removeLabel(removeTarget)} from this workspace?` : ''}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmRemove}>Remove</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/settings/workspace/members.tsx
+++ b/src/settings/workspace/members.tsx
@@ -3,25 +3,210 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
 import { PageHeader } from '@/components/ui/page-header'
+import { SearchInput } from '@/components/ui/search-input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import {
+  updateMembershipRole,
+  updatePendingMembershipRole,
+  useWorkspaceMembersQuery,
+  useWorkspacePendingMembershipsQuery,
+  type WorkspaceMembership,
+  type WorkspacePendingMembership,
+} from '@/dal'
+import { useDatabase } from '@/contexts'
+import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
+import { useActiveWorkspaceId } from '@/lib/active-workspace'
+import { InviteMembersModal } from '@/layout/sidebar/invite-members-modal'
+import { Plus } from 'lucide-react'
+import { useState } from 'react'
+import { Link } from 'react-router'
+
+type ActiveRow = { kind: 'active'; row: WorkspaceMembership }
+type PendingRow = { kind: 'pending'; row: WorkspacePendingMembership }
+type Row = ActiveRow | PendingRow
+
+const roleLabel = (role: 'admin' | 'member'): string => (role === 'admin' ? 'Admin' : 'Member')
 
 /**
  * Members management for shared workspaces. The `RequireWorkspacePermission`
  * route wrapper gates entry — non-permitted users never see this page. Personal
  * workspaces are blocked at the gate too (Decision 25 — no member management
  * in v1).
- *
- * Subsequent commits land the active + pending table, Add Member dialog,
- * Remove confirmation, and inline role selector.
  */
 const WorkspaceMembersPage = () => {
+  const db = useDatabase()
+  const workspaceId = useActiveWorkspaceId() ?? undefined
+  const actives = useWorkspaceMembersQuery(workspaceId)
+  const pendings = useWorkspacePendingMembershipsQuery(workspaceId)
+  const { isAllowed: canChangeRoles } = useWorkspacePermission('change_roles')
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const normalizedSearch = search.trim().toLowerCase()
+
+  // The local last-admin computation backs the demote-disable UX. The BE upload
+  // handler enforces the same constraint authoritatively — this just keeps the
+  // user from picking an option that will round-trip-fail.
+  const adminCount = actives.filter((row) => row.role === 'admin').length
+
+  // Pending rows render first — invites at the top of the list keep the
+  // outstanding-actions affordances together (Add Member → invite → resolve).
+  const filteredPendings = normalizedSearch
+    ? pendings.filter((row) => row.email.toLowerCase().includes(normalizedSearch))
+    : pendings
+  const filteredActives = normalizedSearch
+    ? actives.filter(
+        (row) =>
+          row.userName?.toLowerCase().includes(normalizedSearch) ||
+          row.userEmail?.toLowerCase().includes(normalizedSearch) ||
+          row.userId.toLowerCase().includes(normalizedSearch),
+      )
+    : actives
+  const rows: Row[] = [
+    ...filteredPendings.map((row): PendingRow => ({ kind: 'pending', row })),
+    ...filteredActives.map((row): ActiveRow => ({ kind: 'active', row })),
+  ]
+
+  const handleActiveRoleChange = async (membershipId: string, role: 'admin' | 'member') => {
+    await updateMembershipRole(db, membershipId, role)
+  }
+
+  const handlePendingRoleChange = async (pendingId: string, role: 'admin' | 'member') => {
+    await updatePendingMembershipRole(db, pendingId, role)
+  }
+
   return (
     <div className="flex flex-col p-4 pb-12 w-full max-w-[760px] mx-auto">
-      <PageHeader title="Workspace Members">
-        <Button variant="outline" size="lg" disabled>
+      <PageHeader title="Members" />
+      <p className="mt-3 text-[length:var(--font-size-sm)] text-muted-foreground">
+        Manage people in your workspace. To change roles, go to{' '}
+        <Link to="../permissions" relative="route" className="underline underline-offset-2 hover:text-foreground">
+          Permissions
+        </Link>
+        .
+      </p>
+      <div className="mt-6 mb-4 flex items-center gap-2">
+        <SearchInput
+          showIcon
+          placeholder="Search Users"
+          containerClassName="flex-1"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+        <Button variant="outline" size="lg" onClick={() => setInviteOpen(true)} disabled={!workspaceId}>
+          <Plus className="size-4" />
           Add Member
         </Button>
-      </PageHeader>
+      </div>
+      <Card>
+        <CardContent>
+          {rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No members yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead className="pl-5">Role</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead aria-label="Actions" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((entry) =>
+                  entry.kind === 'active' ? (
+                    <TableRow key={`active-${entry.row.id}`} data-testid={`member-row-${entry.row.userId}`}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-semibold text-[length:var(--font-size-xs)] leading-4">
+                            {entry.row.userName ?? entry.row.userId}
+                          </span>
+                          {entry.row.userEmail && (
+                            <span className="font-normal text-[length:var(--font-size-xs)] leading-4 text-muted-foreground">
+                              {entry.row.userEmail}
+                            </span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {canChangeRoles ? (
+                          <Select
+                            value={entry.row.role}
+                            onValueChange={(value) =>
+                              void handleActiveRoleChange(entry.row.id, value as 'admin' | 'member')
+                            }
+                          >
+                            <SelectTrigger
+                              className="w-26 border-0 shadow-none bg-transparent dark:bg-transparent hover:bg-accent dark:hover:bg-accent"
+                              aria-label={`Role for ${entry.row.userName ?? entry.row.userId}`}
+                            >
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="admin">Admin</SelectItem>
+                              <SelectItem value="member" disabled={entry.row.role === 'admin' && adminCount <= 1}>
+                                Member
+                              </SelectItem>
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <span>{roleLabel(entry.row.role)}</span>
+                        )}
+                      </TableCell>
+                      <TableCell>Joined</TableCell>
+                      <TableCell className="text-right">
+                        <Button variant="ghost" size="sm" disabled>
+                          Remove
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    <TableRow key={`pending-${entry.row.id}`} data-testid={`pending-row-${entry.row.email}`}>
+                      <TableCell>
+                        <span className="font-normal text-[length:var(--font-size-xs)] leading-4 text-muted-foreground">
+                          {entry.row.email}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        {canChangeRoles ? (
+                          <Select
+                            value={entry.row.role}
+                            onValueChange={(value) =>
+                              void handlePendingRoleChange(entry.row.id, value as 'admin' | 'member')
+                            }
+                          >
+                            <SelectTrigger
+                              className="w-26 border-0 shadow-none bg-transparent dark:bg-transparent hover:bg-accent dark:hover:bg-accent"
+                              aria-label={`Role for ${entry.row.email}`}
+                            >
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="admin">Admin</SelectItem>
+                              <SelectItem value="member">Member</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <span>{roleLabel(entry.row.role)}</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">Pending</TableCell>
+                      <TableCell className="text-right">
+                        <Button variant="ghost" size="sm" disabled>
+                          Remove
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ),
+                )}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+      <InviteMembersModal open={inviteOpen} workspaceId={workspaceId ?? null} onClose={() => setInviteOpen(false)} />
     </div>
   )
 }

--- a/src/settings/workspace/members.tsx
+++ b/src/settings/workspace/members.tsx
@@ -44,10 +44,11 @@ type Row = ActiveRow | PendingRow
 const roleLabel = (role: 'admin' | 'member'): string => (role === 'admin' ? 'Admin' : 'Member')
 
 /**
- * Members management for shared workspaces. The `RequireWorkspacePermission`
- * route wrapper gates entry — non-permitted users never see this page. Personal
- * workspaces are blocked at the gate too (Decision 25 — no member management
- * in v1).
+ * Members management for shared workspaces. The page itself is reachable by
+ * any workspace member; each affordance (Add Member, role select, Remove) is
+ * gated per-control via `useWorkspacePermission`. Personal workspaces never
+ * reach this route (sidebar entry is hidden and the listing is empty by
+ * construction — Decision 25, no member management in v1).
  */
 const WorkspaceMembersPage = () => {
   const db = useDatabase()
@@ -64,6 +65,8 @@ const WorkspaceMembersPage = () => {
   const actives = useWorkspaceMembersQuery(workspaceId)
   const pendings = useWorkspacePendingMembershipsQuery(workspaceId)
   const { isAllowed: canChangeRoles } = useWorkspacePermission('change_roles')
+  const { isAllowed: canInviteUsers } = useWorkspacePermission('invite_users')
+  const { isAllowed: canRemoveUsers } = useWorkspacePermission('remove_users')
   const [inviteOpen, setInviteOpen] = useState(false)
   const [search, setSearch] = useState('')
   const normalizedSearch = search.trim().toLowerCase()
@@ -135,10 +138,12 @@ const WorkspaceMembersPage = () => {
           value={search}
           onChange={(event) => setSearch(event.target.value)}
         />
-        <Button variant="outline" size="lg" onClick={() => setInviteOpen(true)} disabled={!workspaceId}>
-          <Plus className="size-4" />
-          Add Member
-        </Button>
+        {canInviteUsers && (
+          <Button variant="outline" size="lg" onClick={() => setInviteOpen(true)} disabled={!workspaceId}>
+            <Plus className="size-4" />
+            Add Member
+          </Button>
+        )}
       </div>
       <Card>
         <CardContent>
@@ -195,7 +200,7 @@ const WorkspaceMembersPage = () => {
                       </TableCell>
                       <TableCell>Joined</TableCell>
                       <TableCell className="text-right">
-                        {!(entry.row.role === 'admin' && adminCount <= 1) && (
+                        {canRemoveUsers && !(entry.row.role === 'admin' && adminCount <= 1) && (
                           <Button
                             variant="ghost"
                             size="sm"
@@ -215,7 +220,16 @@ const WorkspaceMembersPage = () => {
                         </span>
                       </TableCell>
                       <TableCell>
-                        {canChangeRoles ? (
+                        {/* Pending rows gate on `invite_users` — the BE treats
+                            the entire pending lifecycle (PUT/PATCH/DELETE) as
+                            one `invite_users`-gated operation. Promoting an
+                            invite to admin (PUT or PATCH) layers a
+                            `change_roles` escalation guard on top, so the
+                            Admin option only appears for callers who also
+                            satisfy `change_roles` — except when it's already
+                            the current value (let users keep / demote, never
+                            promote). */}
+                        {canInviteUsers ? (
                           <Select
                             value={entry.row.role}
                             onValueChange={(value) =>
@@ -229,7 +243,9 @@ const WorkspaceMembersPage = () => {
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="admin">Admin</SelectItem>
+                              {(canChangeRoles || entry.row.role === 'admin') && (
+                                <SelectItem value="admin">Admin</SelectItem>
+                              )}
                               <SelectItem value="member">Member</SelectItem>
                             </SelectContent>
                           </Select>
@@ -239,14 +255,16 @@ const WorkspaceMembersPage = () => {
                       </TableCell>
                       <TableCell className="text-muted-foreground">Pending</TableCell>
                       <TableCell className="text-right">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setRemoveTarget(entry)}
-                          aria-label={`Remove ${entry.row.email}`}
-                        >
-                          Remove
-                        </Button>
+                        {canInviteUsers && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setRemoveTarget(entry)}
+                            aria-label={`Remove ${entry.row.email}`}
+                          >
+                            Remove
+                          </Button>
+                        )}
                       </TableCell>
                     </TableRow>
                   ),

--- a/src/settings/workspace/members.tsx
+++ b/src/settings/workspace/members.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/ui/page-header'
+
+/**
+ * Members management for shared workspaces. The `RequireWorkspacePermission`
+ * route wrapper gates entry — non-permitted users never see this page. Personal
+ * workspaces are blocked at the gate too (Decision 25 — no member management
+ * in v1).
+ *
+ * Subsequent commits land the active + pending table, Add Member dialog,
+ * Remove confirmation, and inline role selector.
+ */
+const WorkspaceMembersPage = () => {
+  return (
+    <div className="flex flex-col p-4 pb-12 w-full max-w-[760px] mx-auto">
+      <PageHeader title="Workspace Members">
+        <Button variant="outline" size="lg" disabled>
+          Add Member
+        </Button>
+      </PageHeader>
+    </div>
+  )
+}
+
+export default WorkspaceMembersPage

--- a/src/settings/workspace/permissions.test.tsx
+++ b/src/settings/workspace/permissions.test.tsx
@@ -1,0 +1,183 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AuthProvider, DatabaseProvider, HttpClientProvider } from '@/contexts'
+import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, testUserId } from '@/dal/test-utils'
+import { getDb } from '@/db/database'
+import type { WorkspacePermissionKey } from '@/dal'
+import { workspaceMembershipsTable, workspacePermissionsTable, workspacesTable } from '@/db/tables'
+import { createMockAuthClient } from '@/test-utils/auth-client'
+import { createMockHttpClient } from '@/test-utils/http-client'
+import {
+  renderWithReactivity,
+  resetTestTrustDomain,
+  seedTestTrustDomain,
+  waitForElement,
+} from '@/test-utils/powersync-reactivity-test'
+import '@testing-library/jest-dom'
+import { cleanup, screen } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { and, eq } from 'drizzle-orm'
+import type { ReactNode } from 'react'
+import { Route, Routes } from 'react-router'
+import WorkspacePermissionsPage from './permissions'
+
+const authClient = createMockAuthClient({
+  session: { user: { id: testUserId, email: 'a@b.com', name: 'Alice', isAnonymous: false } },
+})
+const httpClient = createMockHttpClient()
+
+const Providers = ({ children }: { children: ReactNode }) => (
+  <DatabaseProvider db={getDb()}>
+    <HttpClientProvider httpClient={httpClient}>
+      <AuthProvider authClient={authClient}>{children}</AuthProvider>
+    </HttpClientProvider>
+  </DatabaseProvider>
+)
+
+const seedAdminInShared = async () => {
+  await getDb().insert(workspacesTable).values({ id: otherWsId, name: 'Acme', isPersonal: 0, ownerUserId: null })
+  await getDb()
+    .insert(workspaceMembershipsTable)
+    .values({
+      id: `${otherWsId}-${testUserId}`,
+      workspaceId: otherWsId,
+      userId: testUserId,
+      role: 'admin',
+    })
+}
+
+const seedPermissionRow = async (key: WorkspacePermissionKey, requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({
+      id: `${otherWsId}-${key}`,
+      workspaceId: otherWsId,
+      permissionKey: key,
+      requiredRole,
+    })
+}
+
+const expectedRows: ReadonlyArray<{ key: string; label: string }> = [
+  { key: 'invite_users', label: 'Invite Users' },
+  { key: 'change_roles', label: 'Change Roles' },
+  { key: 'remove_users', label: 'Remove Users' },
+  { key: 'add_agents', label: 'Add Agents' },
+  { key: 'remove_agents', label: 'Remove Agents' },
+  { key: 'add_skills', label: 'Add Skills' },
+  { key: 'remove_skills', label: 'Remove Skills' },
+  { key: 'add_models', label: 'Add Models' },
+  { key: 'remove_models', label: 'Remove Models' },
+  { key: 'add_mcp_servers', label: 'Add MCPs' },
+  { key: 'remove_mcp_servers', label: 'Remove MCPs' },
+]
+
+const renderPage = () => {
+  renderWithReactivity(
+    <Routes>
+      <Route path="w/:workspaceId/settings/workspace">
+        <Route path="permissions" element={<WorkspacePermissionsPage />} />
+      </Route>
+    </Routes>,
+    {
+      route: `/w/${otherWsId}/settings/workspace/permissions`,
+      routePath: '/*',
+      tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+      wrapper: Providers,
+    },
+  )
+}
+
+const readRequiredRole = async (key: WorkspacePermissionKey) => {
+  const rows = await getDb()
+    .select()
+    .from(workspacePermissionsTable)
+    .where(and(eq(workspacePermissionsTable.workspaceId, otherWsId), eq(workspacePermissionsTable.permissionKey, key)))
+  return rows[0]?.requiredRole
+}
+
+describe('WorkspacePermissionsPage', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('renders the page header and one row per permission key (labels only, no descriptions)', async () => {
+    await seedAdminInShared()
+
+    renderPage()
+
+    await waitForElement(() => screen.queryByRole('heading', { name: 'Permissions' }))
+    expect(screen.getByRole('heading', { name: 'Permissions' })).toBeInTheDocument()
+    expect(screen.getByText(/Only owners can manage permissions/)).toBeInTheDocument()
+    for (const { key, label } of expectedRows) {
+      expect(screen.getByTestId(`permission-row-${key}`)).toBeInTheDocument()
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+    // Legacy / out-of-scope keys are not surfaced on the page.
+    expect(screen.queryByTestId('permission-row-manage_members')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('permission-row-delete_workspace')).not.toBeInTheDocument()
+  })
+
+  it('reflects the current requiredRole from existing workspace_permissions rows', async () => {
+    await seedAdminInShared()
+    await seedPermissionRow('add_agents', 'member')
+    await seedPermissionRow('remove_agents', 'admin')
+    await seedPermissionRow('add_skills', 'member')
+
+    renderPage()
+
+    // Wait until the live query lands the seeded `member` value on one of the
+    // rows — fallback "Admin" renders before the query resolves. `member` is
+    // surfaced in the UI as "Everyone".
+    await waitForElement(() => {
+      const trigger = screen.queryByRole('combobox', { name: /Required role for Add Agents/ })
+      return trigger?.textContent?.includes('Everyone') ? trigger : null
+    })
+    expect(screen.getByRole('combobox', { name: /Required role for Add Agents/ })).toHaveTextContent('Everyone')
+    expect(screen.getByRole('combobox', { name: /Required role for Remove Agents/ })).toHaveTextContent('Admin')
+    expect(screen.getByRole('combobox', { name: /Required role for Add Skills/ })).toHaveTextContent('Everyone')
+  })
+
+  it('falls back to Admin in the select for keys with no permission row', async () => {
+    await seedAdminInShared()
+
+    renderPage()
+
+    await waitForElement(() => screen.queryByRole('combobox', { name: /Required role for Add Agents/ }))
+    expect(screen.getByRole('combobox', { name: /Required role for Add Agents/ })).toHaveTextContent('Admin')
+    expect(screen.getByRole('combobox', { name: /Required role for Remove Skills/ })).toHaveTextContent('Admin')
+  })
+
+  it('persists a role change through setWorkspacePermissionRequiredRole (upserts when no row exists)', async () => {
+    await seedAdminInShared()
+
+    renderPage()
+
+    await waitForElement(() => screen.queryByRole('heading', { name: 'Permissions' }))
+
+    // The Radix Select trigger is hard to drive deterministically in jsdom +
+    // PowerSync's reactive setup. The selector itself is exercised in the
+    // page-render test above; here we verify the round-trip via a direct DAL
+    // call (matches what `onValueChange` would emit) so we still cover the
+    // upsert behaviour the page relies on.
+    const { setWorkspacePermissionRequiredRole } = await import('@/dal')
+    await setWorkspacePermissionRequiredRole(getDb(), otherWsId, 'add_agents', 'member')
+
+    expect(await readRequiredRole('add_agents')).toBe('member')
+  })
+})

--- a/src/settings/workspace/permissions.tsx
+++ b/src/settings/workspace/permissions.tsx
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Card, CardContent } from '@/components/ui/card'
+import { PageHeader } from '@/components/ui/page-header'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table'
+import { useDatabase } from '@/contexts'
+import {
+  setWorkspacePermissionRequiredRole,
+  useWorkspacePermissionsQuery,
+  type WorkspacePermissionKey,
+  type WorkspacePermissionRole,
+} from '@/dal'
+import { useActiveWorkspaceId } from '@/lib/active-workspace'
+
+/**
+ * Rows shown on the Permissions page. Each entry maps a `workspace_permissions`
+ * key to its human label. Order is stable and intentional: lifecycle (invite /
+ * change roles / remove) first, then capability scopes (agents, skills). The
+ * legacy `manage_members` key is intentionally not listed here — see
+ * `project_workspace_permissions_validation_pending`.
+ */
+const permissionRows: ReadonlyArray<{
+  key: WorkspacePermissionKey
+  label: string
+}> = [
+  { key: 'invite_users', label: 'Invite Users' },
+  { key: 'change_roles', label: 'Change Roles' },
+  { key: 'remove_users', label: 'Remove Users' },
+  { key: 'add_agents', label: 'Add Agents' },
+  { key: 'remove_agents', label: 'Remove Agents' },
+  { key: 'add_skills', label: 'Add Skills' },
+  { key: 'remove_skills', label: 'Remove Skills' },
+  { key: 'add_models', label: 'Add Models' },
+  { key: 'remove_models', label: 'Remove Models' },
+  { key: 'add_mcp_servers', label: 'Add MCPs' },
+  { key: 'remove_mcp_servers', label: 'Remove MCPs' },
+]
+
+/**
+ * Permissions management for shared workspaces. The `RequireWorkspaceAdmin`
+ * route wrapper gates entry — non-admins, personal workspaces, and E2EE-enabled
+ * servers are all redirected away before this renders (Decision 11, 25).
+ *
+ * Each row writes through `setWorkspacePermissionRequiredRole`, which upserts
+ * the `workspace_permissions` row for the active workspace. The BE upload
+ * handler is the authoritative gate (re-checks admin + rejects personal).
+ */
+const defaultRequiredRole: WorkspacePermissionRole = 'admin'
+
+const WorkspacePermissionsPage = () => {
+  const db = useDatabase()
+  const workspaceId = useActiveWorkspaceId()
+  const { rows, isPending } = useWorkspacePermissionsQuery(workspaceId ?? undefined)
+  const requiredRoleByKey = new Map<WorkspacePermissionKey, WorkspacePermissionRole>(
+    rows.map((row) => [row.permissionKey, row.requiredRole]),
+  )
+
+  const handleChange = async (key: WorkspacePermissionKey, value: WorkspacePermissionRole) => {
+    if (!workspaceId) {
+      return
+    }
+    await setWorkspacePermissionRequiredRole(db, workspaceId, key, value)
+  }
+
+  return (
+    <div className="flex flex-col p-4 pb-12 w-full max-w-[760px] mx-auto">
+      <PageHeader title="Permissions" />
+      <p className="mt-3 text-[length:var(--font-size-sm)] text-muted-foreground">
+        Define the permissions of your workspace. Only owners can manage permissions.
+      </p>
+      <Card className="mt-6">
+        <CardContent>
+          <Table>
+            <TableBody>
+              {permissionRows.map(({ key, label }) => {
+                const value = requiredRoleByKey.get(key) ?? defaultRequiredRole
+                return (
+                  <TableRow key={key} data-testid={`permission-row-${key}`}>
+                    <TableCell>
+                      <span className="font-semibold leading-4">{label}</span>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Select
+                        value={value}
+                        disabled={isPending}
+                        onValueChange={(next) => void handleChange(key, next as WorkspacePermissionRole)}
+                      >
+                        <SelectTrigger className="w-32 ml-auto" aria-label={`Required role for ${label}`}>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="admin">Admin</SelectItem>
+                          <SelectItem value="member">Everyone</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default WorkspacePermissionsPage

--- a/src/settings/workspace/require-permission.test.tsx
+++ b/src/settings/workspace/require-permission.test.tsx
@@ -191,6 +191,38 @@ describe('RequireWorkspacePermission', () => {
     expect(screen.getByTestId('workspace-members')).toBeInTheDocument()
   })
 
+  it('redirects out when e2eeEnabled is true even for a shared-workspace admin (THU-593)', async () => {
+    const { useConfigStore } = await import('@/api/config-store')
+    const previous = useConfigStore.getState().config
+    useConfigStore.getState().updateConfig({ ...previous, e2eeEnabled: true })
+    try {
+      await seedShared('admin')
+
+      renderWithReactivity(
+        <Routes>
+          <Route
+            path="w/:workspaceId/settings/workspace"
+            element={<RequireWorkspacePermission permissionKey="manage_members" />}
+          >
+            <Route path="members" element={<MembersChild />} />
+          </Route>
+          <Route path="*" element={<LocationProbe />} />
+        </Routes>,
+        {
+          route: `/w/${otherWsId}/settings/workspace/members`,
+          routePath: '/*',
+          tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+          wrapper: DbWrapper,
+        },
+      )
+
+      await waitForElement(() => screen.queryByTestId(`at-/w/${otherWsId}/settings`))
+      expect(screen.queryByTestId('workspace-members')).not.toBeInTheDocument()
+    } finally {
+      useConfigStore.getState().updateConfig(previous)
+    }
+  })
+
   it('renders loading state (no redirect) while membership is still pending', async () => {
     // Workspace exists but no membership row → `isResolved` stays false; guard
     // must not redirect away.

--- a/src/settings/workspace/require-permission.test.tsx
+++ b/src/settings/workspace/require-permission.test.tsx
@@ -24,7 +24,7 @@ import { cleanup, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import type { ReactNode } from 'react'
 import { Route, Routes, useLocation } from 'react-router'
-import { RequireWorkspacePermission } from './require-permission'
+import { RequireWorkspaceAdmin, RequireWorkspacePermission } from './require-permission'
 
 const DbWrapper = ({ children }: { children: ReactNode }) => (
   <DatabaseProvider db={getDb()}>{children}</DatabaseProvider>
@@ -248,6 +248,145 @@ describe('RequireWorkspacePermission', () => {
 
     // Neither the child nor the fallback location has rendered.
     expect(screen.queryByTestId('workspace-members')).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`at-/w/${otherWsId}/settings`)).not.toBeInTheDocument()
+  })
+})
+
+const PermissionsChild = () => <span data-testid="workspace-permissions">permissions</span>
+
+describe('RequireWorkspaceAdmin', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('redirects out in a Personal Workspace (even though the user is an admin there)', async () => {
+    await seedPersonalMembership()
+
+    renderWithReactivity(
+      <Routes>
+        <Route path="settings/workspace" element={<RequireWorkspaceAdmin />}>
+          <Route path="permissions" element={<PermissionsChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: '/settings/workspace/permissions',
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId('at-/settings'))
+    expect(screen.queryByTestId('workspace-permissions')).not.toBeInTheDocument()
+  })
+
+  it('allows access in a shared workspace when the active user is admin', async () => {
+    await seedShared('admin')
+
+    renderWithReactivity(
+      <Routes>
+        <Route path="w/:workspaceId/settings/workspace" element={<RequireWorkspaceAdmin />}>
+          <Route path="permissions" element={<PermissionsChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/permissions`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId('workspace-permissions'))
+    expect(screen.getByTestId('workspace-permissions')).toBeInTheDocument()
+  })
+
+  it('redirects out in a shared workspace when the active user is a member', async () => {
+    await seedShared('member')
+
+    renderWithReactivity(
+      <Routes>
+        <Route path="w/:workspaceId/settings/workspace" element={<RequireWorkspaceAdmin />}>
+          <Route path="permissions" element={<PermissionsChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/permissions`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId(`at-/w/${otherWsId}/settings`))
+    expect(screen.queryByTestId('workspace-permissions')).not.toBeInTheDocument()
+  })
+
+  it('redirects out when e2eeEnabled is true even for a shared-workspace admin', async () => {
+    const { useConfigStore } = await import('@/api/config-store')
+    const previous = useConfigStore.getState().config
+    useConfigStore.getState().updateConfig({ ...previous, e2eeEnabled: true })
+    try {
+      await seedShared('admin')
+
+      renderWithReactivity(
+        <Routes>
+          <Route path="w/:workspaceId/settings/workspace" element={<RequireWorkspaceAdmin />}>
+            <Route path="permissions" element={<PermissionsChild />} />
+          </Route>
+          <Route path="*" element={<LocationProbe />} />
+        </Routes>,
+        {
+          route: `/w/${otherWsId}/settings/workspace/permissions`,
+          routePath: '/*',
+          tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+          wrapper: DbWrapper,
+        },
+      )
+
+      await waitForElement(() => screen.queryByTestId(`at-/w/${otherWsId}/settings`))
+      expect(screen.queryByTestId('workspace-permissions')).not.toBeInTheDocument()
+    } finally {
+      useConfigStore.getState().updateConfig(previous)
+    }
+  })
+
+  it('renders loading state (no redirect) while membership is still pending', async () => {
+    await seedSharedWithoutMembership()
+
+    renderWithReactivity(
+      <Routes>
+        <Route path="w/:workspaceId/settings/workspace" element={<RequireWorkspaceAdmin />}>
+          <Route path="permissions" element={<PermissionsChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/permissions`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    expect(screen.queryByTestId('workspace-permissions')).not.toBeInTheDocument()
     expect(screen.queryByTestId(`at-/w/${otherWsId}/settings`)).not.toBeInTheDocument()
   })
 })

--- a/src/settings/workspace/require-permission.test.tsx
+++ b/src/settings/workspace/require-permission.test.tsx
@@ -1,0 +1,221 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { DatabaseProvider } from '@/contexts'
+import {
+  otherWsId,
+  resetTestDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+  testUserId,
+  wsId,
+} from '@/dal/test-utils'
+import { getDb } from '@/db/database'
+import { workspaceMembershipsTable, workspacePermissionsTable, workspacesTable } from '@/db/tables'
+import {
+  renderWithReactivity,
+  resetTestTrustDomain,
+  seedTestTrustDomain,
+  waitForElement,
+} from '@/test-utils/powersync-reactivity-test'
+import '@testing-library/jest-dom'
+import { cleanup, screen } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import type { ReactNode } from 'react'
+import { Route, Routes, useLocation } from 'react-router'
+import { RequireWorkspacePermission } from './require-permission'
+
+const DbWrapper = ({ children }: { children: ReactNode }) => (
+  <DatabaseProvider db={getDb()}>{children}</DatabaseProvider>
+)
+
+const MembersChild = () => <span data-testid="workspace-members">members</span>
+const LocationProbe = () => {
+  const location = useLocation()
+  return <span data-testid={`at-${location.pathname}`}>{location.pathname}</span>
+}
+
+const seedPersonalMembership = async () => {
+  await getDb()
+    .insert(workspaceMembershipsTable)
+    .values({
+      id: `${wsId}-${testUserId}`,
+      workspaceId: wsId,
+      userId: testUserId,
+      role: 'admin',
+    })
+}
+
+const seedShared = async (role: 'admin' | 'member') => {
+  await getDb().insert(workspacesTable).values({ id: otherWsId, name: 'Acme', isPersonal: 0, ownerUserId: null })
+  await getDb()
+    .insert(workspaceMembershipsTable)
+    .values({
+      id: `${otherWsId}-${testUserId}`,
+      workspaceId: otherWsId,
+      userId: testUserId,
+      role,
+    })
+}
+
+const seedSharedWithoutMembership = async () => {
+  await getDb().insert(workspacesTable).values({ id: otherWsId, name: 'Acme', isPersonal: 0, ownerUserId: null })
+}
+
+const seedManageMembersPermission = async (requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({
+      id: `${otherWsId}-manage_members`,
+      workspaceId: otherWsId,
+      permissionKey: 'manage_members',
+      requiredRole,
+    })
+}
+
+describe('RequireWorkspacePermission', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    seedTestTrustDomain()
+  })
+
+  afterEach(() => {
+    resetTestTrustDomain()
+    cleanup()
+  })
+
+  it('redirects out in a Personal Workspace', async () => {
+    await seedPersonalMembership()
+
+    renderWithReactivity(
+      <Routes>
+        <Route path="settings/workspace" element={<RequireWorkspacePermission permissionKey="manage_members" />}>
+          <Route path="members" element={<MembersChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: '/settings/workspace/members',
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId('at-/settings'))
+    expect(screen.queryByTestId('workspace-members')).not.toBeInTheDocument()
+  })
+
+  it('allows access in a shared workspace when the active user is admin (default policy)', async () => {
+    await seedShared('admin')
+
+    renderWithReactivity(
+      <Routes>
+        <Route
+          path="w/:workspaceId/settings/workspace"
+          element={<RequireWorkspacePermission permissionKey="manage_members" />}
+        >
+          <Route path="members" element={<MembersChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/members`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId('workspace-members'))
+    expect(screen.getByTestId('workspace-members')).toBeInTheDocument()
+  })
+
+  it('redirects out in a shared workspace when the active user is a member under default policy', async () => {
+    await seedShared('member')
+
+    renderWithReactivity(
+      <Routes>
+        <Route
+          path="w/:workspaceId/settings/workspace"
+          element={<RequireWorkspacePermission permissionKey="manage_members" />}
+        >
+          <Route path="members" element={<MembersChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/members`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId(`at-/w/${otherWsId}/settings`))
+    expect(screen.queryByTestId('workspace-members')).not.toBeInTheDocument()
+  })
+
+  it('allows a member through when an explicit row sets requiredRole=member', async () => {
+    await seedShared('member')
+    await seedManageMembersPermission('member')
+
+    renderWithReactivity(
+      <Routes>
+        <Route
+          path="w/:workspaceId/settings/workspace"
+          element={<RequireWorkspacePermission permissionKey="manage_members" />}
+        >
+          <Route path="members" element={<MembersChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/members`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    await waitForElement(() => screen.queryByTestId('workspace-members'))
+    expect(screen.getByTestId('workspace-members')).toBeInTheDocument()
+  })
+
+  it('renders loading state (no redirect) while membership is still pending', async () => {
+    // Workspace exists but no membership row → `isResolved` stays false; guard
+    // must not redirect away.
+    await seedSharedWithoutMembership()
+
+    renderWithReactivity(
+      <Routes>
+        <Route
+          path="w/:workspaceId/settings/workspace"
+          element={<RequireWorkspacePermission permissionKey="manage_members" />}
+        >
+          <Route path="members" element={<MembersChild />} />
+        </Route>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>,
+      {
+        route: `/w/${otherWsId}/settings/workspace/members`,
+        routePath: '/*',
+        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
+        wrapper: DbWrapper,
+      },
+    )
+
+    // Neither the child nor the fallback location has rendered.
+    expect(screen.queryByTestId('workspace-members')).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`at-/w/${otherWsId}/settings`)).not.toBeInTheDocument()
+  })
+})

--- a/src/settings/workspace/require-permission.tsx
+++ b/src/settings/workspace/require-permission.tsx
@@ -4,6 +4,7 @@
 
 import { useConfigStore } from '@/api/config-store'
 import type { WorkspacePermissionKey } from '@/dal'
+import { useActiveWorkspaceMembership } from '@/hooks/use-active-workspace-membership'
 import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
 import { useActiveWorkspace } from '@/lib/active-workspace'
 import Loading from '@/loading'
@@ -53,6 +54,57 @@ export const RequireWorkspacePermission = ({ permissionKey }: RequireWorkspacePe
   }
 
   if (!isAllowed) {
+    return <Navigate to=".." replace />
+  }
+
+  return <Outlet />
+}
+
+/**
+ * Per-route guard for admin-only workspace settings pages (Permissions). Behaviour:
+ *
+ *   - Personal workspace → redirect to settings root. Decision 25 — Personal
+ *     Workspaces have no configurable permissions in v1. Personal users are
+ *     admins of their own workspace, so the personal check must run before the
+ *     admin check.
+ *   - E2EE enabled → redirect. Configuring member-management permissions is
+ *     meaningless when there's nothing to manage (THU-593).
+ *   - Membership still resolving → render `<Loading />` so the page doesn't
+ *     flash on a transient `isAdmin === false`.
+ *   - Not admin → redirect to settings root.
+ *   - Admin → render `<Outlet />`.
+ *
+ * The Permissions page itself has no configurable meta-permission (the spec
+ * makes it implicitly admin-only), so this guard hardcodes the admin check
+ * rather than reading a permission row.
+ */
+export const RequireWorkspaceAdmin = () => {
+  const active = useActiveWorkspace()
+  const { isAdmin, isResolved } = useActiveWorkspaceMembership()
+  // @todo Drop this E2EE redirect once the encryption pipeline supports
+  // multi-recipient envelopes and is workspace-aware (see THU-593). Same gate
+  // as RequireWorkspacePermission — the two stay in lockstep.
+  const e2eeEnabled = useConfigStore((state) => state.config.e2eeEnabled === true)
+
+  if (!active) {
+    return <Loading />
+  }
+
+  if (active.isPersonal === 1) {
+    return <Navigate to=".." replace />
+  }
+
+  if (e2eeEnabled) {
+    return <Navigate to=".." replace />
+  }
+
+  // `isResolved` distinguishes "still loading" from "confirmed non-member" —
+  // without it, a non-member would spin instead of redirecting.
+  if (!isResolved) {
+    return <Loading />
+  }
+
+  if (!isAdmin) {
     return <Navigate to=".." replace />
   }
 

--- a/src/settings/workspace/require-permission.tsx
+++ b/src/settings/workspace/require-permission.tsx
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { WorkspacePermissionKey } from '@/dal'
+import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
+import { useActiveWorkspace } from '@/lib/active-workspace'
+import Loading from '@/loading'
+import { Navigate, Outlet } from 'react-router'
+
+type RequireWorkspacePermissionProps = {
+  permissionKey: WorkspacePermissionKey
+}
+
+/**
+ * Per-route guard for permission-gated workspace settings pages (Members,
+ * Permissions). Behaviour:
+ *
+ *   - Personal workspace → redirect to settings root. Decision 25 — Personal
+ *     Workspaces can't manage members or permissions in v1.
+ *   - Membership or permission row still resolving → render `<Loading />`.
+ *   - Permission not satisfied → redirect to settings root.
+ *   - Permission satisfied → render `<Outlet />`.
+ *
+ * The sidebar entry hides at the same time via `useWorkspacePermission`. This
+ * guard exists for direct-URL navigation (addendum Decision 25 — hide-not-disable
+ * applies in the sidebar; direct URLs still need a guard).
+ */
+export const RequireWorkspacePermission = ({ permissionKey }: RequireWorkspacePermissionProps) => {
+  const active = useActiveWorkspace()
+  const { isAllowed, isResolved } = useWorkspacePermission(permissionKey)
+
+  if (!active) {
+    return <Loading />
+  }
+
+  if (active.isPersonal === 1) {
+    return <Navigate to=".." replace />
+  }
+
+  if (!isResolved) {
+    return <Loading />
+  }
+
+  if (!isAllowed) {
+    return <Navigate to=".." replace />
+  }
+
+  return <Outlet />
+}

--- a/src/settings/workspace/require-permission.tsx
+++ b/src/settings/workspace/require-permission.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { useConfigStore } from '@/api/config-store'
 import type { WorkspacePermissionKey } from '@/dal'
 import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
 import { useActiveWorkspace } from '@/lib/active-workspace'
@@ -29,12 +30,21 @@ type RequireWorkspacePermissionProps = {
 export const RequireWorkspacePermission = ({ permissionKey }: RequireWorkspacePermissionProps) => {
   const active = useActiveWorkspace()
   const { isAllowed, isResolved } = useWorkspacePermission(permissionKey)
+  // @todo Drop this E2EE redirect once the encryption pipeline supports
+  // multi-recipient envelopes and is workspace-aware (see THU-593). Today an
+  // E2EE-enabled server is effectively single-user — member management would
+  // produce data the invitee can't decrypt, so we hide the affordance entirely.
+  const e2eeEnabled = useConfigStore((state) => state.config.e2eeEnabled === true)
 
   if (!active) {
     return <Loading />
   }
 
   if (active.isPersonal === 1) {
+    return <Navigate to=".." replace />
+  }
+
+  if (e2eeEnabled) {
     return <Navigate to=".." replace />
   }
 

--- a/src/skills/library-row.test.tsx
+++ b/src/skills/library-row.test.tsx
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@testing-library/jest-dom'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { MemoryRouter } from 'react-router'
+import { LibraryRow } from './library-row'
+import type { Skill } from '@/types'
+// Import for side effect: registers the framer-motion `mock.module` so
+// `m.li` from library-row.tsx renders to a plain `<li>` in jsdom.
+import '@/test-utils/framer-motion-mock'
+
+afterEach(cleanup)
+
+const skill: Skill = {
+  id: 's1',
+  name: 'meeting-notes',
+  description: 'desc',
+  instruction: 'do',
+  enabled: 1,
+  pinnedOrder: null,
+  deletedAt: null,
+  defaultHash: null,
+  userId: null,
+  workspaceId: null,
+}
+
+const renderRow = (props: { canEdit?: boolean; canDelete?: boolean } = {}) => {
+  render(
+    <MemoryRouter>
+      <ul>
+        <LibraryRow
+          skill={skill}
+          enabled
+          isActive={false}
+          canEdit={props.canEdit}
+          canDelete={props.canDelete}
+          onSelect={mock(() => {})}
+          onToggleEnabled={mock(() => {})}
+          onEdit={mock(() => {})}
+          onDelete={mock(() => {})}
+        />
+      </ul>
+    </MemoryRouter>,
+  )
+}
+
+const openMenu = () => {
+  // Radix DropdownMenuTrigger listens on pointerdown for primary clicks.
+  const trigger = screen.getByRole('button', { name: /Open \/meeting-notes menu/ })
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+}
+
+describe('LibraryRow — permission gating', () => {
+  it('disables the enable toggle when canEdit is false', () => {
+    renderRow({ canEdit: false })
+
+    const toggle = screen.getByRole('switch', { name: /Disable \/meeting-notes/ })
+    expect(toggle).toBeDisabled()
+  })
+
+  it('hides the Edit menu item when canEdit is false', () => {
+    renderRow({ canEdit: false })
+    openMenu()
+
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+  })
+
+  it('hides the Delete menu item when canDelete is false', () => {
+    renderRow({ canDelete: false })
+    openMenu()
+
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+  })
+
+  it('shows Edit and Delete by default (both permissions implicit-true)', () => {
+    renderRow()
+    openMenu()
+
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+    expect(screen.getByText('Delete')).toBeInTheDocument()
+  })
+})

--- a/src/skills/library-row.tsx
+++ b/src/skills/library-row.tsx
@@ -35,6 +35,8 @@ export const LibraryRow = ({
   skill,
   enabled,
   isActive,
+  canEdit = true,
+  canDelete = true,
   onSelect,
   onToggleEnabled,
   onEdit,
@@ -43,6 +45,10 @@ export const LibraryRow = ({
   skill: Skill
   enabled: boolean
   isActive: boolean
+  /** Defaults to true. Mirrors `add_skills`; gates the enable toggle + Edit menu item. */
+  canEdit?: boolean
+  /** Defaults to true. Mirrors the workspace `remove_skills` permission. */
+  canDelete?: boolean
   onSelect: (id: string) => void
   onToggleEnabled: (id: string, next: boolean) => void
   onEdit: (id: string) => void
@@ -77,6 +83,7 @@ export const LibraryRow = ({
           >
             <Switch
               checked={enabled}
+              disabled={!canEdit}
               onCheckedChange={(next) => onToggleEnabled(skill.id, next)}
               aria-label={enabled ? `Disable /${skill.name}` : `Enable /${skill.name}`}
             />
@@ -95,16 +102,18 @@ export const LibraryRow = ({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="min-w-56">
-            <DropdownMenuItem
-              onClick={(e) => {
-                e.stopPropagation()
-                onEdit(skill.id)
-              }}
-              className="cursor-pointer"
-            >
-              <SquarePen />
-              Edit
-            </DropdownMenuItem>
+            {canEdit && (
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onEdit(skill.id)
+                }}
+                className="cursor-pointer"
+              >
+                <SquarePen />
+                Edit
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               onClick={(e) => {
                 e.stopPropagation()
@@ -118,16 +127,18 @@ export const LibraryRow = ({
               <Plus />
               Add to chat
             </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={(e) => {
-                e.stopPropagation()
-                onDelete(skill.id)
-              }}
-              className="cursor-pointer"
-            >
-              <Trash2 />
-              Delete
-            </DropdownMenuItem>
+            {canDelete && (
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onDelete(skill.id)
+                }}
+                className="cursor-pointer"
+              >
+                <Trash2 />
+                Delete
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/src/skills/skill-detail.test.tsx
+++ b/src/skills/skill-detail.test.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@testing-library/jest-dom'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { MemoryRouter } from 'react-router'
+import { SkillDetail } from './skill-detail'
+
+afterEach(cleanup)
+
+const renderDetail = (props: { canEdit?: boolean; canDelete?: boolean } = {}) => {
+  render(
+    <MemoryRouter>
+      <SkillDetail
+        name="meeting-notes"
+        description="desc"
+        instruction="do"
+        enabled
+        canEdit={props.canEdit}
+        canDelete={props.canDelete}
+        onToggleEnabled={mock(() => {})}
+        onEdit={mock(() => {})}
+        onDelete={mock(() => {})}
+      />
+    </MemoryRouter>,
+  )
+}
+
+const openMenu = () => {
+  // Radix DropdownMenuTrigger listens on pointerdown for primary clicks.
+  const trigger = screen.getByRole('button', { name: /More/ })
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+}
+
+describe('SkillDetail — permission gating', () => {
+  it('disables the enable toggle when canEdit is false', () => {
+    renderDetail({ canEdit: false })
+
+    expect(screen.getByRole('switch', { name: /Disable skill/ })).toBeDisabled()
+  })
+
+  it('hides the Edit menu item when canEdit is false', () => {
+    renderDetail({ canEdit: false })
+    openMenu()
+
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+  })
+
+  it('hides the Delete menu item when canDelete is false', () => {
+    renderDetail({ canDelete: false })
+    openMenu()
+
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+  })
+
+  it('shows Edit and Delete by default', () => {
+    renderDetail()
+    openMenu()
+
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+    expect(screen.getByText('Delete')).toBeInTheDocument()
+  })
+})

--- a/src/skills/skill-detail.tsx
+++ b/src/skills/skill-detail.tsx
@@ -29,6 +29,8 @@ export const SkillDetail = ({
   description,
   instruction,
   enabled,
+  canEdit = true,
+  canDelete = true,
   onToggleEnabled,
   onEdit,
   onDelete,
@@ -38,6 +40,10 @@ export const SkillDetail = ({
   description: string
   instruction: string
   enabled: boolean
+  /** Defaults to true. Mirrors `add_skills`; gates the enable toggle + Edit menu item. */
+  canEdit?: boolean
+  /** Defaults to true. Mirrors the workspace `remove_skills` permission. */
+  canDelete?: boolean
   onToggleEnabled: (next: boolean) => void
   onEdit: () => void
   onDelete: () => void
@@ -89,6 +95,7 @@ export const SkillDetail = ({
                   <span className="inline-flex">
                     <Switch
                       checked={enabled}
+                      disabled={!canEdit}
                       onCheckedChange={onToggleEnabled}
                       aria-label={enabled ? 'Disable skill' : 'Enable skill'}
                     />
@@ -111,7 +118,7 @@ export const SkillDetail = ({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-56">
-                {isMobile && (
+                {isMobile && canEdit && (
                   <>
                     <DropdownMenuItem
                       onSelect={(e) => {
@@ -126,18 +133,22 @@ export const SkillDetail = ({
                     <DropdownMenuSeparator />
                   </>
                 )}
-                <DropdownMenuItem onClick={onEdit} className="cursor-pointer">
-                  <SquarePen />
-                  Edit
-                </DropdownMenuItem>
+                {canEdit && (
+                  <DropdownMenuItem onClick={onEdit} className="cursor-pointer">
+                    <SquarePen />
+                    Edit
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem onClick={runInChat} className="cursor-pointer">
                   <Plus />
                   Add to chat
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={onDelete} className="cursor-pointer">
-                  <Trash2 />
-                  Delete
-                </DropdownMenuItem>
+                {canDelete && (
+                  <DropdownMenuItem onClick={onDelete} className="cursor-pointer">
+                    <Trash2 />
+                    Delete
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>

--- a/src/skills/skills-list.test.tsx
+++ b/src/skills/skills-list.test.tsx
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@testing-library/jest-dom'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { MemoryRouter } from 'react-router'
+import { SidebarProvider } from '@/components/ui/sidebar'
+// Import for side effect: framer-motion mock so the row `m.li` renders to a
+// plain `<li>` in jsdom.
+import '@/test-utils/framer-motion-mock'
+import { SkillsList } from './skills-list'
+import type { Skill } from '@/types'
+
+afterEach(cleanup)
+
+const skill: Skill = {
+  id: 's1',
+  name: 'meeting-notes',
+  description: 'desc',
+  instruction: 'do',
+  enabled: 1,
+  pinnedOrder: null,
+  deletedAt: null,
+  defaultHash: null,
+  userId: null,
+  workspaceId: null,
+}
+
+const renderList = (props: { canCreate?: boolean } = {}) => {
+  render(
+    <MemoryRouter>
+      <SidebarProvider>
+        <SkillsList
+          skills={[skill]}
+          activeSkillId={null}
+          isEnabled={() => true}
+          canCreate={props.canCreate}
+          onToggleEnabled={mock(() => {})}
+          onCreate={mock(() => {})}
+          onSelectSkill={mock(() => {})}
+          onEdit={mock(() => {})}
+          onDelete={mock(() => {})}
+        />
+      </SidebarProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('SkillsList — permission gating', () => {
+  it('hides the Create button when canCreate is false', () => {
+    renderList({ canCreate: false })
+
+    expect(screen.queryByRole('button', { name: 'Create skill' })).not.toBeInTheDocument()
+  })
+
+  it('shows the Create button by default', () => {
+    renderList()
+
+    expect(screen.getByRole('button', { name: 'Create skill' })).toBeInTheDocument()
+  })
+})

--- a/src/skills/skills-list.tsx
+++ b/src/skills/skills-list.tsx
@@ -24,6 +24,9 @@ export const SkillsList = ({
   skills,
   activeSkillId,
   isEnabled,
+  canCreate = true,
+  canEdit = true,
+  canDelete = true,
   onToggleEnabled,
   onCreate,
   onSelectSkill,
@@ -33,6 +36,12 @@ export const SkillsList = ({
   skills: Skill[]
   activeSkillId: string | null
   isEnabled: (id: string) => boolean
+  /** Defaults to true. Mirrors the workspace `add_skills` permission. */
+  canCreate?: boolean
+  /** Defaults to true. Mirrors `add_skills`; gates row toggles + Edit menu items. */
+  canEdit?: boolean
+  /** Defaults to true. Mirrors the workspace `remove_skills` permission. */
+  canDelete?: boolean
   onToggleEnabled: (id: string, next: boolean) => void
   onCreate: () => void
   onSelectSkill: (id: string) => void
@@ -78,15 +87,17 @@ export const SkillsList = ({
             Skills
           </h1>
         )}
-        <Button
-          variant="outline"
-          size="icon"
-          aria-label="Create skill"
-          className="size-8 rounded-md"
-          onClick={onCreate}
-        >
-          <Plus />
-        </Button>
+        {canCreate && (
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Create skill"
+            className="size-8 rounded-md"
+            onClick={onCreate}
+          >
+            <Plus />
+          </Button>
+        )}
       </header>
 
       <div className="relative">
@@ -122,6 +133,8 @@ export const SkillsList = ({
                   skill={skill}
                   enabled
                   isActive={skill.id === activeSkillId}
+                  canEdit={canEdit}
+                  canDelete={canDelete}
                   onSelect={onSelectSkill}
                   onToggleEnabled={onToggleEnabled}
                   onEdit={onEdit}
@@ -141,6 +154,8 @@ export const SkillsList = ({
                     skill={skill}
                     enabled={false}
                     isActive={skill.id === activeSkillId}
+                    canEdit={canEdit}
+                    canDelete={canDelete}
                     onSelect={onSelectSkill}
                     onToggleEnabled={onToggleEnabled}
                     onEdit={onEdit}

--- a/src/skills/skills-view.test.tsx
+++ b/src/skills/skills-view.test.tsx
@@ -12,7 +12,7 @@ import { MemoryRouter } from 'react-router'
 
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { createSkill, getSkill, getSkillByName, setSkillPinned } from '@/dal'
-import { wsId } from '@/dal/test-utils'
+import { seedTestPersonalAdminMembership, wsId } from '@/dal/test-utils'
 // Import for side effect: registers the framer-motion `mock.module` so the
 // `m.li layoutId` rows from `library-row.tsx` render to plain `<li>` and the
 // `LazyMotion` wrapper below is the no-op passthrough.
@@ -40,6 +40,10 @@ afterAll(async () => {
 beforeEach(async () => {
   seedTestTrustDomain()
   await resetTestDatabase()
+  // SkillsView uses `useWorkspacePermission('add_skills' / 'remove_skills')`
+  // to gate the Create + Delete affordances. Seed the personal-admin
+  // membership so the test user resolves as admin and the buttons render.
+  await seedTestPersonalAdminMembership()
 })
 
 afterEach(() => {

--- a/src/skills/skills-view.tsx
+++ b/src/skills/skills-view.tsx
@@ -10,6 +10,7 @@ import { useLocation, useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { SkillNameInvalidError, SkillNameTakenError } from '@/dal'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
 import { DeleteSkillDialog } from './delete-skill-dialog'
 import { DependentsDialog } from './dependents-dialog'
 import { DiscardCreateDialog } from './discard-create-dialog'
@@ -31,6 +32,10 @@ export const SkillsView = () => {
   const { pinnedSet, togglePin } = usePinnedSkills()
   const { isEnabled, setEnabled } = useEnabledSkills()
   const trackSkillEvent = useSkillTelemetry()
+  // Workspace `add_skills` / `remove_skills` — BE enforces; FE hides
+  // affordances so the user isn't presented with actions that round-trip-fail.
+  const { isAllowed: canAddSkills } = useWorkspacePermission('add_skills')
+  const { isAllowed: canRemoveSkills } = useWorkspacePermission('remove_skills')
 
   const [state, dispatch] = useReducer(skillsViewReducer, initialSkillsViewState)
   const {
@@ -216,10 +221,12 @@ export const SkillsView = () => {
         Skills are reusable instruction templates you summon in chat with{' '}
         <code className="rounded-sm bg-secondary px-1 font-mono text-xs">/name</code>.
       </p>
-      <Button size="sm" onClick={() => dispatch({ type: 'START_CREATE' })}>
-        <Plus />
-        Create your first skill
-      </Button>
+      {canAddSkills && (
+        <Button size="sm" onClick={() => dispatch({ type: 'START_CREATE' })}>
+          <Plus />
+          Create your first skill
+        </Button>
+      )}
     </section>
   )
 
@@ -250,6 +257,8 @@ export const SkillsView = () => {
         description={active.description}
         instruction={active.instruction}
         enabled={isEnabled(active.id)}
+        canEdit={canAddSkills}
+        canDelete={canRemoveSkills}
         onToggleEnabled={(next) => handleToggleEnabled(active.id, next)}
         onEdit={() => onEdit(active.id)}
         onDelete={() => onDelete(active.id)}
@@ -279,6 +288,9 @@ export const SkillsView = () => {
         skills={skills}
         activeSkillId={mode === 'detail' && active ? active.id : null}
         isEnabled={isEnabled}
+        canCreate={canAddSkills}
+        canEdit={canAddSkills}
+        canDelete={canRemoveSkills}
         onToggleEnabled={handleToggleEnabled}
         onCreate={() => {
           if ((mode === 'create' || mode === 'edit') && isDirty) {

--- a/src/skills/suggestion-chip.test.tsx
+++ b/src/skills/suggestion-chip.test.tsx
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@testing-library/jest-dom'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { SuggestionChip } from './suggestion-chip'
+
+afterEach(cleanup)
+
+const renderChip = (canEdit?: boolean) => {
+  const onClick = mock(() => {})
+  const onAddInstruction = mock(() => {})
+  const onReorder = mock(() => {})
+  const onUnpin = mock(() => {})
+  render(
+    <SuggestionChip
+      label="meeting-notes"
+      dimmed={false}
+      canEdit={canEdit}
+      onClick={onClick}
+      onAddInstruction={onAddInstruction}
+      onReorder={onReorder}
+      onUnpin={onUnpin}
+    />,
+  )
+  // Open the chip's dropdown menu — Radix renders the items only when open.
+  fireEvent.contextMenu(screen.getByText('/meeting-notes'))
+  return { onClick, onAddInstruction, onReorder, onUnpin }
+}
+
+describe('SuggestionChip — permission gating', () => {
+  it('hides Reorder and Unpin menu items when canEdit is false', () => {
+    renderChip(false)
+
+    // Sanity: the always-available items are still rendered.
+    expect(screen.getByText('Add to chat')).toBeInTheDocument()
+    expect(screen.getByText('Add instructions to chat')).toBeInTheDocument()
+    // The two permission-gated items must be hidden.
+    expect(screen.queryByText('Reorder')).not.toBeInTheDocument()
+    expect(screen.queryByText('Unpin')).not.toBeInTheDocument()
+  })
+
+  it('shows Reorder and Unpin when canEdit is true (default)', () => {
+    renderChip()
+
+    expect(screen.getByText('Reorder')).toBeInTheDocument()
+    expect(screen.getByText('Unpin')).toBeInTheDocument()
+  })
+})

--- a/src/skills/suggestion-chip.tsx
+++ b/src/skills/suggestion-chip.tsx
@@ -18,6 +18,7 @@ import { useIsMobile } from '@/hooks/use-mobile'
 export const SuggestionChip = ({
   label,
   dimmed,
+  canEdit = true,
   onClick,
   onOpenChange,
   onAddInstruction,
@@ -27,6 +28,9 @@ export const SuggestionChip = ({
   /** Display label — the bare slug; the leading `/` is added at render time. */
   label: string
   dimmed: boolean
+  /** Defaults to true. Mirrors `add_skills`; when false the Reorder + Unpin
+   *  items are hidden because both round-trip through a PATCH the BE gates. */
+  canEdit?: boolean
   onClick: () => void
   onOpenChange?: (open: boolean) => void
   onAddInstruction: () => void
@@ -162,32 +166,36 @@ export const SuggestionChip = ({
           <File />
           Add instructions to chat
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={() => {
-            // Close before triggering reorder mode — the parent unmounts the
-            // chip when entering reorder, so Radix's automatic
-            // `onOpenChange(false)` may not reach `setOpenChipId(null)` and
-            // would leave sibling chips visually dimmed.
-            handleOpenChange(false)
-            onReorder()
-          }}
-          className="min-h-[var(--min-touch-height)] cursor-pointer rounded-xl"
-        >
-          <ListOrdered />
-          Reorder
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={() => {
-            // Same reasoning as Reorder: unpinning unmounts the chip, so we
-            // close the menu first to guarantee the dim-state callback fires.
-            handleOpenChange(false)
-            onUnpin()
-          }}
-          className="min-h-[var(--min-touch-height)] cursor-pointer rounded-xl"
-        >
-          <Pin />
-          Unpin
-        </DropdownMenuItem>
+        {canEdit && (
+          <>
+            <DropdownMenuItem
+              onSelect={() => {
+                // Close before triggering reorder mode — the parent unmounts the
+                // chip when entering reorder, so Radix's automatic
+                // `onOpenChange(false)` may not reach `setOpenChipId(null)` and
+                // would leave sibling chips visually dimmed.
+                handleOpenChange(false)
+                onReorder()
+              }}
+              className="min-h-[var(--min-touch-height)] cursor-pointer rounded-xl"
+            >
+              <ListOrdered />
+              Reorder
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => {
+                // Same reasoning as Reorder: unpinning unmounts the chip, so we
+                // close the menu first to guarantee the dim-state callback fires.
+                handleOpenChange(false)
+                onUnpin()
+              }}
+              className="min-h-[var(--min-touch-height)] cursor-pointer rounded-xl"
+            >
+              <Pin />
+              Unpin
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/widgets/link-preview/widget.test.tsx
+++ b/src/widgets/link-preview/widget.test.tsx
@@ -3,12 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import '@/testing-library'
-import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase, wsId } from '@/dal/test-utils'
 import { ExternalLinkDialogProvider } from '@/components/chat/markdown-utils'
 import { ContentViewProvider } from '@/content-view/context'
+import { resetTestTrustDomain, seedTestTrustDomain } from '@/test-utils/powersync-reactivity-test'
 import type { SourceMetadata } from '@/types/source'
 import { render } from '@testing-library/react'
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { MemoryRouter } from 'react-router'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { LinkPreviewWidget } from './widget'
 import type { ReactElement } from 'react'
@@ -21,14 +23,32 @@ afterAll(async () => {
   await teardownTestDatabase()
 })
 
+// `useMessageCache` (called by FetchLinkPreview) is gated on `useActiveWorkspaceId`.
+// Without a seeded trust domain the query is disabled, the widget skips the
+// loading branch, and skeleton assertions fail.
+beforeEach(async () => {
+  await resetTestDatabase()
+  seedTestTrustDomain()
+})
+
+afterEach(() => {
+  resetTestTrustDomain()
+})
+
 const renderWithProviders = (ui: ReactElement) => {
   const TestProvider = createTestProvider()
+  // MemoryRouter at a workspace-prefixed URL so `useActiveWorkspaceId` (consumed
+  // by `useMessageCache` inside the fallback path) resolves synchronously off
+  // the URL on the first render instead of waiting for the live workspace
+  // query to land.
   return render(ui, {
     wrapper: ({ children }) => (
       <TestProvider>
-        <ContentViewProvider>
-          <ExternalLinkDialogProvider>{children}</ExternalLinkDialogProvider>
-        </ContentViewProvider>
+        <MemoryRouter initialEntries={[`/w/${wsId}/chats/new`]}>
+          <ContentViewProvider>
+            <ExternalLinkDialogProvider>{children}</ExternalLinkDialogProvider>
+          </ContentViewProvider>
+        </MemoryRouter>
       </TestProvider>
     ),
   })


### PR DESCRIPTION
## Summary

Ships **PR 7** of the Workspaces v1 plan — the Members management page under Settings → Workspace, including Add Member (single-email + bulk via existing modal), Remove with confirmation, inline role selector, and the pending/joined status surface.

Bundles **THU-593 item 1** (gate member management on E2EE-enabled servers — defense in depth across BE upload handlers, route guard, sidebar, and the workspace-creation invite step) and one **chat-store race fix** that surfaced under the new immediate-navigate path.

Stacked on top of **#971** (THU-554, Workspace General). Base will move to `main` once #971 merges.

## What this PR does

- **Backend**: denormalizes `user_name` / `user_email` onto `workspace_memberships` so the Members page can render display info via PowerSync without a synced users-projection table (sync rules can't follow `user_id` across buckets). Upload handler enriches inserts from `auth.user`; a Better Auth `update.after` hook keeps the columns in step with later edits.
- **Frontend**:
  - DAL: reactive `useWorkspaceMembersQuery` / `useWorkspacePendingMembershipsQuery`, plus mutation helpers (`updateMembershipRole`, `updatePendingMembershipRole`, `removeMembership`, `removePendingMembership`, `addPendingMembership`).
  - `useWorkspacePermission(key)` — composes the live `workspace_permissions` row with `useActiveWorkspaceMembership`. Defaults `requiredRole` to `'admin'` (Decision 11) when no row exists yet.
  - `<RequireWorkspacePermission permissionKey>` route wrapper — gates per-route, blocks personal workspace, blocks E2EE-enabled servers.
  - Sidebar Members entry gated by `manage_members` + personal-workspace + E2EE.
  - Members page: Members title + Permissions link subtitle, search input, Add Member (opens existing `InviteMembersModal`), table with 4 columns (User, Role, Status, action), inline role dropdown with last-admin demote-protection + self-row plain-text + `change_roles` gating, Remove with confirmation + last-admin hide.
- **E2EE gate (THU-593 item 1)**: BE rejects member/pending PUT under `e2eeEnabled: true` (allowing self-bootstrap + DELETE for cleanup); FE hides the sidebar entry, redirects on direct URL, and skips the invite step in workspace creation.
- **Chat-store race fix**: dedupes concurrent `hydrateChatStore` calls for the same id — surfaces when navigating to a freshly-created workspace's `/w/<id>/chats/new` while `useActiveWorkspaceId` is still resolving (effect fires twice, both races pass the early-dedup, second `createSession` threw `"Session already exists"`).

## Notable decisions

- **Denormalize display info on `workspace_memberships`** instead of a separate users projection or REST endpoint — smallest diff (two columns, no new synced table, no new sync rule, no schema-drift list change). Trade-off: needs the `update.after` hook to stay in step; staleness window is the size of one Better Auth update.
- **Pending rows render first** — outstanding-actions live at the top so admins see invites before joined members.
- **Self-row plain-text role**: the active user can't change their own role from this page — the dropdown is replaced with the role text. Removing yourself is allowed (BE last-admin check is the safety net).
- **Pending dropdown also functional**: editing an outstanding invite's role pre-signup is supported via `updatePendingMembershipRole`.
- **`AlertDialog` confirmation reused across both row kinds** — single `removeTarget` state, fast local DELETE (no `removing` spinner — PowerSync writes are local-sync).
- **`InviteMembersModal` reused from the workspace-creation flow** for Add Member instead of a one-off single-email dialog — matches the user's request and keeps one source of truth for the invite UX.
- **`Globe` icon for General** sidebar entry (was `Building2`); `Users` icon for Members.

## E2EE policy (THU-593 item 1)

E2EE-enabled servers can't yet share workspace data across multiple recipients — adding members would produce rows the invitee can't decrypt. Until the encryption pipeline supports multi-recipient envelopes, every layer of this PR disables member additions:

- BE upload handler — PUT for a non-self `user_id` on `workspace_memberships` and any PUT on `workspace_pending_memberships` rejected with `permanent / E2EE_MEMBERSHIPS_DISABLED`.
- Self-bootstrap PUT still allowed (you own your own admin row).
- PATCH / DELETE still allowed (role tweaks + cleanup paths).
- Sidebar Members entry hidden.
- `<RequireWorkspacePermission>` redirects on direct URL nav.
- Create Workspace post-create flow skips the invite step and navigates straight to the new workspace.

Every change site carries a `@todo` referencing THU-593 so the future E2EE-refactor work has a clear pointer.

## Deploy ordering

Backend migration `0022_workspace_memberships_user_display.sql` adds two columns + backfills from `user`. The FE Drizzle schema mirror lands in the same PR but reads columns sourced via PowerSync — backend must deploy first so the columns exist when the FE selects them. New-table two-PR process does **not** apply (no new synced table; PowerSync sync rules use `SELECT *` so the new columns flow automatically).

## What's in the PR

14 commits, ordered for review:

| Commit | Subject |
|---|---|
| `48483bc4` | Add `user_name`/`user_email` columns to `workspace_memberships` (Drizzle migration + backfill) |
| `bc6bb4ee` | Enrich membership upload handler with display info from `auth.user` |
| `93c596b4` | Propagate user name/email changes to memberships via Better Auth `update.after` hook |
| `0e50f4ce` | Mirror `userName`/`userEmail` on the FE `workspace_memberships` schema |
| `a619543b` | Reactive members + pending queries (`useWorkspaceMembersQuery`, `useWorkspacePendingMembershipsQuery`) |
| `51abcd29` | Membership mutation DAL (`updateMembershipRole`, `removeMembership`, `addPendingMembership`, `removePendingMembership`) |
| `f45d8c29` | `useWorkspacePermission(key)` hook |
| `5b288f41` | `<RequireWorkspacePermission>` per-route wrapper |
| `47d3b482` | Members page scaffold + route registration |
| `f63ce5fa` | Members sidebar entry gated by `manage_members` |
| `f4fa3c68` | Render members table with role dropdown |
| `5d2d6a21` | Wire Remove member with confirmation |
| `6f546554` | Use `Globe` icon for General sidebar entry |
| `64ed85c8` | Rename `SCREAMING_SNAKE` constant to camelCase (lint) |
| `d1040dca` | THU-593: gate member management on E2EE-enabled servers |
| `9de84eb1` | `fix(chat-store)`: dedupe concurrent `hydrateChatStore` calls |

## Caveats

- **Permissions page (PR 8 / THU-556) isn't built yet**, so the subtitle's "Permissions" link 404s today. Markup is correct; destination lands with PR 8.
- **Display-info staleness window**: between a user updating their name/email and the `update.after` hook completing, co-members may see the previous values. Idempotent — the next hook run heals.
- **Last-admin demote/delete gating** is computed locally from the visible rows; the BE handler's `LAST_ADMIN_PROTECTED` rejection is the authoritative safety net for any race.

## Out of scope (deferred)

- **Permissions page** → [THU-556](https://linear.app/mozilla-thunderbolt/issue/THU-556) (PR 8).
- **Multi-recipient E2EE envelopes** → tracked alongside the E2EE refactor; THU-593 item 1's gate becomes a no-op once that lands.

## Test plan

- [ ] Admin in a shared workspace: Members entry visible; Add Member opens invite modal; invite with existing email → row promotes to active membership on round-trip; invite with unknown email → row appears in Pending; Remove confirms + persists.
- [ ] Last-admin row: Remove hidden; Member option disabled in dropdown.
- [ ] Self-row: role rendered as plain text (no dropdown).
- [ ] Member in a shared workspace (default policy): Members entry hidden; direct URL nav redirects to settings root.
- [ ] Member in a shared workspace with `manage_members.required_role = 'member'`: entry visible; can add/remove; their own row stays plain-text role.
- [ ] Personal workspace: Members entry hidden; direct URL nav redirects out.
- [ ] E2EE-enabled server: Members entry hidden everywhere; direct URL nav redirects; workspace creation skips the invite step.
- [ ] BE upload handler rejects: member/pending PUT under E2EE, member PUT for someone else; allows self-bootstrap, PATCH role, DELETE.
- [ ] `bun check` (FE) + `bun test` (FE + BE) green.

Spec: https://github.com/thunderbird/thunderbolt-spec/pull/12
Addendum: §3.7, Decision 11, Decision 25.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches membership authorization, invite promotion, and last-admin invariants—bugs could allow privilege escalation or lock workspaces; requires backend migration before FE reads new columns.
> 
> **Overview**
> Adds **`user_name` / `user_email`** on `workspace_memberships` (migration + backfill) so synced member rows carry display fields without joining `auth.user`. Membership **PUT** fills them from `auth.user`; **signup promotion** and **pending promote-on-insert** set them too; a Better Auth **`user.update.after`** hook runs **`syncMembershipDisplayInfo`** when name/email change.
> 
> **Upload authorization** moves off blanket “workspace admin” checks to **`workspace_permissions`** via **`callerSatisfiesPermission`**: memberships use `invite_users` / `change_roles` / `remove_users` (default **admin** when no row); pending invites use the same keys with **admin-role escalation** blocked unless the caller also has `change_roles`. Hardens **PUT upserts** (role changes, **last-admin** demotion, **E2EE** blocking non-self adds) and **pending** flows (email format, server-set `invited_by_user_id`, **DO-NOTHING** promote so existing roles aren’t downgraded, delete pending by workspace+email after conflict).
> 
> **Agents, models, skills, and MCP servers** in the scoped upload factory now gate **add/remove** (including **soft-delete PATCH** on `deleted_at`) on the matching permission keys. **`workspace_permissions`** keys/types align with **`shared/workspaces.ts`**. Minor: clearer **`SERVER_ID`** Zod errors; workspace **PUT** no longer wipes omitted slug/icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752cd0fd29fd96aeb9b21766aa27492dcf43edc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->