### PR TITLE
feat(acp): opt-in toggle to allow insecure ws:// for local agents

### DIFF
--- a/src/components/settings/agents/add-custom-agent-dialog.test.tsx
+++ b/src/components/settings/agents/add-custom-agent-dialog.test.tsx
@@ -49,35 +49,42 @@ describe('validateAgentUrl', () => {
   const isIos = () => true
 
   it('accepts wss:// on non-iOS platforms', () => {
-    expect(validateAgentUrl('wss://example.com', notIos)).toEqual({ transport: 'websocket' })
+    expect(validateAgentUrl('wss://example.com', { isIos: notIos })).toEqual({ transport: 'websocket' })
   })
 
-  it('accepts ws:// on non-iOS platforms (LAN/dev use)', () => {
-    expect(validateAgentUrl('ws://localhost:8080/ws', notIos)).toEqual({ transport: 'websocket' })
+  it('rejects ws:// by default (insecure opt-in off)', () => {
+    const result = validateAgentUrl('ws://localhost:8080/ws', { isIos: notIos })
+    expect('error' in result && result.error).toMatch(/insecure|Developer Settings/i)
+  })
+
+  it('accepts ws:// when allowInsecure is opted in (local agent)', () => {
+    expect(validateAgentUrl('ws://localhost:8080/ws', { isIos: notIos, allowInsecure: true })).toEqual({
+      transport: 'websocket',
+    })
   })
 
   it('rejects http:// with a clear "WebSocket only" message', () => {
-    const result = validateAgentUrl('http://example.com/acp', notIos)
+    const result = validateAgentUrl('http://example.com/acp', { isIos: notIos })
     expect('error' in result && result.error).toMatch(/WebSocket|wss:\/\/|ws:\/\//i)
   })
 
   it('rejects https:// with a clear "WebSocket only" message', () => {
-    const result = validateAgentUrl('https://example.com/acp', notIos)
+    const result = validateAgentUrl('https://example.com/acp', { isIos: notIos })
     expect('error' in result && result.error).toMatch(/WebSocket|wss:\/\/|ws:\/\//i)
   })
 
   it('rejects unsupported schemes with a user-facing message', () => {
-    const result = validateAgentUrl('ftp://example.com', notIos)
+    const result = validateAgentUrl('ftp://example.com', { isIos: notIos })
     expect('error' in result && result.error).toMatch(/WebSocket|wss:\/\/|ws:\/\//i)
   })
 
-  it('rejects ws:// on Tauri iOS (ATS forbids cleartext)', () => {
-    const result = validateAgentUrl('ws://example.com', isIos)
+  it('rejects ws:// on Tauri iOS even when opted in (ATS forbids cleartext)', () => {
+    const result = validateAgentUrl('ws://example.com', { isIos, allowInsecure: true })
     expect('error' in result && result.error).toMatch(/iOS.*secure/i)
   })
 
   it('still accepts wss:// on Tauri iOS', () => {
-    expect(validateAgentUrl('wss://example.com', isIos)).toEqual({ transport: 'websocket' })
+    expect(validateAgentUrl('wss://example.com', { isIos })).toEqual({ transport: 'websocket' })
   })
 })
 

--- a/src/components/settings/agents/add-custom-agent-dialog.tsx
+++ b/src/components/settings/agents/add-custom-agent-dialog.tsx
@@ -16,6 +16,7 @@ import {
 import { Dialog } from '@/components/ui/dialog'
 import { StatusCard } from '@/components/ui/status-card'
 import { getPlatform, isTauri } from '@/lib/platform'
+import { useLocalSettingsStore } from '@/stores/local-settings-store'
 import { testAcpConnection as defaultTestAcpConnection } from '@/acp'
 
 /** Maps a user-entered URL to the ACP transport flavor we support, or `null`
@@ -40,17 +41,29 @@ const defaultIsTauriIOS = (): boolean => isTauri() && getPlatform() === 'ios'
 
 /** Pure validation of `url` against the platform's transport rules. Returns
  *  the inferred transport on success, or a user-facing error string. Extracted
- *  so the test suite can exercise it without rendering the dialog. */
+ *  so the test suite can exercise it without rendering the dialog.
+ *
+ *  Cleartext `ws://` is rejected by default — secure `wss://` is required unless
+ *  the user opts in via `allowInsecure` (the "Allow insecure local agents"
+ *  Developer Setting), which exists for connecting to a local agent binary on
+ *  127.0.0.1. iOS rejects `ws://` regardless (Apple ATS blocks cleartext). */
 export const validateAgentUrl = (
   url: string,
-  isIos: () => boolean = defaultIsTauriIOS,
+  { isIos = defaultIsTauriIOS, allowInsecure = false }: { isIos?: () => boolean; allowInsecure?: boolean } = {},
 ): { transport: 'websocket' } | { error: string } => {
   const transport = inferTransport(url)
   if (!transport) {
-    return { error: 'Only WebSocket endpoints are supported (wss:// or ws://)' }
+    return { error: 'Only WebSocket endpoints are supported (wss://, or ws:// for local agents when enabled)' }
   }
-  if (isIos() && new URL(url).protocol === 'ws:') {
+  const isCleartext = new URL(url).protocol === 'ws:'
+  if (isCleartext && isIos()) {
     return { error: 'iOS requires a secure URL (wss://)' }
+  }
+  if (isCleartext && !allowInsecure) {
+    return {
+      error:
+        'Insecure ws:// is disabled. Enable “Allow insecure local agents” in Developer Settings to use a local agent.',
+    }
   }
   return { transport }
 }
@@ -144,11 +157,13 @@ export const AddCustomAgentDialog = ({
   testAcpConnection = defaultTestAcpConnection,
 }: AddCustomAgentDialogProps) => {
   const [state, dispatch] = useReducer(agentDialogReducer, initialState)
+  // Opt-in gate: only permit cleartext ws:// when the user has enabled it.
+  const allowInsecure = useLocalSettingsStore((s) => s.allowInsecureAcp)
 
   const trimmedName = state.name.trim()
   const trimmedUrl = state.url.trim()
   const trimmedDescription = state.description.trim()
-  const validation = validateAgentUrl(trimmedUrl, isIos)
+  const validation = validateAgentUrl(trimmedUrl, { isIos, allowInsecure })
   // Surface an invalid-URL error at render time (once the field is non-empty)
   // so the user sees why Test Connection is unavailable and Add stays gated.
   const urlError = trimmedUrl.length > 0 && 'error' in validation ? validation.error : null

--- a/src/settings/dev-settings.tsx
+++ b/src/settings/dev-settings.tsx
@@ -19,9 +19,10 @@ export default function DevSettingsPage() {
       cloudUrl: s.cloudUrl,
       isNativeFetchEnabled: s.isNativeFetchEnabled,
       debugPosthog: s.debugPosthog,
+      allowInsecureAcp: s.allowInsecureAcp,
     })),
   )
-  const { cloudUrl, isNativeFetchEnabled, debugPosthog } = settings
+  const { cloudUrl, isNativeFetchEnabled, debugPosthog, allowInsecureAcp } = settings
   const setLocalSetting = useLocalSettingsStore((s) => s.setLocalSetting)
 
   const isModified = <K extends keyof typeof settings>(key: K) => settings[key] !== initialLocalSettings[key]
@@ -111,6 +112,26 @@ export default function DevSettingsPage() {
             </div>
             <Switch checked={debugPosthog} onCheckedChange={(value) => setLocalSetting('debugPosthog', value)} />
           </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Agents">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-1">
+            <ModificationIndicator
+              as="label"
+              className="text-sm font-medium"
+              hasModifications={isModified('allowInsecureAcp')}
+              onReset={() => resetSetting('allowInsecureAcp')}
+            >
+              Allow insecure local agents
+            </ModificationIndicator>
+            <p className="text-sm text-muted-foreground">
+              Permit connecting to a custom ACP agent over cleartext <code>ws://</code> (e.g. a local agent binary on
+              127.0.0.1). Off by default — secure <code>wss://</code> is required otherwise.
+            </p>
+          </div>
+          <Switch checked={allowInsecureAcp} onCheckedChange={(value) => setLocalSetting('allowInsecureAcp', value)} />
         </div>
       </SectionCard>
     </div>

--- a/src/stores/local-settings-store.ts
+++ b/src/stores/local-settings-store.ts
@@ -12,6 +12,10 @@ type LocalSettingsState = {
   hapticsEnabled: boolean
   syncEnabled: boolean
   theme: 'light' | 'dark' | 'system'
+  // Opt-in: permit connecting to a custom ACP agent over insecure cleartext
+  // `ws://` (e.g. a local agent binary on 127.0.0.1). Off by default — the
+  // add-custom-agent dialog requires `wss://` unless this is enabled.
+  allowInsecureAcp: boolean
 }
 
 type LocalSettingsActions = {
@@ -27,6 +31,7 @@ export const initialLocalSettings: LocalSettingsState = {
   hapticsEnabled: true,
   syncEnabled: false,
   theme: 'system',
+  allowInsecureAcp: false,
 }
 
 export const useLocalSettingsStore = create<LocalSettingsStore>()(
@@ -47,6 +52,7 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
         hapticsEnabled: s.hapticsEnabled,
         syncEnabled: s.syncEnabled,
         theme: s.theme,
+        allowInsecureAcp: s.allowInsecureAcp,
       }),
     },
   ),


### PR DESCRIPTION
## Why
A user running a **local ACP agent binary** connects over cleartext `ws://127.0.0.1:<port>`. Today the custom-agent dialog accepts `ws://` *unconditionally* (only iOS blocks it). This makes that an explicit, default-off opt-in instead — secure `wss://` is required unless the user knowingly enables insecure local agents.

## What
- **`local-settings-store`**: new persisted `allowInsecureAcp` (default **false**).
- **`validateAgentUrl`**: now takes `{ isIos, allowInsecure }`; **rejects `ws://` by default** with a clear message ("Enable 'Allow insecure local agents' in Developer Settings"). `wss://` always allowed; iOS still rejects `ws://` regardless (Apple ATS).
- **Add-custom-agent dialog**: reads the setting and passes it through.
- **Developer Settings → Agents**: a toggle to enable it (with a localhost/local-binary explanation).
- **Tests**: updated for the new signature + gating (default-deny, opt-in allow, iOS-still-rejects).

`bun run type-check` clean, `eslint` clean, 24/24 dialog tests pass.

## Base
Stacked on **#967** (`coding-agent-broker-provider`) — that's where the remote-ACP provider + this validation live; there's no ACP code on `main` yet. Re-targets `main` once #967 lands. Pairs with the local shim binary (https://github.com/thunderbird/thunderbolt-coding-agent/pull/115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent connection URL policy (cleartext WebSocket), but risk is mitigated by default-off opt-in, developer-only toggle, and unchanged iOS ATS rules.
> 
> **Overview**
> Cleartext **`ws://`** custom ACP agent URLs are **off by default**; **`wss://`** stays allowed everywhere. Users can enable **“Allow insecure local agents”** in Developer Settings for localhost-style agents (e.g. `ws://127.0.0.1`).
> 
> A persisted **`allowInsecureAcp`** flag (default **false**) is added to the local settings store. **`validateAgentUrl`** now takes `{ isIos, allowInsecure }` and rejects `ws://` unless opted in, with copy pointing to Developer Settings; **iOS still blocks `ws://` even when opted in** (ATS). The add-custom-agent dialog reads the setting and passes it into validation. Tests cover default-deny, opt-in allow, and iOS behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26029c1b878286355a6691b0abf1c61ac8aeeaee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->