### PR TITLE
fix: bump tao to 0.35.3 to fix android oauth deep-link crash

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4808,9 +4808,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.35.0"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.11.1",
  "block2",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only patch bump of a Tauri windowing dependency with no app logic changes; typical low-risk dependency fix.
> 
> **Overview**
> Bumps the **tao** windowing dependency from **0.35.0** to **0.35.3** in `Cargo.lock` (patch release; checksum updated). There are no application or manifest changes in this diff.
> 
> This aligns with fixing an **Android crash when OAuth completes via deep link** (`/oauth/callback`), where **tao** sits in the Tauri/Android window stack alongside `tauri-plugin-deep-link`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89541948ba4d6eff7ef8f9d13ae3fce84f72d256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->