### PR TITLE
fix: target iOS simulator by name in `make dev-ios`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,22 +185,25 @@ dev-desktop:
 	sleep 2; \
 	bun tauri:dev:desktop
 
-# Tauri iOS dev on simulator. Picks the first booted simulator to avoid Wi-Fi-paired iPhones
-# being auto-selected by `tauri ios dev`.
+# Tauri iOS dev on simulator. Targets the first booted simulator by NAME to avoid
+# Wi-Fi-paired iPhones being auto-selected by `tauri ios dev`. NB: `tauri ios dev`
+# matches devices by name, not UDID — passing a UDID fails to match (logs
+# "Could not find an iOS Simulator matching {t}") and degrades to opening Xcode
+# without hosting the dev options socket, which then breaks the build phase.
 dev-ios:
 	@echo "$(BLUE)→ Starting backend + Tauri iOS simulator dev...$(NC)"
 	@-lsof -ti:8000 | xargs kill -9 2>/dev/null || true
-	@SIM_UDID=$$(xcrun simctl list devices booted 2>/dev/null | grep -oE '\([0-9A-F-]{36}\)' | head -1 | tr -d '()'); \
-	if [ -z "$$SIM_UDID" ]; then \
+	@SIM_NAME=$$(xcrun simctl list devices booted 2>/dev/null | grep -m1 'Booted' | sed -E 's/^ *//; s/ *\(.*//'); \
+	if [ -z "$$SIM_NAME" ]; then \
 		echo "$(YELLOW)⚠ No booted simulator. Boot one first: open -a Simulator$(NC)"; \
 		exit 1; \
 	fi; \
-	echo "$(GREEN)✓ Targeting simulator $$SIM_UDID$(NC)"; \
+	echo "$(GREEN)✓ Targeting simulator $$SIM_NAME$(NC)"; \
 	cd backend && bun run dev & \
 	BACKEND_PID=$$!; \
 	trap "kill $$BACKEND_PID 2>/dev/null" EXIT; \
 	sleep 2; \
-	bun tauri ios dev --config src-tauri/tauri.dev.conf.json "$$SIM_UDID"
+	bun tauri ios dev --config src-tauri/tauri.dev.conf.json "$$SIM_NAME"
 
 # Tauri Android dev. Re-runs init with the dev config first so the package paths match
 # the .dev identifier (the chart's gen/android is committed for the prod identifier).


### PR DESCRIPTION
## What
`make dev-ios` now passes the booted simulator's **name** to `tauri ios dev` instead of its **UDID**.

## Why
`tauri ios dev` matches simulators by name, not UDID. Passing a UDID fails to match — it logs `Could not find an iOS Simulator matching {t}` and silently degrades to just *opening Xcode* without hosting the dev options socket. That then breaks the Xcode build phase (`tauri ios xcode-script` → `failed to read CLI options: ConnectionRefused`), so `make dev-ios` never actually launches on the simulator.

## Fix
Derive the booted sim's name from `xcrun simctl list devices booted` and pass that:
```make
SIM_NAME=$(xcrun simctl list devices booted | grep -m1 'Booted' | sed -E 's/^ *//; s/ *\(.*//')
...
bun tauri ios dev --config src-tauri/tauri.dev.conf.json "$SIM_NAME"
```
Still targets the first booted sim explicitly (so a Wi-Fi-paired iPhone isn't auto-selected); just by name so Tauri's matcher succeeds and runs its normal serve→build→launch loop.

## Testing
`make dev-ios` now builds and launches on the booted simulator (iPhone 17 Pro, iOS 26.2) without the Xcode fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only dev workflow change with no runtime, auth, or production build impact.
> 
> **Overview**
> Fixes **`make dev-ios`** so Tauri actually targets the booted iOS Simulator instead of falling through to a broken Xcode-only path.
> 
> The recipe now reads the **first booted simulator’s display name** from `xcrun simctl list devices booted` and passes that to `bun tauri ios dev` (replacing UDID extraction). **`tauri ios dev` matches by name**, so the previous UDID argument failed matching, skipped the dev options socket, and broke the Xcode build phase (`ConnectionRefused` on CLI options).
> 
> Comments above `dev-ios` document the name-vs-UDID behavior and the failure mode. Behavior is unchanged in intent: still pin the first booted sim to avoid Wi‑Fi‑paired physical devices being auto-selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be07fc0f48be1aefd97bc72d15fed5314fb9f3d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->