### PR TITLE
feat(THU-615): require successful connection test before saving a model

### DIFF
--- a/src/hooks/use-model-connection-test.test.tsx
+++ b/src/hooks/use-model-connection-test.test.tsx
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ProxyFetchProvider } from '@/lib/proxy-fetch-context'
+import { mockProxyFetch } from '@/test-utils/proxy-fetch'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
+import type { ReactNode } from 'react'
+import {
+  useModelConnectionTest,
+  type ConnectionTestProbe,
+  type ModelConnectionConfig,
+} from './use-model-connection-test'
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ProxyFetchProvider proxyFetch={mockProxyFetch}>{children}</ProxyFetchProvider>
+)
+
+const anthropicConfig: ModelConnectionConfig = {
+  provider: 'anthropic',
+  model: 'claude-3-5-sonnet-20241022',
+  url: null,
+  apiKey: 'sk-existing',
+}
+
+describe('useModelConnectionTest', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('starts idle with no error', () => {
+    const { result } = renderHook(() => useModelConnectionTest(anthropicConfig), { wrapper })
+
+    expect(result.current.status).toBe('idle')
+    expect(result.current.isTesting).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces success when the probe resolves for the current credentials', async () => {
+    const probe: ConnectionTestProbe = mock(async () => {})
+    const { result } = renderHook(() => useModelConnectionTest(anthropicConfig, probe), { wrapper })
+
+    await act(async () => {
+      await result.current.test(anthropicConfig)
+    })
+
+    expect(result.current.status).toBe('success')
+    expect(result.current.isTesting).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces error with the probe failure message', async () => {
+    // The hook logs failures via console.error; muted so the test output stays clean.
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    const probe: ConnectionTestProbe = mock(async () => {
+      throw new Error('invalid api key')
+    })
+    const { result } = renderHook(() => useModelConnectionTest(anthropicConfig, probe), { wrapper })
+
+    await act(async () => {
+      await result.current.test(anthropicConfig)
+    })
+
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).toBe('invalid api key')
+    errorSpy.mockRestore()
+  })
+
+  it('collapses status to idle when current credentials diverge from the tested ones', async () => {
+    const probe: ConnectionTestProbe = mock(async () => {})
+    const { result, rerender } = renderHook(
+      ({ config }: { config: ModelConnectionConfig }) => useModelConnectionTest(config, probe),
+      { wrapper, initialProps: { config: anthropicConfig } },
+    )
+
+    await act(async () => {
+      await result.current.test(anthropicConfig)
+    })
+    expect(result.current.status).toBe('success')
+
+    rerender({ config: { ...anthropicConfig, apiKey: 'sk-different' } })
+
+    expect(result.current.status).toBe('idle')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('treats empty and null credentials as equivalent when matching the tested config', async () => {
+    const probe: ConnectionTestProbe = mock(async () => {})
+    const initial: ModelConnectionConfig = { ...anthropicConfig, url: '', apiKey: 'sk-abc' }
+    const { result, rerender } = renderHook(
+      ({ config }: { config: ModelConnectionConfig }) => useModelConnectionTest(config, probe),
+      { wrapper, initialProps: { config: initial } },
+    )
+
+    await act(async () => {
+      await result.current.test(initial)
+    })
+    expect(result.current.status).toBe('success')
+
+    // Flipping url from '' → null (the shape callers commonly pass through)
+    // must NOT invalidate the tested config.
+    rerender({ config: { ...initial, url: null } })
+
+    expect(result.current.status).toBe('success')
+  })
+
+  it('reset clears status and the stored tested config', async () => {
+    const probe: ConnectionTestProbe = mock(async () => {})
+    const { result } = renderHook(() => useModelConnectionTest(anthropicConfig, probe), { wrapper })
+
+    await act(async () => {
+      await result.current.test(anthropicConfig)
+    })
+    expect(result.current.status).toBe('success')
+
+    act(() => {
+      result.current.reset()
+    })
+
+    expect(result.current.status).toBe('idle')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('ignores probe completions from superseded runs', async () => {
+    let resolveInFlight: (() => void) | null = null
+    const probe: ConnectionTestProbe = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInFlight = resolve
+        }),
+    )
+    const { result } = renderHook(() => useModelConnectionTest(anthropicConfig, probe), { wrapper })
+
+    // Fire the test but do not await — the probe hangs until we call resolveInFlight().
+    let testPromise: Promise<void> = Promise.resolve()
+    act(() => {
+      testPromise = result.current.test(anthropicConfig)
+    })
+    expect(result.current.isTesting).toBe(true)
+
+    // Reset while the probe is still in flight — bumps the runId.
+    act(() => {
+      result.current.reset()
+    })
+    expect(result.current.isTesting).toBe(false)
+
+    // Now let the probe resolve — the guarded dispatch must skip.
+    await act(async () => {
+      resolveInFlight!()
+      await testPromise
+    })
+
+    expect(result.current.status).toBe('idle')
+    expect(result.current.isTesting).toBe(false)
+  })
+})

--- a/src/hooks/use-model-connection-test.test.tsx
+++ b/src/hooks/use-model-connection-test.test.tsx
@@ -122,6 +122,35 @@ describe('useModelConnectionTest', () => {
     expect(result.current.error).toBeNull()
   })
 
+  it('collapses isTesting to false when credentials diverge mid-flight', async () => {
+    let resolveInFlight: (() => void) | null = null
+    const probe: ConnectionTestProbe = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInFlight = resolve
+        }),
+    )
+    const { result, rerender } = renderHook(
+      ({ config }: { config: ModelConnectionConfig }) => useModelConnectionTest(config, probe),
+      { wrapper, initialProps: { config: anthropicConfig } },
+    )
+
+    let testPromise: Promise<void> = Promise.resolve()
+    act(() => {
+      testPromise = result.current.test(anthropicConfig)
+    })
+    expect(result.current.isTesting).toBe(true)
+
+    // Edit credentials mid-flight — spinner must snap off without waiting for the probe.
+    rerender({ config: { ...anthropicConfig, apiKey: 'sk-different' } })
+    expect(result.current.isTesting).toBe(false)
+
+    await act(async () => {
+      resolveInFlight!()
+      await testPromise
+    })
+  })
+
   it('ignores probe completions from superseded runs', async () => {
     let resolveInFlight: (() => void) | null = null
     const probe: ConnectionTestProbe = mock(

--- a/src/hooks/use-model-connection-test.ts
+++ b/src/hooks/use-model-connection-test.ts
@@ -1,0 +1,186 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createModel } from '@/ai/fetch'
+import type { FetchFn } from '@/lib/proxy-fetch'
+import { useProxyFetchGetter } from '@/lib/proxy-fetch-context'
+import type { Model } from '@/types'
+import { generateText } from 'ai'
+import { useCallback, useReducer, useRef } from 'react'
+
+const connectionTestTimeoutMs = 10_000
+
+export type ModelConnectionConfig = {
+  provider: Model['provider']
+  model: string
+  url?: string | null
+  apiKey?: string | null
+}
+
+type NormalizedConfig = {
+  provider: Model['provider']
+  model: string
+  url: string | null
+  apiKey: string | null
+}
+
+type ConnectionTestState = {
+  isTesting: boolean
+  rawStatus: 'idle' | 'success' | 'error'
+  error: string | null
+  tested: NormalizedConfig | null
+}
+
+type ConnectionTestAction =
+  | { type: 'START' }
+  | { type: 'SUCCESS'; tested: NormalizedConfig }
+  | { type: 'FAILURE'; tested: NormalizedConfig; error: string }
+  | { type: 'RESET' }
+
+const initialState: ConnectionTestState = {
+  isTesting: false,
+  rawStatus: 'idle',
+  error: null,
+  tested: null,
+}
+
+const reducer = (_state: ConnectionTestState, action: ConnectionTestAction): ConnectionTestState => {
+  switch (action.type) {
+    case 'START':
+      return { isTesting: true, rawStatus: 'idle', error: null, tested: null }
+    case 'SUCCESS':
+      return { isTesting: false, rawStatus: 'success', error: null, tested: action.tested }
+    case 'FAILURE':
+      return { isTesting: false, rawStatus: 'error', error: action.error, tested: action.tested }
+    case 'RESET':
+      return initialState
+  }
+}
+
+const normalize = (config: ModelConnectionConfig): NormalizedConfig => ({
+  provider: config.provider,
+  model: config.model,
+  url: config.url || null,
+  apiKey: config.apiKey || null,
+})
+
+/**
+ * Probe that issues a real `generateText` round-trip against the configured
+ * provider. Split out so tests can swap in a synchronous stub without touching
+ * global module mocks.
+ */
+export type ConnectionTestProbe = (
+  config: NormalizedConfig,
+  getProxyFetch: () => FetchFn,
+  signal: AbortSignal,
+) => Promise<void>
+
+const defaultProbe: ConnectionTestProbe = async (config, getProxyFetch, signal) => {
+  const aiModel = await createModel(
+    {
+      id: 'test',
+      name: 'Test Model',
+      provider: config.provider,
+      model: config.model,
+      url: config.url,
+      apiKey: config.apiKey,
+      isSystem: 0,
+      enabled: 1,
+      toolUsage: 1,
+      isConfidential: 0,
+      startWithReasoning: 0,
+      supportsParallelToolCalls: 1,
+      contextWindow: null,
+      deletedAt: null,
+      defaultHash: null,
+      vendor: null,
+      description: null,
+      userId: null,
+    },
+    getProxyFetch,
+  )
+  await generateText({
+    model: aiModel,
+    prompt: 'Say "test successful" if you can read this.',
+    maxRetries: 0,
+    abortSignal: signal,
+  })
+}
+
+/**
+ * Manages the state machine for a "Test Model" round-trip: idle → testing →
+ * success/error. Returns a `status` derived at render time from the tested
+ * config vs. the current one: any credential divergence collapses status to
+ * `'idle'` in the same render, so a stale `'success'` can't survive a
+ * credential edit (no useEffect-based invalidation).
+ *
+ * The probe is bounded by a single 10s `AbortSignal.timeout` piped through
+ * both the provider construction (via `Promise.race`) and the `generateText`
+ * request (via `abortSignal`), so a hanging Tinfoil attestation or a stuck
+ * `generateText` request both surface as a timeout error.
+ */
+export const useModelConnectionTest = (current: ModelConnectionConfig, probe: ConnectionTestProbe = defaultProbe) => {
+  const getProxyFetch = useProxyFetchGetter()
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const runIdRef = useRef(0)
+
+  const test = useCallback(
+    async (config: ModelConnectionConfig) => {
+      const runId = ++runIdRef.current
+      const isCurrent = () => runIdRef.current === runId
+
+      dispatch({ type: 'START' })
+
+      const tested = normalize(config)
+      const timeoutSignal = AbortSignal.timeout(connectionTestTimeoutMs)
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutSignal.addEventListener('abort', () =>
+          reject(new Error(`Connection test timed out after ${connectionTestTimeoutMs / 1000} seconds`)),
+        )
+      })
+      // Swallow the losing side's rejection so `Promise.race` doesn't leave an
+      // unhandled rejection when the timeout wins (e.g. a Tinfoil attestation
+      // that resolves after we've already bailed).
+      const runPromise = probe(tested, getProxyFetch, timeoutSignal)
+      runPromise.catch(() => {})
+
+      try {
+        await Promise.race([runPromise, timeoutPromise])
+        if (!isCurrent()) {
+          return
+        }
+        dispatch({ type: 'SUCCESS', tested })
+      } catch (err) {
+        console.error('Connection test error:', err)
+        if (!isCurrent()) {
+          return
+        }
+        dispatch({
+          type: 'FAILURE',
+          tested,
+          error: err instanceof Error ? err.message : 'Failed to connect to model',
+        })
+      }
+    },
+    [getProxyFetch, probe],
+  )
+
+  const reset = useCallback(() => {
+    runIdRef.current += 1
+    dispatch({ type: 'RESET' })
+  }, [])
+
+  const normalizedCurrent = normalize(current)
+  const matchesCurrent =
+    state.tested !== null &&
+    state.tested.provider === normalizedCurrent.provider &&
+    state.tested.model === normalizedCurrent.model &&
+    state.tested.url === normalizedCurrent.url &&
+    state.tested.apiKey === normalizedCurrent.apiKey
+
+  const status: 'idle' | 'success' | 'error' = matchesCurrent ? state.rawStatus : 'idle'
+  const error = matchesCurrent ? state.error : null
+
+  return { isTesting: state.isTesting, status, error, test, reset }
+}

--- a/src/hooks/use-model-connection-test.ts
+++ b/src/hooks/use-model-connection-test.ts
@@ -33,7 +33,7 @@ type ConnectionTestState = {
 }
 
 type ConnectionTestAction =
-  | { type: 'START' }
+  | { type: 'START'; tested: NormalizedConfig }
   | { type: 'SUCCESS'; tested: NormalizedConfig }
   | { type: 'FAILURE'; tested: NormalizedConfig; error: string }
   | { type: 'RESET' }
@@ -48,7 +48,7 @@ const initialState: ConnectionTestState = {
 const reducer = (_state: ConnectionTestState, action: ConnectionTestAction): ConnectionTestState => {
   switch (action.type) {
     case 'START':
-      return { isTesting: true, rawStatus: 'idle', error: null, tested: null }
+      return { isTesting: true, rawStatus: 'idle', error: null, tested: action.tested }
     case 'SUCCESS':
       return { isTesting: false, rawStatus: 'success', error: null, tested: action.tested }
     case 'FAILURE':
@@ -110,10 +110,11 @@ const defaultProbe: ConnectionTestProbe = async (config, getProxyFetch, signal) 
 
 /**
  * Manages the state machine for a "Test Model" round-trip: idle → testing →
- * success/error. Returns a `status` derived at render time from the tested
- * config vs. the current one: any credential divergence collapses status to
- * `'idle'` in the same render, so a stale `'success'` can't survive a
- * credential edit (no useEffect-based invalidation).
+ * success/error. Returns `isTesting`, `status`, and `error` derived at render
+ * time from the tested config vs. the current one: any credential divergence
+ * collapses all three to their idle values in the same render, so a stale
+ * `'success'` can't survive a credential edit and a mid-flight edit stops the
+ * spinner immediately (no useEffect-based invalidation).
  *
  * The probe is bounded by a single 10s `AbortSignal.timeout` piped through
  * both the provider construction (via `Promise.race`) and the `generateText`
@@ -130,20 +131,16 @@ export const useModelConnectionTest = (current: ModelConnectionConfig, probe: Co
       const runId = ++runIdRef.current
       const isCurrent = () => runIdRef.current === runId
 
-      dispatch({ type: 'START' })
-
       const tested = normalize(config)
+      dispatch({ type: 'START', tested })
+
       const timeoutSignal = AbortSignal.timeout(connectionTestTimeoutMs)
       const timeoutPromise = new Promise<never>((_, reject) => {
         timeoutSignal.addEventListener('abort', () =>
           reject(new Error(`Connection test timed out after ${connectionTestTimeoutMs / 1000} seconds`)),
         )
       })
-      // Swallow the losing side's rejection so `Promise.race` doesn't leave an
-      // unhandled rejection when the timeout wins (e.g. a Tinfoil attestation
-      // that resolves after we've already bailed).
       const runPromise = probe(tested, getProxyFetch, timeoutSignal)
-      runPromise.catch(() => {})
 
       try {
         await Promise.race([runPromise, timeoutPromise])
@@ -181,6 +178,7 @@ export const useModelConnectionTest = (current: ModelConnectionConfig, probe: Co
 
   const status: 'idle' | 'success' | 'error' = matchesCurrent ? state.rawStatus : 'idle'
   const error = matchesCurrent ? state.error : null
+  const isTesting = matchesCurrent && state.isTesting
 
-  return { isTesting: state.isTesting, status, error, test, reset }
+  return { isTesting, status, error, test, reset }
 }

--- a/src/settings/models/index.test.tsx
+++ b/src/settings/models/index.test.tsx
@@ -5,16 +5,13 @@
 import { createModel } from '@/dal'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
-import type { FetchFn } from '@/lib/proxy-fetch'
-import { ProxyFetchProvider } from '@/lib/proxy-fetch-context'
 import { renderWithReactivity, waitForElement } from '@/test-utils/powersync-reactivity-test'
 import { getClock } from '@/testing-library'
-import type { Model } from '@/types'
 import '@testing-library/jest-dom'
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { v7 as uuidv7 } from 'uuid'
-import ModelsPage, { EditModelForm } from './index'
+import ModelsPage from './index'
 
 describe('ModelsPage reactivity', () => {
   beforeAll(async () => {
@@ -68,74 +65,5 @@ describe('ModelsPage reactivity', () => {
     })
 
     expect(screen.getByText('Second Model')).toBeInTheDocument()
-  })
-})
-
-const mockProxyFetch = (async () => new Response()) as unknown as FetchFn
-
-const makeModel = (overrides?: Partial<Model>): Model =>
-  ({
-    id: 'test-model-id',
-    name: 'My Model',
-    provider: 'anthropic',
-    model: 'claude-3-5-sonnet-20241022',
-    apiKey: 'sk-existing',
-    url: null,
-    isSystem: 0,
-    enabled: 1,
-    toolUsage: 1,
-    isConfidential: 0,
-    startWithReasoning: 0,
-    supportsParallelToolCalls: 1,
-    contextWindow: null,
-    tokenizer: null,
-    deletedAt: null,
-    defaultHash: null,
-    vendor: null,
-    description: null,
-    userId: null,
-    ...overrides,
-  }) as Model
-
-const renderEditForm = (model: Model) =>
-  render(
-    <ProxyFetchProvider proxyFetch={mockProxyFetch}>
-      <EditModelForm model={model} onCancel={() => {}} onSubmit={() => {}} isPending={false} />
-    </ProxyFetchProvider>,
-  )
-
-describe('EditModelForm connection-test gate', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
-  it('enables Save on rename-only edits without a passing connection test', () => {
-    renderEditForm(makeModel())
-
-    const save = screen.getByRole('button', { name: 'Save' })
-    expect(save).toBeDisabled()
-
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed Model' } })
-
-    expect(save).not.toBeDisabled()
-  })
-
-  it('shows a hint and keeps Save disabled when the API key is cleared on an anthropic model', () => {
-    renderEditForm(makeModel({ provider: 'anthropic' }))
-
-    fireEvent.change(screen.getByLabelText('API Key'), { target: { value: '' } })
-
-    expect(screen.getByText('Enter an API key to test the connection before saving.')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Test Model' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
-  })
-
-  it('requires a passing test when the API key changes on an anthropic model', () => {
-    renderEditForm(makeModel({ provider: 'anthropic' }))
-
-    fireEvent.change(screen.getByLabelText('API Key'), { target: { value: 'sk-rotated' } })
-
-    expect(screen.getByRole('button', { name: 'Test Model' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 })

--- a/src/settings/models/index.test.tsx
+++ b/src/settings/models/index.test.tsx
@@ -5,13 +5,16 @@
 import { createModel } from '@/dal'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
+import type { FetchFn } from '@/lib/proxy-fetch'
+import { ProxyFetchProvider } from '@/lib/proxy-fetch-context'
 import { renderWithReactivity, waitForElement } from '@/test-utils/powersync-reactivity-test'
 import { getClock } from '@/testing-library'
+import type { Model } from '@/types'
 import '@testing-library/jest-dom'
-import { act, cleanup, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { v7 as uuidv7 } from 'uuid'
-import ModelsPage from './index'
+import ModelsPage, { EditModelForm } from './index'
 
 describe('ModelsPage reactivity', () => {
   beforeAll(async () => {
@@ -65,5 +68,74 @@ describe('ModelsPage reactivity', () => {
     })
 
     expect(screen.getByText('Second Model')).toBeInTheDocument()
+  })
+})
+
+const mockProxyFetch = (async () => new Response()) as unknown as FetchFn
+
+const makeModel = (overrides?: Partial<Model>): Model =>
+  ({
+    id: 'test-model-id',
+    name: 'My Model',
+    provider: 'anthropic',
+    model: 'claude-3-5-sonnet-20241022',
+    apiKey: 'sk-existing',
+    url: null,
+    isSystem: 0,
+    enabled: 1,
+    toolUsage: 1,
+    isConfidential: 0,
+    startWithReasoning: 0,
+    supportsParallelToolCalls: 1,
+    contextWindow: null,
+    tokenizer: null,
+    deletedAt: null,
+    defaultHash: null,
+    vendor: null,
+    description: null,
+    userId: null,
+    ...overrides,
+  }) as Model
+
+const renderEditForm = (model: Model) =>
+  render(
+    <ProxyFetchProvider proxyFetch={mockProxyFetch}>
+      <EditModelForm model={model} onCancel={() => {}} onSubmit={() => {}} isPending={false} />
+    </ProxyFetchProvider>,
+  )
+
+describe('EditModelForm connection-test gate', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('enables Save on rename-only edits without a passing connection test', () => {
+    renderEditForm(makeModel())
+
+    const save = screen.getByRole('button', { name: 'Save' })
+    expect(save).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed Model' } })
+
+    expect(save).not.toBeDisabled()
+  })
+
+  it('shows a hint and keeps Save disabled when the API key is cleared on an anthropic model', () => {
+    renderEditForm(makeModel({ provider: 'anthropic' }))
+
+    fireEvent.change(screen.getByLabelText('API Key'), { target: { value: '' } })
+
+    expect(screen.getByText('Enter an API key to test the connection before saving.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Test Model' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('requires a passing test when the API key changes on an anthropic model', () => {
+    renderEditForm(makeModel({ provider: 'anthropic' }))
+
+    fireEvent.change(screen.getByLabelText('API Key'), { target: { value: 'sk-rotated' } })
+
+    expect(screen.getByRole('button', { name: 'Test Model' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 })

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -195,8 +195,8 @@ const useModelConnectionTest = (current: CurrentModelConfig) => {
       const testedConfig: TestedConfig = {
         provider: config.provider,
         model: config.model,
-        url: config.url ?? null,
-        apiKey: config.apiKey ?? null,
+        url: config.url || null,
+        apiKey: config.apiKey || null,
       }
 
       try {
@@ -265,8 +265,8 @@ const useModelConnectionTest = (current: CurrentModelConfig) => {
     tested !== null &&
     tested.provider === current.provider &&
     tested.model === current.model &&
-    tested.url === (current.url ?? null) &&
-    tested.apiKey === (current.apiKey ?? null)
+    tested.url === (current.url || null) &&
+    tested.apiKey === (current.apiKey || null)
 
   const status: 'idle' | 'success' | 'error' = matchesCurrent ? rawStatus : 'idle'
 

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -150,11 +150,26 @@ type ConnectionTestConfig = {
   apiKey?: string | null
 }
 
-const useModelConnectionTest = () => {
+type TestedConfig = {
+  provider: Model['provider']
+  model: string
+  url: string | null
+  apiKey: string | null
+}
+
+type CurrentModelConfig = {
+  provider: Model['provider']
+  model: string
+  url?: string | null
+  apiKey?: string | null
+}
+
+const useModelConnectionTest = (current: CurrentModelConfig) => {
   const getProxyFetch = useProxyFetchGetter()
   const [isTesting, setIsTesting] = useState(false)
-  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  const [rawStatus, setRawStatus] = useState<'idle' | 'success' | 'error'>('idle')
   const [error, setError] = useState<string | null>(null)
+  const [tested, setTested] = useState<TestedConfig | null>(null)
   // Tracks the latest run so completions from superseded tests (started before
   // a credential change or a newer test) can't flip status back to success/error.
   const runIdRef = useRef(0)
@@ -169,12 +184,20 @@ const useModelConnectionTest = () => {
       const isCurrent = () => runIdRef.current === runId
 
       setIsTesting(true)
-      setStatus('idle')
+      setRawStatus('idle')
       setError(null)
+      setTested(null)
 
       const timeoutPromise = new Promise<never>((_, reject) => {
         setTimeout(() => reject(new Error('Connection test timed out after 10 seconds')), 10000)
       })
+
+      const testedConfig: TestedConfig = {
+        provider: config.provider,
+        model: config.model,
+        url: config.url ?? null,
+        apiKey: config.apiKey ?? null,
+      }
 
       try {
         const modelConfig = {
@@ -207,14 +230,16 @@ const useModelConnectionTest = () => {
           return
         }
         console.log('Model test response:', text)
-        setStatus('success')
+        setRawStatus('success')
+        setTested(testedConfig)
       } catch (err) {
         if (!isCurrent()) {
           return
         }
         console.error('Connection test error:', err)
-        setStatus('error')
+        setRawStatus('error')
         setError(err instanceof Error ? err.message : 'Failed to connect to model')
+        setTested(testedConfig)
       } finally {
         if (isCurrent()) {
           setIsTesting(false)
@@ -226,10 +251,24 @@ const useModelConnectionTest = () => {
 
   const reset = useCallback(() => {
     runIdRef.current += 1
-    setStatus('idle')
+    setRawStatus('idle')
     setError(null)
     setIsTesting(false)
+    setTested(null)
   }, [])
+
+  // Derive the exposed status from the tested config vs. the current one: a
+  // test result is only meaningful for the credentials it ran against. Any
+  // divergence collapses status to 'idle' during the same render — no
+  // useEffect-based invalidation, no window where a stale 'success' leaks.
+  const matchesCurrent =
+    tested !== null &&
+    tested.provider === current.provider &&
+    tested.model === current.model &&
+    tested.url === (current.url ?? null) &&
+    tested.apiKey === (current.apiKey ?? null)
+
+  const status: 'idle' | 'success' | 'error' = matchesCurrent ? rawStatus : 'idle'
 
   return { isTesting, status, error, test, reset }
 }
@@ -316,17 +355,21 @@ export const EditModelForm = ({
     },
   })
 
-  const connectionTest = useModelConnectionTest()
-  const { isTesting, status: connectionStatus, error: connectionError, test, reset } = connectionTest
-
   const watchedModel = form.watch('model')
   const watchedUrl = form.watch('url')
   const watchedApiKey = form.watch('apiKey')
 
-  // Any change to credentials/model invalidates a prior successful test.
-  useEffect(() => {
-    reset()
-  }, [watchedModel, watchedUrl, watchedApiKey, reset])
+  const {
+    isTesting,
+    status: connectionStatus,
+    error: connectionError,
+    test,
+  } = useModelConnectionTest({
+    provider: model.provider,
+    model: watchedModel,
+    url: watchedUrl || null,
+    apiKey: watchedApiKey || null,
+  })
 
   const handleSubmit = (values: z.infer<typeof editFormSchema>) => {
     onSubmit({ ...values, id: model.id })
@@ -505,14 +548,6 @@ export default function ModelsPage() {
   const [editingModel, setEditingModel] = useState<Model | null>(null)
   const { isAddDialogOpen, deleteConfirmOpen, isLoadingModels, selectedModelId, allAvailableModels, modelLoadError } =
     state
-  const connectionTest = useModelConnectionTest()
-  const {
-    isTesting: isTestingConnection,
-    status: connectionStatus,
-    error: connectionError,
-    test: runConnectionTest,
-    reset: resetConnectionTest,
-  } = connectionTest
 
   const { data: models = [] } = useQuery({
     queryKey: ['models'],
@@ -984,10 +1019,18 @@ export default function ModelsPage() {
     [watchedApiKey, watchedModel, watchedProvider],
   )
 
-  // Any change to credentials/model invalidates a prior successful test.
-  useEffect(() => {
-    resetConnectionTest()
-  }, [watchedProvider, watchedModel, watchedUrl, watchedApiKey, resetConnectionTest])
+  const {
+    isTesting: isTestingConnection,
+    status: connectionStatus,
+    error: connectionError,
+    test: runConnectionTest,
+    reset: resetConnectionTest,
+  } = useModelConnectionTest({
+    provider: watchedProvider,
+    model: watchedModel,
+    url: watchedUrl || null,
+    apiKey: watchedApiKey || null,
+  })
 
   return (
     <div className="flex flex-col gap-6 p-4 pb-12 w-full max-w-[760px] mx-auto">

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -48,7 +48,7 @@ import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { generateText } from 'ai'
 import { http } from '@/lib/http'
 import { AlertTriangle, Check, Cpu, Loader2, Lock, Pen, Plus, Trash2, X } from 'lucide-react'
-import { useEffect, useMemo, useReducer, useRef, useState, type KeyboardEvent } from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type KeyboardEvent } from 'react'
 import { useForm } from 'react-hook-form'
 import { v7 as uuidv7 } from 'uuid'
 import { z } from 'zod'
@@ -65,9 +65,6 @@ type AvailableModel = {
 type ModelState = {
   isAddDialogOpen: boolean
   deleteConfirmOpen: string | null
-  isTestingConnection: boolean
-  connectionStatus: 'idle' | 'success' | 'error'
-  connectionError: string | null
   isLoadingModels: boolean
   selectedModelId: string
   allAvailableModels: AvailableModel[]
@@ -77,9 +74,6 @@ type ModelState = {
 type ModelAction =
   | { type: 'OPEN_DIALOG' }
   | { type: 'CLOSE_DIALOG' }
-  | { type: 'START_CONNECTION_TEST' }
-  | { type: 'CONNECTION_TEST_SUCCESS' }
-  | { type: 'CONNECTION_TEST_FAILURE'; error: string }
   | { type: 'FETCH_MODELS_START' }
   | { type: 'FETCH_MODELS_SUCCESS'; models: AvailableModel[] }
   | { type: 'FETCH_MODELS_FAILURE'; error: string }
@@ -91,9 +85,6 @@ type ModelAction =
 const initialState: ModelState = {
   isAddDialogOpen: false,
   deleteConfirmOpen: null,
-  isTestingConnection: false,
-  connectionStatus: 'idle',
-  connectionError: null,
   isLoadingModels: false,
   selectedModelId: '',
   allAvailableModels: [],
@@ -107,13 +98,6 @@ const modelReducer = (state: ModelState, action: ModelAction): ModelState => {
       return { ...initialState, isAddDialogOpen: true }
     case 'CLOSE_DIALOG':
       return { ...initialState, isAddDialogOpen: false }
-
-    case 'START_CONNECTION_TEST':
-      return { ...state, isTestingConnection: true, connectionStatus: 'idle', connectionError: null }
-    case 'CONNECTION_TEST_SUCCESS':
-      return { ...state, isTestingConnection: false, connectionStatus: 'success' }
-    case 'CONNECTION_TEST_FAILURE':
-      return { ...state, isTestingConnection: false, connectionStatus: 'error', connectionError: action.error }
 
     case 'FETCH_MODELS_START':
       return {
@@ -146,9 +130,6 @@ const modelReducer = (state: ModelState, action: ModelAction): ModelState => {
         allAvailableModels: [],
         modelLoadError: null,
         isLoadingModels: false,
-        connectionStatus: 'idle',
-        connectionError: null,
-        isTestingConnection: false,
       }
 
     case 'OPEN_DELETE_CONFIRM':
@@ -159,6 +140,93 @@ const modelReducer = (state: ModelState, action: ModelAction): ModelState => {
     default:
       return state
   }
+}
+
+type ConnectionTestConfig = {
+  provider: Model['provider']
+  model: string
+  name?: string
+  url?: string | null
+  apiKey?: string | null
+}
+
+const useModelConnectionTest = () => {
+  const getProxyFetch = useProxyFetchGetter()
+  const [isTesting, setIsTesting] = useState(false)
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const test = useCallback(
+    async (config: ConnectionTestConfig) => {
+      if (!config.provider || !config.model) {
+        return
+      }
+
+      setIsTesting(true)
+      setStatus('idle')
+      setError(null)
+
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('Connection test timed out after 10 seconds')), 10000)
+      })
+
+      try {
+        const modelConfig = {
+          id: 'test',
+          name: config.name || 'Test Model',
+          provider: config.provider,
+          model: config.model,
+          url: config.url || null,
+          apiKey: config.apiKey || null,
+          isSystem: 0,
+          enabled: 1,
+          toolUsage: 1,
+          isConfidential: 0,
+          startWithReasoning: 0,
+          supportsParallelToolCalls: 1,
+          contextWindow: null,
+          tokenizer: null,
+          deletedAt: null,
+          defaultHash: null,
+          vendor: null,
+          description: null,
+          userId: null,
+        }
+        const aiModel = await createModel(modelConfig, getProxyFetch)
+        const { text } = await Promise.race([
+          generateText({ model: aiModel, prompt: 'Say "test successful" if you can read this.', maxRetries: 0 }),
+          timeoutPromise,
+        ])
+        console.log('Model test response:', text)
+        setStatus('success')
+      } catch (err) {
+        console.error('Connection test error:', err)
+        setStatus('error')
+        setError(err instanceof Error ? err.message : 'Failed to connect to model')
+      } finally {
+        setIsTesting(false)
+      }
+    },
+    [getProxyFetch],
+  )
+
+  const reset = useCallback(() => {
+    setStatus('idle')
+    setError(null)
+    setIsTesting(false)
+  }, [])
+
+  return { isTesting, status, error, test, reset }
+}
+
+const canTestModelConnection = (provider: Model['provider'], model?: string, apiKey?: string | null) => {
+  if (!model) {
+    return false
+  }
+  if (['anthropic', 'tinfoil'].includes(provider)) {
+    return !!apiKey
+  }
+  return true
 }
 
 const formSchema = z
@@ -233,9 +301,34 @@ const EditModelForm = ({
     },
   })
 
+  const connectionTest = useModelConnectionTest()
+  const { isTesting, status: connectionStatus, error: connectionError, test, reset } = connectionTest
+
+  const watchedModel = form.watch('model')
+  const watchedUrl = form.watch('url')
+  const watchedApiKey = form.watch('apiKey')
+
+  // Any change to credentials/model invalidates a prior successful test.
+  useEffect(() => {
+    reset()
+  }, [watchedModel, watchedUrl, watchedApiKey, reset])
+
   const handleSubmit = (values: z.infer<typeof editFormSchema>) => {
     onSubmit({ ...values, id: model.id })
   }
+
+  const handleTest = () => {
+    const values = form.getValues()
+    test({
+      provider: model.provider,
+      model: values.model,
+      name: values.name,
+      url: values.url,
+      apiKey: values.apiKey,
+    })
+  }
+
+  const canTest = canTestModelConnection(model.provider, watchedModel, watchedApiKey)
 
   return (
     <Form {...form}>
@@ -300,11 +393,50 @@ const EditModelForm = ({
           />
         )}
 
+        {canTest && (
+          <Button type="button" onClick={handleTest} disabled={isTesting} variant="outline" className="w-full">
+            {isTesting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Testing Model...
+              </>
+            ) : (
+              'Test Model'
+            )}
+          </Button>
+        )}
+
+        {connectionStatus === 'success' && (
+          <StatusCard
+            title={
+              <>
+                <Check className="h-5 w-5 text-green-600" />
+                Test successful!
+              </>
+            }
+            description="Successfully got a response from the model."
+            className="border-green-200/50 dark:border-green-500/20"
+          />
+        )}
+
+        {connectionStatus === 'error' && (
+          <StatusCard
+            title={
+              <>
+                <X className="h-5 w-5 text-red-600" />
+                Test failed
+              </>
+            }
+            description={connectionError || 'Received an error while testing the model.'}
+            className="bg-red-50/50 dark:bg-red-500/10 border-red-200/50 dark:border-red-500/20"
+          />
+        )}
+
         <div className="flex justify-end gap-3 pt-2">
           <Button type="button" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isPending || !form.formState.isDirty}>
+          <Button type="submit" disabled={isPending || !form.formState.isDirty || connectionStatus !== 'success'}>
             Save
           </Button>
         </div>
@@ -345,20 +477,18 @@ const EditModelModal = ({
 
 export default function ModelsPage() {
   const db = useDatabase()
-  const getProxyFetch = useProxyFetchGetter()
   const [state, dispatch] = useReducer(modelReducer, initialState)
   const [editingModel, setEditingModel] = useState<Model | null>(null)
+  const { isAddDialogOpen, deleteConfirmOpen, isLoadingModels, selectedModelId, allAvailableModels, modelLoadError } =
+    state
+  const connectionTest = useModelConnectionTest()
   const {
-    isAddDialogOpen,
-    deleteConfirmOpen,
-    isTestingConnection,
-    connectionStatus,
-    connectionError,
-    isLoadingModels,
-    selectedModelId,
-    allAvailableModels,
-    modelLoadError,
-  } = state
+    isTesting: isTestingConnection,
+    status: connectionStatus,
+    error: connectionError,
+    test: runConnectionTest,
+    reset: resetConnectionTest,
+  } = connectionTest
 
   const { data: models = [] } = useQuery({
     queryKey: ['models'],
@@ -457,77 +587,22 @@ export default function ModelsPage() {
     })
   }
 
-  const testConnection = async () => {
+  const testConnection = () => {
     const values = form.getValues()
     const modelId = selectedModelId === 'custom' && values.customModel ? values.customModel : values.model
-
-    if (!values.provider || !modelId) {
-      return
-    }
-
-    dispatch({ type: 'START_CONNECTION_TEST' })
-
-    // Create a timeout promise
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
-        reject(new Error('Connection test timed out after 10 seconds'))
-      }, 10000)
+    runConnectionTest({
+      provider: values.provider,
+      model: modelId,
+      name: values.name,
+      url: values.url,
+      apiKey: values.apiKey,
     })
-
-    try {
-      // Create a temporary model configuration
-      const modelConfig = {
-        id: 'test',
-        name: values.name || 'Test Model',
-        provider: values.provider,
-        model: modelId,
-        url: values.url || null,
-        apiKey: values.apiKey || null,
-        isSystem: 0,
-        enabled: 1,
-      }
-
-      // Use the same createModel function as the chat
-      const modelConfigWithDefaults = {
-        ...modelConfig,
-        toolUsage: 1,
-        isConfidential: 0,
-        startWithReasoning: 0,
-        supportsParallelToolCalls: 1,
-        contextWindow: null,
-        tokenizer: null,
-        deletedAt: null,
-        defaultHash: null, // User-created, not based on a default
-        vendor: null,
-        description: null,
-        userId: null,
-      }
-      const model = await createModel(modelConfigWithDefaults, getProxyFetch)
-
-      // Test with a minimal prompt - race against timeout
-      const { text } = await Promise.race([
-        generateText({
-          model,
-          prompt: 'Say "test successful" if you can read this.',
-          maxRetries: 0,
-        }),
-        timeoutPromise,
-      ])
-
-      console.log('Model test response:', text)
-      dispatch({ type: 'CONNECTION_TEST_SUCCESS' })
-    } catch (error) {
-      console.error('Connection test error:', error)
-      dispatch({
-        type: 'CONNECTION_TEST_FAILURE',
-        error: error instanceof Error ? error.message : 'Failed to connect to model',
-      })
-    }
   }
 
   const handleDialogOpenChange = (open: boolean) => {
     if (open) {
       dispatch({ type: 'OPEN_DIALOG' })
+      resetConnectionTest()
 
       if (form.getValues('provider') === 'thunderbolt' && allAvailableModels.length === 0) {
         fetchAvailableModels('thunderbolt')
@@ -536,6 +611,7 @@ export default function ModelsPage() {
       form.reset()
       form.clearErrors()
       dispatch({ type: 'CLOSE_DIALOG' })
+      resetConnectionTest()
     }
   }
 
@@ -879,13 +955,15 @@ export default function ModelsPage() {
 
   const watchedModel = form.watch('model')
 
-  const canTestConnection = useMemo(() => {
-    if (['anthropic', 'tinfoil'].includes(watchedProvider)) {
-      return !!watchedModel && watchedApiKey
-    }
+  const canTestConnection = useMemo(
+    () => canTestModelConnection(watchedProvider, watchedModel, watchedApiKey),
+    [watchedApiKey, watchedModel, watchedProvider],
+  )
 
-    return !!watchedModel
-  }, [watchedApiKey, watchedModel, watchedProvider])
+  // Any change to credentials/model invalidates a prior successful test.
+  useEffect(() => {
+    resetConnectionTest()
+  }, [watchedProvider, watchedModel, watchedUrl, watchedApiKey, resetConnectionTest])
 
   return (
     <div className="flex flex-col gap-6 p-4 pb-12 w-full max-w-[760px] mx-auto">
@@ -1143,7 +1221,7 @@ export default function ModelsPage() {
                   <Button type="button" variant="ghost" onClick={() => handleDialogOpenChange(false)}>
                     Cancel
                   </Button>
-                  <Button type="submit" disabled={addModelMutation.isPending}>
+                  <Button type="submit" disabled={addModelMutation.isPending || connectionStatus !== 'success'}>
                     {addModelMutation.isPending ? 'Adding...' : 'Add Model'}
                   </Button>
                 </div>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createModel, getTinfoilClient } from '@/ai/fetch'
+import { getTinfoilClient } from '@/ai/fetch'
 import { ModificationIndicator } from '@/components/modification-indicator'
 import {
   AlertDialog,
@@ -39,16 +39,15 @@ import { createModel as createModelDAL, deleteModel, getAllModels, resetModelToD
 import { defaultModels } from '@shared/defaults/models'
 import { isModelModified } from '@/defaults/utils'
 import { fetch } from '@/lib/fetch'
-import { useProxyFetchGetter } from '@/lib/proxy-fetch-context'
+import { useModelConnectionTest } from '@/hooks/use-model-connection-test'
 import type { Model } from '@/types'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation } from '@tanstack/react-query'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
-import { generateText } from 'ai'
 import { http } from '@/lib/http'
 import { AlertTriangle, Check, Cpu, Loader2, Lock, Pen, Plus, Trash2, X } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type KeyboardEvent } from 'react'
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { v7 as uuidv7 } from 'uuid'
 import { z } from 'zod'
@@ -142,137 +141,6 @@ const modelReducer = (state: ModelState, action: ModelAction): ModelState => {
   }
 }
 
-type ConnectionTestConfig = {
-  provider: Model['provider']
-  model: string
-  name?: string
-  url?: string | null
-  apiKey?: string | null
-}
-
-type TestedConfig = {
-  provider: Model['provider']
-  model: string
-  url: string | null
-  apiKey: string | null
-}
-
-type CurrentModelConfig = {
-  provider: Model['provider']
-  model: string
-  url?: string | null
-  apiKey?: string | null
-}
-
-const useModelConnectionTest = (current: CurrentModelConfig) => {
-  const getProxyFetch = useProxyFetchGetter()
-  const [isTesting, setIsTesting] = useState(false)
-  const [rawStatus, setRawStatus] = useState<'idle' | 'success' | 'error'>('idle')
-  const [error, setError] = useState<string | null>(null)
-  const [tested, setTested] = useState<TestedConfig | null>(null)
-  // Tracks the latest run so completions from superseded tests (started before
-  // a credential change or a newer test) can't flip status back to success/error.
-  const runIdRef = useRef(0)
-
-  const test = useCallback(
-    async (config: ConnectionTestConfig) => {
-      if (!config.provider || !config.model) {
-        return
-      }
-
-      const runId = ++runIdRef.current
-      const isCurrent = () => runIdRef.current === runId
-
-      setIsTesting(true)
-      setRawStatus('idle')
-      setError(null)
-      setTested(null)
-
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error('Connection test timed out after 10 seconds')), 10000)
-      })
-
-      const testedConfig: TestedConfig = {
-        provider: config.provider,
-        model: config.model,
-        url: config.url || null,
-        apiKey: config.apiKey || null,
-      }
-
-      try {
-        const modelConfig = {
-          id: 'test',
-          name: config.name || 'Test Model',
-          provider: config.provider,
-          model: config.model,
-          url: config.url || null,
-          apiKey: config.apiKey || null,
-          isSystem: 0,
-          enabled: 1,
-          toolUsage: 1,
-          isConfidential: 0,
-          startWithReasoning: 0,
-          supportsParallelToolCalls: 1,
-          contextWindow: null,
-          tokenizer: null,
-          deletedAt: null,
-          defaultHash: null,
-          vendor: null,
-          description: null,
-          userId: null,
-        }
-        const aiModel = await createModel(modelConfig, getProxyFetch)
-        const { text } = await Promise.race([
-          generateText({ model: aiModel, prompt: 'Say "test successful" if you can read this.', maxRetries: 0 }),
-          timeoutPromise,
-        ])
-        if (!isCurrent()) {
-          return
-        }
-        console.log('Model test response:', text)
-        setRawStatus('success')
-        setTested(testedConfig)
-      } catch (err) {
-        if (!isCurrent()) {
-          return
-        }
-        console.error('Connection test error:', err)
-        setRawStatus('error')
-        setError(err instanceof Error ? err.message : 'Failed to connect to model')
-        setTested(testedConfig)
-      } finally {
-        if (isCurrent()) {
-          setIsTesting(false)
-        }
-      }
-    },
-    [getProxyFetch],
-  )
-
-  const reset = useCallback(() => {
-    runIdRef.current += 1
-    setRawStatus('idle')
-    setError(null)
-    setIsTesting(false)
-    setTested(null)
-  }, [])
-
-  // Derive the exposed status from the tested config vs. the current one: a
-  // test result is only meaningful for the credentials it ran against. Any
-  // divergence collapses status to 'idle' during the same render — no
-  // useEffect-based invalidation, no window where a stale 'success' leaks.
-  const matchesCurrent =
-    tested !== null &&
-    tested.provider === current.provider &&
-    tested.model === current.model &&
-    tested.url === (current.url || null) &&
-    tested.apiKey === (current.apiKey || null)
-
-  const status: 'idle' | 'success' | 'error' = matchesCurrent ? rawStatus : 'idle'
-
-  return { isTesting, status, error, test, reset }
-}
-
 const canTestModelConnection = (provider: Model['provider'], model?: string, apiKey?: string | null) => {
   if (!model) {
     return false
@@ -281,6 +149,82 @@ const canTestModelConnection = (provider: Model['provider'], model?: string, api
     return !!apiKey
   }
   return true
+}
+
+type ConnectionTestSectionProps = {
+  provider: Model['provider']
+  model: string
+  apiKey: string | undefined
+  isTesting: boolean
+  onTest: () => void
+  status: 'idle' | 'success' | 'error'
+  error: string | null
+}
+
+/**
+ * Test-Model button, success/error status cards, and the "enter an API key"
+ * hint — shared by the Add and Edit dialogs so the display stays in sync.
+ */
+const ConnectionTestSection = ({
+  provider,
+  model,
+  apiKey,
+  isTesting,
+  onTest,
+  status,
+  error,
+}: ConnectionTestSectionProps) => {
+  const canTest = canTestModelConnection(provider, model, apiKey)
+  const showApiKeyHint = !canTest && !!model && ['anthropic', 'tinfoil'].includes(provider)
+
+  return (
+    <>
+      {canTest && (
+        <Button type="button" onClick={onTest} disabled={isTesting} variant="outline" className="w-full">
+          {isTesting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Testing Model...
+            </>
+          ) : (
+            'Test Model'
+          )}
+        </Button>
+      )}
+
+      {showApiKeyHint && (
+        <p className="text-sm text-muted-foreground text-center">
+          Enter an API key to test the connection before saving.
+        </p>
+      )}
+
+      {status === 'success' && (
+        <StatusCard
+          title={
+            <>
+              <Check className="h-5 w-5 text-green-600" />
+              Test successful!
+            </>
+          }
+          description="Successfully got a response from the model."
+          className="border-green-200/50 dark:border-green-500/20"
+        />
+      )}
+
+      {status === 'error' && (
+        <StatusCard
+          title={
+            <>
+              <X className="h-5 w-5 text-red-600" />
+              Test failed
+            </>
+          }
+          description={error || 'Received an error while testing the model.'}
+          className="bg-red-50/50 dark:bg-red-500/10 border-red-200/50 dark:border-red-500/20"
+        />
+      )}
+    </>
+  )
 }
 
 const formSchema = z
@@ -334,7 +278,7 @@ const buildEditFormSchema = (provider: Model['provider']) =>
     path: ['url'],
   })
 
-export const EditModelForm = ({
+const EditModelForm = ({
   model,
   onCancel,
   onSubmit,
@@ -349,7 +293,7 @@ export const EditModelForm = ({
     resolver: zodResolver(buildEditFormSchema(model.provider)),
     defaultValues: {
       name: model.name || '',
-      model: model.model || '',
+      model: model.model,
       url: model.url || '',
       apiKey: model.apiKey || '',
     },
@@ -367,8 +311,8 @@ export const EditModelForm = ({
   } = useModelConnectionTest({
     provider: model.provider,
     model: watchedModel,
-    url: watchedUrl || null,
-    apiKey: watchedApiKey || null,
+    url: watchedUrl,
+    apiKey: watchedApiKey,
   })
 
   const handleSubmit = (values: z.infer<typeof editFormSchema>) => {
@@ -380,16 +324,10 @@ export const EditModelForm = ({
     test({
       provider: model.provider,
       model: values.model,
-      name: values.name,
       url: values.url,
       apiKey: values.apiKey,
     })
   }
-
-  const canTest = canTestModelConnection(model.provider, watchedModel, watchedApiKey)
-  const credentialsDirty =
-    watchedModel !== (model.model || '') || watchedUrl !== (model.url || '') || watchedApiKey !== (model.apiKey || '')
-  const requiresPassingTest = credentialsDirty && connectionStatus !== 'success'
 
   return (
     <Form {...form}>
@@ -454,56 +392,21 @@ export const EditModelForm = ({
           />
         )}
 
-        {canTest && (
-          <Button type="button" onClick={handleTest} disabled={isTesting} variant="outline" className="w-full">
-            {isTesting ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Testing Model...
-              </>
-            ) : (
-              'Test Model'
-            )}
-          </Button>
-        )}
-
-        {!canTest && credentialsDirty && (
-          <p className="text-sm text-muted-foreground text-center">
-            Enter an API key to test the connection before saving.
-          </p>
-        )}
-
-        {connectionStatus === 'success' && (
-          <StatusCard
-            title={
-              <>
-                <Check className="h-5 w-5 text-green-600" />
-                Test successful!
-              </>
-            }
-            description="Successfully got a response from the model."
-            className="border-green-200/50 dark:border-green-500/20"
-          />
-        )}
-
-        {connectionStatus === 'error' && (
-          <StatusCard
-            title={
-              <>
-                <X className="h-5 w-5 text-red-600" />
-                Test failed
-              </>
-            }
-            description={connectionError || 'Received an error while testing the model.'}
-            className="bg-red-50/50 dark:bg-red-500/10 border-red-200/50 dark:border-red-500/20"
-          />
-        )}
+        <ConnectionTestSection
+          provider={model.provider}
+          model={watchedModel}
+          apiKey={watchedApiKey}
+          isTesting={isTesting}
+          onTest={handleTest}
+          status={connectionStatus}
+          error={connectionError}
+        />
 
         <div className="flex justify-end gap-3 pt-2">
           <Button type="button" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isPending || !form.formState.isDirty || requiresPassingTest}>
+          <Button type="submit" disabled={isPending || !form.formState.isDirty || connectionStatus === 'error'}>
             Save
           </Button>
         </div>
@@ -652,7 +555,6 @@ export default function ModelsPage() {
     runConnectionTest({
       provider: values.provider,
       model: modelId,
-      name: values.name,
       url: values.url,
       apiKey: values.apiKey,
     })
@@ -672,26 +574,6 @@ export default function ModelsPage() {
       dispatch({ type: 'CLOSE_DIALOG' })
       resetConnectionTest()
     }
-  }
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    // Only handle Enter key on input elements
-    if (e.key === 'Enter' && (e.target as HTMLElement).tagName === 'INPUT') {
-      e.preventDefault()
-
-      const values = form.getValues()
-      const modelId = selectedModelId === 'custom' && values.customModel ? values.customModel : values.model
-
-      // Check if we can test connection
-      if (connectionStatus !== 'success' && values.provider && modelId) {
-        testConnection()
-      }
-      // If connection is successful, submit the form
-      else if (connectionStatus === 'success') {
-        form.handleSubmit(onSubmit)()
-      }
-    }
-    // Let all other keys and elements handle their default behavior
   }
 
   const fetchAvailableModels = async (provider: string, apiKey?: string, url?: string) => {
@@ -1014,11 +896,6 @@ export default function ModelsPage() {
 
   const watchedModel = form.watch('model')
 
-  const canTestConnection = useMemo(
-    () => canTestModelConnection(watchedProvider, watchedModel, watchedApiKey),
-    [watchedApiKey, watchedModel, watchedProvider],
-  )
-
   const {
     isTesting: isTestingConnection,
     status: connectionStatus,
@@ -1028,8 +905,8 @@ export default function ModelsPage() {
   } = useModelConnectionTest({
     provider: watchedProvider,
     model: watchedModel,
-    url: watchedUrl || null,
-    apiKey: watchedApiKey || null,
+    url: watchedUrl,
+    apiKey: watchedApiKey,
   })
 
   return (
@@ -1047,7 +924,7 @@ export default function ModelsPage() {
               <ResponsiveModalDescription className="sr-only">Add a new AI model</ResponsiveModalDescription>
             </ResponsiveModalHeader>
             <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} onKeyDown={handleKeyDown} className="grid gap-4 pt-4 pb-2">
+              <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4 pt-4 pb-2">
                 <FormField
                   control={form.control}
                   name="provider"
@@ -1055,13 +932,7 @@ export default function ModelsPage() {
                     <FormItem>
                       <FormLabel>Provider</FormLabel>
                       <FormControl>
-                        <Select
-                          onValueChange={(value) => {
-                            field.onChange(value)
-                            resetConnectionTest()
-                          }}
-                          value={field.value}
-                        >
+                        <Select onValueChange={field.onChange} value={field.value}>
                           <SelectTrigger className="w-full rounded-lg">
                             <SelectValue placeholder="Select provider" />
                           </SelectTrigger>
@@ -1243,67 +1114,21 @@ export default function ModelsPage() {
                   />
                 )}
 
-                {/* Test Connection Button */}
-                {canTestConnection && (
-                  <Button
-                    type="button"
-                    onClick={testConnection}
-                    disabled={isTestingConnection}
-                    variant="outline"
-                    className="w-full"
-                  >
-                    {isTestingConnection ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        Testing Model...
-                      </>
-                    ) : (
-                      'Test Model'
-                    )}
-                  </Button>
-                )}
-
-                {!canTestConnection &&
-                  !!watchedModel &&
-                  ['anthropic', 'tinfoil'].includes(watchedProvider) &&
-                  !watchedApiKey && (
-                    <p className="text-sm text-muted-foreground text-center">
-                      Enter an API key to test the connection before saving.
-                    </p>
-                  )}
-
-                {/* Connection Status Messages */}
-                {connectionStatus === 'success' && (
-                  <StatusCard
-                    title={
-                      <>
-                        <Check className="h-5 w-5 text-green-600" />
-                        Test successful!
-                      </>
-                    }
-                    description="Successfully got a response from the model."
-                    className="border-green-200/50 dark:border-green-500/20"
-                  />
-                )}
-
-                {connectionStatus === 'error' && (
-                  <StatusCard
-                    title={
-                      <>
-                        <X className="h-5 w-5 text-red-600" />
-                        Test failed
-                      </>
-                    }
-                    description={connectionError || 'Received an error while testing the model.'}
-                    className="bg-red-50/50 dark:bg-red-500/10 border-red-200/50 dark:border-red-500/20"
-                  />
-                )}
+                <ConnectionTestSection
+                  provider={watchedProvider}
+                  model={watchedModel}
+                  apiKey={watchedApiKey}
+                  isTesting={isTestingConnection}
+                  onTest={testConnection}
+                  status={connectionStatus}
+                  error={connectionError}
+                />
 
                 <div className="flex justify-end gap-3 pt-2">
                   <Button type="button" variant="ghost" onClick={() => handleDialogOpenChange(false)}>
                     Cancel
                   </Button>
-                  <Button type="submit" disabled={addModelMutation.isPending || connectionStatus !== 'success'}>
+                  <Button type="submit" disabled={addModelMutation.isPending || connectionStatus === 'error'}>
                     {addModelMutation.isPending ? 'Adding...' : 'Add Model'}
                   </Button>
                 </div>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -155,12 +155,18 @@ const useModelConnectionTest = () => {
   const [isTesting, setIsTesting] = useState(false)
   const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
   const [error, setError] = useState<string | null>(null)
+  // Tracks the latest run so completions from superseded tests (started before
+  // a credential change or a newer test) can't flip status back to success/error.
+  const runIdRef = useRef(0)
 
   const test = useCallback(
     async (config: ConnectionTestConfig) => {
       if (!config.provider || !config.model) {
         return
       }
+
+      const runId = ++runIdRef.current
+      const isCurrent = () => runIdRef.current === runId
 
       setIsTesting(true)
       setStatus('idle')
@@ -197,20 +203,29 @@ const useModelConnectionTest = () => {
           generateText({ model: aiModel, prompt: 'Say "test successful" if you can read this.', maxRetries: 0 }),
           timeoutPromise,
         ])
+        if (!isCurrent()) {
+          return
+        }
         console.log('Model test response:', text)
         setStatus('success')
       } catch (err) {
+        if (!isCurrent()) {
+          return
+        }
         console.error('Connection test error:', err)
         setStatus('error')
         setError(err instanceof Error ? err.message : 'Failed to connect to model')
       } finally {
-        setIsTesting(false)
+        if (isCurrent()) {
+          setIsTesting(false)
+        }
       }
     },
     [getProxyFetch],
   )
 
   const reset = useCallback(() => {
+    runIdRef.current += 1
     setStatus('idle')
     setError(null)
     setIsTesting(false)

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -295,7 +295,7 @@ const buildEditFormSchema = (provider: Model['provider']) =>
     path: ['url'],
   })
 
-const EditModelForm = ({
+export const EditModelForm = ({
   model,
   onCancel,
   onSubmit,
@@ -344,6 +344,9 @@ const EditModelForm = ({
   }
 
   const canTest = canTestModelConnection(model.provider, watchedModel, watchedApiKey)
+  const credentialsDirty =
+    watchedModel !== (model.model || '') || watchedUrl !== (model.url || '') || watchedApiKey !== (model.apiKey || '')
+  const requiresPassingTest = credentialsDirty && connectionStatus !== 'success'
 
   return (
     <Form {...form}>
@@ -421,6 +424,12 @@ const EditModelForm = ({
           </Button>
         )}
 
+        {!canTest && credentialsDirty && (
+          <p className="text-sm text-muted-foreground text-center">
+            Enter an API key to test the connection before saving.
+          </p>
+        )}
+
         {connectionStatus === 'success' && (
           <StatusCard
             title={
@@ -451,7 +460,7 @@ const EditModelForm = ({
           <Button type="button" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isPending || !form.formState.isDirty || connectionStatus !== 'success'}>
+          <Button type="submit" disabled={isPending || !form.formState.isDirty || requiresPassingTest}>
             Save
           </Button>
         </div>
@@ -1204,6 +1213,15 @@ export default function ModelsPage() {
                     )}
                   </Button>
                 )}
+
+                {!canTestConnection &&
+                  !!watchedModel &&
+                  ['anthropic', 'tinfoil'].includes(watchedProvider) &&
+                  !watchedApiKey && (
+                    <p className="text-sm text-muted-foreground text-center">
+                      Enter an API key to test the connection before saving.
+                    </p>
+                  )}
 
                 {/* Connection Status Messages */}
                 {connectionStatus === 'success' && (

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -148,6 +148,13 @@ const modelReducer = (state: ModelState, action: ModelAction): ModelState => {
  */
 const providerRequiresConnectionTest = (provider: Model['provider']) => provider !== 'thunderbolt'
 
+/**
+ * Providers that need an API key to authenticate the test round-trip. Custom
+ * (OpenAI-compatible) endpoints may or may not need one, so the key is treated
+ * as optional there.
+ */
+const providerRequiresApiKey = (provider: Model['provider']) => provider !== 'thunderbolt' && provider !== 'custom'
+
 const canTestModelConnection = (provider: Model['provider'], model?: string, apiKey?: string | null) => {
   if (!providerRequiresConnectionTest(provider)) {
     return false
@@ -155,7 +162,7 @@ const canTestModelConnection = (provider: Model['provider'], model?: string, api
   if (!model) {
     return false
   }
-  if (['anthropic', 'tinfoil'].includes(provider)) {
+  if (providerRequiresApiKey(provider)) {
     return !!apiKey
   }
   return true
@@ -185,7 +192,7 @@ const ConnectionTestSection = ({
   error,
 }: ConnectionTestSectionProps) => {
   const canTest = canTestModelConnection(provider, model, apiKey)
-  const showApiKeyHint = !canTest && !!model && ['anthropic', 'tinfoil'].includes(provider)
+  const showApiKeyHint = !canTest && !!model && providerRequiresApiKey(provider)
 
   return (
     <>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -1055,7 +1055,13 @@ export default function ModelsPage() {
                     <FormItem>
                       <FormLabel>Provider</FormLabel>
                       <FormControl>
-                        <Select onValueChange={field.onChange} value={field.value}>
+                        <Select
+                          onValueChange={(value) => {
+                            field.onChange(value)
+                            resetConnectionTest()
+                          }}
+                          value={field.value}
+                        >
                           <SelectTrigger className="w-full rounded-lg">
                             <SelectValue placeholder="Select provider" />
                           </SelectTrigger>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -141,7 +141,17 @@ const modelReducer = (state: ModelState, action: ModelAction): ModelState => {
   }
 }
 
+/**
+ * Thunderbolt uses the app's authenticated cloud endpoint — no user-supplied
+ * credentials to verify — so Save is not gated on a live test. Every other
+ * provider requires a passing connection test before Save is enabled.
+ */
+const providerRequiresConnectionTest = (provider: Model['provider']) => provider !== 'thunderbolt'
+
 const canTestModelConnection = (provider: Model['provider'], model?: string, apiKey?: string | null) => {
+  if (!providerRequiresConnectionTest(provider)) {
+    return false
+  }
   if (!model) {
     return false
   }
@@ -406,7 +416,14 @@ const EditModelForm = ({
           <Button type="button" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isPending || !form.formState.isDirty || connectionStatus === 'error'}>
+          <Button
+            type="submit"
+            disabled={
+              isPending ||
+              !form.formState.isDirty ||
+              (providerRequiresConnectionTest(model.provider) && connectionStatus !== 'success')
+            }
+          >
             Save
           </Button>
         </div>
@@ -1128,7 +1145,13 @@ export default function ModelsPage() {
                   <Button type="button" variant="ghost" onClick={() => handleDialogOpenChange(false)}>
                     Cancel
                   </Button>
-                  <Button type="submit" disabled={addModelMutation.isPending || connectionStatus === 'error'}>
+                  <Button
+                    type="submit"
+                    disabled={
+                      addModelMutation.isPending ||
+                      (providerRequiresConnectionTest(watchedProvider) && connectionStatus !== 'success')
+                    }
+                  >
                     {addModelMutation.isPending ? 'Adding...' : 'Add Model'}
                   </Button>
                 </div>

--- a/src/test-utils/powersync-reactivity-test.tsx
+++ b/src/test-utils/powersync-reactivity-test.tsx
@@ -6,11 +6,9 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { act, render, type RenderOptions, type RenderResult } from '@testing-library/react'
 import type { ReactElement, ReactNode } from 'react'
 import { getClock } from '@/testing-library'
-import type { FetchFn } from '@/lib/proxy-fetch'
 import { ProxyFetchProvider } from '@/lib/proxy-fetch-context'
 import { PowerSyncReactivityTestProvider } from './powersync-mock'
-
-const mockProxyFetch = (async () => new Response()) as unknown as FetchFn
+import { mockProxyFetch } from './proxy-fetch'
 
 /**
  * Poll for element with fake timers. Avoids waitFor's jest.advanceTimersByTime issues in Bun.

--- a/src/test-utils/proxy-fetch.ts
+++ b/src/test-utils/proxy-fetch.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { FetchFn } from '@/lib/proxy-fetch'
+
+/**
+ * A no-op `FetchFn` for tests. Every call resolves to an empty `Response` and
+ * `preconnect` resolves to `true`, satisfying the full `FetchFn` shape so
+ * consumers don't need a `as unknown as FetchFn` cast.
+ */
+export const mockProxyFetch: FetchFn = Object.assign(async () => new Response(), {
+  preconnect: async () => true,
+})

--- a/src/test-utils/test-provider.tsx
+++ b/src/test-utils/test-provider.tsx
@@ -4,15 +4,13 @@
 
 import { AuthProvider, DatabaseProvider, HttpClientProvider, type AuthClient, type HttpClient } from '@/contexts'
 import { getDb } from '@/db/database'
-import type { FetchFn } from '@/lib/proxy-fetch'
 import { ProxyFetchProvider } from '@/lib/proxy-fetch-context'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { type ReactNode } from 'react'
 import { createMockAuthClient } from './auth-client'
 import { createMockHttpClient } from './http-client'
 import { PowerSyncMockProvider } from './powersync-mock'
-
-const mockProxyFetch = (async () => new Response()) as unknown as FetchFn
+import { mockProxyFetch } from './proxy-fetch'
 
 type TestProviderOptions = {
   mockResponse?: unknown


### PR DESCRIPTION
Extracts the model-connection-test logic from the Add Model dialog into a reusable `useModelConnectionTest` hook and wires it into the Edit Model flow, so users editing an existing model (e.g. updating its API key or URL) can verify the credentials before saving — same Test Model button, success/error cards, and 10s timeout as the add path. Any edit to the model id, URL, or API key invalidates a prior successful test.

Fixes THU-615.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model credential configuration and live provider round-trips; behavior changes for Edit save gating and timeout/abort handling, though scope is limited to settings UI.
> 
> **Overview**
> Introduces **`useModelConnectionTest`**, moving the Add Model “Test Model” flow out of `models/index.tsx` into a dedicated hook that runs a `generateText` probe (10s `AbortSignal.timeout`, injectable probe for tests), tracks idle/success/error, invalidates displayed success when model/URL/API key no longer match the last tested config (including `''` vs `null`), and ignores stale in-flight results after `reset`.
> 
> The **Models settings page** drops reducer-driven connection state and inline `createModel`/`generateText` logic; Add and Edit both use the hook plus a shared **`ConnectionTestSection`** (test button, API-key hint for Anthropic/Tinfoil, status cards). **Edit Model** gains the same test-before-save UX; Save/Add stay disabled while a test is in **error** (not gated on success). Add dialog **resets** connection test on open/close; the Enter-key shortcut that triggered test/submit was removed.
> 
> Adds **hook unit tests** and a shared **`mockProxyFetch`** in test utils (used by powersync-reactivity and test-provider).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a821c18229df0b7005d4f5b17114f252ea7188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->