### PR TITLE
feat(THU-616): explain why opposite-mode models are disabled in selector

### DIFF
--- a/src/components/ui/model-selector/model-selector.test.ts
+++ b/src/components/ui/model-selector/model-selector.test.ts
@@ -52,8 +52,8 @@ describe('categorizeModels', () => {
 
     const disabled = groups.find((g) => g.id === 'standard-disabled')
     expect(disabled).toBeDefined()
-    expect(disabled!.label).toBeUndefined()
-    expect(disabled!.subtitle).toBeUndefined()
+    expect(disabled!.label).toBe('Standard Models')
+    expect(disabled!.subtitle).toBe('Not available in confidential chats.')
     expect(disabled!.items).toHaveLength(1)
     expect(disabled!.items[0].id).toBe('std-1')
     expect(disabled!.items[0].disabled).toBe(true)
@@ -69,8 +69,8 @@ describe('categorizeModels', () => {
 
     const disabled = groups.find((g) => g.id === 'confidential-disabled')
     expect(disabled).toBeDefined()
-    expect(disabled!.label).toBeUndefined()
-    expect(disabled!.subtitle).toBeUndefined()
+    expect(disabled!.label).toBe('Confidential Models')
+    expect(disabled!.subtitle).toBe('Available only in confidential chats.')
     expect(disabled!.items).toHaveLength(1)
     expect(disabled!.items[0].id).toBe('conf-1')
     expect(disabled!.items[0].disabled).toBe(true)

--- a/src/components/ui/model-selector/model-selector.tsx
+++ b/src/components/ui/model-selector/model-selector.tsx
@@ -96,14 +96,24 @@ export const categorizeModels = (
   if (custom.length > 0) {
     groups.push({ id: 'custom', label: 'Custom Models', items: custom })
   }
-  // Models disabled by an encryption mismatch are shown greyed out with no
-  // group heading or explanation (only one of these buckets is ever non-empty
-  // for a given chat, since the mismatch is one-directional).
+  // A chat is locked to its confidentiality mode, so the opposite-mode models
+  // are shown greyed out with a header explaining why. Only one of these
+  // buckets is ever non-empty for a given chat.
   if (disabledStandard.length > 0) {
-    groups.push({ id: 'standard-disabled', items: disabledStandard })
+    groups.push({
+      id: 'standard-disabled',
+      label: 'Standard Models',
+      subtitle: 'Not available in confidential chats.',
+      items: disabledStandard,
+    })
   }
   if (disabledConfidential.length > 0) {
-    groups.push({ id: 'confidential-disabled', items: disabledConfidential })
+    groups.push({
+      id: 'confidential-disabled',
+      label: 'Confidential Models',
+      subtitle: 'Available only in confidential chats.',
+      items: disabledConfidential,
+    })
   }
 
   return groups


### PR DESCRIPTION
A chat is locked to its confidentiality mode, so the opposite-mode models appear greyed out in the model selector with no explanation. Adds a header + helper text above the disabled bucket — **Standard Models** / *Not available in confidential chats.* and **Confidential Models** / *Available only in confidential chats.* — using the `label`+`subtitle` slot `SearchableMenu` already renders for groups.

Fixes THU-616.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI grouping in the model selector; no selection logic or backend changes.
> 
> **Overview**
> Greyed-out models in the model selector now show **why** they can’t be selected, instead of appearing in a silent disabled bucket.
> 
> `categorizeModels` sets `label` and `subtitle` on the encryption-mismatch groups: **Standard Models** with *Not available in confidential chats.* in confidential chats, and **Confidential Models** with *Available only in confidential chats.* in standard chats. `SearchableMenu` already renders those group fields; tests were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ddc07ade09b78420927d750b541f07cdad12700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->