### PR TITLE
fix(THU-537): advertise host-reachable PowerSync URL in local docker-compose

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -42,7 +42,11 @@ services:
       # discovery host — Better Auth's SSO plugin validates both against trustedOrigins.
       TRUSTED_ORIGINS: http://localhost:${FRONTEND_PORT:-3000},http://localhost:${KEYCLOAK_PORT:-8180},http://keycloak:8080
       CORS_ORIGINS: http://localhost:${FRONTEND_PORT:-3000}
-      POWERSYNC_URL: http://powersync:8080
+      # Unlike OIDC_DISCOVERY_URL above, this URL is echoed to the BROWSER in the
+      # /v1/powersync/token response, so it must be host-reachable — the internal
+      # `powersync:8080` Docker hostname doesn't resolve in the browser, leaving the
+      # SharedWorker stuck offline. Use the host port mapping (localhost:POWERSYNC_PORT).
+      POWERSYNC_URL: http://localhost:${POWERSYNC_PORT:-8080}
       # Must match the base64-decoded `k` in deploy/config/powersync-config.yaml
       # AND be >=32 chars (backend/src/config/settings.ts:76).
       POWERSYNC_JWT_SECRET: enterprise-thunderbolt-powersync-jwt-default-secret


### PR DESCRIPTION
## Problem
In the local `deploy/docker-compose.yml` stack, Cloud Sync never establishes — the panel sits on "Changes will sync when back online".

`POWERSYNC_URL` was set to the **internal** Docker hostname `http://powersync:8080`. The backend echoes that value back to the browser in `/v1/powersync/token` (`backend/src/api/powersync.ts`), and the frontend SharedWorker then tries to connect to `http://powersync:8080/...` — which only resolves inside the Docker network. Browser DNS fails silently → SharedWorker stays offline.

## Fix
Point `POWERSYNC_URL` at the **host-reachable** URL via the existing port mapping:
```yaml
POWERSYNC_URL: http://localhost:${POWERSYNC_PORT:-8080}
```
(`powersync` already maps `${POWERSYNC_PORT:-8080}:8080` to the host.) Added a comment contrasting this with `OIDC_DISCOVERY_URL` right above it, which intentionally *does* use the internal hostname (backend-only, never sent to the browser).

## Note vs. ticket
The ticket suggested port **8081**, but the actual host mapping in this file defaults to **8080** (`${POWERSYNC_PORT:-8080}:8080`). Used 8080 to match the real mapping — 8081 would point at nothing.

## Testing
Config-only. With this change the backend advertises `http://localhost:8080`, which the browser can reach, so the SharedWorker connects. (Out of scope: preview-env PowerSync architecture — separate/larger issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single local dev compose env change with no application code or production config impact.
> 
> **Overview**
> Fixes local Docker Cloud Sync staying offline by changing backend **`POWERSYNC_URL`** from the internal service URL (`http://powersync:8080`) to **`http://localhost:${POWERSYNC_PORT:-8080}`**, matching the published host port on the `powersync` service.
> 
> That value is returned to the browser (e.g. `/v1/powersync/token`), so the client must use a host-resolvable URL—not a Docker-only hostname. A short comment was added next to the env var to contrast this with **`OIDC_DISCOVERY_URL`**, which correctly stays on an internal hostname because only the backend uses it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0615e56958e1316fc9ce7bc45c5bca418400fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->