### PR TITLE
fix: fail closed on unknown client IP in rate limiting

### DIFF
--- a/backend/src/middleware/rate-limit.test.ts
+++ b/backend/src/middleware/rate-limit.test.ts
@@ -257,15 +257,34 @@ describe('Rate Limiting', () => {
       expect(allowedResponse.status).toBe(200)
     })
 
-    it('should skip rate limiting when IP is unknown (no proxy header, no socket)', async () => {
+    it('should fail CLOSED when IP is unknown — throttle via a shared bucket instead of skipping', async () => {
       const app = createIpTestApp(database, ipSettings)
 
       // Request without cf-connecting-ip header — extractClientIp returns the socket IP fallback.
-      // In test (no real server), socket IP is 'unknown', so rate limiting is skipped.
-      for (let i = 0; i < 15; i++) {
+      // In test (no real server), socket IP is 'unknown'. Unidentifiable traffic must NOT bypass
+      // the limit: it shares a single `ip:unknown` bucket and gets a 429 past the threshold.
+      for (let i = 0; i < 10; i++) {
         const response = await app.handle(new Request('http://localhost/v1/test'))
         expect(response.status).toBe(200)
       }
+
+      const blocked = await app.handle(new Request('http://localhost/v1/test'))
+      expect(blocked.status).toBe(429)
+      const body = await blocked.json()
+      expect(body.error).toBe('Too many requests. Please try again later.')
+    })
+
+    it('should isolate the shared unknown bucket from identifiable IPs (no funnelling of real clients)', async () => {
+      const app = createIpTestApp(database, ipSettings)
+
+      // Exhaust the shared `ip:unknown` bucket with unidentifiable requests.
+      for (let i = 0; i < 10; i++) {
+        await app.handle(new Request('http://localhost/v1/test'))
+      }
+      expect((await app.handle(new Request('http://localhost/v1/test'))).status).toBe(429)
+
+      // A request with a resolvable IP keeps its own bucket and is unaffected.
+      expect((await app.handle(requestWithIp('10.2.0.1'))).status).toBe(200)
     })
 
     it('should track independently from user-based tiers', async () => {

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -109,18 +109,24 @@ const createUserRateLimitMiddleware = (limiter: RateLimiterDrizzle) =>
  * Uses `extractClientIp` to resolve the real client IP behind a trusted proxy,
  * falling back to the Bun socket IP when no proxy is configured.
  *
- * Skips rate limiting when the IP cannot be determined (returns 'unknown'),
- * to avoid funnelling all unidentifiable traffic into a single bucket.
+ * Fails CLOSED when the client IP cannot be resolved: unidentifiable traffic
+ * shares a single `ip:unknown` bucket rather than skipping the limit, so this
+ * control guarding abuse-prone unauthenticated endpoints (OTP send, waitlist
+ * join) can never silently disable itself. Identifiable clients are unaffected —
+ * each keeps its own `ip:<addr>` bucket, so real traffic is never funnelled into
+ * the shared one. In practice 'unknown' never occurs under TCP-listening Bun
+ * (`server.requestIP()` always returns the peer address); it would only arise on
+ * a non-TCP transport (e.g. a Unix-domain socket), where collectively capping
+ * unattributable traffic is the safe default.
  */
 const createIpRateLimitMiddleware = (limiter: RateLimiterDrizzle, trustedProxy: IpRateLimitSettings['trustedProxy']) =>
   new Elysia()
     .onBeforeHandle(async (ctx) => {
       const { set } = ctx
-      const socketIp = ctx.server?.requestIP(ctx.request)?.address ?? 'unknown'
+      // `|| 'unknown'` (not `??`): a degenerate empty-string address folds into the
+      // same shared fail-closed bucket as a missing one, never a stray `ip:` key.
+      const socketIp = ctx.server?.requestIP(ctx.request)?.address || 'unknown'
       const clientIp = extractClientIp(ctx.request.headers, socketIp, trustedProxy)
-      if (clientIp === 'unknown') {
-        return
-      }
       return consumeOrReject(limiter, `ip:${clientIp}`, set)
     })
     .as('scoped')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes abuse protection on unauthenticated auth endpoints; behavior shifts from no limit to collective throttling only when IP resolution fails (rare in production TCP), with identifiable clients unchanged.
> 
> **Overview**
> **IP-based auth rate limiting no longer bypasses limits when the client address cannot be resolved.** Previously, `createIpRateLimitMiddleware` returned early when `extractClientIp` yielded `unknown`, which could disable protection on unauthenticated routes (e.g. OTP, waitlist). Requests now always call `consumeOrReject` under `ip:${clientIp}`, so unidentifiable traffic shares one **`ip:unknown`** bucket and gets **429** after the auth tier threshold.
> 
> Socket fallback uses **`|| 'unknown'`** instead of **`?? 'unknown'`** so empty-string addresses join the same shared bucket instead of a separate `ip:` key. Comments document fail-closed intent and that identifiable IPs keep per-address buckets.
> 
> Tests replace the “skip when unknown” case with assertions for throttling via the shared bucket and isolation from requests with a resolvable `CF-Connecting-IP`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba7e60d6a2f73b465de73f45594f31eb1a55d27b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->