### PR TITLE
fix(THU-539): make Preview Destroy idempotent when the Pulumi stack is gone

### DIFF
--- a/.github/workflows/stack-deploy.yml
+++ b/.github/workflows/stack-deploy.yml
@@ -243,7 +243,26 @@ jobs:
         working-directory: deploy/pulumi
         run: bun install --frozen-lockfile
 
+      # Destroy must be idempotent: the stack may already be gone (manual destroy,
+      # a prior run that tore it down but still failed, or a PR that never deployed).
+      # Without this guard `pulumi destroy` errors with "no stack named ... found",
+      # surfacing a red ✗ on every PR close even though the env is already clean (THU-539).
+      - name: Check whether the stack still exists
+        id: stack_check
+        working-directory: deploy/pulumi
+        run: |
+          curl -fsSL https://get.pulumi.com | sh
+          export PATH="$HOME/.pulumi/bin:$PATH"
+          if pulumi stack select "${{ inputs.stack_name }}" --non-interactive 2>/dev/null; then
+            echo "Stack ${{ inputs.stack_name }} exists — proceeding to destroy."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Stack ${{ inputs.stack_name }} not found — nothing to destroy."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Destroy
+        if: steps.stack_check.outputs.exists == 'true'
         uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0
         with:
           command: destroy


### PR DESCRIPTION
## Problem
`Preview Destroy` fails its `destroy / destroy` step with `error: no stack named 'preview-pr-NNN' found` whenever the Pulumi stack no longer exists at destroy time — a PR that never deployed, or whose stack was already torn down. The env is actually clean, but every PR close/merge throws a red ✗ in Actions (now constant per the urgency bump), drowning out real CI signal.

## Fix
The destroy job uses the `pulumi/actions@v7` wrapper (`command: destroy`), which errors on a missing stack. Added a guard step before it that checks existence via `pulumi stack select` (exit code) and gates the destroy:

```yaml
- name: Check whether the stack still exists
  id: stack_check
  run: |
    curl -fsSL https://get.pulumi.com | sh
    export PATH="$HOME/.pulumi/bin:$PATH"
    if pulumi stack select "${{ inputs.stack_name }}" --non-interactive 2>/dev/null; then
      echo "exists=true"  >> "$GITHUB_OUTPUT"
    else
      echo "Stack not found — nothing to destroy."
      echo "exists=false" >> "$GITHUB_OUTPUT"
    fi

- name: Destroy
  if: steps.stack_check.outputs.exists == 'true'
  uses: pulumi/actions@…
  with: { command: destroy, … }
```

Auth is inherited from the workflow-level `PULUMI_ACCESS_TOKEN` env. When the stack is gone, the destroy is skipped and the job goes green.

## Notes
- I gate rather than blanket `continue-on-error`, so a *real* destroy failure still fails loudly.
- Adapted from the ticket's shell sketch — the destroy path uses the pulumi/actions wrapper, not a raw `pulumi destroy`, so the check is a separate gating step.
- Out of scope (per ticket): why pr-886's stack vanished before destroy.

## Testing
YAML validated. Behavioral verification happens on the next PR close (stack-present → destroys as before; stack-absent → skips, green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; destroy still runs and fails loudly when the stack exists and teardown fails.
> 
> **Overview**
> Makes **Preview Destroy** in `stack-deploy.yml` succeed when the Pulumi stack is already gone, instead of failing with `no stack named ... found` on every PR close (THU-539).
> 
> A new **Check whether the stack still exists** step installs the Pulumi CLI, runs `pulumi stack select` for the target stack, and sets `exists=true|false`. The **Destroy** `pulumi/actions` step runs only when `exists == 'true'`, so missing stacks are skipped with a green job; actual destroy errors still fail the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5edef0e308ce234da69e4bedfaf05149cabcbca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->