### PR TITLE
fix(THU-586): reduce keyboard↔input gap on mobile to match horizontal margins

### DIFF
--- a/src/layout/main-layout.tsx
+++ b/src/layout/main-layout.tsx
@@ -106,7 +106,13 @@ export default function Page() {
             <div
               className="flex-1 overflow-auto"
               style={{
-                paddingBottom: 'var(--safe-area-bottom-padding)',
+                // Reserve the home-indicator safe area, but don't double-count it
+                // with the on-screen keyboard: when the keyboard is open (`--kb` > 0)
+                // it already covers that region, so subtract it. Without this, the
+                // safe-area inset stacks on top of `chat-ui`'s `var(--kb)` and shoves
+                // a bottom-anchored input well above the keyboard (THU-586). At rest
+                // (`--kb` = 0) this is just the full safe-area inset, unchanged.
+                paddingBottom: 'max(var(--safe-area-bottom-padding) - var(--kb, 0px), 0px)',
               }}
             >
               <Suspense fallback={<PageFallback />}>


### PR DESCRIPTION
## What
On mobile, the vertical gap between the on-screen keyboard and the chat prompt input was much larger than the horizontal margins around the input. This makes the spacing symmetric.

## Why
The main-layout content container set `paddingBottom: var(--safe-area-bottom-padding)` (home-indicator inset), and `chat-ui` separately adds `paddingBottom: var(--kb)` (keyboard height). When the keyboard opens, these **stacked** — the safe-area inset got added on top of the keyboard inset, pushing the input ~24–34px above the keyboard top (plus the input's own `pb-3`/`pb-4`), versus the 12/16px side margins.

## Fix
`src/layout/main-layout.tsx` — change the content `paddingBottom` to:
\`max(var(--safe-area-bottom-padding) - var(--kb, 0px), 0px)\`

This subtracts the keyboard inset from the safe-area padding so they never double-count:
- **Keyboard closed** (`--kb = 0`): full safe area — at-rest behavior unchanged.
- **Keyboard open**: safe area collapses (the keyboard already covers the home-indicator region), leaving only the keyboard inset + the input's `pb-3`/`pb-4` → gap matches the 12px (mobile) / 16px (desktop) horizontal margins.

Globally safe: non-chat routes don't add their own `--kb`, so their at-rest spacing is unchanged.

## Testing
CSS-only change; verified on the iOS simulator (iPhone 17 Pro) — keyboard-to-input gap now matches the side margins. Typecheck/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS-only layout tweak in main-layout; at-rest behavior unchanged and scoped to avoiding double-counting when `--kb` is set.
> 
> **Overview**
> Fixes **THU-586**: on mobile, the chat input sat too far above the keyboard because **bottom safe-area padding** on the main scroll container stacked with **`chat-ui`’s `paddingBottom: var(--kb)`**.
> 
> The main content area now uses **`paddingBottom: max(var(--safe-area-bottom-padding) - var(--kb, 0px), 0px)`** so when the keyboard is open, the home-indicator inset is not applied on top of the keyboard height; when the keyboard is closed (`--kb` is 0), spacing is unchanged. Non-chat routes that do not set `--kb` are unaffected at rest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea67f76337dfc6b0302fd82b1b9ef48e1cfb0b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->