### PR TITLE
fix(workspaces): address review comments across stacked PRs

### DIFF
--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -212,8 +212,10 @@ export const createAuth = (database: typeof DbType, emailDeps: AuthEmailDeps = {
           }),
           // Promote any pending memberships invited by email. The personal workspace
           // itself is FE-created (uploaded via PowerSync with a deterministic id), so
-          // this hook only handles the admin-only pending-membership flow that the FE
-          // can't see. Skipped for anonymous users — anon never receives invites.
+          // this hook only handles the cross-workspace promotion flow — a brand-new
+          // user isn't a member of anything yet, so no FE client can see (let alone
+          // act on) the invite at signup time. Skipped for anonymous users — anon
+          // never receives invites.
           after: async (createdUser) => {
             const isAnonymous = (createdUser as { isAnonymous?: boolean }).isAnonymous === true
             if (isAnonymous) {

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -52,9 +52,6 @@ describe('Config Settings', () => {
   })
 
   describe('SERVER_ID validation', () => {
-    // Friendly error messages mirror the BETTER_AUTH_SECRET ergonomics — a raw
-    // `Expected string, received undefined` ZodError doesn't tell a fresh dev
-    // what to do. (#932 r3388801939)
     const savedServerId = process.env.SERVER_ID
 
     afterEach(() => {

--- a/backend/src/config/settings.test.ts
+++ b/backend/src/config/settings.test.ts
@@ -51,6 +51,36 @@ describe('Config Settings', () => {
     })
   })
 
+  describe('SERVER_ID validation', () => {
+    // Friendly error messages mirror the BETTER_AUTH_SECRET ergonomics — a raw
+    // `Expected string, received undefined` ZodError doesn't tell a fresh dev
+    // what to do. (#932 r3388801939)
+    const savedServerId = process.env.SERVER_ID
+
+    afterEach(() => {
+      if (savedServerId !== undefined) {
+        process.env.SERVER_ID = savedServerId
+      } else {
+        delete process.env.SERVER_ID
+      }
+      clearSettingsCache()
+    })
+
+    it('surfaces a setup-pointing error when SERVER_ID is unset', () => {
+      delete process.env.SERVER_ID
+      clearSettingsCache()
+
+      expect(() => getSettings()).toThrow(/SERVER_ID env var must be set.*make doctor/)
+    })
+
+    it('surfaces a UUID-format error when SERVER_ID is set but not a UUID', () => {
+      process.env.SERVER_ID = 'not-a-uuid'
+      clearSettingsCache()
+
+      expect(() => getSettings()).toThrow(/SERVER_ID must be a valid UUID/)
+    })
+  })
+
   describe('CORS default security', () => {
     const corsEnvKeys = ['CORS_ORIGINS'] as const
 

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -13,7 +13,15 @@ const settingsSchema = z
     // key the trust-domain registry (auth token, device ID, encryption keys, DB filename
     // are all namespaced by this). No default — TS-enforced to prevent ID duplication
     // across deployments. `make doctor` auto-generates one for local dev.
-    serverId: z.string().uuid(),
+    //
+    // Custom messages mirror the BETTER_AUTH_SECRET ergonomics: a raw `Expected
+    // string, received undefined` ZodError doesn't tell a fresh dev what to do.
+    serverId: z
+      .string({
+        error:
+          'SERVER_ID env var must be set to a stable per-deployment UUID. Run `make doctor` to auto-generate one for local dev.',
+      })
+      .uuid({ error: 'SERVER_ID must be a valid UUID.' }),
 
     // API Keys
     fireworksApiKey: z.string().default(''),

--- a/backend/src/dal/workspaces.ts
+++ b/backend/src/dal/workspaces.ts
@@ -252,6 +252,30 @@ export const getMembershipById = async (
   return rows[0] ?? null
 }
 
+/**
+ * Look up a membership by `(workspace_id, user_id)` — the unique constraint
+ * that `upsertMembership` collides on. Upload-handler validation uses this to
+ * detect when a PUT would effectively change an existing role (treated as a
+ * PATCH for auth purposes).
+ */
+export const getMembershipByWorkspaceAndUser = async (
+  database: typeof DbType,
+  workspaceId: string,
+  userId: string,
+): Promise<MembershipRow | null> => {
+  const rows = await database
+    .select({
+      id: workspaceMembershipsTable.id,
+      workspaceId: workspaceMembershipsTable.workspaceId,
+      userId: workspaceMembershipsTable.userId,
+      role: workspaceMembershipsTable.role,
+    })
+    .from(workspaceMembershipsTable)
+    .where(and(eq(workspaceMembershipsTable.workspaceId, workspaceId), eq(workspaceMembershipsTable.userId, userId)))
+    .limit(1)
+  return rows[0] ?? null
+}
+
 export const getPendingMembershipById = async (database: typeof DbType, id: string): Promise<PendingRow | null> => {
   const rows = await database
     .select({

--- a/backend/src/dal/workspaces.ts
+++ b/backend/src/dal/workspaces.ts
@@ -410,6 +410,23 @@ export const upsertMembership = async (database: typeof DbType, input: Membershi
 }
 
 /**
+ * Insert a membership row only if no row with the same `(workspace_id, user_id)`
+ * already exists. Used by the promote-on-insert path in the pending-membership
+ * upload handler: an invite for an email that already belongs to a member must
+ * not overwrite that member's existing role (otherwise an invite for an admin's
+ * own email would downgrade them to whatever role the invite carried). Mirrors
+ * the `promotePendingMemberships` DO-NOTHING semantics for the signup path.
+ */
+export const insertMembershipIfMissing = async (database: typeof DbType, input: MembershipInput): Promise<void> => {
+  await database
+    .insert(workspaceMembershipsTable)
+    .values(input)
+    .onConflictDoNothing({
+      target: [workspaceMembershipsTable.workspaceId, workspaceMembershipsTable.userId],
+    })
+}
+
+/**
  * Mirrors a user's current display info onto every one of their membership rows.
  * Called from the Better Auth `update.after` hook so name/email changes propagate
  * to co-members on the next sync round-trip. Idempotent — safe to call on every

--- a/backend/src/dal/workspaces.ts
+++ b/backend/src/dal/workspaces.ts
@@ -527,6 +527,32 @@ export const deletePendingMembership = async (database: typeof DbType, id: strin
   return rows.length
 }
 
+/**
+ * Deletes the pending row for `(workspace_id, email)`. Used by the
+ * promote-on-insert path in the upload handler: when `upsertPendingMembership`
+ * conflicts on the `(workspace_id, email)` unique constraint, Postgres keeps
+ * the existing row's id, so a delete keyed on the upload's `op.id` would no-op
+ * and leave a stale pending invite behind for someone who is now a real
+ * member. Email is normalized to match `upsertPendingMembership`'s storage.
+ */
+export const deletePendingMembershipByWorkspaceAndEmail = async (
+  database: typeof DbType,
+  workspaceId: string,
+  email: string,
+): Promise<number> => {
+  const normalizedEmail = normalizeEmail(email)
+  const rows = await database
+    .delete(workspacePendingMembershipsTable)
+    .where(
+      and(
+        eq(workspacePendingMembershipsTable.workspaceId, workspaceId),
+        eq(workspacePendingMembershipsTable.email, normalizedEmail),
+      ),
+    )
+    .returning()
+  return rows.length
+}
+
 export type WorkspacePermissionInput = {
   id: string
   workspaceId: string

--- a/backend/src/dal/workspaces.ts
+++ b/backend/src/dal/workspaces.ts
@@ -20,8 +20,9 @@ import { v7 as uuidv7 } from 'uuid'
  * Called from the Better Auth post-user-create hook. The personal workspace
  * itself is FE-created (uploaded via PowerSync with a deterministic id from
  * `shared/workspaces.ts`) — the BE no longer creates one here. Pending
- * promotion stays server-side because pending rows live in an admin-only
- * sync bucket and FE can't see other users' invites until they're memberships.
+ * promotion stays server-side because a brand-new user isn't a member of any
+ * workspace yet, so no FE client can see (or act on) the pending invite at
+ * signup time.
  *
  * Skipped for anonymous users — anon never receives pending invites.
  */

--- a/backend/src/lib/email.ts
+++ b/backend/src/lib/email.ts
@@ -8,3 +8,13 @@
  * - Trims whitespace
  */
 export const normalizeEmail = (email: string) => email.toLowerCase().trim()
+
+/**
+ * Format check (same regex as the FE's `isValidEmailFormat`) — guards
+ * upload-handler inserts against junk strings before they hit the DB. Run
+ * against the normalized form so case/whitespace don't sneak past.
+ */
+const emailRegex =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
+
+export const isValidEmailFormat = (email: string): boolean => emailRegex.test(normalizeEmail(email))

--- a/backend/src/powersync/upload-handlers/helpers.ts
+++ b/backend/src/powersync/upload-handlers/helpers.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { HandlerResult } from './types'
+import { getRequiredRoleForPermission, getUserRoleInWorkspace } from '@/dal/workspaces'
+import { permissionAllows, type WorkspacePermissionKey } from '@shared/workspaces'
+import type { HandlerResult, UploadTx } from './types'
 
 /** Column names Drizzle declares as `timestamp(...)`; JSON sends them as ISO strings. */
 const timestampDbColumns = new Set(['deleted_at', 'last_seen', 'created_at', 'revoked_at', 'updated_at'])
@@ -42,3 +44,22 @@ export const reject = (rejectionClass: 'permanent' | 'transient', code: string):
   class: rejectionClass,
   code,
 })
+
+/**
+ * Resolves the caller's role + the configured permission's required role and
+ * returns whether the op is allowed. Defaults `required_role` to `'admin'`
+ * when no `workspace_permissions` row exists for the key (Decision 11) so an
+ * unconfigured workspace stays admin-only. Shared by every handler that gates
+ * writes on `workspace_permissions` — keep the lookup in one place so the
+ * default-to-admin policy can't drift between tables.
+ */
+export const callerSatisfiesPermission = async (
+  tx: UploadTx,
+  workspaceId: string,
+  userId: string,
+  permissionKey: WorkspacePermissionKey,
+): Promise<boolean> => {
+  const required = (await getRequiredRoleForPermission(tx, workspaceId, permissionKey)) ?? 'admin'
+  const userRole = await getUserRoleInWorkspace(tx, workspaceId, userId)
+  return permissionAllows(userRole, required)
+}

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -606,6 +606,47 @@ describe('workspace upload handlers', () => {
       return sharedId
     }
 
+    it('allows a member to invite when invite_users is granted to member role', async () => {
+      // Regression: the BE previously hardcoded isWorkspaceAdmin for pending
+      // invites, so the FE Members UI granting `member` the `invite_users`
+      // permission led to silent sync rejections. The BE now reads the same
+      // `workspace_permissions` row. (#974 r3397677057)
+      await insertUser('a-perm', 'a-perm@test.com')
+      await insertUser('b-perm', 'b-perm@test.com')
+      await bootstrapPersonalViaUpload('a-perm')
+      const sharedId = await seedSharedAsAdmin('a-perm')
+
+      // b-perm becomes a member of the shared workspace.
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'b-perm',
+        role: 'member',
+      })
+
+      // Workspace grants `invite_users` to the `member` role.
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      // b-perm (member) sends a pending invite — should succeed.
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: {
+          workspace_id: sharedId,
+          email: 'newcomer@test.com',
+          role: 'member',
+        },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('b-perm'))
+      expect(result.ok).toBe(true)
+    })
+
     it('rejects writes by non-admins of the target workspace', async () => {
       await insertUser('a5', 'a5@test.com')
       await insertUser('b5', 'b5@test.com')
@@ -624,7 +665,7 @@ describe('workspace upload handlers', () => {
         },
       }
       const result = await applyUploadBatch(db, [op], ctxFor('b5'))
-      expectPermanentReject(result, 'NOT_WORKSPACE_ADMIN')
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
     })
 
     it('normalizes email on insert', async () => {

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -843,6 +843,33 @@ describe('workspace upload handlers', () => {
       expect(coadminRow?.role).toBe('admin')
     })
 
+    it('overrides client-supplied invited_by_user_id with ctx.userId', async () => {
+      await insertUser('inviter', 'inviter@test.com')
+      await bootstrapPersonalViaUpload('inviter')
+      const sharedId = await seedSharedAsAdmin('inviter')
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: {
+          workspace_id: sharedId,
+          email: 'pending@test.com',
+          role: 'member',
+          // Attempt to attribute the invite to someone else.
+          invited_by_user_id: 'someone-else',
+        },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('inviter'))
+      expect(result.ok).toBe(true)
+
+      const stored = await db
+        .select()
+        .from(workspacePendingMembershipsTable)
+        .where(eq(workspacePendingMembershipsTable.id, op.id))
+      expect(stored[0]?.invitedByUserId).toBe('inviter')
+    })
+
     it('keeps pending row when invited email does not match any user', async () => {
       await insertUser('admin8', 'admin8@test.com')
       await bootstrapPersonalViaUpload('admin8')

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -700,6 +700,49 @@ describe('workspace upload handlers', () => {
       expect(invitee?.role).toBe('admin')
     })
 
+    it('preserves an existing membership role on promote-on-insert (no downgrade)', async () => {
+      // Regression: promote-on-insert previously used upsertMembership, which
+      // overwrote the role on conflict — inviting an existing admin's own
+      // email would downgrade them to whatever role the invite carried.
+      // (#965 r3382145640)
+      await insertUser('admin9', 'admin9@test.com')
+      await insertUser('coadmin', 'coadmin@test.com')
+      await bootstrapPersonalViaUpload('admin9')
+      const sharedId = await seedSharedAsAdmin('admin9')
+
+      // Make coadmin an admin of the same workspace directly.
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'coadmin',
+        role: 'admin',
+        userName: 'Test User',
+        userEmail: 'coadmin@test.com',
+      })
+
+      // Invite coadmin's email with role='member' — should NOT downgrade.
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: {
+          workspace_id: sharedId,
+          email: 'coadmin@test.com',
+          role: 'member',
+          invited_by_user_id: 'admin9',
+        },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('admin9'))
+      expect(result.ok).toBe(true)
+
+      const memberships = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.workspaceId, sharedId))
+      const coadminRow = memberships.find((m) => m.userId === 'coadmin')
+      expect(coadminRow?.role).toBe('admin')
+    })
+
     it('keeps pending row when invited email does not match any user', async () => {
       await insertUser('admin8', 'admin8@test.com')
       await bootstrapPersonalViaUpload('admin8')

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -843,6 +843,21 @@ describe('workspace upload handlers', () => {
       expect(coadminRow?.role).toBe('admin')
     })
 
+    it('rejects malformed email on pending PUT with INVALID_EMAIL', async () => {
+      await insertUser('admin-email', 'admin-email@test.com')
+      await bootstrapPersonalViaUpload('admin-email')
+      const sharedId = await seedSharedAsAdmin('admin-email')
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, email: 'not-an-email', role: 'member' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('admin-email'))
+      expectPermanentReject(result, 'INVALID_EMAIL')
+    })
+
     it('overrides client-supplied invited_by_user_id with ctx.userId', async () => {
       await insertUser('inviter', 'inviter@test.com')
       await bootstrapPersonalViaUpload('inviter')

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -375,11 +375,7 @@ describe('workspace upload handlers', () => {
       expect(stored[0].slug).toBeNull()
     })
 
-    it('PUT does not clear server-side slug/icon when payload omits them (#971 r3391725303)', async () => {
-      // Regression: an admin's idempotent PUT without slug/icon would write
-      // null into both columns via ON CONFLICT DO UPDATE, clearing values
-      // previously set by a PATCH or earlier PUT. Fix: pass undefined (not
-      // null) to upsertWorkspace when the payload omits the key.
+    it('PUT does not clear server-side slug/icon when payload omits them', async () => {
       await insertUser('keepfields', 'keepfields@test.com')
       const workspaceId = await createSharedAs('keepfields', 'Initial')
 
@@ -607,10 +603,6 @@ describe('workspace upload handlers', () => {
     }
 
     it('allows a member to invite when invite_users is granted to member role', async () => {
-      // Regression: the BE previously hardcoded isWorkspaceAdmin for pending
-      // invites, so the FE Members UI granting `member` the `invite_users`
-      // permission led to silent sync rejections. The BE now reads the same
-      // `workspace_permissions` row. (#974 r3397677057)
       await insertUser('a-perm', 'a-perm@test.com')
       await insertUser('b-perm', 'b-perm@test.com')
       await bootstrapPersonalViaUpload('a-perm')
@@ -772,11 +764,6 @@ describe('workspace upload handlers', () => {
     })
 
     it('deletes the actual pending row on promote-on-insert even after unique-key conflict', async () => {
-      // Regression: when a pending row for (workspace_id, email) already exists
-      // with id=X and a new upload op arrives with op.id=Y, upsertPendingMembership
-      // ON CONFLICT keeps id=X. A delete keyed on op.id=Y wouldn't match,
-      // leaving a stale pending invite for someone who is now a real member.
-      // (#965 r3382104740)
       await insertUser('admin10', 'admin10@test.com')
       await insertUser('invitee3', 'invitee3@test.com')
       await bootstrapPersonalViaUpload('admin10')
@@ -818,10 +805,6 @@ describe('workspace upload handlers', () => {
     })
 
     it('preserves an existing membership role on promote-on-insert (no downgrade)', async () => {
-      // Regression: promote-on-insert previously used upsertMembership, which
-      // overwrote the role on conflict — inviting an existing admin's own
-      // email would downgrade them to whatever role the invite carried.
-      // (#965 r3382145640)
       await insertUser('admin9', 'admin9@test.com')
       await insertUser('coadmin', 'coadmin@test.com')
       await bootstrapPersonalViaUpload('admin9')

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -375,6 +375,36 @@ describe('workspace upload handlers', () => {
       expect(stored[0].slug).toBeNull()
     })
 
+    it('PUT does not clear server-side slug/icon when payload omits them (#971 r3391725303)', async () => {
+      // Regression: an admin's idempotent PUT without slug/icon would write
+      // null into both columns via ON CONFLICT DO UPDATE, clearing values
+      // previously set by a PATCH or earlier PUT. Fix: pass undefined (not
+      // null) to upsertWorkspace when the payload omits the key.
+      await insertUser('keepfields', 'keepfields@test.com')
+      const workspaceId = await createSharedAs('keepfields', 'Initial')
+
+      // Set slug + icon via PATCH.
+      const patchResult = await applyUploadBatch(
+        db,
+        [{ op: 'PATCH', type: 'workspaces', id: workspaceId, data: { slug: 'kept-slug', icon: '🎯' } }],
+        ctxFor('keepfields'),
+      )
+      expect(patchResult.ok).toBe(true)
+
+      // Now PUT with only `name` — slug + icon must survive.
+      const putResult = await applyUploadBatch(
+        db,
+        [{ op: 'PUT', type: 'workspaces', id: workspaceId, data: { name: 'Renamed' } }],
+        ctxFor('keepfields'),
+      )
+      expect(putResult.ok).toBe(true)
+
+      const stored = await db.select().from(workspacesTable).where(eq(workspacesTable.id, workspaceId))
+      expect(stored[0].name).toBe('Renamed')
+      expect(stored[0].slug).toBe('kept-slug')
+      expect(stored[0].icon).toBe('🎯')
+    })
+
     it('PUT rejects shared workspace with a slug already taken', async () => {
       await insertUser('first', 'first@test.com')
       await insertUser('second', 'second@test.com')

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -572,6 +572,67 @@ describe('workspace upload handlers', () => {
       expect(stored[0].role).toBe('admin')
     })
 
+    it('rejects PUT that would demote the last admin (last-admin protection)', async () => {
+      // PUT's apply path upserts via `ON CONFLICT DO UPDATE SET role`. Without
+      // a last-admin guard in apply, a caller satisfying `change_roles` could
+      // demote the workspace's only admin to member by PUT — leaving zero
+      // admins, while PATCH/DELETE would reject with LAST_ADMIN_PROTECTED.
+      await insertUser('lone-admin', 'lone-admin@test.com')
+      await bootstrapPersonalViaUpload('lone-admin')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({
+        id: sharedId,
+        name: 'Shared',
+        isPersonal: false,
+        ownerUserId: null,
+      })
+      const adminMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: adminMembershipId,
+        workspaceId: sharedId,
+        userId: 'lone-admin',
+        role: 'admin',
+      })
+      const memberId = 'member-with-cr-demote'
+      await insertUser(memberId, 'member-with-cr-demote@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      // Grant both keys so PUT validate passes — the test exercises the apply
+      // layer's last-admin guard.
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'change_roles',
+        requiredRole: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, user_id: 'lone-admin', role: 'member' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'LAST_ADMIN_PROTECTED')
+
+      // The admin row is unchanged.
+      const stored = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.id, adminMembershipId))
+      expect(stored[0].role).toBe('admin')
+    })
+
     it('rejects a second membership write to a personal workspace (immutable)', async () => {
       await insertUser('owner6', 'owner6@test.com')
       await insertUser('victim', 'victim@test.com')

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -700,6 +700,52 @@ describe('workspace upload handlers', () => {
       expect(invitee?.role).toBe('admin')
     })
 
+    it('deletes the actual pending row on promote-on-insert even after unique-key conflict', async () => {
+      // Regression: when a pending row for (workspace_id, email) already exists
+      // with id=X and a new upload op arrives with op.id=Y, upsertPendingMembership
+      // ON CONFLICT keeps id=X. A delete keyed on op.id=Y wouldn't match,
+      // leaving a stale pending invite for someone who is now a real member.
+      // (#965 r3382104740)
+      await insertUser('admin10', 'admin10@test.com')
+      await insertUser('invitee3', 'invitee3@test.com')
+      await bootstrapPersonalViaUpload('admin10')
+      const sharedId = await seedSharedAsAdmin('admin10')
+
+      // Seed an existing pending row with id=X.
+      const originalPendingId = uuidv7()
+      await db.insert(workspacePendingMembershipsTable).values({
+        id: originalPendingId,
+        workspaceId: sharedId,
+        email: 'invitee3@test.com',
+        role: 'admin',
+        invitedByUserId: 'admin10',
+      })
+
+      // Now upload a NEW pending op (id=Y) for the same workspace+email.
+      const newOpId = uuidv7()
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: newOpId,
+        data: {
+          workspace_id: sharedId,
+          email: 'invitee3@test.com',
+          role: 'member',
+          invited_by_user_id: 'admin10',
+        },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor('admin10'))
+      expect(result.ok).toBe(true)
+
+      // Both the id=X row (the actual one in DB) and the id=Y delete target
+      // must result in zero pending rows for (workspace_id, email).
+      const pending = await db
+        .select()
+        .from(workspacePendingMembershipsTable)
+        .where(eq(workspacePendingMembershipsTable.workspaceId, sharedId))
+      expect(pending).toHaveLength(0)
+    })
+
     it('preserves an existing membership role on promote-on-insert (no downgrade)', async () => {
       // Regression: promote-on-insert previously used upsertMembership, which
       // overwrote the role on conflict — inviting an existing admin's own

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -508,6 +508,70 @@ describe('workspace upload handlers', () => {
       expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
     })
 
+    it('rejects PUT that demotes an existing admin without change_roles', async () => {
+      // `upsertMembership` does ON CONFLICT DO UPDATE SET role on
+      // `(workspace_id, user_id)`. A caller with `invite_users` alone could
+      // otherwise PUT `role: 'member'` at an existing admin's pair and
+      // demote them without `change_roles` — same effective action as a
+      // PATCH demote, which DOES require `change_roles`.
+      await insertUser('demote-admin', 'demote-admin@test.com')
+      await bootstrapPersonalViaUpload('demote-admin')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({
+        id: sharedId,
+        name: 'Shared',
+        isPersonal: false,
+        ownerUserId: null,
+      })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'demote-admin',
+        role: 'admin',
+      })
+      const targetAdminId = 'demote-target-admin'
+      await insertUser(targetAdminId, 'demote-target-admin@test.com')
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: targetAdminId,
+        role: 'admin',
+      })
+      const memberId = 'demote-actor-invite-only'
+      await insertUser(memberId, 'demote-actor-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      // PUT with a fresh op.id (so the lookup must hit by `(workspace_id, user_id)`)
+      // and the demoted role on the existing admin's pair.
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, user_id: targetAdminId, role: 'member' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+
+      // Existing admin row is untouched.
+      const stored = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.id, targetMembershipId))
+      expect(stored[0].role).toBe('admin')
+    })
+
     it('rejects a second membership write to a personal workspace (immutable)', async () => {
       await insertUser('owner6', 'owner6@test.com')
       await insertUser('victim', 'victim@test.com')

--- a/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
+++ b/backend/src/powersync/upload-handlers/workspace-handlers.test.ts
@@ -462,6 +462,52 @@ describe('workspace upload handlers', () => {
       expect(stored[0].userEmail).toBe('owner5@test.com')
     })
 
+    it('rejects an admin-role membership PUT from invite_users-only caller (escalation guard)', async () => {
+      // Direct `workspace_memberships` PUT with `role: 'admin'` must require
+      // `change_roles` in addition to `invite_users` — same shape as the
+      // pending-membership escalation guard.
+      await insertUser('admin-ws', 'admin-ws@test.com')
+      await bootstrapPersonalViaUpload('admin-ws')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({
+        id: sharedId,
+        name: 'Shared',
+        isPersonal: false,
+        ownerUserId: null,
+      })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-ws',
+        role: 'admin',
+      })
+      const memberId = 'ws-member-invite-only'
+      await insertUser(memberId, 'ws-member-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+      const newUserId = 'new-admin-target'
+      await insertUser(newUserId, 'new-admin-target@test.com')
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, user_id: newUserId, role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
     it('rejects a second membership write to a personal workspace (immutable)', async () => {
       await insertUser('owner6', 'owner6@test.com')
       await insertUser('victim', 'victim@test.com')
@@ -530,6 +576,165 @@ describe('workspace upload handlers', () => {
         .from(workspaceMembershipsTable)
         .where(eq(workspaceMembershipsTable.id, a4MembershipId))
       expect(stillThere).toHaveLength(1)
+    })
+
+    it('PATCH role: allowed when caller has change_roles=member', async () => {
+      await insertUser('admin-cr-ok', 'admin-cr-ok@test.com')
+      await insertUser('target-cr-ok', 'target-cr-ok@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'Shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-cr-ok',
+        role: 'admin',
+      })
+      const memberId = 'member-with-cr'
+      await insertUser(memberId, 'member-with-cr@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: 'target-cr-ok',
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'change_roles',
+        requiredRole: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'PATCH',
+        type: 'workspace_memberships',
+        id: targetMembershipId,
+        data: { role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expect(result.ok).toBe(true)
+    })
+
+    it('PATCH role: rejected when caller lacks change_roles', async () => {
+      await insertUser('admin-cr-no', 'admin-cr-no@test.com')
+      await insertUser('target-cr-no', 'target-cr-no@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'Shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-cr-no',
+        role: 'admin',
+      })
+      const memberId = 'member-no-cr'
+      await insertUser(memberId, 'member-no-cr@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: 'target-cr-no',
+        role: 'member',
+      })
+      // No workspace_permissions row → change_roles defaults to admin.
+
+      const op: UploadOp = {
+        op: 'PATCH',
+        type: 'workspace_memberships',
+        id: targetMembershipId,
+        data: { role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('DELETE: allowed when caller has remove_users=member', async () => {
+      await insertUser('admin-ru-ok', 'admin-ru-ok@test.com')
+      await insertUser('target-ru-ok', 'target-ru-ok@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'Shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-ru-ok',
+        role: 'admin',
+      })
+      const memberId = 'member-with-ru'
+      await insertUser(memberId, 'member-with-ru@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: 'target-ru-ok',
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'remove_users',
+        requiredRole: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'DELETE',
+        type: 'workspace_memberships',
+        id: targetMembershipId,
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expect(result.ok).toBe(true)
+    })
+
+    it('DELETE: rejected when caller lacks remove_users', async () => {
+      await insertUser('admin-ru-no', 'admin-ru-no@test.com')
+      await insertUser('target-ru-no', 'target-ru-no@test.com')
+      const sharedId = uuidv7()
+      await db.insert(workspacesTable).values({ id: sharedId, name: 'Shared', isPersonal: false })
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: 'admin-ru-no',
+        role: 'admin',
+      })
+      const memberId = 'member-no-ru'
+      await insertUser(memberId, 'member-no-ru@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      const targetMembershipId = uuidv7()
+      await db.insert(workspaceMembershipsTable).values({
+        id: targetMembershipId,
+        workspaceId: sharedId,
+        userId: 'target-ru-no',
+        role: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'DELETE',
+        type: 'workspace_memberships',
+        id: targetMembershipId,
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
     })
 
     it('rejects a PUT adding another user when e2eeEnabled is true (THU-593)', async () => {
@@ -636,6 +841,154 @@ describe('workspace upload handlers', () => {
         },
       }
       const result = await applyUploadBatch(db, [op], ctxFor('b-perm'))
+      expect(result.ok).toBe(true)
+    })
+
+    it('rejects an admin-role pending invite from invite_users-only caller (escalation guard)', async () => {
+      // `invite_users` alone must not be enough to invite `role: 'admin'` —
+      // otherwise the signup-promote path would mint a new admin and bypass
+      // the `change_roles` gate that protects existing-member promotions.
+      await insertUser('inviter-only', 'inviter-only@test.com')
+      await bootstrapPersonalViaUpload('inviter-only')
+      const sharedId = await seedSharedAsAdmin('inviter-only')
+      const memberId = 'member-with-invite-only'
+      await insertUser(memberId, 'member-with-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, email: 'pending-admin@test.com', role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('rejects PATCH that promotes a pending invite to admin without change_roles', async () => {
+      // PATCH-to-admin must hit the same escalation guard as PUT-to-admin —
+      // otherwise an inviter could quietly elevate a pending invite they
+      // shouldn't be able to promote.
+      await insertUser('patch-inviter', 'patch-inviter@test.com')
+      await bootstrapPersonalViaUpload('patch-inviter')
+      const sharedId = await seedSharedAsAdmin('patch-inviter')
+      const memberId = 'patch-member-invite-only'
+      await insertUser(memberId, 'patch-member-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      // Seed a pending invite at role=member, then try to PATCH to admin.
+      const pendingId = uuidv7()
+      await db.insert(workspacePendingMembershipsTable).values({
+        id: pendingId,
+        workspaceId: sharedId,
+        email: 'pending-target@test.com',
+        role: 'member',
+        invitedByUserId: 'patch-inviter',
+      })
+
+      const op: UploadOp = {
+        op: 'PATCH',
+        type: 'workspace_pending_memberships',
+        id: pendingId,
+        data: { role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expectPermanentReject(result, 'INSUFFICIENT_PERMISSION')
+    })
+
+    it('allows PATCH demoting a pending admin invite to member from invite_users-only caller', async () => {
+      // The escalation guard is intentionally one-way: promotions to admin
+      // require `change_roles`, but demotions stay gated on `invite_users`
+      // alone. Demoting a pending admin invite is tampering, not escalation,
+      // and matching the broader "any role change" rule from the memberships
+      // handler would cost an extra DB read for a non-security concern.
+      await insertUser('demote-inviter', 'demote-inviter@test.com')
+      await bootstrapPersonalViaUpload('demote-inviter')
+      const sharedId = await seedSharedAsAdmin('demote-inviter')
+      const memberId = 'demote-member-invite-only'
+      await insertUser(memberId, 'demote-member-invite-only@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      await db.insert(workspacePermissionsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        permissionKey: 'invite_users',
+        requiredRole: 'member',
+      })
+
+      const pendingId = uuidv7()
+      await db.insert(workspacePendingMembershipsTable).values({
+        id: pendingId,
+        workspaceId: sharedId,
+        email: 'pending-admin-to-demote@test.com',
+        role: 'admin',
+        invitedByUserId: 'demote-inviter',
+      })
+
+      const op: UploadOp = {
+        op: 'PATCH',
+        type: 'workspace_pending_memberships',
+        id: pendingId,
+        data: { role: 'member' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
+      expect(result.ok).toBe(true)
+    })
+
+    it('allows an admin-role pending invite when caller has BOTH invite_users and change_roles', async () => {
+      await insertUser('inviter-both', 'inviter-both@test.com')
+      await bootstrapPersonalViaUpload('inviter-both')
+      const sharedId = await seedSharedAsAdmin('inviter-both')
+      const memberId = 'member-with-both'
+      await insertUser(memberId, 'member-with-both@test.com')
+      await db.insert(workspaceMembershipsTable).values({
+        id: uuidv7(),
+        workspaceId: sharedId,
+        userId: memberId,
+        role: 'member',
+      })
+      for (const key of ['invite_users', 'change_roles'] as const) {
+        await db.insert(workspacePermissionsTable).values({
+          id: uuidv7(),
+          workspaceId: sharedId,
+          permissionKey: key,
+          requiredRole: 'member',
+        })
+      }
+
+      const op: UploadOp = {
+        op: 'PUT',
+        type: 'workspace_pending_memberships',
+        id: uuidv7(),
+        data: { workspace_id: sharedId, email: 'pending-admin-allowed@test.com', role: 'admin' },
+      }
+      const result = await applyUploadBatch(db, [op], ctxFor(memberId))
       expect(result.ok).toBe(true)
     })
 

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -138,7 +138,6 @@ export const workspaceMembershipsHandler: UploadHandler = {
     // Defaults to admin when the row is absent (Decision 11). Aligned with what
     // the FE Members UI checks via `useWorkspacePermission` so a workspace that
     // grants `member` the permission can actually exercise it on upload.
-    // (#974 r3397677057)
     if (op.op === 'PUT' && !targetWorkspaceId) {
       const existing = await getMembershipById(tx, op.id)
       if (!existing) {

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -71,6 +71,10 @@ const isPersonalAdminBootstrap = async (
  * - Each op gates on a `workspace_permissions` key — `invite_users` for PUT,
  *   `change_roles` for PATCH, `remove_users` for DELETE — defaulting to
  *   admin-only when the permission row is absent (Decision 11).
+ * - Adding a membership with `role: 'admin'` additionally requires
+ *   `change_roles` — `invite_users` alone could otherwise mint new admins
+ *   via either a direct PUT or via the pending-invite signup-promote path,
+ *   bypassing the gate that protects existing-member promotions.
  * - Personal workspaces are immutable past the FE-driven admin bootstrap
  *   (`isPersonalAdminBootstrap`), which lands exactly one admin row for the
  *   owner the first time the workspace appears server-side.
@@ -144,6 +148,11 @@ export const workspaceMembershipsHandler: UploadHandler = {
     // Defaults to admin when the row is absent (Decision 11). Aligned with what
     // the FE Members UI checks via `useWorkspacePermission` so a workspace that
     // grants `member` the permission can actually exercise it on upload.
+    //
+    // Adding a membership with `role: 'admin'` additionally requires
+    // `change_roles` — otherwise `invite_users` alone could mint new admins
+    // and bypass the gate that protects existing-member promotions.
+    const targetsAdminRole = op.data?.role === 'admin'
     if (op.op === 'PUT' && !targetWorkspaceId) {
       const existing = await getMembershipById(tx, op.id)
       if (!existing) {
@@ -155,6 +164,12 @@ export const workspaceMembershipsHandler: UploadHandler = {
       if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
         return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
+      if (
+        targetsAdminRole &&
+        !(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'change_roles'))
+      ) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
+      }
       return allow()
     }
 
@@ -164,6 +179,9 @@ export const workspaceMembershipsHandler: UploadHandler = {
         return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
       }
       if (!(await callerSatisfiesPermission(tx, targetWorkspaceId!, ctx.userId, 'invite_users'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
+      }
+      if (targetsAdminRole && !(await callerSatisfiesPermission(tx, targetWorkspaceId!, ctx.userId, 'change_roles'))) {
         return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -9,14 +9,13 @@ import {
   getMembershipById,
   getWorkspaceById,
   isPersonalWorkspace,
-  isWorkspaceAdmin,
   type Role,
   updateMembership,
   upsertMembership,
 } from '@/dal/workspaces'
 import { getUserById } from '@/dal/users'
 import { computePersonalAdminMembershipId, computePersonalWorkspaceId } from '@shared/workspaces'
-import { allow, reject } from './helpers'
+import { allow, callerSatisfiesPermission, reject } from './helpers'
 import { UploadRejection, type UploadHandler, type UploadTx } from './types'
 
 const isRole = (v: unknown): v is Role => v === 'admin' || v === 'member'
@@ -135,6 +134,11 @@ export const workspaceMembershipsHandler: UploadHandler = {
     const targetWorkspaceId =
       op.op === 'PUT' ? (typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : null) : null
 
+    // Per-op permission keys read from `workspace_permissions.required_role`.
+    // Defaults to admin when the row is absent (Decision 11). Aligned with what
+    // the FE Members UI checks via `useWorkspacePermission` so a workspace that
+    // grants `member` the permission can actually exercise it on upload.
+    // (#974 r3397677057)
     if (op.op === 'PUT' && !targetWorkspaceId) {
       const existing = await getMembershipById(tx, op.id)
       if (!existing) {
@@ -143,8 +147,8 @@ export const workspaceMembershipsHandler: UploadHandler = {
       if (await isPersonalWorkspace(tx, existing.workspaceId)) {
         return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
       }
-      if (!(await isWorkspaceAdmin(tx, existing.workspaceId, ctx.userId))) {
-        return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+      if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()
     }
@@ -154,8 +158,8 @@ export const workspaceMembershipsHandler: UploadHandler = {
       if (await isPersonalWorkspace(tx, targetWorkspaceId!)) {
         return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
       }
-      if (!(await isWorkspaceAdmin(tx, targetWorkspaceId!, ctx.userId))) {
-        return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+      if (!(await callerSatisfiesPermission(tx, targetWorkspaceId!, ctx.userId, 'invite_users'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()
     }
@@ -168,8 +172,9 @@ export const workspaceMembershipsHandler: UploadHandler = {
     if (await isPersonalWorkspace(tx, existing.workspaceId)) {
       return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
     }
-    if (!(await isWorkspaceAdmin(tx, existing.workspaceId, ctx.userId))) {
-      return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+    const permissionKey: 'change_roles' | 'remove_users' = op.op === 'PATCH' ? 'change_roles' : 'remove_users'
+    if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, permissionKey))) {
+      return reject('permanent', 'INSUFFICIENT_PERMISSION')
     }
     return allow()
   },

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -7,6 +7,7 @@ import {
   countWorkspaceMemberships,
   deleteMembership,
   getMembershipById,
+  getMembershipByWorkspaceAndUser,
   getWorkspaceById,
   isPersonalWorkspace,
   type Role,
@@ -71,10 +72,15 @@ const isPersonalAdminBootstrap = async (
  * - Each op gates on a `workspace_permissions` key — `invite_users` for PUT,
  *   `change_roles` for PATCH, `remove_users` for DELETE — defaulting to
  *   admin-only when the permission row is absent (Decision 11).
- * - Adding a membership with `role: 'admin'` additionally requires
- *   `change_roles` — `invite_users` alone could otherwise mint new admins
- *   via either a direct PUT or via the pending-invite signup-promote path,
- *   bypassing the gate that protects existing-member promotions.
+ * - PUT that would effectively change an existing membership's role
+ *   additionally requires `change_roles`. PUT applies via `upsertMembership`
+ *   (ON CONFLICT DO UPDATE SET role), so a payload demoting an admin to
+ *   member at the same `(workspace_id, user_id)` would otherwise bypass
+ *   PATCH's `change_roles` gate.
+ * - Adding a brand-new membership with `role: 'admin'` requires
+ *   `change_roles` for the same reason — `invite_users` alone could
+ *   otherwise mint new admins (also via the pending-invite signup-promote
+ *   path).
  * - Personal workspaces are immutable past the FE-driven admin bootstrap
  *   (`isPersonalAdminBootstrap`), which lands exactly one admin row for the
  *   owner the first time the workspace appears server-side.
@@ -148,11 +154,8 @@ export const workspaceMembershipsHandler: UploadHandler = {
     // Defaults to admin when the row is absent (Decision 11). Aligned with what
     // the FE Members UI checks via `useWorkspacePermission` so a workspace that
     // grants `member` the permission can actually exercise it on upload.
-    //
-    // Adding a membership with `role: 'admin'` additionally requires
-    // `change_roles` — otherwise `invite_users` alone could mint new admins
-    // and bypass the gate that protects existing-member promotions.
-    const targetsAdminRole = op.data?.role === 'admin'
+    const newRole = isRole(op.data?.role) ? op.data.role : null
+    const targetsAdminRole = newRole === 'admin'
     if (op.op === 'PUT' && !targetWorkspaceId) {
       const existing = await getMembershipById(tx, op.id)
       if (!existing) {
@@ -164,8 +167,12 @@ export const workspaceMembershipsHandler: UploadHandler = {
       if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
         return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
+      // Effective role change (either direction) requires `change_roles`.
+      // `upsertMembership` overwrites `role` on conflict, so a PUT that
+      // changes role would otherwise bypass PATCH's gate.
+      const wouldChangeRole = newRole !== null && existing.role !== newRole
       if (
-        targetsAdminRole &&
+        (wouldChangeRole || targetsAdminRole) &&
         !(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'change_roles'))
       ) {
         return reject('permanent', 'INSUFFICIENT_PERMISSION')
@@ -181,7 +188,19 @@ export const workspaceMembershipsHandler: UploadHandler = {
       if (!(await callerSatisfiesPermission(tx, targetWorkspaceId!, ctx.userId, 'invite_users'))) {
         return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
-      if (targetsAdminRole && !(await callerSatisfiesPermission(tx, targetWorkspaceId!, ctx.userId, 'change_roles'))) {
+      // Resolve the existing row at the conflict target `(workspace_id, user_id)`
+      // — that's what `upsertMembership` updates, not the row at `op.id`.
+      // A PUT changing an existing role (either direction) requires
+      // `change_roles`; a fresh insert with `role: 'admin'` also requires it.
+      const payloadUserId = typeof op.data?.user_id === 'string' ? op.data.user_id : null
+      const existing =
+        payloadUserId !== null ? await getMembershipByWorkspaceAndUser(tx, targetWorkspaceId!, payloadUserId) : null
+      const wouldChangeRole = existing !== null && newRole !== null && existing.role !== newRole
+      const wouldMintNewAdmin = existing === null && targetsAdminRole
+      if (
+        (wouldChangeRole || wouldMintNewAdmin) &&
+        !(await callerSatisfiesPermission(tx, targetWorkspaceId!, ctx.userId, 'change_roles'))
+      ) {
         return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -230,6 +230,17 @@ export const workspaceMembershipsHandler: UploadHandler = {
         if (!workspaceId || !userId || !role) {
           throw new UploadRejection('permanent', 'MEMBERSHIP_FIELDS_REQUIRED')
         }
+        // Last-admin protection mirrors PATCH/DELETE. `upsertMembership` does
+        // ON CONFLICT DO UPDATE SET role on `(workspace_id, user_id)`, so a
+        // PUT demoting the workspace's only admin to member would otherwise
+        // bypass the guard those paths enforce.
+        const existing = await getMembershipByWorkspaceAndUser(tx, workspaceId, userId)
+        if (existing && existing.role === 'admin' && role !== 'admin') {
+          const remainingAdmins = await countWorkspaceAdmins(tx, workspaceId, existing.id)
+          if (remainingAdmins === 0) {
+            throw new UploadRejection('permanent', 'LAST_ADMIN_PROTECTED')
+          }
+        }
         // Enrich the row with the canonical name/email from `auth.user` so the
         // FE Members page has display info without a synced `users` table. The
         // FE never gets to set these fields directly — the BE is the only

--- a/backend/src/powersync/upload-handlers/workspace-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-memberships.ts
@@ -68,12 +68,18 @@ const isPersonalAdminBootstrap = async (
 /**
  * Upload handler for `workspace_memberships`. Enforces:
  *
- * - All writes require admin role in the target workspace.
- * - Personal workspaces are immutable — admin membership exists exactly once and
- *   is created by the Better Auth post-create hook (Decision 11 / Decision 12).
- * - DELETE that would leave zero remaining admins in the workspace is permanently
- *   rejected. The count is taken inside the same transaction as the delete so
- *   concurrent revokes can't both pass the check.
+ * - Each op gates on a `workspace_permissions` key — `invite_users` for PUT,
+ *   `change_roles` for PATCH, `remove_users` for DELETE — defaulting to
+ *   admin-only when the permission row is absent (Decision 11).
+ * - Personal workspaces are immutable past the FE-driven admin bootstrap
+ *   (`isPersonalAdminBootstrap`), which lands exactly one admin row for the
+ *   owner the first time the workspace appears server-side.
+ * - The first admin membership for a freshly-created shared workspace is
+ *   allowed by `isSharedWorkspaceAdminBootstrap` (caller is the row's user,
+ *   role is admin, workspace has zero members yet).
+ * - DELETE that would leave zero remaining admins is permanently rejected.
+ *   The count is taken inside the same transaction so concurrent revokes
+ *   can't both pass the check.
  */
 /**
  * Shared workspace creator bootstrap: the FE creates a shared workspace and its

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -80,17 +80,18 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         const workspaceId = typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : null
         const email = typeof op.data?.email === 'string' ? op.data.email : null
         const role = isRole(op.data?.role) ? op.data.role : null
-        const invitedByUserId =
-          typeof op.data?.invited_by_user_id === 'string' ? op.data.invited_by_user_id : ctx.userId
         if (!workspaceId || !email || !role) {
           throw new UploadRejection('permanent', 'PENDING_FIELDS_REQUIRED')
         }
+        // `invitedByUserId` is server-truth — the caller is the inviter, full
+        // stop. Trusting the payload would let a client attribute the invite
+        // to someone else.
         await upsertPendingMembership(tx, {
           id: op.id,
           workspaceId,
           email,
           role,
-          invitedByUserId,
+          invitedByUserId: ctx.userId,
         })
 
         // Promote-on-insert: if the invited email already belongs to a real
@@ -126,14 +127,16 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         return
       }
       case 'PATCH': {
+        // `invited_by_user_id` is server-truth and not patchable by the
+        // client — silently drop it from the payload rather than rewriting
+        // it to an attacker-supplied value.
         const email = typeof op.data?.email === 'string' ? op.data.email : undefined
         const role = isRole(op.data?.role) ? op.data.role : undefined
-        const invitedByUserId = typeof op.data?.invited_by_user_id === 'string' ? op.data.invited_by_user_id : undefined
 
-        if (email === undefined && role === undefined && invitedByUserId === undefined) {
+        if (email === undefined && role === undefined) {
           throw new UploadRejection('permanent', 'EMPTY_PAYLOAD')
         }
-        const affected = await updatePendingMembership(tx, op.id, { email, role, invitedByUserId })
+        const affected = await updatePendingMembership(tx, op.id, { email, role })
         if (affected === 0) {
           throw new UploadRejection('permanent', 'ROW_NOT_FOUND')
         }

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -8,14 +8,13 @@ import {
   getPendingMembershipById,
   insertMembershipIfMissing,
   isPersonalWorkspace,
-  isWorkspaceAdmin,
   type Role,
   updatePendingMembership,
   upsertPendingMembership,
 } from '@/dal/workspaces'
 import { getUserByEmail } from '@/dal/users'
 import { normalizeEmail } from '@/lib/email'
-import { allow, reject } from './helpers'
+import { allow, callerSatisfiesPermission, reject } from './helpers'
 import { UploadRejection, type UploadHandler } from './types'
 
 const isRole = (v: unknown): v is Role => v === 'admin' || v === 'member'
@@ -35,6 +34,9 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
       return reject('permanent', 'E2EE_MEMBERSHIPS_DISABLED')
     }
 
+    // All pending-membership writes (create / edit / cancel an invite) gate on
+    // `invite_users` so a workspace that grants `member` the permission can
+    // exercise it on upload. Defaults to admin via Decision 11. (#974 r3397677057)
     if (op.op === 'PUT') {
       const targetWorkspaceId = typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : undefined
       if (!targetWorkspaceId) {
@@ -45,16 +47,16 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         if (await isPersonalWorkspace(tx, existing.workspaceId)) {
           return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
         }
-        if (!(await isWorkspaceAdmin(tx, existing.workspaceId, ctx.userId))) {
-          return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+        if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
+          return reject('permanent', 'INSUFFICIENT_PERMISSION')
         }
         return allow()
       }
       if (await isPersonalWorkspace(tx, targetWorkspaceId)) {
         return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
       }
-      if (!(await isWorkspaceAdmin(tx, targetWorkspaceId, ctx.userId))) {
-        return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+      if (!(await callerSatisfiesPermission(tx, targetWorkspaceId, ctx.userId, 'invite_users'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()
     }
@@ -66,8 +68,8 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
     if (await isPersonalWorkspace(tx, existing.workspaceId)) {
       return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
     }
-    if (!(await isWorkspaceAdmin(tx, existing.workspaceId, ctx.userId))) {
-      return reject('permanent', 'NOT_WORKSPACE_ADMIN')
+    if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
+      return reject('permanent', 'INSUFFICIENT_PERMISSION')
     }
     return allow()
   },

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -4,6 +4,7 @@
 
 import {
   deletePendingMembership,
+  deletePendingMembershipByWorkspaceAndEmail,
   getPendingMembershipById,
   insertMembershipIfMissing,
   isPersonalWorkspace,
@@ -113,7 +114,12 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
             userName: matched.name,
             userEmail: matched.email,
           })
-          await deletePendingMembership(tx, op.id)
+          // Delete by `(workspace_id, email)` rather than `op.id` — the upsert
+          // above hit the `(workspace_id, email)` unique constraint when the
+          // pending row already existed, in which case Postgres kept the
+          // original id and the upload's `op.id` no longer matches. Keying on
+          // workspace+email always lands on the actual row. (#965 r3382104740)
+          await deletePendingMembershipByWorkspaceAndEmail(tx, workspaceId, email)
         }
         return
       }

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -36,7 +36,7 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
 
     // All pending-membership writes (create / edit / cancel an invite) gate on
     // `invite_users` so a workspace that grants `member` the permission can
-    // exercise it on upload. Defaults to admin via Decision 11. (#974 r3397677057)
+    // exercise it on upload. Defaults to admin via Decision 11.
     if (op.op === 'PUT') {
       const targetWorkspaceId = typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : undefined
       if (!targetWorkspaceId) {
@@ -120,7 +120,7 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
           // above hit the `(workspace_id, email)` unique constraint when the
           // pending row already existed, in which case Postgres kept the
           // original id and the upload's `op.id` no longer matches. Keying on
-          // workspace+email always lands on the actual row. (#965 r3382104740)
+          // workspace+email always lands on the actual row.
           await deletePendingMembershipByWorkspaceAndEmail(tx, workspaceId, email)
         }
         return

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -13,7 +13,7 @@ import {
   upsertPendingMembership,
 } from '@/dal/workspaces'
 import { getUserByEmail } from '@/dal/users'
-import { normalizeEmail } from '@/lib/email'
+import { isValidEmailFormat, normalizeEmail } from '@/lib/email'
 import { allow, callerSatisfiesPermission, reject } from './helpers'
 import { UploadRejection, type UploadHandler } from './types'
 
@@ -83,6 +83,9 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         if (!workspaceId || !email || !role) {
           throw new UploadRejection('permanent', 'PENDING_FIELDS_REQUIRED')
         }
+        if (!isValidEmailFormat(email)) {
+          throw new UploadRejection('permanent', 'INVALID_EMAIL')
+        }
         // `invitedByUserId` is server-truth — the caller is the inviter, full
         // stop. Trusting the payload would let a client attribute the invite
         // to someone else.
@@ -135,6 +138,9 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
 
         if (email === undefined && role === undefined) {
           throw new UploadRejection('permanent', 'EMPTY_PAYLOAD')
+        }
+        if (email !== undefined && !isValidEmailFormat(email)) {
+          throw new UploadRejection('permanent', 'INVALID_EMAIL')
         }
         const affected = await updatePendingMembership(tx, op.id, { email, role })
         if (affected === 0) {

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -5,11 +5,11 @@
 import {
   deletePendingMembership,
   getPendingMembershipById,
+  insertMembershipIfMissing,
   isPersonalWorkspace,
   isWorkspaceAdmin,
   type Role,
   updatePendingMembership,
-  upsertMembership,
   upsertPendingMembership,
 } from '@/dal/workspaces'
 import { getUserByEmail } from '@/dal/users'
@@ -97,9 +97,15 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         // which removes its optimistic local pending row organically. The
         // signup hook (`promotePendingMemberships`) covers the unknown-email
         // path when the invitee later signs up.
+        //
+        // DO-NOTHING semantics: if the user is already a member of this
+        // workspace, the invite must NOT overwrite their current role —
+        // inviting an existing admin's email would otherwise downgrade them
+        // to whatever role the invite carried. Mirrors
+        // `promotePendingMemberships` (the signup-time bulk-promote path).
         const matched = await getUserByEmail(tx, normalizeEmail(email))
         if (matched) {
-          await upsertMembership(tx, {
+          await insertMembershipIfMissing(tx, {
             id: crypto.randomUUID(),
             workspaceId,
             userId: matched.id,

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -20,8 +20,10 @@ import { UploadRejection, type UploadHandler } from './types'
 const isRole = (v: unknown): v is Role => v === 'admin' || v === 'member'
 
 /**
- * Upload handler for `workspace_pending_memberships`. All operations require admin
- * role in the target workspace; personal workspaces cannot have pending memberships.
+ * Upload handler for `workspace_pending_memberships`. Every write gates on the
+ * `invite_users` permission (admin by default, Decision 11). Promoting/editing
+ * a pending invite to `role: 'admin'` additionally requires `change_roles` —
+ * see the inline guard. Personal workspaces cannot have pending memberships.
  * Email is normalized server-side by the DAL to match the Better Auth `before` hook.
  */
 export const workspacePendingMembershipsHandler: UploadHandler = {

--- a/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
+++ b/backend/src/powersync/upload-handlers/workspace-pending-memberships.ts
@@ -37,6 +37,12 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
     // All pending-membership writes (create / edit / cancel an invite) gate on
     // `invite_users` so a workspace that grants `member` the permission can
     // exercise it on upload. Defaults to admin via Decision 11.
+    //
+    // Inviting (or editing the invite to) `role: 'admin'` additionally requires
+    // `change_roles` — otherwise `invite_users` alone could mint new admins
+    // via the signup-promote path, bypassing the gate that protects existing
+    // members from being promoted by non-role-managers.
+    const targetsAdminRole = op.data?.role === 'admin'
     if (op.op === 'PUT') {
       const targetWorkspaceId = typeof op.data?.workspace_id === 'string' ? op.data.workspace_id : undefined
       if (!targetWorkspaceId) {
@@ -50,12 +56,21 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
         if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
           return reject('permanent', 'INSUFFICIENT_PERMISSION')
         }
+        if (
+          targetsAdminRole &&
+          !(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'change_roles'))
+        ) {
+          return reject('permanent', 'INSUFFICIENT_PERMISSION')
+        }
         return allow()
       }
       if (await isPersonalWorkspace(tx, targetWorkspaceId)) {
         return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
       }
       if (!(await callerSatisfiesPermission(tx, targetWorkspaceId, ctx.userId, 'invite_users'))) {
+        return reject('permanent', 'INSUFFICIENT_PERMISSION')
+      }
+      if (targetsAdminRole && !(await callerSatisfiesPermission(tx, targetWorkspaceId, ctx.userId, 'change_roles'))) {
         return reject('permanent', 'INSUFFICIENT_PERMISSION')
       }
       return allow()
@@ -69,6 +84,19 @@ export const workspacePendingMembershipsHandler: UploadHandler = {
       return reject('permanent', 'PERSONAL_WORKSPACE_IMMUTABLE')
     }
     if (!(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'invite_users'))) {
+      return reject('permanent', 'INSUFFICIENT_PERMISSION')
+    }
+    // Guard fires only on promotions (role becoming admin). Demoting an
+    // existing pending admin invite to `member` stays gated on `invite_users`
+    // alone — it's tampering, not escalation, and matching the broader
+    // "any role change requires change_roles" rule from the memberships
+    // handler would cost an extra DB read (load existing pending row) for
+    // a non-security concern.
+    if (
+      op.op === 'PATCH' &&
+      targetsAdminRole &&
+      !(await callerSatisfiesPermission(tx, existing.workspaceId, ctx.userId, 'change_roles'))
+    ) {
       return reject('permanent', 'INSUFFICIENT_PERMISSION')
     }
     return allow()

--- a/backend/src/powersync/upload-handlers/workspace-scoped.ts
+++ b/backend/src/powersync/upload-handlers/workspace-scoped.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getRequiredRoleForPermission, getUserRoleInWorkspace, isWorkspaceMember } from '@/dal/workspaces'
+import { isWorkspaceMember } from '@/dal/workspaces'
 import {
   powersyncConflictTarget,
   powersyncDbNameToSchemaKey,
@@ -10,10 +10,10 @@ import {
   powersyncTablesByName,
 } from '@/db/powersync-schema'
 import type { PowerSyncTableName } from '@shared/powersync-tables'
-import { permissionAllows, type WorkspacePermissionKey } from '@shared/workspaces'
+import { type WorkspacePermissionKey } from '@shared/workspaces'
 import { and, eq } from 'drizzle-orm'
 import type { AnyPgColumn, AnyPgTable } from 'drizzle-orm/pg-core'
-import { allow, reject, toSchemaRecord } from './helpers'
+import { allow, callerSatisfiesPermission, reject, toSchemaRecord } from './helpers'
 import { UploadRejection, type UploadHandler, type UploadTx } from './types'
 
 export type WorkspaceScopedConfig = {
@@ -50,23 +50,6 @@ export type WorkspaceScopedConfig = {
    * mcp_servers) whose FE DAL soft-deletes via UPDATE rather than DELETE.
    */
   softDeleteColumn?: string
-}
-
-/**
- * Resolves the caller's role + the configured permission's required role and
- * returns whether the op is allowed. Defaults `required_role` to `'admin'`
- * when no `workspace_permissions` row exists for the key (Decision 11) so an
- * unconfigured workspace stays admin-only.
- */
-const callerSatisfiesPermission = async (
-  tx: UploadTx,
-  workspaceId: string,
-  userId: string,
-  permissionKey: WorkspacePermissionKey,
-): Promise<boolean> => {
-  const required = (await getRequiredRoleForPermission(tx, workspaceId, permissionKey)) ?? 'admin'
-  const userRole = await getUserRoleInWorkspace(tx, workspaceId, userId)
-  return permissionAllows(userRole, required)
 }
 
 const isString = (v: unknown): v is string => typeof v === 'string'

--- a/backend/src/powersync/upload-handlers/workspaces.ts
+++ b/backend/src/powersync/upload-handlers/workspaces.ts
@@ -111,15 +111,20 @@ export const workspacesHandler: UploadHandler = {
         if (!name) {
           throw new UploadRejection('permanent', 'WORKSPACE_NAME_REQUIRED')
         }
-        const slug = typeof op.data?.slug === 'string' ? op.data.slug : null
-        const icon = typeof op.data?.icon === 'string' ? op.data.icon : null
+        // Distinguish "key omitted from payload" (undefined) from "explicitly
+        // null" so an admin's idempotent PUT that doesn't carry slug/icon
+        // doesn't clobber values already on the server. `upsertWorkspace`'s
+        // ON CONFLICT only writes columns whose input value is `!== undefined`.
+        // (#971 r3391725303)
+        const slug = op.data?.slug === undefined ? undefined : typeof op.data.slug === 'string' ? op.data.slug : null
+        const icon = op.data?.icon === undefined ? undefined : typeof op.data.icon === 'string' ? op.data.icon : null
         if (isPersonalPut) {
           // `DO NOTHING` on conflict — preserves any later changes if a second
           // device's bootstrap PUT lands after the user already mutated the row.
           await insertPersonalWorkspaceIfMissing(tx, {
             id: op.id,
             name,
-            icon,
+            icon: icon ?? null,
             ownerUserId: ctx.userId,
           })
           return

--- a/backend/src/powersync/upload-handlers/workspaces.ts
+++ b/backend/src/powersync/upload-handlers/workspaces.ts
@@ -115,7 +115,6 @@ export const workspacesHandler: UploadHandler = {
         // null" so an admin's idempotent PUT that doesn't carry slug/icon
         // doesn't clobber values already on the server. `upsertWorkspace`'s
         // ON CONFLICT only writes columns whose input value is `!== undefined`.
-        // (#971 r3391725303)
         const slug = op.data?.slug === undefined ? undefined : typeof op.data.slug === 'string' ? op.data.slug : null
         const icon = op.data?.icon === undefined ? undefined : typeof op.data.icon === 'string' ? op.data.icon : null
         if (isPersonalPut) {

--- a/deploy/config/powersync-config.yaml
+++ b/deploy/config/powersync-config.yaml
@@ -47,12 +47,19 @@ sync_rules:
           - SELECT * FROM powersync.workspaces WHERE id = bucket.workspace_id
           - SELECT * FROM powersync.workspace_permissions WHERE workspace_id = bucket.workspace_id
 
-      # Workspace shared data — full member list and shared workspace-scoped config.
+      # Workspace shared data — full member list, pending invites, and shared
+      # workspace-scoped config. Pending memberships sync to every member (not
+      # just admins) because `invite_users`/`change_roles`/`remove_users` are
+      # per-key permissions that can be granted to `member` role; without the
+      # row syncing down, a permitted non-admin would see an empty pending list.
+      # Write authorization is enforced by the upload handlers, not by the
+      # sync rule.
       workspace_data:
         priority: 2
         parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id()
         data:
           - SELECT * FROM powersync.workspace_memberships WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.models WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.mcp_servers WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.prompts WHERE workspace_id = bucket.workspace_id
@@ -61,14 +68,6 @@ sync_rules:
           - SELECT * FROM powersync.modes WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.model_profiles WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.agents WHERE workspace_id = bucket.workspace_id
-
-      # Admin-only data — one bucket per workspace where the user is an admin.
-      # Pending memberships sync down only to admins so they can manage invites.
-      workspace_admin_data:
-        priority: 2
-        parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id() AND role = 'admin'
-        data:
-          - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
 
 client_auth:
   supabase: false

--- a/deploy/k8s/templates/configmaps.yaml
+++ b/deploy/k8s/templates/configmaps.yaml
@@ -55,12 +55,19 @@ data:
               - SELECT * FROM powersync.workspaces WHERE id = bucket.workspace_id
               - SELECT * FROM powersync.workspace_permissions WHERE workspace_id = bucket.workspace_id
 
-          # Workspace shared data — full member list and shared workspace-scoped config.
+          # Workspace shared data — full member list, pending invites, and shared
+          # workspace-scoped config. Pending memberships sync to every member (not
+          # just admins) because `invite_users`/`change_roles`/`remove_users` are
+          # per-key permissions that can be granted to `member` role; without the
+          # row syncing down, a permitted non-admin would see an empty pending list.
+          # Write authorization is enforced by the upload handlers, not by the
+          # sync rule.
           workspace_data:
             priority: 2
             parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id()
             data:
               - SELECT * FROM powersync.workspace_memberships WHERE workspace_id = bucket.workspace_id
+              - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.models WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.mcp_servers WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.prompts WHERE workspace_id = bucket.workspace_id
@@ -69,14 +76,6 @@ data:
               - SELECT * FROM powersync.modes WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.model_profiles WHERE workspace_id = bucket.workspace_id
               - SELECT * FROM powersync.agents WHERE workspace_id = bucket.workspace_id
-
-          # Admin-only data — one bucket per workspace where the user is an admin.
-          # Pending memberships sync down only to admins so they can manage invites.
-          workspace_admin_data:
-            priority: 2
-            parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id() AND role = 'admin'
-            data:
-              - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
 
     client_auth:
       supabase: false

--- a/powersync-service/config/config.yaml
+++ b/powersync-service/config/config.yaml
@@ -47,12 +47,19 @@ sync_rules:
           - SELECT * FROM powersync.workspaces WHERE id = bucket.workspace_id
           - SELECT * FROM powersync.workspace_permissions WHERE workspace_id = bucket.workspace_id
 
-      # Workspace shared data — full member list and shared workspace-scoped config.
+      # Workspace shared data — full member list, pending invites, and shared
+      # workspace-scoped config. Pending memberships sync to every member (not
+      # just admins) because `invite_users`/`change_roles`/`remove_users` are
+      # per-key permissions that can be granted to `member` role; without the
+      # row syncing down, a permitted non-admin would see an empty pending list.
+      # Write authorization is enforced by the upload handlers, not by the
+      # sync rule.
       workspace_data:
         priority: 2
         parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id()
         data:
           - SELECT * FROM powersync.workspace_memberships WHERE workspace_id = bucket.workspace_id
+          - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.models WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.mcp_servers WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.prompts WHERE workspace_id = bucket.workspace_id
@@ -61,14 +68,6 @@ sync_rules:
           - SELECT * FROM powersync.modes WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.model_profiles WHERE workspace_id = bucket.workspace_id
           - SELECT * FROM powersync.agents WHERE workspace_id = bucket.workspace_id
-
-      # Admin-only data — one bucket per workspace where the user is an admin.
-      # Pending memberships sync down only to admins so they can manage invites.
-      workspace_admin_data:
-        priority: 2
-        parameters: SELECT workspace_id FROM powersync.workspace_memberships WHERE user_id = request.user_id() AND role = 'admin'
-        data:
-          - SELECT * FROM powersync.workspace_pending_memberships WHERE workspace_id = bucket.workspace_id
 
 client_auth:
   supabase: false

--- a/shared/workspaces.ts
+++ b/shared/workspaces.ts
@@ -42,9 +42,10 @@ export const computePersonalAdminMembershipId = (userId: string): string =>
  * `workspace_permissions.permission_key` column. Order matches the rendering
  * order of the Permissions settings page (lifecycle → capabilities → admin).
  *
- * `manage_members` is a legacy key kept for the existing Members route guard
- * until per-operation enforcement lands — new code should prefer the more
- * granular keys (see `project_workspace_permissions_validation_pending`).
+ * `manage_members` is a legacy key superseded by per-operation gates
+ * (`invite_users`/`change_roles`/`remove_users`). Kept in the union so older
+ * `workspace_permissions` rows still type-check; not surfaced on the
+ * Permissions page and not consulted by any route guard or upload handler.
  *
  * Add a new key here, then the FE/BE schemas, the FE/BE types, and the upload
  * handler's runtime check all stay in sync via this constant.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -36,6 +36,7 @@ import { useViewportLock } from '@/hooks/use-viewport-lock'
 import { useMcpSync } from '@/hooks/use-mcp-sync'
 import { PostHogProvider } from '@/lib/posthog'
 import { ThemeProvider } from '@/lib/theme-provider'
+import { AppErrorBoundary } from './components/app-error-boundary'
 import { AppErrorScreen } from './components/app-error-screen'
 import { ModePicker } from './components/boot/mode-picker'
 import { AuthGate } from './components/auth-gate'
@@ -173,11 +174,13 @@ const AppContent = ({ initData }: { initData: InitData }) => {
   useSafeAreaInset()
 
   return (
-    <BrowserRouter>
-      <AppRoutes initData={initData} />
-      <UpdateNotification />
-      <PendingDeviceModal />
-    </BrowserRouter>
+    <AppErrorBoundary>
+      <BrowserRouter>
+        <AppRoutes initData={initData} />
+        <UpdateNotification />
+        <PendingDeviceModal />
+      </BrowserRouter>
+    </AppErrorBoundary>
   )
 }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -42,7 +42,7 @@ import { AuthGate } from './components/auth-gate'
 import { WorkspaceGate } from './components/workspace-gate'
 import { WorkspaceMembershipGate } from './components/workspace-membership-gate'
 import { WorkspaceSettingsGate } from './settings/workspace/gate'
-import { RequireWorkspaceAdmin, RequireWorkspacePermission } from './settings/workspace/require-permission'
+import { RequireWorkspaceAdmin } from './settings/workspace/require-permission'
 import { OnboardingDialog } from './components/onboarding/onboarding-dialog'
 import { WelcomeDialog } from './components/welcome-dialog'
 import { PendingDeviceModal } from './components/pending-device-modal'
@@ -128,9 +128,7 @@ const renderWorkspaceRoutes = ({ experimentalFeatureTasks }: { experimentalFeatu
         <Route element={<WorkspaceSettingsGate />}>
           <Route path="general" element={<WorkspaceGeneralPage />} />
         </Route>
-        <Route element={<RequireWorkspacePermission permissionKey="manage_members" />}>
-          <Route path="members" element={<WorkspaceMembersPage />} />
-        </Route>
+        <Route path="members" element={<WorkspaceMembersPage />} />
         <Route element={<RequireWorkspaceAdmin />}>
           <Route path="permissions" element={<WorkspacePermissionsPage />} />
         </Route>

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -157,8 +157,12 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
 
     const db = getDb()
 
-    if (session.chatThread?.workspaceId) {
-      await updateChatThread(db, session.chatThread.workspaceId, session.chatThread.id, { agentId: agent.id })
+    // `session.workspaceId` is the source of truth — the in-memory thread row
+    // may have been hydrated before the workspace_id column was added or from
+    // a partial row, but the session carries the workspaceId as a required
+    // field. The thread is the gate (need its id to PATCH).
+    if (session.chatThread) {
+      await updateChatThread(db, session.workspaceId, session.chatThread.id, { agentId: agent.id })
     }
 
     // Persist the global last-used agent so new chats default to it (mirrors

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -133,6 +133,11 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
     const existingSession = sessions.get(id)
     if (existingSession) {
       if (existingSession.workspaceId !== workspaceId) {
+        // Drop `isReady` before we evict so consumers don't render against a
+        // session we've just removed during the async rebuild below — they'd
+        // see `isReady=true` with no matching session entry and throw
+        // missing-session errors.
+        setIsReady(false)
         const nextSessions = new Map(sessions)
         nextSessions.delete(id)
         useChatStore.setState({ sessions: nextSessions })

--- a/src/components/app-error-boundary.test.tsx
+++ b/src/components/app-error-boundary.test.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { setupConsoleSpy, type ConsoleSpies } from '@/test-utils/console-spies'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { AppErrorBoundary } from './app-error-boundary'
+
+const Boom = ({ message }: { message: string }) => {
+  throw new Error(message)
+}
+
+describe('AppErrorBoundary', () => {
+  let consoleSpies: ConsoleSpies
+
+  beforeEach(() => {
+    consoleSpies = setupConsoleSpy()
+  })
+
+  afterEach(() => {
+    consoleSpies.restore()
+  })
+
+  it('renders the children when no error is thrown', () => {
+    render(
+      <AppErrorBoundary>
+        <span>OK</span>
+      </AppErrorBoundary>,
+    )
+    expect(screen.getByText('OK')).toBeInTheDocument()
+  })
+
+  it('renders AppErrorScreen with the caught message when a child throws', () => {
+    render(
+      <AppErrorBoundary>
+        <Boom message="bootstrap failed" />
+      </AppErrorBoundary>,
+    )
+    expect(screen.getByText('Failed to initialize app')).toBeInTheDocument()
+    expect(screen.getByText('bootstrap failed')).toBeInTheDocument()
+  })
+})

--- a/src/components/app-error-boundary.tsx
+++ b/src/components/app-error-boundary.tsx
@@ -13,7 +13,7 @@ type AppErrorBoundaryState = {
  * Catches uncaught render-time errors so a failed bootstrap (e.g. the
  * `SessionToWorkspaceBootstrap` throw in `auth-context.tsx`) lands on an
  * actionable error screen instead of a blank page. Mounted just above
- * `BrowserRouter` so the boundary scope covers every route. (#944 r3389077091)
+ * `BrowserRouter` so the boundary scope covers every route.
  */
 export class AppErrorBoundary extends Component<{ children: ReactNode }, AppErrorBoundaryState> {
   state: AppErrorBoundaryState = { error: null }

--- a/src/components/app-error-boundary.tsx
+++ b/src/components/app-error-boundary.tsx
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { AppErrorScreen } from './app-error-screen'
+
+type AppErrorBoundaryState = {
+  error: Error | null
+}
+
+/**
+ * Catches uncaught render-time errors so a failed bootstrap (e.g. the
+ * `SessionToWorkspaceBootstrap` throw in `auth-context.tsx`) lands on an
+ * actionable error screen instead of a blank page. Mounted just above
+ * `BrowserRouter` so the boundary scope covers every route. (#944 r3389077091)
+ */
+export class AppErrorBoundary extends Component<{ children: ReactNode }, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[AppErrorBoundary] Uncaught render error:', error, info.componentStack)
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    if (error) {
+      return (
+        <AppErrorScreen
+          error={{
+            code: 'UNKNOWN_ERROR',
+            message: error.message,
+            stackTrace: error.stack,
+            originalError: error,
+          }}
+          isClearingDatabase={false}
+          // Reload as the universal recovery for non-DB render errors. The DB
+          // wipe affordance is gated inside AppErrorScreen on init-specific
+          // error codes and doesn't render for UNKNOWN_ERROR.
+          onClearDatabase={() => window.location.reload()}
+        />
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/components/boot/mode-picker.test.tsx
+++ b/src/components/boot/mode-picker.test.tsx
@@ -223,6 +223,60 @@ describe('ModePicker', () => {
       expect(mockValidate).toHaveBeenCalledWith('http://localhost:8000/v1')
     })
 
+    it('drops a stale blur result when the user edits the field during validation', async () => {
+      // Hold validate() pending so we can interleave a SET_URL between
+      // dispatch(VALIDATE_START) and the result.
+      let resolveValidate: (r: ValidationResult) => void = () => {}
+      mockValidate.mockImplementation(
+        () =>
+          new Promise<ValidationResult>((resolve) => {
+            resolveValidate = resolve
+          }),
+      )
+
+      renderModePicker()
+      fireEvent.click(screen.getByText('Connect to AI server'))
+
+      const input = screen.getByPlaceholderText('app.thunderbolt.io/')
+      fireEvent.change(input, { target: { value: 'http://stale.local' } })
+      fireEvent.blur(input)
+      // No flush yet — validate() is still pending.
+
+      // User edits the field while validate is in flight.
+      fireEvent.change(input, { target: { value: 'http://fresh.local' } })
+
+      // Stale validate finally resolves with success for the OLD URL.
+      resolveValidate(okValidation())
+      await flush()
+
+      // Checkmark must NOT appear — the success was for stale text.
+      expect(input.parentElement?.querySelector('svg')).not.toBeInTheDocument()
+    })
+
+    it('reuses the blur-time validation when Continue submits the same URL', async () => {
+      const serverId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      mockValidate.mockResolvedValue(okValidation({ serverId }))
+
+      renderModePicker()
+      fireEvent.click(screen.getByText('Connect to AI server'))
+
+      const input = screen.getByPlaceholderText('app.thunderbolt.io/')
+      fireEvent.change(input, { target: { value: 'http://localhost:8000' } })
+      fireEvent.blur(input)
+      await flush()
+
+      // Blur fires one validate call.
+      expect(mockValidate).toHaveBeenCalledTimes(1)
+
+      // Continue against the SAME URL must not re-validate.
+      const buttons = screen.getAllByRole('button')
+      fireEvent.click(buttons[buttons.length - 1])
+      await flush()
+
+      expect(mockValidate).toHaveBeenCalledTimes(1)
+      expect(useTrustDomainRegistry.getState().activeTrustDomain).toEqual({ kind: 'server', serverId })
+    })
+
     it('shows inline error and returns to picker on validation failure', async () => {
       mockValidate.mockResolvedValue(errorValidation("Couldn't reach this server"))
 

--- a/src/components/boot/mode-picker.test.tsx
+++ b/src/components/boot/mode-picker.test.tsx
@@ -223,6 +223,32 @@ describe('ModePicker', () => {
       expect(mockValidate).toHaveBeenCalledWith('http://localhost:8000/v1')
     })
 
+    it('does not leave Continue stuck disabled after a stale blur + edit', async () => {
+      let resolveValidate: (r: ValidationResult) => void = () => {}
+      mockValidate.mockImplementation(
+        () =>
+          new Promise<ValidationResult>((resolve) => {
+            resolveValidate = resolve
+          }),
+      )
+
+      renderModePicker()
+      fireEvent.click(screen.getByText('Connect to AI server'))
+
+      const input = screen.getByPlaceholderText('app.thunderbolt.io/')
+      fireEvent.change(input, { target: { value: 'http://stale.local' } })
+      fireEvent.blur(input)
+      // Edit before validate() resolves — isValidating must clear so Continue
+      // enables once a non-empty URL is in the field.
+      fireEvent.change(input, { target: { value: 'http://fresh.local' } })
+
+      resolveValidate(okValidation())
+      await flush()
+
+      const buttons = screen.getAllByRole('button')
+      expect((buttons[buttons.length - 1] as HTMLButtonElement).disabled).toBe(false)
+    })
+
     it('drops a stale blur result when the user edits the field during validation', async () => {
       // Hold validate() pending so we can interleave a SET_URL between
       // dispatch(VALIDATE_START) and the result.

--- a/src/components/boot/mode-picker.tsx
+++ b/src/components/boot/mode-picker.tsx
@@ -182,7 +182,9 @@ export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {
       const result = await validate(urlAtCall)
       if (urlAtCall !== serverUrlRef.current) {
         // User edited the field during the network call — bail rather than
-        // surface a result for stale text.
+        // surface a result for stale text. Reset the stage so we don't strand
+        // the user on the "Connecting to Server" screen with no recovery path.
+        dispatch({ type: 'VALIDATE_ERROR', message: '' })
         return
       }
       lastValidationRef.current = { url: urlAtCall, result }

--- a/src/components/boot/mode-picker.tsx
+++ b/src/components/boot/mode-picker.tsx
@@ -111,7 +111,10 @@ export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {
   // Mirror of the live `serverUrl` so async validate callbacks can detect that
   // the user typed something else while the request was in flight, and bail
   // out of applying a result that no longer matches. Updated on every render
-  // — the ref always reflects the latest committed state.
+  // AND synchronously in the input's `onChange` — the render-time write alone
+  // races with a validate Promise that resolves before React commits the
+  // SET_URL re-render, since the closure's `urlAtCall` and the (stale) ref
+  // both still equal the previous value at that moment.
   const serverUrlRef = useRef(state.serverUrl)
   serverUrlRef.current = state.serverUrl
 
@@ -266,7 +269,13 @@ export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {
                 type="url"
                 placeholder="app.thunderbolt.io/"
                 value={state.serverUrl}
-                onChange={(e) => dispatch({ type: 'SET_URL', url: e.target.value })}
+                onChange={(e) => {
+                  // Close the in-flight-validate race window — keep the ref
+                  // in lockstep with user input so a Promise resolving before
+                  // the SET_URL render commit can still detect the mismatch.
+                  serverUrlRef.current = e.target.value
+                  dispatch({ type: 'SET_URL', url: e.target.value })
+                }}
                 onBlur={handleBlur}
                 state={state.serverUrlError ? 'error' : 'default'}
                 disabled={state.isValidating}

--- a/src/components/boot/mode-picker.tsx
+++ b/src/components/boot/mode-picker.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useReducer } from 'react'
+import { useReducer, useRef } from 'react'
 import { ArrowRight, Bot, Check, Server } from 'lucide-react'
 import { AppLogo } from '@/components/app-logo'
 import { Button } from '@/components/ui/button'
@@ -104,6 +104,19 @@ type ModePickerProps = {
 export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {}) => {
   const [state, dispatch] = useReducer(reducer, initialState)
 
+  // Mirror of the live `serverUrl` so async validate callbacks can detect that
+  // the user typed something else while the request was in flight, and bail
+  // out of applying a result that no longer matches. Updated on every render
+  // — the ref always reflects the latest committed state.
+  const serverUrlRef = useRef(state.serverUrl)
+  serverUrlRef.current = state.serverUrl
+
+  // Cache of the last validate() resolution by URL. Reused when Continue
+  // submits the same URL the user just blurred, so we don't pay the
+  // /v1/config round-trip twice (and don't visually "re-validate" a URL the
+  // user already saw a checkmark on).
+  const lastValidationRef = useRef<{ url: string; result: ValidationResult } | null>(null)
+
   const isServerMode = state.selection === 'server'
   // Dots: left = initial pick, right = server URL step
   const activeDot = isServerMode ? 1 : 0
@@ -120,8 +133,23 @@ export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {
     if (!isServerMode || !state.serverUrl.trim()) {
       return
     }
+    const urlAtCall = state.serverUrl
+    // Skip if we already have a cached result for this exact URL — the second
+    // blur after Continue's pre-validation would otherwise re-fire the network.
+    if (lastValidationRef.current?.url === urlAtCall) {
+      const cached = lastValidationRef.current.result
+      dispatch(cached.ok ? { type: 'VALIDATE_SUCCESS' } : { type: 'VALIDATE_ERROR', message: cached.message })
+      return
+    }
     dispatch({ type: 'VALIDATE_START' })
-    const result = await validate(state.serverUrl)
+    const result = await validate(urlAtCall)
+    // Drop the result if the input has changed since we started — applying it
+    // would either show a checkmark for the new text (when the old URL passed)
+    // or show an error for text the user already replaced.
+    if (urlAtCall !== serverUrlRef.current) {
+      return
+    }
+    lastValidationRef.current = { url: urlAtCall, result }
     dispatch(result.ok ? { type: 'VALIDATE_SUCCESS' } : { type: 'VALIDATE_ERROR', message: result.message })
   }
 
@@ -133,8 +161,27 @@ export const ModePicker = ({ validate = validateServerUrl }: ModePickerProps = {
     }
 
     if (state.selection === 'server') {
+      // Reuse the blur-time result when the URL hasn't changed since — avoids
+      // a second round-trip and the click-while-blur-pending double-tap UX.
+      const cached = lastValidationRef.current
+      if (cached && cached.url === state.serverUrl && cached.result.ok) {
+        dispatch({ type: 'CONNECT' })
+        useTrustDomainRegistry
+          .getState()
+          .activateServer({ serverId: cached.result.serverId, cloudUrl: cached.result.cloudUrl })
+        window.location.reload()
+        return
+      }
+
       dispatch({ type: 'CONNECT' })
-      const result = await validate(state.serverUrl)
+      const urlAtCall = state.serverUrl
+      const result = await validate(urlAtCall)
+      if (urlAtCall !== serverUrlRef.current) {
+        // User edited the field during the network call — bail rather than
+        // surface a result for stale text.
+        return
+      }
+      lastValidationRef.current = { url: urlAtCall, result }
       if (!result.ok) {
         dispatch({ type: 'VALIDATE_ERROR', message: result.message })
         return

--- a/src/components/boot/mode-picker.tsx
+++ b/src/components/boot/mode-picker.tsx
@@ -45,7 +45,11 @@ const reducer = (state: State, action: Action): State => {
     case 'SELECT':
       return { ...state, selection: action.mode, serverUrlError: null, isUrlValidated: false }
     case 'SET_URL':
-      return { ...state, serverUrl: action.url, serverUrlError: null, isUrlValidated: false }
+      // Reset `isValidating` too: if a blur kicked off `validate()` and the
+      // user then edits the field, the in-flight result is stale and gets
+      // dropped without dispatching success/error — without this reset the
+      // flag would stick at true and the Continue button would never enable.
+      return { ...state, serverUrl: action.url, serverUrlError: null, isUrlValidated: false, isValidating: false }
     case 'VALIDATE_START':
       return { ...state, isValidating: true, serverUrlError: null }
     case 'VALIDATE_SUCCESS':

--- a/src/components/chat/chat-skills-bar.test.tsx
+++ b/src/components/chat/chat-skills-bar.test.tsx
@@ -147,6 +147,17 @@ describe('ChatSkillsBar', () => {
       expect(screen.queryByLabelText('Pin a skill')).not.toBeInTheDocument()
     })
 
+    it('renders nothing when the user lacks add_skills and has no pinned chips, regardless of candidates', () => {
+      const a = skill('a', 'daily-brief')
+      const { container } = renderBar({
+        usePinnedSkills: fakeUsePinnedSkills({ pinned: [] }),
+        useLibrarySkills: fakeUseLibrarySkills([a]),
+        useEnabledSkills: fakeUseEnabledSkills(new Set(['a'])),
+        useWorkspacePermission: fakeUseWorkspacePermission(false),
+      })
+      expect(container.firstChild).toBeNull()
+    })
+
     it('still renders pinned chips when the user lacks add_skills (read-only chips)', () => {
       const a = skill('a', 'daily-brief')
       renderBar({

--- a/src/components/chat/chat-skills-bar.tsx
+++ b/src/components/chat/chat-skills-bar.tsx
@@ -122,10 +122,12 @@ export const ChatSkillsBar = ({
       ? 'No more skills to pin'
       : 'Pin a skill'
 
-  // Hide the whole bar only when there's nothing to display *and* nothing
-  // to add. If the user has zero pins but unpinned skills exist, we still
-  // show the `+` button so they can pin one.
-  if (pinned.length === 0 && pinnable.length === 0) {
+  // Hide the whole bar when there's nothing to display *and* nothing the user
+  // can act on. Zero pins + unpinned candidates still warrants the `+` button
+  // — but only when the user can actually pin (`canEditSkills`); otherwise
+  // both the chips row and the trigger are empty and the strip would render
+  // as a thin blank line above the composer.
+  if (pinned.length === 0 && (pinnable.length === 0 || !canEditSkills)) {
     return null
   }
 

--- a/src/components/logout-modal.test.tsx
+++ b/src/components/logout-modal.test.tsx
@@ -140,6 +140,23 @@ describe('LogoutModal', () => {
     })
   })
 
+  describe('double-click guard', () => {
+    it('only fires signOutAndWipe once when Log out is clicked rapidly', () => {
+      // Regression: handleLogout previously relied solely on the button's
+      // `disabled={isLoggingOut}` to block repeat clicks, but the disabled
+      // attribute only applies after React commits the setState. A second
+      // click in the same tick (or a queued event) could fire a second
+      // signOutAndWipe before then. The ref-guard at handleLogout entry
+      // closes that window.
+      renderModal()
+      const button = screen.getByRole('button', { name: 'Log out' })
+      fireEvent.click(button)
+      fireEvent.click(button)
+      fireEvent.click(button)
+      expect(mockSignOutAndWipe).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('cancel behavior', () => {
     it('closes the dialog when cancel is clicked', () => {
       renderModal()

--- a/src/components/logout-modal.test.tsx
+++ b/src/components/logout-modal.test.tsx
@@ -142,12 +142,6 @@ describe('LogoutModal', () => {
 
   describe('double-click guard', () => {
     it('only fires signOutAndWipe once when Log out is clicked rapidly', () => {
-      // Regression: handleLogout previously relied solely on the button's
-      // `disabled={isLoggingOut}` to block repeat clicks, but the disabled
-      // attribute only applies after React commits the setState. A second
-      // click in the same tick (or a queued event) could fire a second
-      // signOutAndWipe before then. The ref-guard at handleLogout entry
-      // closes that window.
       renderModal()
       const button = screen.getByRole('button', { name: 'Log out' })
       fireEvent.click(button)

--- a/src/components/logout-modal.tsx
+++ b/src/components/logout-modal.tsx
@@ -41,6 +41,13 @@ export const LogoutModal = ({ open, onOpenChange, signOutAndWipe = defaultSignOu
   // per-trust-domain SQLite files — leftover data without a matching auth token has no
   // path back to the user.
   const handleLogout = () => {
+    // Ref-guard at entry: the button's `disabled={isLoggingOut}` only applies
+    // after React commits the setState below. A rapid double-click (or a
+    // queued click event firing in the same tick as the first) would
+    // otherwise launch a second signOutAndWipe concurrent with the first.
+    if (isLoggingOutRef.current) {
+      return
+    }
     isLoggingOutRef.current = true
     setIsLoggingOut(true)
     // SSO lands on `/signed-out` because IdP-bounce-back would silently re-auth the

--- a/src/components/workspace-membership-gate.tsx
+++ b/src/components/workspace-membership-gate.tsx
@@ -5,7 +5,7 @@
 import { useDatabase } from '@/contexts'
 import { getMembershipQuery } from '@/dal'
 import Loading from '@/loading'
-import { stripWorkspacePrefix } from '@/lib/active-workspace'
+import { crossWorkspaceSubPath } from '@/lib/active-workspace'
 import { useTrustDomainRegistry } from '@/stores/trust-domain-registry'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { useQuery } from '@powersync/tanstack-react-query'
@@ -81,9 +81,11 @@ export const WorkspaceMembershipGate = () => {
     return <Loading />
   }
 
-  // Drop the `/w/<id>` segment and forward to the personal workspace, which is
-  // the unprefixed canonical URL. Preserves search params (e.g. OAuth callback
+  // Drop the `/w/<id>` segment and forward to the personal workspace (the
+  // unprefixed canonical URL). Chat ids are per-workspace, so a chat-detail
+  // path is collapsed to `/chats/new` rather than landing on Not Found in
+  // the personal workspace. Preserves search params (e.g. OAuth callback
   // context) so the user lands on the right place if they had one.
-  const target = `${stripWorkspacePrefix(location.pathname)}${location.search}`
+  const target = `${crossWorkspaceSubPath(location.pathname)}${location.search}`
   return <Navigate to={target} replace />
 }

--- a/src/crypto/key-storage.ts
+++ b/src/crypto/key-storage.ts
@@ -148,25 +148,6 @@ const putEntries = async (entries: Array<{ id: string; value: StorableValue }>):
   })
 }
 
-const deleteKeys = async (ids: string[]): Promise<void> => {
-  const db = await openDB()
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(storeName, 'readwrite')
-    const store = tx.objectStore(storeName)
-    for (const id of ids) {
-      store.delete(id)
-    }
-    tx.oncomplete = () => {
-      db.close()
-      resolve()
-    }
-    tx.onerror = () => {
-      db.close()
-      reject(new StorageError('Failed to delete keys', { cause: tx.error }))
-    }
-  })
-}
-
 // =============================================================================
 // Key pair (ECDH P-256 + ML-KEM-768)
 // =============================================================================
@@ -228,10 +209,27 @@ export const clearCK = async (): Promise<void> => deleteKey(ckId)
 // Full wipe
 // =============================================================================
 
-/** Clear all keys and delete the IDB database for the active server (full data wipe / revocation). */
-export const clearAllKeys = async (): Promise<void> => {
-  await deleteKeys([privateKeyId, publicKeyId, mlkemPublicKeyId, mlkemSecretKeyId, ckId])
-  const dbName = resolveDbName()
+/**
+ * Clear all keys and delete the IDB database for the given server (full data
+ * wipe / revocation). The `serverId` defaults to the active server in the
+ * trust-domain registry, but callers running after the registry has been
+ * cleared (the cleanup pipeline does this early to keep reloaded tabs out of
+ * the wiping server) must pass it explicitly — otherwise the wipe would no-op
+ * and leave the per-server IDB database on disk.
+ */
+export const clearAllKeys = async (serverId?: string): Promise<void> => {
+  const resolvedServerId = serverId ?? resolveServerId()
+  if (!resolvedServerId) {
+    throw new StorageError('Cannot clear encryption keys without an active server trust domain')
+  }
+  const dbName = `${dbNamePrefix}${resolvedServerId}`
+  // Best-effort per-key delete first so a blocked `deleteDatabase` (open
+  // connection in another tab) still leaves no key material behind.
+  try {
+    await deleteKeysInDB(dbName, [privateKeyId, publicKeyId, mlkemPublicKeyId, mlkemSecretKeyId, ckId])
+  } catch (err) {
+    console.warn(`[clearAllKeys] per-key delete failed for ${dbName}; relying on deleteDatabase`, err)
+  }
   await new Promise<void>((resolve) => {
     const request = indexedDB.deleteDatabase(dbName)
     request.onsuccess = () => resolve()
@@ -242,6 +240,36 @@ export const clearAllKeys = async (): Promise<void> => {
     request.onblocked = () => {
       console.warn(`[clearAllKeys] IDB delete blocked for ${dbName} — open connections still alive`)
       resolve()
+    }
+  })
+}
+
+/** Internal: open the IDB DB by explicit name and delete the listed keys. Mirrors `deleteKeys` but doesn't go through `resolveDbName`. */
+const deleteKeysInDB = async (dbName: string, ids: string[]): Promise<void> => {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(dbName, dbVersion)
+    request.onupgradeneeded = () => {
+      const upgradeDb = request.result
+      if (!upgradeDb.objectStoreNames.contains(storeName)) {
+        upgradeDb.createObjectStore(storeName)
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(new StorageError('Failed to open IndexedDB', { cause: request.error }))
+  })
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite')
+    const store = tx.objectStore(storeName)
+    for (const id of ids) {
+      store.delete(id)
+    }
+    tx.oncomplete = () => {
+      db.close()
+      resolve()
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(new StorageError('Failed to delete keys', { cause: tx.error }))
     }
   })
 }

--- a/src/dal/workspace-pending-memberships.ts
+++ b/src/dal/workspace-pending-memberships.ts
@@ -47,8 +47,10 @@ export const getPendingByWorkspaceQuery = (db: AnyDrizzleDatabase, workspaceId: 
 
 /**
  * Reactive hook returning every pending invite on `workspaceId`. Returns `[]`
- * until the live query lands rows. Pending rows only sync to admins (see the
- * `workspace_admin_data` bucket), so for non-admins this is always empty.
+ * until the live query lands rows. Pending rows sync to every workspace
+ * member (see the `workspace_data` bucket) so non-admins with
+ * `invite_users` / `change_roles` / `remove_users` can still see and act on
+ * the invite list.
  */
 export const useWorkspacePendingMembershipsQuery = (workspaceId: string | undefined): WorkspacePendingMembership[] => {
   const db = useDatabase()

--- a/src/db/encryption/config.ts
+++ b/src/db/encryption/config.ts
@@ -32,8 +32,9 @@ export const needsSyncSetupWizard = async (): Promise<boolean> => {
  * - `workspaces.is_personal` / `owner_user_id` — the BE handler branches on
  *   these to gate personal vs shared writes; encrypting them would break the
  *   policy logic.
- * - `workspace_memberships.role` — the sync rules use `role = 'admin'` to scope
- *   the admin-only bucket.
+ * - `workspace_memberships.role` — the BE upload handlers read it to resolve
+ *   per-key permissions (admin satisfies every key by default, Decision 11)
+ *   and to enforce the admin-escalation guard on membership/pending writes.
  * - `workspace_memberships.user_name` / `user_email` — written by the BE upload
  *   handler from `auth.user`, so they're inherently server-known. Encrypting
  *   them would also block the Members page from rendering display info.

--- a/src/hooks/use-active-workspace-membership.ts
+++ b/src/hooks/use-active-workspace-membership.ts
@@ -12,6 +12,13 @@ import { useQuery } from '@powersync/tanstack-react-query'
 export type ActiveWorkspaceMembership = {
   membership: WorkspaceMembership | null
   isAdmin: boolean
+  /**
+   * True once the live membership query has returned at least once — whether
+   * with a row or empty. Consumers that need to distinguish "still loading"
+   * from "user has no membership" should check this before treating
+   * `membership === null` as a definitive non-member signal.
+   */
+  isResolved: boolean
 }
 
 /**
@@ -19,9 +26,9 @@ export type ActiveWorkspaceMembership = {
  * URL-driven (via `useActiveWorkspaceId`); reactively flips when the user
  * navigates between workspaces or a sync round-trip lands a new membership row.
  *
- * Returns `{ membership: null, isAdmin: false }` until both the workspace and
- * the user id resolve — consumers should treat that as "not yet known," not as
- * "definitively not a member." The same React Query key is used by
+ * Returns `membership: null` both during the initial load and when the user is
+ * not a member. Disambiguate via `isResolved` — it flips to true once the live
+ * query has returned at least once. The same React Query key is used by
  * `WorkspaceMembershipGate` so the two share a single subscription.
  */
 export const useActiveWorkspaceMembership = (): ActiveWorkspaceMembership => {
@@ -37,15 +44,17 @@ export const useActiveWorkspaceMembership = (): ActiveWorkspaceMembership => {
     return undefined
   })
 
-  const { data } = useQuery({
+  const enabled = !!workspaceId && !!userId
+  const { data, isPending } = useQuery({
     queryKey: ['workspace-memberships', workspaceId, userId],
     query: toCompilableQuery(getMembershipQuery(db, workspaceId ?? '', userId ?? '')),
-    enabled: !!workspaceId && !!userId,
+    enabled,
   })
 
   const membership = (data?.[0] ?? null) as WorkspaceMembership | null
   return {
     membership,
     isAdmin: membership?.role === 'admin',
+    isResolved: enabled && !isPending,
   }
 }

--- a/src/hooks/use-workspace-permission.ts
+++ b/src/hooks/use-workspace-permission.ts
@@ -62,7 +62,6 @@ export const useWorkspacePermission = (permissionKey: WorkspacePermissionKey): W
   // once — regardless of whether they found rows. Missing membership means
   // `isAllowed=false` (so RequireWorkspacePermission can redirect), NOT
   // `isResolved=false` (which would spin the loading state forever).
-  // (#974 r3397677049)
   const permissionResolved = !!workspaceId && !isPending
   const isResolved = membershipResolved && permissionResolved
 

--- a/src/hooks/use-workspace-permission.ts
+++ b/src/hooks/use-workspace-permission.ts
@@ -46,7 +46,7 @@ export type WorkspacePermissionState = {
 export const useWorkspacePermission = (permissionKey: WorkspacePermissionKey): WorkspacePermissionState => {
   const db = useDatabase()
   const workspaceId = useActiveWorkspaceId()
-  const { membership } = useActiveWorkspaceMembership()
+  const { membership, isResolved: membershipResolved } = useActiveWorkspaceMembership()
 
   // Live row (if any). Empty result means "no row yet" → default to admin.
   const { data, isPending } = useQuery({
@@ -58,14 +58,19 @@ export const useWorkspacePermission = (permissionKey: WorkspacePermissionKey): W
   const row = (data?.[0] ?? null) as WorkspacePermission | null
   const requiredRole = row?.requiredRole ?? defaultRequiredRole
 
-  // `isResolved` requires both: a membership row and a permission query that
-  // has at least returned once (either a row or an empty result).
+  // `isResolved` flips true once BOTH live queries have returned at least
+  // once — regardless of whether they found rows. Missing membership means
+  // `isAllowed=false` (so RequireWorkspacePermission can redirect), NOT
+  // `isResolved=false` (which would spin the loading state forever).
+  // (#974 r3397677049)
   const permissionResolved = !!workspaceId && !isPending
-  const isResolved = !!membership && permissionResolved
+  const isResolved = membershipResolved && permissionResolved
 
   const userRole = membership?.role
   const isAllowed =
-    isResolved && (requiredRole === 'member' ? userRole === 'admin' || userRole === 'member' : userRole === 'admin')
+    isResolved &&
+    !!membership &&
+    (requiredRole === 'member' ? userRole === 'admin' || userRole === 'member' : userRole === 'admin')
 
   return { requiredRole, isAllowed, isResolved }
 }

--- a/src/layout/sidebar/create-workspace-modal.tsx
+++ b/src/layout/sidebar/create-workspace-modal.tsx
@@ -67,6 +67,16 @@ export const CreateWorkspaceModal = ({ open, onOpenChange, onCreated }: CreateWo
     previouslyOpenRef.current = open
   }, [open, form])
 
+  // Tracks `open` synchronously so the submit handler can skip the post-create
+  // callback when the user dismissed the modal during the in-flight transaction.
+  // Otherwise `onCreated` runs against a closed flow, opens the invite modal,
+  // and navigates the user into a workspace they thought they'd cancelled out of.
+  // (#965 r3382104755)
+  const openRef = useRef(open)
+  useEffect(() => {
+    openRef.current = open
+  }, [open])
+
   const userId = session?.user?.id
   const creatorEmail = session?.user?.email ?? undefined
   const slugPrefix = formatWorkspaceSlugPrefix(cloudUrl)
@@ -84,6 +94,12 @@ export const CreateWorkspaceModal = ({ open, onOpenChange, onCreated }: CreateWo
       slug: slugifyWorkspaceName(values.slug) || null,
       icon: values.icon,
     })
+    // The local DB transaction commits regardless — the workspace will show up
+    // in the user's list once they reopen the selector. We just skip the
+    // navigation + invite-modal handoff when they've already moved on.
+    if (!openRef.current) {
+      return
+    }
     onCreated(workspaceId)
   })
 

--- a/src/layout/sidebar/create-workspace-modal.tsx
+++ b/src/layout/sidebar/create-workspace-modal.tsx
@@ -72,9 +72,7 @@ export const CreateWorkspaceModal = ({ open, onOpenChange, onCreated }: CreateWo
   // Otherwise `onCreated` runs against a closed flow, opens the invite modal,
   // and navigates the user into a workspace they thought they'd cancelled out of.
   const openRef = useRef(open)
-  useEffect(() => {
-    openRef.current = open
-  }, [open])
+  openRef.current = open
 
   const userId = session?.user?.id
   const creatorEmail = session?.user?.email ?? undefined

--- a/src/layout/sidebar/create-workspace-modal.tsx
+++ b/src/layout/sidebar/create-workspace-modal.tsx
@@ -71,7 +71,6 @@ export const CreateWorkspaceModal = ({ open, onOpenChange, onCreated }: CreateWo
   // callback when the user dismissed the modal during the in-flight transaction.
   // Otherwise `onCreated` runs against a closed flow, opens the invite modal,
   // and navigates the user into a workspace they thought they'd cancelled out of.
-  // (#965 r3382104755)
   const openRef = useRef(open)
   useEffect(() => {
     openRef.current = open

--- a/src/layout/sidebar/settings-sidebar.test.tsx
+++ b/src/layout/sidebar/settings-sidebar.test.tsx
@@ -14,7 +14,7 @@ import {
   wsId,
 } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
-import { workspaceMembershipsTable, workspacePermissionsTable, workspacesTable } from '@/db/tables'
+import { workspaceMembershipsTable, workspacesTable } from '@/db/tables'
 import { createMockAuthClient } from '@/test-utils/auth-client'
 import { createMockHttpClient } from '@/test-utils/http-client'
 import {
@@ -230,17 +230,6 @@ describe('SettingsSidebarContent — Workspace > General entry visibility', () =
   })
 })
 
-const seedManageMembersPermission = async (requiredRole: 'admin' | 'member') => {
-  await getDb()
-    .insert(workspacePermissionsTable)
-    .values({
-      id: `${otherWsId}-manage_members`,
-      workspaceId: otherWsId,
-      permissionKey: 'manage_members',
-      requiredRole,
-    })
-}
-
 describe('SettingsSidebarContent — Workspace > Members entry visibility', () => {
   beforeAll(async () => {
     await setupTestDatabase()
@@ -277,27 +266,12 @@ describe('SettingsSidebarContent — Workspace > Members entry visibility', () =
     expect(screen.getByText('Members')).toBeInTheDocument()
   })
 
-  it('hides the Members entry for a member of a shared workspace (default policy)', async () => {
+  it('shows the Members entry for a member of a shared workspace (read-friendly, per-action gates apply within)', async () => {
+    // Decision: Members is visible to every member of a shared workspace. The
+    // page is read-friendly without action permissions; individual actions
+    // (invite / change role / remove) gate themselves on the granular
+    // permission keys (invite_users / change_roles / remove_users).
     await seedSharedWorkspaceWithMembership('member')
-
-    renderWithReactivity(
-      <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,
-      {
-        route: `/w/${otherWsId}/settings`,
-        routePath: '/*',
-        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
-        wrapper: ReactiveSidebarWrapper,
-      },
-    )
-
-    // Wait for another Workspace-group item so the active workspace has resolved.
-    await waitForElement(() => screen.queryByText('Models'))
-    expect(screen.queryByText('Members')).not.toBeInTheDocument()
-  })
-
-  it('shows the Members entry for a member when explicit manage_members.required_role=member', async () => {
-    await seedSharedWorkspaceWithMembership('member')
-    await seedManageMembersPermission('member')
 
     renderWithReactivity(
       <SettingsSidebarContent onBackClick={() => {}} onSettingsNavigate={() => {}} isStandalone={onTauri} />,

--- a/src/layout/sidebar/settings-sidebar.tsx
+++ b/src/layout/sidebar/settings-sidebar.tsx
@@ -17,7 +17,6 @@ import {
 import { useConfigStore } from '@/api/config-store'
 import { useActiveWorkspaceMembership } from '@/hooks/use-active-workspace-membership'
 import { useAgentsSettingsHidden } from '@/hooks/use-agents-settings-hidden'
-import { useWorkspacePermission } from '@/hooks/use-workspace-permission'
 import { stripWorkspacePrefix, useActiveWorkspace } from '@/lib/active-workspace'
 import { ArrowLeft, Bot, Cpu, Globe, Lock, Plug, Server, SlidersHorizontal, Smartphone, Users, Zap } from 'lucide-react'
 import { useLocation } from 'react-router'
@@ -47,16 +46,16 @@ export const SettingsSidebarContent = ({
   // per Decision 25 (hide-not-disable). Personal is treated as admin-equivalent
   // for nav purposes; the page renders read-only.
   const workspaceAdminItemsVisible = activeWorkspace?.isPersonal === 1 || isAdmin
-  // Members visibility follows the configurable `manage_members` permission and
-  // is always hidden in Personal Workspaces (Decision 25 — personal can't manage
-  // members in v1).
+  // Members is visible to every member of a shared workspace — the page is
+  // read-friendly without action permissions, and individual actions (invite /
+  // change role / remove) gate themselves on the granular permission keys.
+  // Always hidden in Personal Workspaces (Decision 25 — no members to manage).
   // @todo Drop the e2eeEnabled gate once the encryption pipeline supports
   // multi-recipient envelopes and is workspace-aware (see THU-593). Until then
   // an E2EE-enabled server is effectively single-user and there's nothing to
-  // manage here.
-  const { isAllowed: canManageMembers } = useWorkspacePermission('manage_members')
+  // show here.
   const e2eeEnabled = useConfigStore((state) => state.config.e2eeEnabled === true)
-  const membersItemVisible = activeWorkspace?.isPersonal !== 1 && canManageMembers && !e2eeEnabled
+  const membersItemVisible = activeWorkspace?.isPersonal !== 1 && !e2eeEnabled
   // Permissions is implicitly admin-only — there is no configurable
   // meta-permission for editing the permissions grid itself.
   const permissionsItemVisible = activeWorkspace?.isPersonal !== 1 && isAdmin && !e2eeEnabled

--- a/src/layout/sidebar/workspace-selector.tsx
+++ b/src/layout/sidebar/workspace-selector.tsx
@@ -9,7 +9,7 @@ import { useWorkspacesQuery, type Workspace } from '@/dal'
 import { useCanCreateWorkspace } from '@/hooks/use-can-create-workspace'
 import { isDataUrlIcon } from '@/components/workspace/icon-utils'
 import { useIsMobile } from '@/hooks/use-mobile'
-import { stripWorkspacePrefix, toWorkspaceUrl, useActiveWorkspace } from '@/lib/active-workspace'
+import { crossWorkspaceSubPath, toWorkspaceUrl, useActiveWorkspace } from '@/lib/active-workspace'
 import { cn } from '@/lib/utils'
 import { ChevronDown, Plus } from 'lucide-react'
 import { useMemo, useState } from 'react'
@@ -173,7 +173,10 @@ export const WorkspaceSelector = ({ collapsed = false }: WorkspaceSelectorProps)
     if (!target || target.id === active.id) {
       return
     }
-    const subPath = stripWorkspacePrefix(location.pathname)
+    // Chat ids are per-workspace; carrying the current chat id across the
+    // switch would land on Not Found. `crossWorkspaceSubPath` collapses
+    // `/chats/<id>` to `/chats/new` for the target workspace.
+    const subPath = crossWorkspaceSubPath(location.pathname)
     navigate(`${toWorkspaceUrl(target, subPath)}${location.search}`)
   }
 

--- a/src/lib/active-workspace.test.tsx
+++ b/src/lib/active-workspace.test.tsx
@@ -141,10 +141,6 @@ describe('useActiveWorkspaceId reactivity', () => {
   })
 
   it('surfaces the URL-encoded id immediately even before the workspace row materializes', async () => {
-    // Regression: the hook previously waited for the local `workspaces` row to
-    // load before exposing an id, while the non-React `getActiveWorkspaceId`
-    // returned the URL segment immediately. The split delayed sidebar queries
-    // / OAuth completion / automations. (#961 r3375770853)
     renderWithReactivity(<ActiveIdProbe />, {
       route: `/w/${otherWsId}/chats/new`,
       routePath: '*',

--- a/src/lib/active-workspace.test.tsx
+++ b/src/lib/active-workspace.test.tsx
@@ -14,6 +14,7 @@ import {
   waitForElement,
 } from '@/test-utils/powersync-reactivity-test'
 import {
+  crossWorkspaceSubPath,
   stripWorkspacePrefix,
   toWorkspaceUrl,
   useActiveWorkspace,
@@ -84,6 +85,21 @@ describe('stripWorkspacePrefix', () => {
   })
 })
 
+describe('crossWorkspaceSubPath', () => {
+  it('collapses chat-detail paths to /chats/new across the switch', () => {
+    expect(crossWorkspaceSubPath(`/w/${otherWsId}/chats/abc-123`)).toBe('/chats/new')
+    expect(crossWorkspaceSubPath('/chats/abc-123')).toBe('/chats/new')
+    // The bare /chats route is also collapsed for consistency.
+    expect(crossWorkspaceSubPath(`/w/${otherWsId}/chats`)).toBe('/chats/new')
+  })
+
+  it('passes through non-chat paths', () => {
+    expect(crossWorkspaceSubPath(`/w/${otherWsId}/settings/preferences`)).toBe('/settings/preferences')
+    expect(crossWorkspaceSubPath('/tasks')).toBe('/tasks')
+    expect(crossWorkspaceSubPath(`/w/${otherWsId}/`)).toBe('/')
+  })
+})
+
 describe('useActiveWorkspaceId reactivity', () => {
   beforeAll(async () => {
     await setupTestDatabase()
@@ -122,6 +138,22 @@ describe('useActiveWorkspaceId reactivity', () => {
     })
     await waitForElement(() => screen.queryByTestId(`active-id-${wsId}`))
     expect(screen.getByTestId(`active-id-${wsId}`)).toBeInTheDocument()
+  })
+
+  it('surfaces the URL-encoded id immediately even before the workspace row materializes', async () => {
+    // Regression: the hook previously waited for the local `workspaces` row to
+    // load before exposing an id, while the non-React `getActiveWorkspaceId`
+    // returned the URL segment immediately. The split delayed sidebar queries
+    // / OAuth completion / automations. (#961 r3375770853)
+    renderWithReactivity(<ActiveIdProbe />, {
+      route: `/w/${otherWsId}/chats/new`,
+      routePath: '*',
+      tables: ['workspaces'],
+      wrapper: DbWrapper,
+    })
+    // No row inserted for `otherWsId` — the URL id should still surface.
+    await waitForElement(() => screen.queryByTestId(`active-id-${otherWsId}`))
+    expect(screen.getByTestId(`active-id-${otherWsId}`)).toBeInTheDocument()
   })
 
   it('resolves to the URL-encoded workspace id when /w/<id>/ is present', async () => {

--- a/src/lib/active-workspace.ts
+++ b/src/lib/active-workspace.ts
@@ -182,7 +182,6 @@ export const useActiveWorkspace = (): Workspace | null => {
  * For unprefixed paths (personal workspace), the id only resolves once the
  * row is in the local DB — `WorkspaceGate` is the upstream readiness barrier
  * so consumers inside it can treat the result as eventually-non-null.
- * (#961 r3375770853)
  */
 export const useActiveWorkspaceId = (): string | null => {
   const pathname = useReactivePathname()
@@ -196,7 +195,6 @@ export const useActiveWorkspaceId = (): string | null => {
  * or `WorkspaceMembershipGate` redirect). Strips the `/w/<id>` prefix, then
  * collapses chat-detail paths to `/chats/new`: chat ids are per-workspace, so
  * carrying one across would land the user on Not Found in the target.
- * (#961 r3404612032 + r3404615075)
  */
 export const crossWorkspaceSubPath = (pathname: string): string => {
   const subPath = stripWorkspacePrefix(pathname)

--- a/src/lib/active-workspace.ts
+++ b/src/lib/active-workspace.ts
@@ -173,10 +173,38 @@ export const useActiveWorkspace = (): Workspace | null => {
 }
 
 /**
- * Convenience wrapper for the common case — just the id. Tracks the same URL
- * + personal-fallback rule as `useActiveWorkspace`.
+ * Convenience wrapper for the common case — just the id. URL-derived ids
+ * surface IMMEDIATELY (without waiting for the local `workspaces` row to
+ * materialize), keeping the hook in lockstep with the non-React
+ * `getActiveWorkspaceId` async helper. The full `useActiveWorkspace()` row
+ * is still loaded in the background for consumers that need name/icon/etc.
+ *
+ * For unprefixed paths (personal workspace), the id only resolves once the
+ * row is in the local DB — `WorkspaceGate` is the upstream readiness barrier
+ * so consumers inside it can treat the result as eventually-non-null.
+ * (#961 r3375770853)
  */
-export const useActiveWorkspaceId = (): string | null => useActiveWorkspace()?.id ?? null
+export const useActiveWorkspaceId = (): string | null => {
+  const pathname = useReactivePathname()
+  const fromUrl = matchWorkspaceIdInPath(pathname)
+  const workspace = useActiveWorkspace()
+  return fromUrl ?? workspace?.id ?? null
+}
+
+/**
+ * Subpath to use when navigating BETWEEN workspaces (workspace selector swap
+ * or `WorkspaceMembershipGate` redirect). Strips the `/w/<id>` prefix, then
+ * collapses chat-detail paths to `/chats/new`: chat ids are per-workspace, so
+ * carrying one across would land the user on Not Found in the target.
+ * (#961 r3404612032 + r3404615075)
+ */
+export const crossWorkspaceSubPath = (pathname: string): string => {
+  const subPath = stripWorkspacePrefix(pathname)
+  if (/^\/chats(\/|$)/.test(subPath)) {
+    return '/chats/new'
+  }
+  return subPath
+}
 
 /**
  * Build a URL for `path` in the active workspace. Returns `path` unchanged

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -62,22 +62,27 @@ export const setAuthToken = (token: string): void => {
   localStorage.setItem(authTokenKeyFor(serverId), token)
 }
 
-/** Clear the auth token for the active server (for sign-out). No-op when no server is active. */
-export const clearAuthToken = (): void => {
-  const serverId = getActiveServerId()
-  if (!serverId) {
+/**
+ * Clear the auth token. Defaults to the active server (registry-resolved), but
+ * the wipe path passes the captured serverId explicitly because cleanup.ts
+ * clears `activeTrustDomain` from the registry before this runs (so the
+ * default would resolve to undefined and no-op).
+ */
+export const clearAuthToken = (serverId?: string): void => {
+  const id = serverId ?? getActiveServerId()
+  if (!id) {
     return
   }
-  localStorage.removeItem(authTokenKeyFor(serverId))
+  localStorage.removeItem(authTokenKeyFor(id))
 }
 
-/** Clear the device ID for the active server (forces a new ID on next login). */
-export const clearDeviceId = (): void => {
-  const serverId = getActiveServerId()
-  if (!serverId) {
+/** Same shape as `clearAuthToken` — explicit serverId for callers running after a registry clear. */
+export const clearDeviceId = (serverId?: string): void => {
+  const id = serverId ?? getActiveServerId()
+  if (!id) {
     return
   }
-  localStorage.removeItem(deviceIdKeyFor(serverId))
+  localStorage.removeItem(deviceIdKeyFor(id))
 }
 
 /**

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -44,13 +44,39 @@ export const getDeviceId = (): string => {
   return id
 }
 
+// Scoped override consulted before the registry-derived lookup. The sign-out
+// wipe sequence empties `activeTrustDomain` before calling Better Auth's
+// `signOut()`, so the normal `getActiveServerId()` resolution would return
+// `null` and the sign-out request would go out bearer-less. `withCapturedAuthToken`
+// replays the pre-wipe token for the duration of that call.
+let capturedAuthToken: string | null = null
+
 /** Get the active server's auth token, or null if there is no active server / not signed in. */
 export const getAuthToken = (): string | null => {
+  if (capturedAuthToken !== null) {
+    return capturedAuthToken
+  }
   const serverId = getActiveServerId()
   if (!serverId) {
     return null
   }
   return localStorage.getItem(authTokenKeyFor(serverId))
+}
+
+/**
+ * Run `fn` with `getAuthToken()` short-circuited to return `token`. Used by
+ * `signOutAndWipe` so the sign-out HTTP call stays authenticated even though
+ * `clearLocalData` has already cleared `activeTrustDomain` from the registry
+ * by the time signOut runs.
+ */
+export const withCapturedAuthToken = async <T>(token: string | null, fn: () => Promise<T>): Promise<T> => {
+  const prev = capturedAuthToken
+  capturedAuthToken = token
+  try {
+    return await fn()
+  } finally {
+    capturedAuthToken = prev
+  }
 }
 
 /** Store the auth token under the active server's namespace. No-op when no server is active. */

--- a/src/lib/cleanup.test.ts
+++ b/src/lib/cleanup.test.ts
@@ -286,4 +286,12 @@ describe('signOutAndWipe', () => {
     expect(clearAuthToken).toHaveBeenCalledWith(serverId)
     expect(clearDeviceId).toHaveBeenCalledWith(serverId)
   })
+
+  it('passes the captured serverId to handleFullWipe (registry already cleared)', async () => {
+    const onComplete = mock(() => {})
+
+    await signOutAndWipe({ onComplete, ...deps })
+
+    expect(handleFullWipe).toHaveBeenCalledWith(serverId)
+  })
 })

--- a/src/lib/cleanup.test.ts
+++ b/src/lib/cleanup.test.ts
@@ -294,4 +294,32 @@ describe('signOutAndWipe', () => {
 
     expect(handleFullWipe).toHaveBeenCalledWith(serverId)
   })
+
+  it('keeps getAuthToken() resolvable during signOut even though the registry was cleared', async () => {
+    // clearLocalData empties `activeTrustDomain` before signOut runs, so the
+    // registry-derived lookup inside `getAuthToken()` would return null and
+    // Better Auth's `auth.token` callback would send the sign-out request
+    // bearer-less. `withCapturedAuthToken` (used inside `signOutAndWipe`)
+    // must replay the pre-wipe token for the duration of the signOut call.
+    const { getAuthToken } = await import('@/lib/auth-token')
+    const tokenKey = `thunderbolt_auth_token__${serverId}`
+    const tokenValue = 'sentinel-token-value'
+    localStorage.setItem(tokenKey, tokenValue)
+
+    const observed: { token: string | null } = { token: null }
+    const signOut = mock(async () => {
+      observed.token = getAuthToken()
+    })
+    const onComplete = mock(() => {})
+
+    try {
+      await signOutAndWipe({ signOut, onComplete, ...deps })
+    } finally {
+      localStorage.removeItem(tokenKey)
+    }
+
+    expect(observed.token).toBe(tokenValue)
+    // And after signOut returns, the override is dropped — no leakage.
+    expect(getAuthToken()).toBeNull()
+  })
 })

--- a/src/lib/cleanup.test.ts
+++ b/src/lib/cleanup.test.ts
@@ -152,6 +152,23 @@ describe('clearLocalData', () => {
     expect(calls).toContain('clearAuthToken')
     expect(calls).toContain('clearDeviceId')
   })
+
+  it('clears activeTrustDomain from the registry before broadcasting db-closing', async () => {
+    // Regression: reloaded tabs that receive `db-closing` read the persisted
+    // registry on boot. If we broadcast first and clear later, those tabs
+    // re-resolve to the same server and race resetDatabase/deleteDbFile by
+    // reopening the SQLite file (#932 r3369942991). The clear has to land
+    // before the broadcast so reloaded tabs see NO_TRUST_DOMAIN → ModePicker.
+    let registryAtBroadcast: ReturnType<typeof useTrustDomainRegistry.getState>['activeTrustDomain']
+    broadcastDbLifecycle.mockImplementationOnce((event: { kind: string }) => {
+      calls.push(`broadcast:${event.kind}`)
+      registryAtBroadcast = useTrustDomainRegistry.getState().activeTrustDomain
+    })
+
+    await clearLocalData(deps)
+
+    expect(registryAtBroadcast).toBeUndefined()
+  })
 })
 
 describe('signOutAndWipe', () => {
@@ -268,5 +285,20 @@ describe('signOutAndWipe', () => {
 
     expect(clearAuthToken).toHaveBeenCalledTimes(1)
     expect(clearDeviceId).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the captured serverId to the credential clearers (registry already cleared)', async () => {
+    // Regression: clearLocalData clears `activeTrustDomain` from the registry
+    // before broadcasting db-closing (#932 r3369942991). The deferred
+    // credential clear would no-op if it read serverId from the registry at
+    // that point — the per-server localStorage keys would survive sign-out
+    // and the next ModePicker → activateServer → boot path would auto-sign-in
+    // off the stale token.
+    const onComplete = mock(() => {})
+
+    await signOutAndWipe({ onComplete, ...deps })
+
+    expect(clearAuthToken).toHaveBeenCalledWith(serverId)
+    expect(clearDeviceId).toHaveBeenCalledWith(serverId)
   })
 })

--- a/src/lib/cleanup.test.ts
+++ b/src/lib/cleanup.test.ts
@@ -231,4 +231,42 @@ describe('signOutAndWipe', () => {
 
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
+
+  it('clears credentials AFTER signOut so the server can revoke the session', async () => {
+    // Regression: the previous version cleared the auth token inside
+    // clearLocalData (before signOut), so the /sign-out HTTP call went out
+    // bearer-less and the BE never revoked. Order has to be
+    // wipe → signOut → clearAuthToken/clearDeviceId → onComplete.
+    const signOut = mock(async () => {
+      calls.push('signOut')
+    })
+    const onComplete = mock(() => {
+      calls.push('onComplete')
+    })
+
+    await signOutAndWipe({ signOut, onComplete, ...deps })
+
+    const signOutIdx = calls.indexOf('signOut')
+    const authTokenIdx = calls.indexOf('clearAuthToken')
+    const deviceIdIdx = calls.indexOf('clearDeviceId')
+    const onCompleteIdx = calls.indexOf('onComplete')
+
+    expect(signOutIdx).toBeGreaterThan(-1)
+    expect(authTokenIdx).toBeGreaterThan(signOutIdx)
+    expect(deviceIdIdx).toBeGreaterThan(signOutIdx)
+    expect(onCompleteIdx).toBeGreaterThan(authTokenIdx)
+    expect(onCompleteIdx).toBeGreaterThan(deviceIdIdx)
+  })
+
+  it('still clears credentials on the revoked-device path (no signOut)', async () => {
+    // RevokedDeviceModal doesn't pass `signOut` (the server already
+    // invalidated the session). The deferred-credential clear still has to
+    // run so the local token is wiped.
+    const onComplete = mock(() => {})
+
+    await signOutAndWipe({ onComplete, ...deps })
+
+    expect(clearAuthToken).toHaveBeenCalledTimes(1)
+    expect(clearDeviceId).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/lib/cleanup.test.ts
+++ b/src/lib/cleanup.test.ts
@@ -154,11 +154,6 @@ describe('clearLocalData', () => {
   })
 
   it('clears activeTrustDomain from the registry before broadcasting db-closing', async () => {
-    // Regression: reloaded tabs that receive `db-closing` read the persisted
-    // registry on boot. If we broadcast first and clear later, those tabs
-    // re-resolve to the same server and race resetDatabase/deleteDbFile by
-    // reopening the SQLite file (#932 r3369942991). The clear has to land
-    // before the broadcast so reloaded tabs see NO_TRUST_DOMAIN → ModePicker.
     let registryAtBroadcast: ReturnType<typeof useTrustDomainRegistry.getState>['activeTrustDomain']
     broadcastDbLifecycle.mockImplementationOnce((event: { kind: string }) => {
       calls.push(`broadcast:${event.kind}`)
@@ -250,10 +245,6 @@ describe('signOutAndWipe', () => {
   })
 
   it('clears credentials AFTER signOut so the server can revoke the session', async () => {
-    // Regression: the previous version cleared the auth token inside
-    // clearLocalData (before signOut), so the /sign-out HTTP call went out
-    // bearer-less and the BE never revoked. Order has to be
-    // wipe → signOut → clearAuthToken/clearDeviceId → onComplete.
     const signOut = mock(async () => {
       calls.push('signOut')
     })
@@ -288,12 +279,6 @@ describe('signOutAndWipe', () => {
   })
 
   it('passes the captured serverId to the credential clearers (registry already cleared)', async () => {
-    // Regression: clearLocalData clears `activeTrustDomain` from the registry
-    // before broadcasting db-closing (#932 r3369942991). The deferred
-    // credential clear would no-op if it read serverId from the registry at
-    // that point — the per-server localStorage keys would survive sign-out
-    // and the next ModePicker → activateServer → boot path would auto-sign-in
-    // off the stale token.
     const onComplete = mock(() => {})
 
     await signOutAndWipe({ onComplete, ...deps })

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -147,14 +147,25 @@ export const signOutAndWipe = async ({
   signOut?: () => Promise<void>
   onComplete: () => void
 } & CleanupDeps): Promise<void> => {
-  // Wipe local data BEFORE calling signOut so that Better Auth's session cache
-  // stays populated during the wipe. If signOut ran first, Better Auth would
-  // immediately set useSession() → null, letting AuthGate redirect to
-  // /sso-redirect (SSO mode) or /waitlist between the awaits inside
-  // clearLocalData — potentially kicking off a new IdP sign-in flow before
-  // onComplete() can navigate away.
+  // Two ordering constraints have to hold together:
+  //   1. The wipe runs BEFORE signOut so Better Auth's session cache stays
+  //      populated during it — otherwise useSession() flips to null mid-wipe
+  //      and AuthGate could redirect to /sso-redirect (SSO) or /waitlist
+  //      between awaits, kicking off a new IdP sign-in before onComplete()
+  //      navigates away.
+  //   2. The auth token has to stay present THROUGH signOut() so the HTTP
+  //      call to /sign-out is authenticated and the server can revoke the
+  //      session row. Clearing it before signOut() (as the previous version
+  //      did, inside clearLocalData) sent the request bearer-less and left
+  //      the session valid server-side until natural expiry.
+  // Resolve below: pass no-op credential-clear callbacks into clearLocalData
+  // so the wipe runs in its normal order WITHOUT touching the token, then
+  // clear credentials ourselves after signOut() has revoked the session.
+  const clearAuthToken = deps.clearAuthToken ?? defaultClearAuthToken
+  const clearDeviceId = deps.clearDeviceId ?? defaultClearDeviceId
+
   try {
-    await clearLocalData(deps)
+    await clearLocalData({ ...deps, clearAuthToken: () => {}, clearDeviceId: () => {} })
   } catch (error) {
     console.error('[signOutAndWipe] clearLocalData failed:', error)
   }
@@ -167,7 +178,14 @@ export const signOutAndWipe = async ({
     }
   }
 
-  // onComplete fires synchronously right after signOut resolves — no await
-  // between them so React cannot schedule a re-render before the hard navigation.
+  // Token is no longer useful: signOut() has revoked the session, or
+  // RevokedDeviceModal is the caller (server already invalidated). Safe to
+  // wipe locally without breaking the revoke call above.
+  clearAuthToken()
+  clearDeviceId()
+
+  // onComplete fires synchronously right after the credential clear — no
+  // await between them so React cannot schedule a re-render before the
+  // hard navigation.
   onComplete()
 }

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -12,12 +12,12 @@ import { deleteDbFile } from '@/lib/fs'
 import { withTimeout } from '@/lib/timeout'
 import { handleFullWipe as defaultHandleFullWipe } from '@/services/encryption'
 import { initialLocalSettings, useLocalSettingsStore } from '@/stores/local-settings-store'
-import { getActiveTrustDomain } from '@/stores/trust-domain-registry'
+import { getActiveTrustDomain, useTrustDomainRegistry } from '@/stores/trust-domain-registry'
 import { resetPostAuthBootstrap } from '@/lib/post-auth-bootstrap'
 
 type CleanupDeps = {
-  clearAuthToken?: () => void
-  clearDeviceId?: () => void
+  clearAuthToken?: (serverId?: string) => void
+  clearDeviceId?: (serverId?: string) => void
   handleFullWipe?: () => Promise<void>
 }
 
@@ -59,6 +59,11 @@ export const clearLocalData = async ({
   resetVolatileStores()
 
   const trustDomain = getActiveTrustDomain()
+  // Capture the serverId BEFORE we empty `activeTrustDomain` from the
+  // registry (below). The credential clearers default to reading serverId
+  // from the registry; once it's cleared they'd no-op and the per-server
+  // localStorage keys would survive the wipe.
+  const serverIdForClear = trustDomain?.kind === 'server' ? trustDomain.serverId : undefined
 
   // Tear down every warm ACP connection first so no agent transport survives
   // across user identities (sign-out, account deletion, device revocation all
@@ -67,6 +72,19 @@ export const clearLocalData = async ({
     await disposeAllAdapters()
   } catch (error) {
     console.error('[clearLocalData] Failed to dispose ACP adapters:', error)
+  }
+
+  // Clear the registry's `activeTrustDomain` BEFORE broadcasting `db-closing`
+  // (step 2 below). Other tabs receive the broadcast and reload; on reload
+  // they re-read the persisted registry and now see no active trust domain,
+  // so boot resolves to `NO_TRUST_DOMAIN` → ModePicker. Without this they'd
+  // boot into the same server entry and race our `resetDatabase` /
+  // `deleteDbFile` by trying to reopen the same SQLite file (cursor flagged
+  // this on #932 r3369942991). Our own tab continues using the local
+  // `trustDomain` capture above, so the rest of the wipe sequence still
+  // targets the right server.
+  if (trustDomain) {
+    useTrustDomainRegistry.setState({ activeTrustDomain: undefined })
   }
 
   // Step 1: flip the persisted `syncEnabled` flag to false and disconnect. The flag
@@ -111,9 +129,11 @@ export const clearLocalData = async ({
   // a logout into the next user's session.
   useLocalSettingsStore.setState(initialLocalSettings)
 
-  // Step 6: clear per-server credentials. No-op in standalone.
-  clearAuthToken()
-  clearDeviceId()
+  // Step 6: clear per-server credentials. No-op in standalone. The
+  // `serverIdForClear` capture above feeds the explicit serverId — the
+  // registry has already been emptied so the default lookup wouldn't find one.
+  clearAuthToken(serverIdForClear)
+  clearDeviceId(serverIdForClear)
 
   // Step 7: clear encryption keys (server-only — `handleFullWipe` throws on standalone
   // via `key-storage.ts`'s active-server guard; we skip it cleanly when there's no server).
@@ -163,6 +183,11 @@ export const signOutAndWipe = async ({
   // clear credentials ourselves after signOut() has revoked the session.
   const clearAuthToken = deps.clearAuthToken ?? defaultClearAuthToken
   const clearDeviceId = deps.clearDeviceId ?? defaultClearDeviceId
+  // Capture serverId BEFORE clearLocalData empties `activeTrustDomain` from
+  // the registry — the deferred clear below would otherwise no-op (the
+  // default reads serverId from the now-empty registry).
+  const trustDomainAtStart = getActiveTrustDomain()
+  const serverIdForClear = trustDomainAtStart?.kind === 'server' ? trustDomainAtStart.serverId : undefined
 
   try {
     await clearLocalData({ ...deps, clearAuthToken: () => {}, clearDeviceId: () => {} })
@@ -181,8 +206,8 @@ export const signOutAndWipe = async ({
   // Token is no longer useful: signOut() has revoked the session, or
   // RevokedDeviceModal is the caller (server already invalidated). Safe to
   // wipe locally without breaking the revoke call above.
-  clearAuthToken()
-  clearDeviceId()
+  clearAuthToken(serverIdForClear)
+  clearDeviceId(serverIdForClear)
 
   // onComplete fires synchronously right after the credential clear — no
   // await between them so React cannot schedule a re-render before the

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -7,7 +7,12 @@ import { broadcastDbLifecycle } from '@/db/db-lifecycle-broadcast'
 import { resetDatabase } from '@/db/database'
 import { disposeAllAdapters } from '@/acp/adapter-cache'
 import { setSyncEnabled } from '@/db/powersync'
-import { clearAuthToken as defaultClearAuthToken, clearDeviceId as defaultClearDeviceId } from '@/lib/auth-token'
+import {
+  clearAuthToken as defaultClearAuthToken,
+  clearDeviceId as defaultClearDeviceId,
+  getAuthToken,
+  withCapturedAuthToken,
+} from '@/lib/auth-token'
 import { deleteDbFile } from '@/lib/fs'
 import { withTimeout } from '@/lib/timeout'
 import { handleFullWipe as defaultHandleFullWipe } from '@/services/encryption'
@@ -181,15 +186,20 @@ export const signOutAndWipe = async ({
   //      did, inside clearLocalData) sent the request bearer-less and left
   //      the session valid server-side until natural expiry.
   // Resolve below: pass no-op credential-clear callbacks into clearLocalData
-  // so the wipe runs in its normal order WITHOUT touching the token, then
-  // clear credentials ourselves after signOut() has revoked the session.
+  // so the wipe runs in its normal order WITHOUT touching the token, capture
+  // the token before the registry is emptied, and replay it via
+  // `withCapturedAuthToken` so Better Auth's `auth.token` callback returns it
+  // when signOut runs. Then clear credentials ourselves.
   const clearAuthToken = deps.clearAuthToken ?? defaultClearAuthToken
   const clearDeviceId = deps.clearDeviceId ?? defaultClearDeviceId
-  // Capture serverId BEFORE clearLocalData empties `activeTrustDomain` from
-  // the registry — the deferred clear below would otherwise no-op (the
-  // default reads serverId from the now-empty registry).
+  // Capture serverId + token BEFORE clearLocalData empties `activeTrustDomain`
+  // from the registry. Both are registry-derived: the deferred credential
+  // clear below would otherwise no-op, and `getAuthToken()` inside
+  // Better Auth's signOut fetch would return null, sending the request
+  // bearer-less.
   const trustDomainAtStart = getActiveTrustDomain()
   const serverIdForClear = trustDomainAtStart?.kind === 'server' ? trustDomainAtStart.serverId : undefined
+  const tokenAtStart = getAuthToken()
 
   try {
     await clearLocalData({ ...deps, clearAuthToken: () => {}, clearDeviceId: () => {} })
@@ -199,7 +209,7 @@ export const signOutAndWipe = async ({
 
   if (signOut) {
     try {
-      await signOut()
+      await withCapturedAuthToken(tokenAtStart, signOut)
     } catch (error) {
       console.error('[signOutAndWipe] signOut failed:', error)
     }

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -79,10 +79,9 @@ export const clearLocalData = async ({
   // they re-read the persisted registry and now see no active trust domain,
   // so boot resolves to `NO_TRUST_DOMAIN` → ModePicker. Without this they'd
   // boot into the same server entry and race our `resetDatabase` /
-  // `deleteDbFile` by trying to reopen the same SQLite file (cursor flagged
-  // this on #932 r3369942991). Our own tab continues using the local
-  // `trustDomain` capture above, so the rest of the wipe sequence still
-  // targets the right server.
+  // `deleteDbFile` by trying to reopen the same SQLite file. Our own tab
+  // continues using the local `trustDomain` capture above, so the rest of
+  // the wipe sequence still targets the right server.
   if (trustDomain) {
     useTrustDomainRegistry.setState({ activeTrustDomain: undefined })
   }

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -18,7 +18,7 @@ import { resetPostAuthBootstrap } from '@/lib/post-auth-bootstrap'
 type CleanupDeps = {
   clearAuthToken?: (serverId?: string) => void
   clearDeviceId?: (serverId?: string) => void
-  handleFullWipe?: () => Promise<void>
+  handleFullWipe?: (serverId?: string) => Promise<void>
 }
 
 /**
@@ -136,9 +136,12 @@ export const clearLocalData = async ({
 
   // Step 7: clear encryption keys (server-only — `handleFullWipe` throws on standalone
   // via `key-storage.ts`'s active-server guard; we skip it cleanly when there's no server).
+  // Pass `serverIdForClear` explicitly because the registry was emptied above —
+  // the default lookup inside `clearAllKeys` would no-op and the per-server
+  // IDB database with all encryption keys would survive the wipe.
   if (trustDomain?.kind === 'server') {
     try {
-      await handleFullWipe()
+      await handleFullWipe(serverIdForClear)
     } catch (error) {
       console.error('[clearLocalData] Failed to clear encryption keys:', error)
     }

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -295,7 +295,7 @@ export const recoverWithKey = async (httpClient: HttpClient, recoveryPhrase: str
 // Flow G — Full wipe (clear all keys)
 // =============================================================================
 
-export const handleFullWipe = async (): Promise<void> => {
-  await clearAllKeys()
+export const handleFullWipe = async (serverId?: string): Promise<void> => {
+  await clearAllKeys(serverId)
   resetCodecState()
 }

--- a/src/settings/dev-settings.tsx
+++ b/src/settings/dev-settings.tsx
@@ -3,21 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ModificationIndicator } from '@/components/modification-indicator'
-import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
 import { SectionCard } from '@/components/ui/section-card'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { initialLocalSettings, useLocalSettingsStore } from '@/stores/local-settings-store'
-import { useActiveCloudUrl, useTrustDomainRegistry } from '@/stores/trust-domain-registry'
 import { getCapabilities, isTauri } from '@/lib/platform'
 import { useQuery } from '@tanstack/react-query'
 import { useShallow } from 'zustand/react/shallow'
-
-// The env-var fallback the boot resolver uses. If it were unset, boot would fail with
-// NO_TRUST_DOMAIN before this page renders, so a hardcoded localhost default would only
-// drift from whatever the rest of the app considers "default."
-const defaultCloudUrl = import.meta.env.VITE_THUNDERBOLT_CLOUD_URL ?? ''
 
 export default function DevSettingsPage() {
   const settings = useLocalSettingsStore(
@@ -28,15 +21,6 @@ export default function DevSettingsPage() {
   )
   const { isNativeFetchEnabled, debugPosthog } = settings
   const setLocalSetting = useLocalSettingsStore((s) => s.setLocalSetting)
-
-  // Cloud URL lives on the active server entry in the trust-domain registry; editing
-  // it here updates the registry directly so runtime consumers (HTTP, PowerSync, etc.)
-  // see the change on next read. Resetting falls back to the env-var default that the
-  // boot resolver also uses. NOTE: changing the URL does NOT update the active server's
-  // `serverId` — pointing at a different backend (different serverId) is post-v1 territory.
-  const cloudUrl = useActiveCloudUrl() ?? defaultCloudUrl
-  const patchActiveServer = useTrustDomainRegistry((s) => s.patchActiveServer)
-  const setCloudUrl = (value: string) => patchActiveServer({ cloudUrl: value || defaultCloudUrl })
 
   const isModified = <K extends keyof typeof settings>(key: K) => settings[key] !== initialLocalSettings[key]
 
@@ -55,28 +39,6 @@ export default function DevSettingsPage() {
 
       <SectionCard title="Network">
         <div className="flex flex-col gap-8">
-          {/* Cloud URL Setting */}
-          <div className="space-y-2">
-            <ModificationIndicator
-              as="label"
-              className="block text-sm font-medium"
-              hasModifications={cloudUrl !== defaultCloudUrl}
-              onReset={() => setCloudUrl(defaultCloudUrl)}
-            >
-              Cloud URL
-            </ModificationIndicator>
-            <Input
-              type="url"
-              value={cloudUrl}
-              onChange={(e) => setCloudUrl(e.target.value)}
-              placeholder="http://localhost:8000"
-            />
-            <p className="text-sm text-muted-foreground">The URL of the Thunderbolt backend</p>
-          </div>
-
-          {/* Divider between settings */}
-          <div className="border-t -mx-6" />
-
           <div className="flex items-center justify-between">
             <div className="flex flex-col gap-1">
               <ModificationIndicator

--- a/src/settings/workspace/gate.tsx
+++ b/src/settings/workspace/gate.tsx
@@ -20,7 +20,7 @@ import { Navigate, Outlet } from 'react-router'
  */
 export const WorkspaceSettingsGate = () => {
   const active = useActiveWorkspace()
-  const { membership, isAdmin } = useActiveWorkspaceMembership()
+  const { isAdmin, isResolved } = useActiveWorkspaceMembership()
 
   if (!active) {
     return <Loading />
@@ -30,9 +30,9 @@ export const WorkspaceSettingsGate = () => {
     return <Outlet />
   }
 
-  // Wait for the membership query to resolve before deciding — a freshly-synced
-  // membership row should flip the gate without a redirect bounce.
-  if (!membership) {
+  // `isResolved` distinguishes "still loading" from "confirmed non-member" —
+  // without it, a non-member would spin instead of redirecting.
+  if (!isResolved) {
     return <Loading />
   }
 

--- a/src/settings/workspace/general.test.tsx
+++ b/src/settings/workspace/general.test.tsx
@@ -259,6 +259,75 @@ describe('WorkspaceGeneralPage', () => {
     expect(rows[0].slug).toBe('engineering-team')
   })
 
+  it('reflects remote sync updates into the form when the user has no in-progress edits', async () => {
+    // Regression: defaultValues was initialized once per mount and never
+    // realigned. A remote update via sync would leave the form showing stale
+    // values; the next autosave would then PATCH against the user's typed
+    // baseline and clobber the remote change. (#971 r3391725307)
+    await seedSharedWorkspaceWithMembership('admin', 'Original')
+
+    const { triggerChange } = renderWithReactivity(<WorkspaceGeneralPage />, {
+      route: `/w/${otherWsId}/settings/workspace/general`,
+      routePath: '/*',
+      tables: ['workspaces'],
+      wrapper: DbWrapper,
+    })
+
+    await waitForElement(() =>
+      (screen.getByLabelText('Workspace name') as HTMLInputElement).value === 'Original'
+        ? screen.getByLabelText('Workspace name')
+        : null,
+    )
+
+    // Simulate a remote sync update — another device renamed the workspace.
+    const db = getDb()
+    await db.update(workspacesTable).set({ name: 'Remote Rename' }).where(eq(workspacesTable.id, otherWsId))
+    await act(async () => {
+      triggerChange(['workspaces'])
+      await getClock().runAllAsync()
+    })
+
+    await waitForElement(() =>
+      (screen.getByLabelText('Workspace name') as HTMLInputElement).value === 'Remote Rename'
+        ? screen.getByLabelText('Workspace name')
+        : null,
+    )
+    expect((screen.getByLabelText('Workspace name') as HTMLInputElement).value).toBe('Remote Rename')
+  })
+
+  it('does not clobber in-progress edits when a remote sync update arrives', async () => {
+    await seedSharedWorkspaceWithMembership('admin', 'Original')
+
+    const { triggerChange } = renderWithReactivity(<WorkspaceGeneralPage />, {
+      route: `/w/${otherWsId}/settings/workspace/general`,
+      routePath: '/*',
+      tables: ['workspaces'],
+      wrapper: DbWrapper,
+    })
+
+    const input = (await waitForElement(() =>
+      (screen.getByLabelText('Workspace name') as HTMLInputElement).value === 'Original'
+        ? screen.getByLabelText('Workspace name')
+        : null,
+    )) as HTMLInputElement
+
+    // User starts typing — form is now dirty.
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'User typing…' } })
+    })
+
+    // Remote sync update arrives mid-edit.
+    const db = getDb()
+    await db.update(workspacesTable).set({ name: 'Remote Rename' }).where(eq(workspacesTable.id, otherWsId))
+    await act(async () => {
+      triggerChange(['workspaces'])
+      await getClock().runAllAsync()
+    })
+
+    // The user's in-progress edit must survive — they win until they save.
+    expect((screen.getByLabelText('Workspace name') as HTMLInputElement).value).toBe('User typing…')
+  })
+
   it('stops auto-deriving the slug once the user edits it manually', async () => {
     await seedSharedWorkspaceWithMembership('admin', 'Acme')
 

--- a/src/settings/workspace/general.test.tsx
+++ b/src/settings/workspace/general.test.tsx
@@ -260,10 +260,6 @@ describe('WorkspaceGeneralPage', () => {
   })
 
   it('reflects remote sync updates into the form when the user has no in-progress edits', async () => {
-    // Regression: defaultValues was initialized once per mount and never
-    // realigned. A remote update via sync would leave the form showing stale
-    // values; the next autosave would then PATCH against the user's typed
-    // baseline and clobber the remote change. (#971 r3391725307)
     await seedSharedWorkspaceWithMembership('admin', 'Original')
 
     const { triggerChange } = renderWithReactivity(<WorkspaceGeneralPage />, {

--- a/src/settings/workspace/general.tsx
+++ b/src/settings/workspace/general.tsx
@@ -97,7 +97,7 @@ const WorkspaceActions = ({ workspace }: { workspace: Workspace }) => {
       const newId = await duplicateWorkspace(db, workspace, {
         creatorUserId: userId,
         name: `${workspace.name} Copy`,
-        slug: workspace.slug ? `${workspace.slug}-copy-${crypto.randomUUID().slice(0, 4)}` : null,
+        slug: workspace.slug ? `${workspace.slug}-copy-${crypto.randomUUID().slice(0, 8)}` : null,
         icon: workspace.icon,
       })
       navigate(`/w/${newId}/`)

--- a/src/settings/workspace/general.tsx
+++ b/src/settings/workspace/general.tsx
@@ -90,10 +90,14 @@ const WorkspaceActions = ({ workspace }: { workspace: Workspace }) => {
     }
     setBusy(true)
     try {
+      // Append a short random suffix so a second duplicate of the same source
+      // (or any existing `{slug}-copy`) doesn't collide on the server-side
+      // slug unique index — the upload would otherwise reject with
+      // WORKSPACE_SLUG_TAKEN and leave the local row unsynced. (#971 r3391725310)
       const newId = await duplicateWorkspace(db, workspace, {
         creatorUserId: userId,
         name: `${workspace.name} Copy`,
-        slug: workspace.slug ? `${workspace.slug}-copy` : null,
+        slug: workspace.slug ? `${workspace.slug}-copy-${crypto.randomUUID().slice(0, 4)}` : null,
         icon: workspace.icon,
       })
       navigate(`/w/${newId}/`)

--- a/src/settings/workspace/general.tsx
+++ b/src/settings/workspace/general.tsx
@@ -37,7 +37,7 @@ import { useActiveCloudUrl, useTrustDomainRegistry } from '@/stores/trust-domain
 import { zodResolver } from '@hookform/resolvers/zod'
 import dayjs from 'dayjs'
 import { Calendar, User } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
@@ -151,6 +151,16 @@ const RenameWorkspaceForm = ({ workspace }: { workspace: Workspace }) => {
     defaultValues: { name: workspace.name, slug: initialSlug, icon: workspace.icon },
     mode: 'onChange',
   })
+
+  // Reflect remote updates (another device renamed / changed icon / changed
+  // slug) into the form baseline so a subsequent autosave doesn't clobber
+  // them. `keepDirtyValues: true` preserves any field the user is actively
+  // editing — the user wins, and the next autosave then PATCHes against the
+  // freshest server value. (#971 r3391725307)
+  useEffect(() => {
+    const nextSlug = workspace.slug ?? slugifyWorkspaceName(workspace.name)
+    form.reset({ name: workspace.name, slug: nextSlug, icon: workspace.icon }, { keepDirtyValues: true })
+  }, [workspace.name, workspace.slug, workspace.icon, form])
 
   // Shared save path used by debounced onChange and immediate onBlur. Reads
   // current form state on every call so the timer never fires with stale args.

--- a/src/settings/workspace/general.tsx
+++ b/src/settings/workspace/general.tsx
@@ -93,7 +93,7 @@ const WorkspaceActions = ({ workspace }: { workspace: Workspace }) => {
       // Append a short random suffix so a second duplicate of the same source
       // (or any existing `{slug}-copy`) doesn't collide on the server-side
       // slug unique index — the upload would otherwise reject with
-      // WORKSPACE_SLUG_TAKEN and leave the local row unsynced. (#971 r3391725310)
+      // WORKSPACE_SLUG_TAKEN and leave the local row unsynced.
       const newId = await duplicateWorkspace(db, workspace, {
         creatorUserId: userId,
         name: `${workspace.name} Copy`,
@@ -156,11 +156,10 @@ const RenameWorkspaceForm = ({ workspace }: { workspace: Workspace }) => {
     mode: 'onChange',
   })
 
-  // Reflect remote updates (another device renamed / changed icon / changed
-  // slug) into the form baseline so a subsequent autosave doesn't clobber
-  // them. `keepDirtyValues: true` preserves any field the user is actively
-  // editing — the user wins, and the next autosave then PATCHes against the
-  // freshest server value. (#971 r3391725307)
+  // Reflect remote updates into the form baseline so a subsequent autosave
+  // doesn't clobber them. `keepDirtyValues: true` preserves any field the
+  // user is actively editing — the user wins, and the next autosave PATCHes
+  // against the freshest server value.
   useEffect(() => {
     const nextSlug = workspace.slug ?? slugifyWorkspaceName(workspace.name)
     form.reset({ name: workspace.name, slug: nextSlug, icon: workspace.icon }, { keepDirtyValues: true })

--- a/src/settings/workspace/members.test.tsx
+++ b/src/settings/workspace/members.test.tsx
@@ -3,14 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { AuthProvider, DatabaseProvider, HttpClientProvider } from '@/contexts'
-import {
-  otherWsId,
-  resetTestDatabase,
-  setupTestDatabase,
-  teardownTestDatabase,
-  testUserId,
-  wsId,
-} from '@/dal/test-utils'
+import { otherWsId, resetTestDatabase, setupTestDatabase, teardownTestDatabase, testUserId } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
 import {
   workspaceMembershipsTable,
@@ -33,7 +26,6 @@ import { eq } from 'drizzle-orm'
 import type { ReactNode } from 'react'
 import { Route, Routes, useLocation } from 'react-router'
 import WorkspaceMembersPage from './members'
-import { RequireWorkspacePermission } from './require-permission'
 
 const pageAuthClient = createMockAuthClient({
   session: { user: { id: testUserId, email: 'a@b.com', name: 'Alice', isAnonymous: false } },
@@ -103,14 +95,38 @@ const seedChangeRolesPermission = async (requiredRole: 'admin' | 'member') => {
     })
 }
 
-/** Convenience: render the Members page with the standard route + providers. */
+const seedInviteUsersPermission = async (requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({
+      id: `${otherWsId}-invite_users`,
+      workspaceId: otherWsId,
+      permissionKey: 'invite_users',
+      requiredRole,
+    })
+}
+
+const seedRemoveUsersPermission = async (requiredRole: 'admin' | 'member') => {
+  await getDb()
+    .insert(workspacePermissionsTable)
+    .values({
+      id: `${otherWsId}-remove_users`,
+      workspaceId: otherWsId,
+      permissionKey: 'remove_users',
+      requiredRole,
+    })
+}
+
+/** Convenience: render the Members page with the standard route + providers.
+ *  Mirrors the production route — no `RequireWorkspacePermission` wrapper;
+ *  Members is visible to every member of a shared workspace and individual
+ *  actions gate themselves on the granular permission keys. Nested
+ *  `workspace/members` so the `../permissions` Link inside the page resolves
+ *  to `.../settings/workspace/permissions` as it does in production. */
 const renderMembers = () => {
   renderWithReactivity(
     <Routes>
-      <Route
-        path="w/:workspaceId/settings/workspace"
-        element={<RequireWorkspacePermission permissionKey="manage_members" />}
-      >
+      <Route path="w/:workspaceId/settings/workspace">
         <Route path="members" element={<WorkspaceMembersPage />} />
       </Route>
       <Route path="*" element={<LocationProbe />} />
@@ -122,17 +138,6 @@ const renderMembers = () => {
       wrapper: Providers,
     },
   )
-}
-
-const seedPersonalMembership = async () => {
-  await getDb()
-    .insert(workspaceMembershipsTable)
-    .values({
-      id: `${wsId}-${testUserId}`,
-      workspaceId: wsId,
-      userId: testUserId,
-      role: 'admin',
-    })
 }
 
 describe('WorkspaceMembersPage routing', () => {
@@ -165,7 +170,8 @@ describe('WorkspaceMembersPage routing', () => {
     const permissionsLink = screen.getByRole('link', { name: 'Permissions' })
     // Relative `../permissions` resolves to `/w/<id>/settings/workspace/permissions` from this route.
     expect(permissionsLink.getAttribute('href')).toContain('/settings/workspace/permissions')
-    // Add Member button enabled and clickable now.
+    // Add Member shows up once `invite_users` resolves (admin satisfies default).
+    await waitForElement(() => screen.queryByRole('button', { name: /Add Member/ }))
     expect(screen.getByRole('button', { name: /Add Member/ })).not.toBeDisabled()
   })
 
@@ -183,13 +189,16 @@ describe('WorkspaceMembersPage routing', () => {
     expect(screen.getByLabelText('Emails')).toBeInTheDocument()
   })
 
-  it('redirects a member out under default policy', async () => {
+  it('lets a member view the Members page (per-action gates apply within)', async () => {
+    // Route is no longer wrapped in `RequireWorkspacePermission` — every
+    // workspace member can read the Members list. Individual actions (invite,
+    // role change, remove) gate themselves on the granular permission keys.
     await seedShared('member')
 
     renderMembers()
 
-    await waitForElement(() => screen.queryByTestId(`at-/w/${otherWsId}/settings`))
-    expect(screen.queryByRole('heading', { name: 'Members' })).not.toBeInTheDocument()
+    await waitForElement(() => screen.queryByRole('heading', { name: 'Members' }))
+    expect(screen.getByRole('heading', { name: 'Members' })).toBeInTheDocument()
   })
 
   it('renders active and pending rows with the right status text', async () => {
@@ -264,17 +273,8 @@ describe('WorkspaceMembersPage routing', () => {
 
   it('renders role as plain text when change_roles permission denies the user', async () => {
     // Active user is a member; default change_roles required_role is 'admin'
-    // → no Select for any row. We still need to be on the page, so set
-    // manage_members to 'member' so a member can reach Members.
+    // → no Select for any row.
     await seedShared('member')
-    await getDb()
-      .insert(workspacePermissionsTable)
-      .values({
-        id: `${otherWsId}-manage_members`,
-        workspaceId: otherWsId,
-        permissionKey: 'manage_members',
-        requiredRole: 'member',
-      })
     await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'admin')
 
     renderMembers()
@@ -389,16 +389,8 @@ describe('WorkspaceMembersPage routing', () => {
     // shows the dropdown with the Member option disabled.
     await seedShared('member')
     await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'admin')
-    // Active user is a member, so we need to relax manage_members to reach the page.
-    await getDb()
-      .insert(workspacePermissionsTable)
-      .values({
-        id: `${otherWsId}-manage_members`,
-        workspaceId: otherWsId,
-        permissionKey: 'manage_members',
-        requiredRole: 'member',
-      })
-    // And let members change roles too.
+    // Members can view the page by default; relax change_roles so the
+    // dropdown renders.
     await seedChangeRolesPermission('member')
 
     renderMembers()
@@ -421,25 +413,99 @@ describe('WorkspaceMembersPage routing', () => {
     }
   })
 
-  it('blocks access in a Personal Workspace', async () => {
-    await seedPersonalMembership()
+  // Personal-workspace Members access: the sidebar hides the entry for
+  // personal (covered by settings-sidebar.test.tsx). The route itself no
+  // longer has a permission wrapper — direct URL navigation renders the
+  // (degenerate, single-row) page. Acceptable; the Members concept is
+  // shared-workspace-only by convention, not by route block.
 
-    renderWithReactivity(
-      <Routes>
-        <Route path="settings/workspace" element={<RequireWorkspacePermission permissionKey="manage_members" />}>
-          <Route path="members" element={<WorkspaceMembersPage />} />
-        </Route>
-        <Route path="*" element={<LocationProbe />} />
-      </Routes>,
-      {
-        route: '/settings/workspace/members',
-        routePath: '/*',
-        tables: ['workspaces', 'workspace_memberships', 'workspace_permissions'],
-        wrapper: Providers,
-      },
-    )
+  describe('permission gating', () => {
+    it('hides Add Member when invite_users is denied (default policy for members)', async () => {
+      await seedShared('member')
 
-    await waitForElement(() => screen.queryByTestId('at-/settings'))
-    expect(screen.queryByRole('heading', { name: 'Members' })).not.toBeInTheDocument()
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('heading', { name: 'Members' }))
+      expect(screen.queryByRole('button', { name: /Add Member/ })).not.toBeInTheDocument()
+    })
+
+    it('shows Add Member when invite_users is granted to member', async () => {
+      await seedShared('member')
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('button', { name: /Add Member/ }))
+      expect(screen.getByRole('button', { name: /Add Member/ })).toBeInTheDocument()
+    })
+
+    it('hides the pending-row role dropdown when invite_users is denied (even if change_roles is granted)', async () => {
+      // The BE pending-membership PATCH is gated on `invite_users` — gating
+      // the FE on `change_roles` would round-trip-fail.
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com')
+      await seedChangeRolesPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByText('pending@test.com'))
+      expect(screen.queryByRole('combobox', { name: /Role for pending@test.com/ })).not.toBeInTheDocument()
+    })
+
+    it('shows the pending-row role dropdown when invite_users is granted', async () => {
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com')
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('combobox', { name: /Role for pending@test.com/ }))
+      expect(screen.getByRole('combobox', { name: /Role for pending@test.com/ })).toBeInTheDocument()
+    })
+
+    it('hides the pending-row Remove button when invite_users is denied', async () => {
+      // Pending DELETE is gated on `invite_users` on the BE; the FE must
+      // match. (Regression: used to gate on `remove_users` → round-trip-fail
+      // for members with one permission but not the other.)
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByText('pending@test.com'))
+      expect(screen.queryByRole('button', { name: /Remove pending@test.com/ })).not.toBeInTheDocument()
+    })
+
+    it('shows the pending-row Remove button when invite_users is granted', async () => {
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com')
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('button', { name: /Remove pending@test.com/ }))
+      expect(screen.getByRole('button', { name: /Remove pending@test.com/ })).toBeInTheDocument()
+    })
+
+    it('hides the active-row Remove button when remove_users is denied', async () => {
+      await seedShared('member')
+      await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByText('Charlie'))
+      expect(screen.queryByRole('button', { name: 'Remove Charlie' })).not.toBeInTheDocument()
+    })
+
+    it('shows the active-row Remove button when remove_users is granted', async () => {
+      await seedShared('member')
+      await seedAdditionalMember('u-charlie', 'Charlie', 'charlie@test.com', 'member')
+      await seedRemoveUsersPermission('member')
+
+      renderMembers()
+
+      await waitForElement(() => screen.queryByRole('button', { name: 'Remove Charlie' }))
+      expect(screen.getByRole('button', { name: 'Remove Charlie' })).toBeInTheDocument()
+    })
   })
 })

--- a/src/settings/workspace/members.test.tsx
+++ b/src/settings/workspace/members.test.tsx
@@ -463,6 +463,57 @@ describe('WorkspaceMembersPage routing', () => {
       expect(screen.getByRole('combobox', { name: /Role for pending@test.com/ })).toBeInTheDocument()
     })
 
+    it('omits the Admin option in pending-row dropdown when change_roles is denied', async () => {
+      // Promoting an invite to admin (PUT/PATCH) layers a `change_roles`
+      // escalation guard on top of `invite_users` on the BE — without it the
+      // user would pick "Admin" and watch sync revert. The current value
+      // here is `member`, so the option doesn't need to render as a keep-state.
+      await seedShared('member')
+      await seedPendingInvite('pending@test.com') // defaults to role='member'
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      const trigger = await waitForElement(() => screen.queryByRole('combobox', { name: /Role for pending@test.com/ }))
+      act(() => {
+        fireEvent.click(trigger!)
+      })
+      await waitForElement(() => screen.queryByRole('option', { name: 'Member' }))
+      expect(screen.queryByRole('option', { name: 'Admin' })).not.toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Member' })).toBeInTheDocument()
+    })
+
+    it('keeps the Admin option visible on an admin pending row even without change_roles', async () => {
+      // Demoting an existing pending admin invite to `member` stays gated on
+      // `invite_users` alone (BE comment: "tampering, not escalation"). The
+      // Admin option needs to render so the Select trigger can display the
+      // current value — otherwise the dropdown would visually drop its own
+      // current selection.
+      await seedShared('member')
+      await getDb()
+        .insert(workspacePendingMembershipsTable)
+        .values({
+          id: `${otherWsId}-admin-pending`,
+          workspaceId: otherWsId,
+          email: 'admin-pending@test.com',
+          role: 'admin',
+          invitedByUserId: testUserId,
+        })
+      await seedInviteUsersPermission('member')
+
+      renderMembers()
+
+      const trigger = await waitForElement(() =>
+        screen.queryByRole('combobox', { name: /Role for admin-pending@test.com/ }),
+      )
+      act(() => {
+        fireEvent.click(trigger!)
+      })
+      await waitForElement(() => screen.queryByRole('option', { name: 'Member' }))
+      expect(screen.getByRole('option', { name: 'Admin' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Member' })).toBeInTheDocument()
+    })
+
     it('hides the pending-row Remove button when invite_users is denied', async () => {
       // Pending DELETE is gated on `invite_users` on the BE; the FE must
       // match. (Regression: used to gate on `remove_users` → round-trip-fail

--- a/src/settings/workspace/members.tsx
+++ b/src/settings/workspace/members.tsx
@@ -64,6 +64,8 @@ const WorkspaceMembersPage = () => {
   const actives = useWorkspaceMembersQuery(workspaceId)
   const pendings = useWorkspacePendingMembershipsQuery(workspaceId)
   const { isAllowed: canChangeRoles } = useWorkspacePermission('change_roles')
+  const { isAllowed: canInviteUsers } = useWorkspacePermission('invite_users')
+  const { isAllowed: canRemoveUsers } = useWorkspacePermission('remove_users')
   const [inviteOpen, setInviteOpen] = useState(false)
   const [search, setSearch] = useState('')
   const normalizedSearch = search.trim().toLowerCase()
@@ -135,10 +137,12 @@ const WorkspaceMembersPage = () => {
           value={search}
           onChange={(event) => setSearch(event.target.value)}
         />
-        <Button variant="outline" size="lg" onClick={() => setInviteOpen(true)} disabled={!workspaceId}>
-          <Plus className="size-4" />
-          Add Member
-        </Button>
+        {canInviteUsers && (
+          <Button variant="outline" size="lg" onClick={() => setInviteOpen(true)} disabled={!workspaceId}>
+            <Plus className="size-4" />
+            Add Member
+          </Button>
+        )}
       </div>
       <Card>
         <CardContent>
@@ -195,7 +199,7 @@ const WorkspaceMembersPage = () => {
                       </TableCell>
                       <TableCell>Joined</TableCell>
                       <TableCell className="text-right">
-                        {!(entry.row.role === 'admin' && adminCount <= 1) && (
+                        {canRemoveUsers && !(entry.row.role === 'admin' && adminCount <= 1) && (
                           <Button
                             variant="ghost"
                             size="sm"
@@ -239,14 +243,16 @@ const WorkspaceMembersPage = () => {
                       </TableCell>
                       <TableCell className="text-muted-foreground">Pending</TableCell>
                       <TableCell className="text-right">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setRemoveTarget(entry)}
-                          aria-label={`Remove ${entry.row.email}`}
-                        >
-                          Remove
-                        </Button>
+                        {canRemoveUsers && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setRemoveTarget(entry)}
+                            aria-label={`Remove ${entry.row.email}`}
+                          >
+                            Remove
+                          </Button>
+                        )}
                       </TableCell>
                     </TableRow>
                   ),

--- a/src/settings/workspace/members.tsx
+++ b/src/settings/workspace/members.tsx
@@ -222,10 +222,13 @@ const WorkspaceMembersPage = () => {
                       <TableCell>
                         {/* Pending rows gate on `invite_users` — the BE treats
                             the entire pending lifecycle (PUT/PATCH/DELETE) as
-                            one `invite_users`-gated operation, so a user with
-                            `change_roles` or `remove_users` but not
-                            `invite_users` would click and the upload would
-                            revert. */}
+                            one `invite_users`-gated operation. Promoting an
+                            invite to admin (PUT or PATCH) layers a
+                            `change_roles` escalation guard on top, so the
+                            Admin option only appears for callers who also
+                            satisfy `change_roles` — except when it's already
+                            the current value (let users keep / demote, never
+                            promote). */}
                         {canInviteUsers ? (
                           <Select
                             value={entry.row.role}
@@ -240,7 +243,9 @@ const WorkspaceMembersPage = () => {
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="admin">Admin</SelectItem>
+                              {(canChangeRoles || entry.row.role === 'admin') && (
+                                <SelectItem value="admin">Admin</SelectItem>
+                              )}
                               <SelectItem value="member">Member</SelectItem>
                             </SelectContent>
                           </Select>

--- a/src/settings/workspace/members.tsx
+++ b/src/settings/workspace/members.tsx
@@ -219,7 +219,13 @@ const WorkspaceMembersPage = () => {
                         </span>
                       </TableCell>
                       <TableCell>
-                        {canChangeRoles ? (
+                        {/* Pending rows gate on `invite_users` — the BE treats
+                            the entire pending lifecycle (PUT/PATCH/DELETE) as
+                            one `invite_users`-gated operation, so a user with
+                            `change_roles` or `remove_users` but not
+                            `invite_users` would click and the upload would
+                            revert. */}
+                        {canInviteUsers ? (
                           <Select
                             value={entry.row.role}
                             onValueChange={(value) =>
@@ -243,7 +249,7 @@ const WorkspaceMembersPage = () => {
                       </TableCell>
                       <TableCell className="text-muted-foreground">Pending</TableCell>
                       <TableCell className="text-right">
-                        {canRemoveUsers && (
+                        {canInviteUsers && (
                           <Button
                             variant="ghost"
                             size="sm"

--- a/src/settings/workspace/members.tsx
+++ b/src/settings/workspace/members.tsx
@@ -44,10 +44,11 @@ type Row = ActiveRow | PendingRow
 const roleLabel = (role: 'admin' | 'member'): string => (role === 'admin' ? 'Admin' : 'Member')
 
 /**
- * Members management for shared workspaces. The `RequireWorkspacePermission`
- * route wrapper gates entry — non-permitted users never see this page. Personal
- * workspaces are blocked at the gate too (Decision 25 — no member management
- * in v1).
+ * Members management for shared workspaces. The page itself is reachable by
+ * any workspace member; each affordance (Add Member, role select, Remove) is
+ * gated per-control via `useWorkspacePermission`. Personal workspaces never
+ * reach this route (sidebar entry is hidden and the listing is empty by
+ * construction — Decision 25, no member management in v1).
  */
 const WorkspaceMembersPage = () => {
   const db = useDatabase()

--- a/src/settings/workspace/permissions.test.tsx
+++ b/src/settings/workspace/permissions.test.tsx
@@ -60,6 +60,9 @@ const seedPermissionRow = async (key: WorkspacePermissionKey, requiredRole: 'adm
 }
 
 const expectedRows: ReadonlyArray<{ key: string; label: string }> = [
+  { key: 'invite_users', label: 'Invite Users' },
+  { key: 'change_roles', label: 'Change Roles' },
+  { key: 'remove_users', label: 'Remove Users' },
   { key: 'add_agents', label: 'Add Agents' },
   { key: 'remove_agents', label: 'Remove Agents' },
   { key: 'add_skills', label: 'Add Skills' },
@@ -125,10 +128,8 @@ describe('WorkspacePermissionsPage', () => {
       expect(screen.getByTestId(`permission-row-${key}`)).toBeInTheDocument()
       expect(screen.getByText(label)).toBeInTheDocument()
     }
-    // Keys that used to be exposed are no longer surfaced on the page.
+    // Legacy / out-of-scope keys are not surfaced on the page.
     expect(screen.queryByTestId('permission-row-manage_members')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('permission-row-invite_users')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('permission-row-change_roles')).not.toBeInTheDocument()
     expect(screen.queryByTestId('permission-row-delete_workspace')).not.toBeInTheDocument()
   })
 

--- a/src/settings/workspace/permissions.tsx
+++ b/src/settings/workspace/permissions.tsx
@@ -17,16 +17,18 @@ import { useActiveWorkspaceId } from '@/lib/active-workspace'
 
 /**
  * Rows shown on the Permissions page. Each entry maps a `workspace_permissions`
- * key to its human label. Order is stable and intentional: lifecycle (join /
- * invite / change roles / remove) first, then capability scopes (agents, skills),
- * then admin actions (general settings, permissions, delete). The legacy
- * `manage_members` key is intentionally not listed here — see
+ * key to its human label. Order is stable and intentional: lifecycle (invite /
+ * change roles / remove) first, then capability scopes (agents, skills). The
+ * legacy `manage_members` key is intentionally not listed here — see
  * `project_workspace_permissions_validation_pending`.
  */
 const permissionRows: ReadonlyArray<{
   key: WorkspacePermissionKey
   label: string
 }> = [
+  { key: 'invite_users', label: 'Invite Users' },
+  { key: 'change_roles', label: 'Change Roles' },
+  { key: 'remove_users', label: 'Remove Users' },
   { key: 'add_agents', label: 'Add Agents' },
   { key: 'remove_agents', label: 'Remove Agents' },
   { key: 'add_skills', label: 'Add Skills' },

--- a/src/settings/workspace/require-permission.tsx
+++ b/src/settings/workspace/require-permission.tsx
@@ -80,7 +80,7 @@ export const RequireWorkspacePermission = ({ permissionKey }: RequireWorkspacePe
  */
 export const RequireWorkspaceAdmin = () => {
   const active = useActiveWorkspace()
-  const { membership, isAdmin } = useActiveWorkspaceMembership()
+  const { isAdmin, isResolved } = useActiveWorkspaceMembership()
   // @todo Drop this E2EE redirect once the encryption pipeline supports
   // multi-recipient envelopes and is workspace-aware (see THU-593). Same gate
   // as RequireWorkspacePermission — the two stay in lockstep.
@@ -98,7 +98,9 @@ export const RequireWorkspaceAdmin = () => {
     return <Navigate to=".." replace />
   }
 
-  if (membership === null) {
+  // `isResolved` distinguishes "still loading" from "confirmed non-member" —
+  // without it, a non-member would spin instead of redirecting.
+  if (!isResolved) {
     return <Loading />
   }
 

--- a/src/widgets/link-preview/widget.test.tsx
+++ b/src/widgets/link-preview/widget.test.tsx
@@ -3,12 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import '@/testing-library'
-import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase, wsId } from '@/dal/test-utils'
 import { ExternalLinkDialogProvider } from '@/components/chat/markdown-utils'
 import { ContentViewProvider } from '@/content-view/context'
+import { resetTestTrustDomain, seedTestTrustDomain } from '@/test-utils/powersync-reactivity-test'
 import type { SourceMetadata } from '@/types/source'
 import { render } from '@testing-library/react'
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { MemoryRouter } from 'react-router'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { LinkPreviewWidget } from './widget'
 import type { ReactElement } from 'react'
@@ -21,14 +23,32 @@ afterAll(async () => {
   await teardownTestDatabase()
 })
 
+// `useMessageCache` (called by FetchLinkPreview) is gated on `useActiveWorkspaceId`.
+// Without a seeded trust domain the query is disabled, the widget skips the
+// loading branch, and skeleton assertions fail.
+beforeEach(async () => {
+  await resetTestDatabase()
+  seedTestTrustDomain()
+})
+
+afterEach(() => {
+  resetTestTrustDomain()
+})
+
 const renderWithProviders = (ui: ReactElement) => {
   const TestProvider = createTestProvider()
+  // MemoryRouter at a workspace-prefixed URL so `useActiveWorkspaceId` (consumed
+  // by `useMessageCache` inside the fallback path) resolves synchronously off
+  // the URL on the first render instead of waiting for the live workspace
+  // query to land.
   return render(ui, {
     wrapper: ({ children }) => (
       <TestProvider>
-        <ContentViewProvider>
-          <ExternalLinkDialogProvider>{children}</ExternalLinkDialogProvider>
-        </ContentViewProvider>
+        <MemoryRouter initialEntries={[`/w/${wsId}/chats/new`]}>
+          <ContentViewProvider>
+            <ExternalLinkDialogProvider>{children}</ExternalLinkDialogProvider>
+          </ContentViewProvider>
+        </MemoryRouter>
       </TestProvider>
     ),
   })


### PR DESCRIPTION
Single follow-up PR addressing review comments across the stacked workspaces feature PRs. One commit per fix; each original thread has a \`Fixed in <sha>\` reply pointing here.

Stacked PRs covered (base → tip):

- #932
- #944
- #951
- #958
- #961
- #965
- #971
- #974
- #978

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization on membership and pending-invite uploads, expands who receives pending-invite sync data, and reorders sign-out/token/credential wiping—mistakes could allow privilege escalation, leave sessions or keys on disk, or break multi-tab logout.
> 
> **Overview**
> This PR tightens **workspace membership authorization** end-to-end: PowerSync upload handlers no longer treat “workspace admin” as the only gate. Writes use **`workspace_permissions`** keys (`invite_users`, `change_roles`, `remove_users`) via shared `callerSatisfiesPermission`, with extra guards so **`invite_users` alone cannot mint or promote admins**, PUT upserts cannot **demote admins or bypass `change_roles`**, and **last-admin protection** applies on membership PUT as well as PATCH/DELETE. Pending-invite handling is hardened: **email format validation**, **`invited_by_user_id` forced to the caller**, promote-on-insert uses **insert-if-missing** (no role downgrade) and **delete pending by workspace+email** after unique-key conflicts.
> 
> **Sync rules** move `workspace_pending_memberships` from the admin-only bucket into **`workspace_data`** so members granted invite/role/remove permissions can see pending rows; upload handlers remain the write authority.
> 
> On the client, the **Members** route is readable by any shared-workspace member; **Add / role / remove** controls align with the granular keys (pending lifecycle gated on `invite_users`). **`useActiveWorkspaceId`** can resolve from the URL before the workspace row exists; **cross-workspace navigation** resets chat detail paths to `/chats/new`. **Sign-out wipe** clears `activeTrustDomain` early for multi-tab safety, passes **captured `serverId`** into credential and encryption key cleanup, and **defers token clearing until after authenticated `signOut`** (`withCapturedAuthToken`). Smaller fixes include workspace PUT preserving omitted slug/icon, **`SERVER_ID` validation messages**, app error boundary, mode-picker stale validation, and duplicate-workspace slug suffixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9607c0d4ee2bb58e1cd026779040ecb727b453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->