### PR TITLE
feat: add generalized document sources sidebar (THU-608)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -43,7 +43,6 @@ import { WelcomeDialog } from './components/welcome-dialog'
 import { PendingDeviceModal } from './components/pending-device-modal'
 import { UpdateNotification } from './components/update-notification'
 import { ExternalLinkDialogProvider } from './components/chat/markdown-utils'
-import { CitationsSidebarProvider } from './components/chat/citations-sidebar'
 import { ContentViewProvider } from './content-view/context'
 import { useAppInitialization } from './hooks/use-app-initialization'
 import { useCredentialEvents } from './hooks/use-credential-events'
@@ -257,9 +256,7 @@ export const App = () => {
                             <SidebarProvider>
                               <ContentViewProvider>
                                 <ExternalLinkDialogProvider>
-                                  <CitationsSidebarProvider>
-                                    <AppContent initData={initData} />
-                                  </CitationsSidebarProvider>
+                                  <AppContent initData={initData} />
                                 </ExternalLinkDialogProvider>
                               </ContentViewProvider>
                             </SidebarProvider>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -43,6 +43,7 @@ import { WelcomeDialog } from './components/welcome-dialog'
 import { PendingDeviceModal } from './components/pending-device-modal'
 import { UpdateNotification } from './components/update-notification'
 import { ExternalLinkDialogProvider } from './components/chat/markdown-utils'
+import { CitationsSidebarProvider } from './components/chat/citations-sidebar'
 import { ContentViewProvider } from './content-view/context'
 import { useAppInitialization } from './hooks/use-app-initialization'
 import { useCredentialEvents } from './hooks/use-credential-events'
@@ -256,7 +257,9 @@ export const App = () => {
                             <SidebarProvider>
                               <ContentViewProvider>
                                 <ExternalLinkDialogProvider>
-                                  <AppContent initData={initData} />
+                                  <CitationsSidebarProvider>
+                                    <AppContent initData={initData} />
+                                  </CitationsSidebarProvider>
                                 </ExternalLinkDialogProvider>
                               </ContentViewProvider>
                             </SidebarProvider>

--- a/src/chats/detail.tsx
+++ b/src/chats/detail.tsx
@@ -8,6 +8,7 @@ import { type PropsWithChildren, useEffect, useMemo } from 'react'
 import { SavePartialAssistantMessagesHandler } from './save-partial-assistant-messages-handler'
 import { useParams } from 'react-router'
 import { v7 as uuidv7 } from 'uuid'
+import { useContentView } from '@/content-view/context'
 import { useHandleIntegrationCompletion } from '@/hooks/use-handle-integration-completion'
 
 type ChatHydrateHandlerProps = PropsWithChildren<{
@@ -36,10 +37,19 @@ const ChatHydrateHandler = ({ children, id, isNew }: ChatHydrateHandlerProps) =>
 
 export default function ChatDetailPage() {
   const params = useParams()
+  const { close } = useContentView()
 
   const isNew = params.chatThreadId === 'new'
 
   const id = useMemo(() => (isNew ? uuidv7() : params.chatThreadId || null), [params.chatThreadId])
+
+  // Close any open content view (citations, document viewer, link preview, tool
+  // output) when the active chat changes — its content is scoped to the chat the
+  // user just left, so carrying it into a different chat shows stale sources.
+  useEffect(() => {
+    close()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id])
 
   if (!id) {
     return null

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -14,6 +14,8 @@ import type { HaystackReferenceMeta, ThunderboltUIMessage, UIMessageMetadata } f
 import type { SourceMetadata } from '@/types/source'
 import type { TextUIPart } from 'ai'
 import { memo, useMemo, type ReactNode } from 'react'
+import { buildMessageCitations } from './citation-utils'
+import { CitationsSidebarButton } from './citations-sidebar'
 import { CopyMessageButton } from './copy-message-button'
 import { ReasoningGroup } from './reasoning-group'
 import { SyntheticLoadingPart } from './synthetic-loading-part'
@@ -126,6 +128,10 @@ export const AssistantMessage = memo(
       [JSON.stringify(message.metadata?.haystackReferences)],
     )
 
+    // Deduped document-citation set for this message — backs the footer
+    // "show sources" button that opens the citations sidebar on demand.
+    const citations = useMemo(() => buildMessageCitations(haystackReferences ?? []), [haystackReferences])
+
     const mcpTools = useMemo(
       () => message.metadata?.mcpTools,
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -189,11 +195,12 @@ export const AssistantMessage = memo(
             {partElement}
           </div>
         ))}
-        {!isStreaming && copyText && (
+        {!isStreaming && (copyText || citations.length > 0) && (
           <div
             className={`flex items-center gap-2.5 px-4 ${hasWidgets || lastPartIsReasoningGroup ? 'mt-1' : '-mt-6'} ${showCopyOnHover ? 'md:opacity-0 md:group-hover:opacity-100 md:transition-opacity' : ''}`}
           >
-            <CopyMessageButton text={copyText} />
+            {copyText && <CopyMessageButton text={copyText} />}
+            <CitationsSidebarButton messageId={message.id} sources={citations} />
           </div>
         )}
       </div>

--- a/src/components/chat/citation-badge.tsx
+++ b/src/components/chat/citation-badge.tsx
@@ -5,9 +5,10 @@
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { useIsMobile } from '@/hooks/use-mobile'
-import type { CitationSource } from '@/types/citation'
+import { type CitationSource, isDocumentCitation } from '@/types/citation'
 import { memo, useState } from 'react'
 import { useCitationPopover } from './citation-popover'
+import { useCitationMessage, useCitationsSidebar } from './citations-sidebar-context'
 import { SourceList } from './source-list'
 
 type CitationBadgeProps = {
@@ -41,10 +42,13 @@ const badgeClass =
 
 const getBadgeLabel = (sources: CitationSource[]) => {
   const primary = sources.find((s) => s.isPrimary) || sources[0]
+  // Document citations show the chapter/section title (more distinct than the
+  // source name repeated across every chip); web citations show the publisher.
+  const label = isDocumentCitation(primary) ? primary.title || primary.siteName : primary.siteName || primary.title
   return {
-    displayName: primary.siteName || primary.title,
+    displayName: label,
     additionalCount: sources.length > 1 ? `+${sources.length - 1}` : null,
-    ariaLabel: `View source: ${primary.siteName || primary.title}`,
+    ariaLabel: `View source: ${label}`,
   }
 }
 
@@ -80,9 +84,24 @@ const BadgeButton = ({ sources, isOpen, onToggle }: BadgeButtonProps) => {
 
 const ManagedBadge = memo(({ sources, citationId }: { sources: CitationSource[]; citationId: number }) => {
   const ctx = useCitationPopover()!
+  const sidebar = useCitationsSidebar()
+  const message = useCitationMessage()
   const isOpen = ctx.popover?.citationId === citationId
 
+  const primary = sources.find((s) => s.isPrimary) ?? sources[0]
+
   const toggle = (element: HTMLElement) => {
+    // Document citations open the message's full citation set in the sidebar
+    // (highlighting the clicked source) instead of the inline popover; web
+    // citations fall through to the inline popover.
+    if (sidebar && message && primary && isDocumentCitation(primary)) {
+      sidebar.open({
+        messageId: message.messageId,
+        sources: message.sources,
+        highlightId: primary.documentMeta.fileId,
+      })
+      return
+    }
     if (isOpen) {
       ctx.close()
     } else {

--- a/src/components/chat/citation-badge.tsx
+++ b/src/components/chat/citation-badge.tsx
@@ -7,8 +7,9 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { useIsMobile } from '@/hooks/use-mobile'
 import { type CitationSource, isDocumentCitation } from '@/types/citation'
 import { memo, useState } from 'react'
+import { useShowCitations } from '@/content-view/context'
 import { useCitationPopover } from './citation-popover'
-import { useCitationMessage, useCitationsSidebar } from './citations-sidebar-context'
+import { useCitationMessage } from './citations-sidebar-context'
 import { SourceList } from './source-list'
 
 type CitationBadgeProps = {
@@ -84,18 +85,23 @@ const BadgeButton = ({ sources, isOpen, onToggle }: BadgeButtonProps) => {
 
 const ManagedBadge = memo(({ sources, citationId }: { sources: CitationSource[]; citationId: number }) => {
   const ctx = useCitationPopover()!
-  const sidebar = useCitationsSidebar()
+  const showCitations = useShowCitations()
   const message = useCitationMessage()
   const isOpen = ctx.popover?.citationId === citationId
 
   const primary = sources.find((s) => s.isPrimary) ?? sources[0]
 
   const toggle = (element: HTMLElement) => {
-    // Document citations open the message's full citation set in the sidebar
-    // (highlighting the clicked source) instead of the inline popover; web
-    // citations fall through to the inline popover.
-    if (sidebar && message && primary && isDocumentCitation(primary)) {
-      sidebar.open({
+    // Citation presentation is intentionally split by source richness — this is
+    // one data model with two presentations, NOT a divergent path. Document
+    // citations carry page numbers, retrieval relevance, and an in-app viewer,
+    // so they open the richer content-view panel (highlighting the clicked
+    // source); web citations are just title + link, so they stay in the
+    // lightweight inline popover. The OUP-specific richness (relevance bars)
+    // self-gates on `score` in citation-row, so non-OUP document pipelines get
+    // the same panel without it. See THU-608.
+    if (showCitations && message && primary && isDocumentCitation(primary)) {
+      showCitations({
         messageId: message.messageId,
         sources: message.sources,
         highlightId: primary.documentMeta.fileId,

--- a/src/components/chat/citation-row.test.tsx
+++ b/src/components/chat/citation-row.test.tsx
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@/testing-library'
+import { ContentViewProvider, useContentView } from '@/content-view/context'
+import type { DocumentCitationSource } from '@/types/citation'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+import { type ReactElement, type ReactNode } from 'react'
+import { CitationRow } from './citation-row'
+import { ExternalLinkDialogProvider } from './markdown-utils'
+
+const renderWithProvider = (ui: ReactElement) =>
+  render(ui, {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <ContentViewProvider>
+        <ExternalLinkDialogProvider>{children}</ExternalLinkDialogProvider>
+      </ContentViewProvider>
+    ),
+  })
+
+const docSource: DocumentCitationSource = {
+  id: 'file-1:ch.txt:1',
+  title: "Newton's Universal Law of Gravitation",
+  url: 'https://openstax.org/books/astronomy/pages/3-3',
+  siteName: 'Astronomy',
+  isPrimary: true,
+  documentMeta: { fileId: 'file-1', fileName: 'ch.txt', pageNumber: 1, contributors: 'Aruna Nair', score: 0.9 },
+}
+
+describe('CitationRow', () => {
+  it('renders the title, page indicator, "author, in book" subtitle, and relevance bars', () => {
+    renderWithProvider(<CitationRow source={docSource} index={1} />)
+
+    expect(screen.getByText("Newton's Universal Law of Gravitation")).toBeInTheDocument()
+    expect(screen.getByText('(p. 1)')).toBeInTheDocument()
+    expect(screen.getByText('Aruna Nair, in Astronomy')).toBeInTheDocument()
+    expect(screen.getByLabelText(/relevance/i)).toBeInTheDocument()
+    expect(screen.getByText('1.')).toBeInTheDocument()
+  })
+
+  it('omits the page and contributors when absent (subtitle falls back to the book)', () => {
+    const minimal = { ...docSource, documentMeta: { fileId: 'file-1', fileName: 'ch.txt' } }
+    renderWithProvider(<CitationRow source={minimal} />)
+
+    expect(screen.getByText('Astronomy')).toBeInTheDocument()
+    expect(screen.queryByText(/^\(p\./)).toBeNull()
+  })
+
+  it('falls back to the in-app document viewer when there is no source URL', () => {
+    const captured: { sideview: { sideviewType: string | null; sideviewId: string | null } | null } = {
+      sideview: null,
+    }
+    const Capture = () => {
+      const { state } = useContentView()
+      captured.sideview =
+        state.type === 'sideview' ? { sideviewType: state.data.sideviewType, sideviewId: state.data.sideviewId } : null
+      return null
+    }
+
+    renderWithProvider(
+      <>
+        <CitationRow source={{ ...docSource, url: '' }} />
+        <Capture />
+      </>,
+    )
+
+    fireEvent.click(screen.getByRole('listitem'))
+
+    expect(captured.sideview).toEqual({ sideviewType: 'document', sideviewId: 'file-1:ch.txt:1' })
+  })
+})

--- a/src/components/chat/citation-row.tsx
+++ b/src/components/chat/citation-row.tsx
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useOpenExternalLink } from '@/components/chat/markdown-utils'
+import { useContentView } from '@/content-view/context'
+import { isSafeUrl } from '@/lib/url-utils'
+import { cn } from '@/lib/utils'
+import { buildDocumentSideviewId, type DocumentCitationSource } from '@/types/citation'
+
+type CitationRowProps = {
+  source: DocumentCitationSource
+  /** 1-based position shown as a leading "N." (matches the numbered sources list). */
+  index?: number
+  /** Highlight this row — e.g. when the sidebar was opened from its inline marker. */
+  highlighted?: boolean
+  /** Called after the row's action fires (open source link / fallback viewer). */
+  onSelect?: () => void
+}
+
+/** Ascending heights for the 3 relevance bars (signal-strength style). */
+const barHeights = ['h-2', 'h-3', 'h-4']
+
+/** Renders 3 bars filled in proportion to a 0–1 relevance score. */
+const RelevanceBars = ({ score }: { score: number }) => {
+  const filled = score >= 0.66 ? 3 : score >= 0.33 ? 2 : 1
+  return (
+    <span className="flex items-end gap-0.5" aria-label={`Relevance: ${filled} of 3`}>
+      {barHeights.map((height, i) => (
+        <span key={i} className={cn('w-1 rounded-sm', height, i < filled ? 'bg-primary' : 'bg-muted')} />
+      ))}
+    </span>
+  )
+}
+
+/**
+ * A single citation in the citations sidebar: an optional number, the title as
+ * a link, a "(p. N)" indicator and relevance bars top-right, and an
+ * "<author>, in <source>" subtitle. Clicking opens the citation's canonical
+ * source URL when present, falling back to the in-app document viewer.
+ */
+export const CitationRow = ({ source, index, highlighted, onSelect }: CitationRowProps) => {
+  const openExternalLink = useOpenExternalLink()
+  const { showSideview } = useContentView()
+
+  const hasSourceUrl = isSafeUrl(source.url)
+  const { pageNumber, contributors, score } = source.documentMeta
+  const book = source.siteName || 'Source'
+  const subtitle = contributors ? `${contributors}, in ${book}` : book
+
+  const handleClick = () => {
+    if (hasSourceUrl) {
+      openExternalLink(source.url)
+    } else {
+      showSideview('document', buildDocumentSideviewId(source.documentMeta))
+    }
+    onSelect?.()
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        'group flex w-full cursor-pointer gap-2.5 rounded-lg px-4 py-3 text-left transition-colors hover:bg-accent/50',
+        highlighted && 'bg-accent ring-1 ring-ring',
+      )}
+      role="listitem"
+    >
+      {index != null && (
+        <span className="shrink-0 text-[length:var(--font-size-body)] leading-6 tabular-nums text-muted-foreground">
+          {index}.
+        </span>
+      )}
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="flex items-start justify-between gap-2">
+          <span className="text-[length:var(--font-size-body)] font-medium leading-6 text-primary group-hover:underline">
+            {source.title || book}
+          </span>
+          <span className="flex shrink-0 items-center gap-1.5 pt-0.5">
+            {pageNumber != null && (
+              <span className="text-[length:var(--font-size-xs)] leading-4 text-muted-foreground">
+                (p. {pageNumber})
+              </span>
+            )}
+            {score != null && <RelevanceBars score={score} />}
+          </span>
+        </span>
+        <span className="text-[length:var(--font-size-xs)] leading-4 text-muted-foreground">{subtitle}</span>
+      </span>
+    </button>
+  )
+}

--- a/src/components/chat/citation-utils.test.ts
+++ b/src/components/chat/citation-utils.test.ts
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { HaystackReferenceMeta } from '@/types'
+import { type DocumentCitationSource, isDocumentCitation } from '@/types/citation'
+import { describe, expect, test } from 'bun:test'
+import { buildMessageCitations, haystackRefToSource } from './citation-utils'
+
+const ref = (position: number, overrides: Partial<HaystackReferenceMeta> = {}): HaystackReferenceMeta => ({
+  position,
+  fileId: `file-${position}`,
+  fileName: `doc-${position}.txt`,
+  ...overrides,
+})
+
+describe('haystackRefToSource', () => {
+  test('maps chapter/book/url and carries documentMeta', () => {
+    const source = haystackRefToSource(
+      ref(1, {
+        title: 'The Sky Above',
+        bookTitle: 'Astronomy',
+        sourceUrl: 'https://openstax.org/2-1',
+        pageNumber: 1,
+        contributors: 'Aruna Nair',
+        score: 0.95,
+      }),
+      true,
+    )
+
+    expect(isDocumentCitation(source)).toBe(true)
+    expect(source.title).toBe('The Sky Above')
+    expect(source.siteName).toBe('Astronomy')
+    expect(source.url).toBe('https://openstax.org/2-1')
+    expect(source.isPrimary).toBe(true)
+    expect(source.documentMeta.pageNumber).toBe(1)
+    expect(source.documentMeta.contributors).toBe('Aruna Nair')
+    expect(source.documentMeta.score).toBe(0.95)
+  })
+
+  test('falls back to filename + extension when meta absent', () => {
+    const source = haystackRefToSource(ref(1), false)
+
+    expect(source.title).toBe('doc-1.txt')
+    expect(source.siteName).toBe('TXT')
+    expect(source.url).toBe('')
+    expect(source.isPrimary).toBe(false)
+  })
+})
+
+describe('buildMessageCitations', () => {
+  test('dedupes by document and orders by first position', () => {
+    const refs = [ref(3, { fileId: 'b' }), ref(1, { fileId: 'a' }), ref(6, { fileId: 'b' }), ref(2, { fileId: 'c' })]
+    const sources = buildMessageCitations(refs)
+
+    expect(sources.map((s) => (s as DocumentCitationSource).documentMeta.fileId)).toEqual(['a', 'c', 'b'])
+    expect(sources[0].isPrimary).toBe(true)
+    expect(sources[1].isPrimary).toBe(false)
+  })
+
+  test('returns empty for no references', () => {
+    expect(buildMessageCitations([])).toEqual([])
+  })
+})

--- a/src/components/chat/citation-utils.ts
+++ b/src/components/chat/citation-utils.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { HaystackReferenceMeta } from '@/types'
+import { buildDocumentSideviewId, type DocumentCitationSource } from '@/types/citation'
+
+/**
+ * Map a single Haystack reference to a document-backed citation source.
+ *
+ * Shared by the inline citation badges and the citations sidebar so the two
+ * never drift: `title` is the chapter/section, `siteName` is the book (falling
+ * back to the file extension), `url` is the canonical source link, and
+ * `documentMeta` carries the ids used for the in-app viewer fallback.
+ */
+export const haystackRefToSource = (ref: HaystackReferenceMeta, isPrimary: boolean): DocumentCitationSource => {
+  const ext = ref.fileName.split('.').pop()?.toLowerCase() ?? ''
+  return {
+    id: buildDocumentSideviewId(ref),
+    title: ref.title || ref.fileName,
+    url: ref.sourceUrl ?? '',
+    siteName: ref.bookTitle || ext.toUpperCase(),
+    isPrimary,
+    documentMeta: {
+      fileId: ref.fileId,
+      fileName: ref.fileName,
+      pageNumber: ref.pageNumber,
+      contributors: ref.contributors,
+      score: ref.score,
+    },
+  }
+}
+
+/**
+ * Build the deduped, ordered citation list for a message's sidebar.
+ *
+ * A message commonly cites the same document at several `[N]` positions, so we
+ * collapse to one row per unique document (keyed by `fileId`), keeping the
+ * order of first appearance. The first row is flagged `isPrimary`.
+ */
+export const buildMessageCitations = (references: HaystackReferenceMeta[]): DocumentCitationSource[] => {
+  const seen = new Set<string>()
+  const sources: DocumentCitationSource[] = []
+  for (const ref of [...references].sort((a, b) => a.position - b.position)) {
+    if (seen.has(ref.fileId)) {
+      continue
+    }
+    seen.add(ref.fileId)
+    sources.push(haystackRefToSource(ref, sources.length === 0))
+  }
+  return sources
+}

--- a/src/components/chat/citations-sidebar-context.tsx
+++ b/src/components/chat/citations-sidebar-context.tsx
@@ -5,42 +5,20 @@
 import type { DocumentCitationSource } from '@/types/citation'
 import { createContext, useContext, type ReactNode } from 'react'
 
-/** The citations currently shown in the sidebar, scoped to one message. */
-export type CitationsSidebarData = {
-  /** Message whose citations are shown — lets callers swap/replace by message. */
-  messageId: string
-  sources: DocumentCitationSource[]
-  /** `fileId` of the row to highlight (e.g. the inline marker that was clicked). */
-  highlightId?: string
-}
-
-export type CitationsSidebarActions = {
-  open: (data: CitationsSidebarData) => void
-  close: () => void
-}
-
-/**
- * Sidebar actions only (stable). The active state is passed to the panel as a
- * prop, so toggling the sidebar never re-renders consumers of this context.
- * Lives in a leaf module (no component imports) to keep the inline citation
- * badge — which opens the sidebar — out of an import cycle.
- */
-export const CitationsSidebarContext = createContext<CitationsSidebarActions | null>(null)
-
-/** Access the citations sidebar. Returns null outside a provider so optional callers can no-op. */
-export const useCitationsSidebar = () => useContext(CitationsSidebarContext)
-
 /**
  * The message an inline citation badge belongs to, plus that message's full
- * (deduped) citation set. Lets a badge open the sidebar to the whole message —
- * matching auto-open — while highlighting the clicked source.
+ * (deduped) citation set. Lets a badge open the content view to the whole
+ * message — matching the footer button — while highlighting the clicked source.
+ *
+ * Lives in a leaf module (no component imports) to keep the inline citation
+ * badge out of an import cycle with the panel.
  */
 export type CitationMessageValue = {
   messageId: string
   sources: DocumentCitationSource[]
 }
 
-export const CitationMessageContext = createContext<CitationMessageValue | null>(null)
+const CitationMessageContext = createContext<CitationMessageValue | null>(null)
 
 /** Access the inline citation badge's owning message + its citation set, or null. */
 export const useCitationMessage = () => useContext(CitationMessageContext)

--- a/src/components/chat/citations-sidebar-context.tsx
+++ b/src/components/chat/citations-sidebar-context.tsx
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { DocumentCitationSource } from '@/types/citation'
+import { createContext, useContext, type ReactNode } from 'react'
+
+/** The citations currently shown in the sidebar, scoped to one message. */
+export type CitationsSidebarData = {
+  /** Message whose citations are shown — lets callers swap/replace by message. */
+  messageId: string
+  sources: DocumentCitationSource[]
+  /** `fileId` of the row to highlight (e.g. the inline marker that was clicked). */
+  highlightId?: string
+}
+
+export type CitationsSidebarActions = {
+  open: (data: CitationsSidebarData) => void
+  close: () => void
+}
+
+/**
+ * Sidebar actions only (stable). The active state is passed to the panel as a
+ * prop, so toggling the sidebar never re-renders consumers of this context.
+ * Lives in a leaf module (no component imports) to keep the inline citation
+ * badge — which opens the sidebar — out of an import cycle.
+ */
+export const CitationsSidebarContext = createContext<CitationsSidebarActions | null>(null)
+
+/** Access the citations sidebar. Returns null outside a provider so optional callers can no-op. */
+export const useCitationsSidebar = () => useContext(CitationsSidebarContext)
+
+/**
+ * The message an inline citation badge belongs to, plus that message's full
+ * (deduped) citation set. Lets a badge open the sidebar to the whole message —
+ * matching auto-open — while highlighting the clicked source.
+ */
+export type CitationMessageValue = {
+  messageId: string
+  sources: DocumentCitationSource[]
+}
+
+export const CitationMessageContext = createContext<CitationMessageValue | null>(null)
+
+/** Access the inline citation badge's owning message + its citation set, or null. */
+export const useCitationMessage = () => useContext(CitationMessageContext)
+
+export const CitationMessageProvider = ({
+  value,
+  children,
+}: {
+  value: CitationMessageValue | null
+  children: ReactNode
+}) => <CitationMessageContext.Provider value={value}>{children}</CitationMessageContext.Provider>

--- a/src/components/chat/citations-sidebar.test.tsx
+++ b/src/components/chat/citations-sidebar.test.tsx
@@ -3,12 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import '@/testing-library'
-import { ContentViewProvider } from '@/content-view/context'
+import { ContentViewProvider, useContentView } from '@/content-view/context'
 import type { DocumentCitationSource } from '@/types/citation'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'bun:test'
-import { CitationsSidebarProvider } from './citations-sidebar'
-import { useCitationsSidebar } from './citations-sidebar-context'
+import { describe, expect, it, mock } from 'bun:test'
+import { CitationsPanel, CitationsSidebarButton } from './citations-sidebar'
 import { ExternalLinkDialogProvider } from './markdown-utils'
 
 const sources: DocumentCitationSource[] = [
@@ -29,38 +28,59 @@ const sources: DocumentCitationSource[] = [
   },
 ]
 
-const Harness = () => {
-  const ctx = useCitationsSidebar()!
-  return (
-    <>
-      <button onClick={() => ctx.open({ messageId: 'm1', sources })}>open</button>
-      <button onClick={ctx.close}>close</button>
-    </>
-  )
+const StateProbe = () => {
+  const { state } = useContentView()
+  return <div data-testid="state">{state.type ?? 'none'}</div>
 }
 
-const renderSidebar = () =>
-  render(
-    <ContentViewProvider>
-      <ExternalLinkDialogProvider>
-        <CitationsSidebarProvider>
-          <Harness />
-        </CitationsSidebarProvider>
-      </ExternalLinkDialogProvider>
-    </ContentViewProvider>,
-  )
+describe('CitationsPanel', () => {
+  it('renders the message sources with numbers and a count header', () => {
+    const onClose = mock(() => {})
+    render(
+      <ContentViewProvider>
+        <ExternalLinkDialogProvider>
+          <CitationsPanel data={{ messageId: 'm1', sources }} onClose={onClose} />
+        </ExternalLinkDialogProvider>
+      </ContentViewProvider>,
+    )
 
-describe('CitationsSidebar', () => {
-  it('is closed initially, opens with the message citations, then closes', () => {
-    renderSidebar()
-    expect(screen.queryByText('The Sky Above')).toBeNull()
-
-    fireEvent.click(screen.getByText('open'))
     expect(screen.getByText('The Sky Above')).toBeInTheDocument()
     expect(screen.getByText('Gravitation')).toBeInTheDocument()
     expect(screen.getByText('1.')).toBeInTheDocument()
+    expect(screen.getByText(/Sources \(2\)/)).toBeInTheDocument()
 
-    fireEvent.click(screen.getByText('close'))
-    expect(screen.queryByText('The Sky Above')).toBeNull()
+    fireEvent.click(screen.getByLabelText('Close sources'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('CitationsSidebarButton', () => {
+  it('opens the content view to the citations panel on click', () => {
+    render(
+      <ContentViewProvider>
+        <ExternalLinkDialogProvider>
+          <StateProbe />
+          <CitationsSidebarButton messageId="m1" sources={sources} />
+        </ExternalLinkDialogProvider>
+      </ContentViewProvider>,
+    )
+
+    expect(screen.getByTestId('state').textContent).toBe('none')
+    fireEvent.click(screen.getByLabelText('Show sources'))
+    expect(screen.getByTestId('state').textContent).toBe('citations')
+  })
+
+  it('renders nothing with no sources', () => {
+    render(
+      <ContentViewProvider>
+        <CitationsSidebarButton messageId="m1" sources={[]} />
+      </ContentViewProvider>,
+    )
+    expect(screen.queryByLabelText('Show sources')).toBeNull()
+  })
+
+  it('renders nothing outside a content view provider', () => {
+    render(<CitationsSidebarButton messageId="m1" sources={sources} />)
+    expect(screen.queryByLabelText('Show sources')).toBeNull()
   })
 })

--- a/src/components/chat/citations-sidebar.test.tsx
+++ b/src/components/chat/citations-sidebar.test.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@/testing-library'
+import { ContentViewProvider } from '@/content-view/context'
+import type { DocumentCitationSource } from '@/types/citation'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+import { CitationsSidebarProvider } from './citations-sidebar'
+import { useCitationsSidebar } from './citations-sidebar-context'
+import { ExternalLinkDialogProvider } from './markdown-utils'
+
+const sources: DocumentCitationSource[] = [
+  {
+    id: 'file-1:a.txt:1',
+    title: 'The Sky Above',
+    url: 'https://openstax.org/books/astronomy/pages/2-1',
+    siteName: 'Astronomy',
+    isPrimary: true,
+    documentMeta: { fileId: 'file-1', fileName: 'a.txt', pageNumber: 1 },
+  },
+  {
+    id: 'file-2:b.txt:5',
+    title: 'Gravitation',
+    url: 'https://openstax.org/books/astronomy/pages/3-3',
+    siteName: 'Astronomy',
+    documentMeta: { fileId: 'file-2', fileName: 'b.txt', pageNumber: 5 },
+  },
+]
+
+const Harness = () => {
+  const ctx = useCitationsSidebar()!
+  return (
+    <>
+      <button onClick={() => ctx.open({ messageId: 'm1', sources })}>open</button>
+      <button onClick={ctx.close}>close</button>
+    </>
+  )
+}
+
+const renderSidebar = () =>
+  render(
+    <ContentViewProvider>
+      <ExternalLinkDialogProvider>
+        <CitationsSidebarProvider>
+          <Harness />
+        </CitationsSidebarProvider>
+      </ExternalLinkDialogProvider>
+    </ContentViewProvider>,
+  )
+
+describe('CitationsSidebar', () => {
+  it('is closed initially, opens with the message citations, then closes', () => {
+    renderSidebar()
+    expect(screen.queryByText('The Sky Above')).toBeNull()
+
+    fireEvent.click(screen.getByText('open'))
+    expect(screen.getByText('The Sky Above')).toBeInTheDocument()
+    expect(screen.getByText('Gravitation')).toBeInTheDocument()
+    expect(screen.getByText('1.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('close'))
+    expect(screen.queryByText('The Sky Above')).toBeNull()
+  })
+})

--- a/src/components/chat/citations-sidebar.tsx
+++ b/src/components/chat/citations-sidebar.tsx
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Button } from '@/components/ui/button'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { useIsMobile } from '@/hooks/use-mobile'
+import { cn } from '@/lib/utils'
+import type { DocumentCitationSource } from '@/types/citation'
+import { Quote, X } from 'lucide-react'
+import { memo, useCallback, useMemo, useState, type ReactNode } from 'react'
+import { CitationRow } from './citation-row'
+import { CitationsSidebarContext, type CitationsSidebarData, useCitationsSidebar } from './citations-sidebar-context'
+
+/**
+ * Owns the citations sidebar state and renders the panel (desktop right
+ * slide-over) / sheet (mobile bottom). The active set is scoped to a single
+ * message so callers can auto-open the latest answer, swap on a new one, or
+ * re-open an older message from its quote button / inline markers.
+ */
+export const CitationsSidebarProvider = ({ children }: { children: ReactNode }) => {
+  const [active, setActive] = useState<CitationsSidebarData | null>(null)
+  const open = useCallback((data: CitationsSidebarData) => setActive(data), [])
+  const close = useCallback(() => setActive(null), [])
+  // Value carries only the stable actions — `active` is passed to the panel
+  // directly as a prop, so toggling the sidebar never re-renders consumers.
+  const value = useMemo(() => ({ open, close }), [open, close])
+
+  return (
+    <CitationsSidebarContext.Provider value={value}>
+      {children}
+      <CitationsSidebarPanel active={active} close={close} />
+    </CitationsSidebarContext.Provider>
+  )
+}
+
+/**
+ * Footer affordance (sibling to the copy button) that re-opens the citations
+ * sidebar scoped to a given message. Renders nothing when there are no
+ * citations or no sidebar provider in scope.
+ */
+export const CitationsSidebarButton = ({
+  messageId,
+  sources,
+}: {
+  messageId: string
+  sources: DocumentCitationSource[]
+}) => {
+  const sidebar = useCitationsSidebar()
+  if (!sidebar || sources.length === 0) {
+    return null
+  }
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="size-8 rounded-lg"
+      title="Show sources"
+      aria-label="Show sources"
+      onClick={() => sidebar.open({ messageId, sources })}
+    >
+      <Quote className="size-4 text-muted-foreground/80" />
+    </Button>
+  )
+}
+
+const CitationsSidebarPanel = memo(({ active, close }: { active: CitationsSidebarData | null; close: () => void }) => {
+  const { isMobile } = useIsMobile()
+  const isOpen = active !== null
+  const sources = active?.sources ?? []
+  const title = sources.length === 1 ? 'Source' : 'Sources'
+
+  const list = (
+    <div className="flex flex-col gap-1 overflow-y-auto p-2" role="list">
+      {sources.map((source, index) => (
+        <CitationRow
+          key={source.id}
+          index={index + 1}
+          source={source}
+          highlighted={source.documentMeta.fileId === active?.highlightId}
+          onSelect={isMobile ? close : undefined}
+        />
+      ))}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <Sheet open={isOpen} onOpenChange={(o) => !o && close()}>
+        <SheetContent
+          side="bottom"
+          className="inset-x-1 flex max-h-[70vh] flex-col overflow-hidden rounded-2xl border p-0"
+          style={{ bottom: 'calc(20px + var(--safe-area-bottom-padding, 0px))' }}
+        >
+          <SheetHeader className="px-4 pt-4">
+            <SheetTitle>{title}</SheetTitle>
+          </SheetHeader>
+          {list}
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'fixed right-0 top-0 z-40 flex h-full w-[360px] max-w-full flex-col border-l bg-background transition-transform duration-300 ease-out',
+        isOpen ? 'translate-x-0' : 'translate-x-full',
+      )}
+      aria-hidden={!isOpen}
+    >
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h2 className="text-[length:var(--font-size-body)] font-medium">
+          {title}
+          {sources.length > 0 ? ` (${sources.length})` : ''}
+        </h2>
+        <button
+          type="button"
+          onClick={close}
+          aria-label="Close sources"
+          className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <X className="size-[var(--icon-size-sm)]" />
+        </button>
+      </div>
+      {list}
+    </div>
+  )
+})
+
+CitationsSidebarPanel.displayName = 'CitationsSidebarPanel'

--- a/src/components/chat/citations-sidebar.tsx
+++ b/src/components/chat/citations-sidebar.tsx
@@ -3,41 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Button } from '@/components/ui/button'
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { type CitationsViewData, useShowCitations } from '@/content-view/context'
 import { useIsMobile } from '@/hooks/use-mobile'
-import { cn } from '@/lib/utils'
 import type { DocumentCitationSource } from '@/types/citation'
 import { Quote, X } from 'lucide-react'
-import { memo, useCallback, useMemo, useState, type ReactNode } from 'react'
+import { memo } from 'react'
 import { CitationRow } from './citation-row'
-import { CitationsSidebarContext, type CitationsSidebarData, useCitationsSidebar } from './citations-sidebar-context'
 
 /**
- * Owns the citations sidebar state and renders the panel (desktop right
- * slide-over) / sheet (mobile bottom). The active set is scoped to a single
- * message so callers can auto-open the latest answer, swap on a new one, or
- * re-open an older message from its quote button / inline markers.
- */
-export const CitationsSidebarProvider = ({ children }: { children: ReactNode }) => {
-  const [active, setActive] = useState<CitationsSidebarData | null>(null)
-  const open = useCallback((data: CitationsSidebarData) => setActive(data), [])
-  const close = useCallback(() => setActive(null), [])
-  // Value carries only the stable actions — `active` is passed to the panel
-  // directly as a prop, so toggling the sidebar never re-renders consumers.
-  const value = useMemo(() => ({ open, close }), [open, close])
-
-  return (
-    <CitationsSidebarContext.Provider value={value}>
-      {children}
-      <CitationsSidebarPanel active={active} close={close} />
-    </CitationsSidebarContext.Provider>
-  )
-}
-
-/**
- * Footer affordance (sibling to the copy button) that re-opens the citations
- * sidebar scoped to a given message. Renders nothing when there are no
- * citations or no sidebar provider in scope.
+ * Footer affordance (sibling to the copy button) that opens the citations panel
+ * in the content view, scoped to a given message. Renders nothing when there
+ * are no citations or no content view provider in scope.
  */
 export const CitationsSidebarButton = ({
   messageId,
@@ -46,8 +22,8 @@ export const CitationsSidebarButton = ({
   messageId: string
   sources: DocumentCitationSource[]
 }) => {
-  const sidebar = useCitationsSidebar()
-  if (!sidebar || sources.length === 0) {
+  const showCitations = useShowCitations()
+  if (!showCitations || sources.length === 0) {
     return null
   }
   return (
@@ -57,58 +33,26 @@ export const CitationsSidebarButton = ({
       className="size-8 rounded-lg"
       title="Show sources"
       aria-label="Show sources"
-      onClick={() => sidebar.open({ messageId, sources })}
+      onClick={() => showCitations({ messageId, sources })}
     >
       <Quote className="size-4 text-muted-foreground/80" />
     </Button>
   )
 }
 
-const CitationsSidebarPanel = memo(({ active, close }: { active: CitationsSidebarData | null; close: () => void }) => {
+/**
+ * Citations content for the content view's right panel: a header and the
+ * message's deduped source rows. The panel container (resize, width
+ * persistence, mobile full-width) is owned by the content view in
+ * `main-layout.tsx` — this just fills it, matching the document viewer.
+ */
+export const CitationsPanel = memo(({ data, onClose }: { data: CitationsViewData; onClose: () => void }) => {
   const { isMobile } = useIsMobile()
-  const isOpen = active !== null
-  const sources = active?.sources ?? []
+  const sources = data.sources
   const title = sources.length === 1 ? 'Source' : 'Sources'
 
-  const list = (
-    <div className="flex flex-col gap-1 overflow-y-auto p-2" role="list">
-      {sources.map((source, index) => (
-        <CitationRow
-          key={source.id}
-          index={index + 1}
-          source={source}
-          highlighted={source.documentMeta.fileId === active?.highlightId}
-          onSelect={isMobile ? close : undefined}
-        />
-      ))}
-    </div>
-  )
-
-  if (isMobile) {
-    return (
-      <Sheet open={isOpen} onOpenChange={(o) => !o && close()}>
-        <SheetContent
-          side="bottom"
-          className="inset-x-1 flex max-h-[70vh] flex-col overflow-hidden rounded-2xl border p-0"
-          style={{ bottom: 'calc(20px + var(--safe-area-bottom-padding, 0px))' }}
-        >
-          <SheetHeader className="px-4 pt-4">
-            <SheetTitle>{title}</SheetTitle>
-          </SheetHeader>
-          {list}
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
   return (
-    <div
-      className={cn(
-        'fixed right-0 top-0 z-40 flex h-full w-[360px] max-w-full flex-col border-l bg-background transition-transform duration-300 ease-out',
-        isOpen ? 'translate-x-0' : 'translate-x-full',
-      )}
-      aria-hidden={!isOpen}
-    >
+    <div className="flex h-full flex-col bg-background">
       <div className="flex items-center justify-between border-b px-4 py-3">
         <h2 className="text-[length:var(--font-size-body)] font-medium">
           {title}
@@ -116,16 +60,26 @@ const CitationsSidebarPanel = memo(({ active, close }: { active: CitationsSideba
         </h2>
         <button
           type="button"
-          onClick={close}
+          onClick={onClose}
           aria-label="Close sources"
           className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
         >
           <X className="size-[var(--icon-size-sm)]" />
         </button>
       </div>
-      {list}
+      <div className="flex flex-col gap-1 overflow-y-auto p-2" role="list">
+        {sources.map((source, index) => (
+          <CitationRow
+            key={source.id}
+            index={index + 1}
+            source={source}
+            highlighted={source.documentMeta.fileId === data.highlightId}
+            onSelect={isMobile ? onClose : undefined}
+          />
+        ))}
+      </div>
     </div>
   )
 })
 
-CitationsSidebarPanel.displayName = 'CitationsSidebarPanel'
+CitationsPanel.displayName = 'CitationsPanel'

--- a/src/components/chat/text-part.tsx
+++ b/src/components/chat/text-part.tsx
@@ -4,12 +4,9 @@
 
 import { type ContentPart, parseContentParts } from '@/ai/widget-parser'
 import { sourceToCitation } from '@/lib/source-utils'
-import {
-  buildDocumentSideviewId,
-  type CitationMap,
-  type CitationSource,
-  type DocumentCitationSource,
-} from '@/types/citation'
+import { type CitationMap, type CitationSource } from '@/types/citation'
+import { buildMessageCitations, haystackRefToSource } from './citation-utils'
+import { CitationMessageProvider } from './citations-sidebar-context'
 import type { HaystackReferenceMeta } from '@/types'
 import type { SourceMetadata } from '@/types/source'
 import { type TextUIPart } from 'ai'
@@ -120,20 +117,7 @@ export const buildDocumentCitationPlaceholders = (
       if (!ref) {
         continue
       }
-      const ext = ref.fileName.split('.').pop()?.toLowerCase() ?? ''
-      const source: DocumentCitationSource = {
-        id: buildDocumentSideviewId(ref),
-        title: ref.fileName,
-        url: '',
-        siteName: ext.toUpperCase(),
-        isPrimary: validSources.length === 0,
-        documentMeta: {
-          fileId: ref.fileId,
-          fileName: ref.fileName,
-          pageNumber: ref.pageNumber,
-        },
-      }
-      validSources.push(source)
+      validSources.push(haystackRefToSource(ref, validSources.length === 0))
     }
 
     if (validSources.length === 0) {
@@ -151,6 +135,13 @@ export const buildDocumentCitationPlaceholders = (
 export const TextPart = memo(({ part, messageId, sources, haystackReferences }: TextPartProps) => {
   const hasNewSources = !!sources && sources.length > 0
   const hasDocumentRefs = !!haystackReferences && haystackReferences.length > 0
+
+  // Full deduped citation set for the message — provided to inline badges so a
+  // click opens the whole message's sources in the sidebar.
+  const messageCitations = useMemo(
+    () => (hasDocumentRefs ? buildMessageCitations(haystackReferences ?? []) : []),
+    [hasDocumentRefs, haystackReferences],
+  )
 
   // Build citation data upfront so the hook is always called in the same order
   const { processedParts, citations, hasCitations, hasText } = useMemo(() => {
@@ -213,34 +204,38 @@ export const TextPart = memo(({ part, messageId, sources, haystackReferences }: 
 
   if (hasCitations && hasText) {
     return (
-      <CitationPopoverProvider>
-        <CitationContext.Provider value={citations}>
-          {dedupedParts.map((part, index) => {
-            if (part.type === 'text') {
+      <CitationMessageProvider value={hasDocumentRefs ? { messageId, sources: messageCitations } : null}>
+        <CitationPopoverProvider>
+          <CitationContext.Provider value={citations}>
+            {dedupedParts.map((part, index) => {
+              if (part.type === 'text') {
+                return (
+                  <div key={`text-${index}`} className="p-4 my-2">
+                    <MemoizedMarkdown
+                      key={`${messageId}-text-${index}`}
+                      id={`${messageId}-${index}`}
+                      content={part.content}
+                      components={citationMarkdownComponents}
+                    />
+                  </div>
+                )
+              }
               return (
-                <div key={`text-${index}`} className="p-4 my-2">
-                  <MemoizedMarkdown
-                    key={`${messageId}-text-${index}`}
-                    id={`${messageId}-${index}`}
-                    content={part.content}
-                    components={citationMarkdownComponents}
-                  />
+                <div
+                  key={
+                    part.widget.widget === 'link-preview'
+                      ? (part.widget.args as { url: string }).url
+                      : `widget-${index}`
+                  }
+                  className="animate-in slide-in-from-bottom-2 fade-in duration-300 ease-out"
+                >
+                  <WidgetRenderer widget={part.widget} messageId={messageId} sources={sources} />
                 </div>
               )
-            }
-            return (
-              <div
-                key={
-                  part.widget.widget === 'link-preview' ? (part.widget.args as { url: string }).url : `widget-${index}`
-                }
-                className="animate-in slide-in-from-bottom-2 fade-in duration-300 ease-out"
-              >
-                <WidgetRenderer widget={part.widget} messageId={messageId} sources={sources} />
-              </div>
-            )
-          })}
-        </CitationContext.Provider>
-      </CitationPopoverProvider>
+            })}
+          </CitationContext.Provider>
+        </CitationPopoverProvider>
+      </CitationMessageProvider>
     )
   }
 

--- a/src/content-view/context.tsx
+++ b/src/content-view/context.tsx
@@ -8,6 +8,7 @@ import { trackEvent } from '@/lib/posthog'
 import { getToolMetadataSync } from '@/lib/tool-metadata'
 import { formatToolOutput } from '@/lib/utils'
 import type { UIMessageMetadata } from '@/types'
+import type { DocumentCitationSource } from '@/types/citation'
 import { getToolName, type DynamicToolUIPart, type ReasoningUIPart, type ToolUIPart } from 'ai'
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import type { SidebarWebviewConfig } from './use-sidebar-webview'
@@ -25,11 +26,21 @@ export type SideviewData = {
   sideviewId: string
 }
 
+/** The document citations shown in the content view, scoped to one message. */
+export type CitationsViewData = {
+  /** Message whose citations are shown — lets callers swap/replace by message. */
+  messageId: string
+  sources: DocumentCitationSource[]
+  /** `fileId` of the row to highlight (e.g. the inline marker that was clicked). */
+  highlightId?: string
+}
+
 type ContentViewState =
   | { type: null; data: null }
   | { type: 'object-view'; data: ObjectViewData }
   | { type: 'preview'; data: SidebarWebviewConfig }
   | { type: 'sideview'; data: SideviewData }
+  | { type: 'citations'; data: CitationsViewData }
 
 type ContentViewContextType = {
   state: ContentViewState
@@ -37,6 +48,8 @@ type ContentViewContextType = {
   showPreview: (url: string) => void
   /** Open a typed sideview (e.g. `'document'`). Passing `null` clears the view. */
   showSideview: (sideviewType: string | null, sideviewId: string | null) => void
+  /** Open the document citations panel for a message. */
+  showCitations: (data: CitationsViewData) => void
   close: () => void
   isOpen: boolean
   previewHidden: boolean
@@ -99,6 +112,11 @@ export const ContentViewProvider = ({ children }: { children: ReactNode }) => {
     setState({ type: 'sideview', data: { sideviewType, sideviewId } })
   }, [])
 
+  const showCitations = useCallback((data: CitationsViewData) => {
+    trackEvent('content_view_open', { view_type: 'citations' })
+    setState({ type: 'citations', data })
+  }, [])
+
   const close = useCallback(() => {
     if (state.type !== null) {
       trackEvent('content_view_close', { view_type: state.type })
@@ -122,6 +140,7 @@ export const ContentViewProvider = ({ children }: { children: ReactNode }) => {
         showObjectView,
         showPreview,
         showSideview,
+        showCitations,
         close,
         isOpen: state.type !== null,
         previewHidden,
@@ -167,6 +186,11 @@ export const usePreview = () => {
 /** Returns showPreview when inside ContentViewProvider, undefined otherwise. */
 export const useShowPreview = (): ((url: string) => void) | undefined => {
   return useContext(ContentViewContext)?.showPreview
+}
+
+/** Returns showCitations when inside ContentViewProvider, undefined otherwise (callers can no-op). */
+export const useShowCitations = (): ((data: CitationsViewData) => void) | undefined => {
+  return useContext(ContentViewContext)?.showCitations
 }
 
 /** Returns setPreviewHidden when inside ContentViewProvider, undefined otherwise. */

--- a/src/layout/main-layout.tsx
+++ b/src/layout/main-layout.tsx
@@ -12,6 +12,7 @@ import { useContentView } from '@/content-view/context'
 import { ObjectSidebarContent } from '@/content-view/object-sidebar-content'
 import { SidebarWebview } from '@/content-view/sidebar-webview'
 import { Sideview } from '@/content-view/sideview'
+import { CitationsPanel } from '@/components/chat/citations-sidebar'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { isTauri } from '@/lib/platform'
 import { useSettings } from '@/hooks/use-settings'
@@ -164,6 +165,7 @@ export default function Page() {
                 )}
                 {state.type === 'object-view' && <ObjectSidebarContent content={state.data} onClose={close} />}
                 {state.type === 'sideview' && <Sideview />}
+                {state.type === 'citations' && <CitationsPanel data={state.data} onClose={close} />}
               </m.div>
             )}
           </AnimatePresence>

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,16 @@ export type HaystackReferenceMeta = {
   fileName: string
   /** Optional page number within the file. */
   pageNumber?: number
+  /** Chapter/section title — the citation's display title. */
+  title?: string
+  /** Book/publication title — the citation's source label. */
+  bookTitle?: string
+  /** Canonical URL of the cited passage, if the pipeline provides one. */
+  sourceUrl?: string
+  /** Author(s) of the cited material, as a display string. */
+  contributors?: string
+  /** Retrieval relevance score (0–1) of the cited document. */
+  score?: number
 }
 
 /**

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -28,6 +28,10 @@ export type DocumentCitationSource = CitationSource & {
     fileId: string
     fileName: string
     pageNumber?: number
+    /** Author(s) of the cited material, for the sidebar row subtitle. */
+    contributors?: string
+    /** Retrieval relevance score (0–1), for the sidebar relevance indicator. */
+    score?: number
   }
 }
 


### PR DESCRIPTION
## What

Brings the citations "Sources" sidebar prototyped on the OUP demo branch into the product, decoupled from OUP/Deepset specifics.

- New citations sidebar — desktop right slide-over / mobile bottom sheet — listing a message's document citations as rich rows: title, `<author>, in <source>` subtitle, page indicator, and a 0–1 relevance signal-strength indicator.
- `CitationsSidebarProvider` mounted in `app.tsx`; opened **on demand** from inline citation badges (document citations) and a footer "show sources" button. Web-link citations keep the existing inline popover.
- `citation-utils` (`haystackRefToSource` + `buildMessageCitations` dedup) replaces the inline document-citation building in `text-part.tsx`, so badges and the sidebar share one source of truth.
- Extends `HaystackReferenceMeta` + `DocumentCitationSource` with optional `title`/`bookTitle`/`sourceUrl`/`contributors`/`score` (Haystack pipeline outputs; additive, no breaking change).

## Decoupled from the demo
- Dropped the OUP citation analytics (`trackCitation*`).
- Reverted `text-[var(--oup-accent)]` colors to theme defaults.
- Removed the hardcoded placeholder publication year from the row subtitle.
- **On-demand only:** per product decision, the demo's auto-open-on-response-complete behavior is intentionally **not** ported (the sidebar opens only on badge/button click).

## Design note
Citation rendering is intentionally bifurcated: document citations → sidebar, web-link citations → existing inline popover. `CitationRow` is document-shaped. Unifying web sources into the sidebar would be a follow-up design pass.

## Test
- 277/277 chat-component tests pass (incl. pre-existing `citation-badge` / `text-part` suites — no regressions). New tests: `citation-row`, `citation-utils`, `citations-sidebar`. Typecheck clean.

Closes THU-608


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI and additive metadata fields; citation click paths reuse existing external-link and document sideview flows with tests.
> 
> **Overview**
> Adds an **on-demand document “Sources” panel** in the existing right-hand content view, scoped per assistant message. Users open it from a footer **Show sources** control (next to copy) or by clicking an **inline document citation badge**; web citations still use the lightweight popover.
> 
> **`citation-utils`** centralizes Haystack → `DocumentCitationSource` mapping and **dedupes by `fileId`** (first appearance order), replacing ad-hoc building in `text-part` so badges, footer, and panel stay aligned. **`HaystackReferenceMeta`** / **`DocumentCitationSource`** gain optional `title`, `bookTitle`, `sourceUrl`, `contributors`, and `score` for richer rows (page, “author, in book”, relevance bars). Row clicks open a safe external URL or fall back to the in-app document sideview.
> 
> Switching chats **closes** the content view so citations/previews from the previous thread don’t linger. New unit tests cover utils, rows, and sidebar wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5b84c9079bfa24a84db7e15b0be5a19eeab93b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

