### PR TITLE
build: bump tar to 0.4.46 to patch GHSA-3pv8-6f4r-ffg2 (PAX desync)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4859,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no Rust source changes; typical low-risk security patch for archive parsing used in the update path.
> 
> **Overview**
> Updates the locked **`tar`** crate from **0.4.45** to **0.4.46** in `src-tauri/Cargo.lock` to address **GHSA-3pv8-6f4r-ffg2** (PAX header parsing desync). No application source changes—only the dependency version and checksum in the lockfile.
> 
> **`tar`** is pulled in transitively (e.g. via the Tauri updater stack for archive handling during updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87f1848c154d1e1123bf4355f7e6d7261d2148a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->