### PR TITLE
fix(THU-587): tighten & equalize prompt-area selector/button sizing

### DIFF
--- a/src/components/chat/chat-skills-bar.tsx
+++ b/src/components/chat/chat-skills-bar.tsx
@@ -156,7 +156,7 @@ export const ChatSkillsBar = ({
                   size="icon-sm"
                   aria-label="Pin a skill"
                   disabled={addDisabled}
-                  className={`shrink-0 cursor-pointer rounded-full bg-card transition-opacity disabled:cursor-not-allowed disabled:opacity-40 ${
+                  className={`size-[var(--touch-height-control)] shrink-0 cursor-pointer rounded-full bg-card transition-opacity disabled:cursor-not-allowed disabled:opacity-40 ${
                     openChipId ? 'opacity-40' : ''
                   }`}
                 >

--- a/src/components/ui/mode-selector/mode-selector.tsx
+++ b/src/components/ui/mode-selector/mode-selector.tsx
@@ -54,7 +54,7 @@ export const ModeSelector = ({ modes, selectedMode, onModeChange, iconOnly = fal
     <div
       className={cn(
         'flex items-center rounded-lg cursor-pointer transition-colors text-[length:var(--font-size-sm)] border border-border',
-        iconOnly ? 'size-[var(--touch-height-sm)] justify-center' : 'gap-1.5 px-2.5 h-[var(--touch-height-sm)]',
+        iconOnly ? 'size-[var(--touch-height-control)] justify-center' : 'gap-1.5 px-2 h-[var(--touch-height-control)]',
         isOpen ? 'bg-accent' : 'hover:bg-accent/50',
       )}
     >

--- a/src/components/ui/model-selector/model-selector.tsx
+++ b/src/components/ui/model-selector/model-selector.tsx
@@ -127,7 +127,7 @@ export const ModelSelector = ({
         'flex items-center cursor-pointer transition-colors',
         variant === 'bordered'
           ? cn(
-              'gap-1.5 px-2.5 h-[var(--touch-height-sm)] rounded-lg border border-border text-[length:var(--font-size-sm)]',
+              'gap-1.5 px-2 h-[var(--touch-height-control)] rounded-lg border border-border text-[length:var(--font-size-sm)]',
               isOpen ? 'bg-accent' : 'hover:bg-accent/50',
             )
           : cn(

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -130,7 +130,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <Button
           type="button"
           variant="default"
-          className="size-[var(--touch-height-sm)] rounded-lg flex items-center justify-center flex-shrink-0"
+          className="size-[var(--touch-height-control)] rounded-lg flex items-center justify-center flex-shrink-0"
           onClick={onStop}
         >
           <Square className="size-[var(--icon-size-default)]" />
@@ -139,7 +139,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <Button
           type="submit"
           variant="default"
-          className="size-[var(--touch-height-sm)] rounded-lg flex items-center justify-center flex-shrink-0"
+          className="size-[var(--touch-height-control)] rounded-lg flex items-center justify-center flex-shrink-0"
           disabled={isLoading || !value.trim()}
         >
           <ArrowUp className="size-[var(--icon-size-default)]" />

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,7 @@
   --touch-height-lg: 3rem; /* 48px mobile */
   --touch-height-default: 2.75rem; /* 44px mobile - primary touch target */
   --touch-height-sm: 2.5rem; /* 40px mobile */
+  --touch-height-control: 2.5rem; /* 40px mobile — prompt-area selectors/buttons; held at --min-touch-height */
 
   /* Icon sizes */
   --icon-size-default: 1.25rem; /* 20px mobile */
@@ -94,6 +95,7 @@
     --touch-height-lg: 2.5rem; /* 40px desktop */
     --touch-height-default: 2.25rem; /* 36px desktop */
     --touch-height-sm: 2rem; /* 32px desktop */
+    --touch-height-control: 1.75rem; /* 28px desktop — tightened prompt-area controls (THU-587) */
 
     /* Icon sizes */
     --icon-size-default: 1rem; /* 16px desktop */

--- a/src/skills/suggestion-chip.tsx
+++ b/src/skills/suggestion-chip.tsx
@@ -117,7 +117,7 @@ export const SuggestionChip = ({
           // share/copy callout pops) while our long-press timer is waiting
           // to open the action menu. Leaving `touch-action` at its default
           // so the chip strip's horizontal scroll on mobile still works.
-          className={`h-[var(--touch-height-sm)] shrink-0 cursor-pointer select-none rounded-full bg-card px-3 text-sm font-normal transition-opacity [-webkit-touch-callout:none] ${
+          className={`h-[var(--touch-height-control)] shrink-0 cursor-pointer select-none rounded-full bg-card px-2 text-sm font-normal transition-opacity [-webkit-touch-callout:none] ${
             dimmed ? 'opacity-40' : ''
           }`}
           aria-label={`Pinned skill /${label}`}

--- a/src/skills/suggestion-chip.tsx
+++ b/src/skills/suggestion-chip.tsx
@@ -107,7 +107,7 @@ export const SuggestionChip = ({
             clearLongPress()
             handleOpenChange(true)
           }}
-          // `h-[var(--touch-height-sm)]` resolves to 40px on mobile, 32px on
+          // `h-[var(--touch-height-control)]` resolves to 40px on mobile, 28px on
           // desktop — keeps the compact desktop look while meeting the
           // 40px-min touch target the rest of the app uses on touch devices.
           //


### PR DESCRIPTION
## What
Tightens the prompt-area selectors/buttons so they're a touch smaller and all share **one** height, while staying ≥ the mobile touch minimum.

## Approach
Most of these controls already shared `--touch-height-sm` (40px mobile / 32px desktop). The lever for "a tad smaller" is **desktop only** — on mobile `--touch-height-sm` already equals `--min-touch-height` (40px), so shrinking mobile would break the touch target.

Added a single responsive token and applied it uniformly:

```css
--touch-height-control: 2.5rem;  /* 40px mobile — held at --min-touch-height */
--touch-height-control: 1.75rem; /* 28px desktop — tightened */
```

Applied `h-[var(--touch-height-control)]` (or `size-[…]` for the square buttons) to: mode picker, model picker (bordered), send/stop button, the skills `+` button, and pinned skill chips. Also trimmed horizontal padding `px-2.5`/`px-3` → `px-2`.

## Result
- **Mobile:** 40px (= `--min-touch-height`) — unchanged, touch-safe.
- **Desktop:** 32 → 28px + tighter padding → visibly tighter, all controls identical height.
- Border-radius and font sizes left as-is (out of scope; the `rounded-full` chips/`+` are intentional).

## Testing
CSS/layout-only. Typecheck/lint/format clean. Visual verification in `bun dev` recommended (web + a mobile-width check at the 768px breakpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only sizing and padding in the chat composer; no logic, auth, or data changes.
> 
> **Overview**
> Introduces a shared **`--touch-height-control`** token so prompt-area controls share one height: **40px on mobile** (unchanged, still at the touch minimum) and **28px on desktop** (down from 32px via the old `--touch-height-sm`).
> 
> **Mode selector**, **bordered model selector**, **send/stop** buttons, the skills **`+`** button, and **pinned skill chips** now use `h-[var(--touch-height-control)]` / `size-[…]` instead of `--touch-height-sm`. Horizontal padding is slightly reduced (`px-2.5`/`px-3` → `px-2`) on the affected triggers and chips.
> 
> The pill model selector and other non–prompt-area uses of `--touch-height-sm` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144ac7b3f584f9b28095dc5efd832d97d86ed762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->