### PR TITLE
feat(THU-618): support editing MCP servers in settings

### DIFF
--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -72,6 +72,8 @@ export {
   deleteMcpServer,
   getAllMcpServers,
   getRemoteMcpServers,
+  updateMcpServer,
+  updateMcpServerWithCredentials,
   type McpServerWithCredential,
 } from './mcp-servers'
 

--- a/src/dal/mcp-servers.test.ts
+++ b/src/dal/mcp-servers.test.ts
@@ -13,6 +13,7 @@ import {
   deleteMcpServer,
   getAllMcpServers,
   getRemoteMcpServers,
+  updateMcpServerWithCredentials,
 } from './mcp-servers'
 import { getMcpServerCredentials } from './mcp-secrets'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
@@ -313,6 +314,69 @@ describe('MCP Servers DAL', () => {
       // Verify original deletedAt is preserved
       const rawServer = await db.select().from(mcpServersTable).get()
       expect(rawServer?.deletedAt).toBe(originalDeletedAt)
+    })
+  })
+
+  describe('updateMcpServerWithCredentials', () => {
+    it('patches mutable fields and leaves credentials alone when none given', async () => {
+      const db = getDb()
+      const id = uuidv7()
+      await createMcpServerWithCredentials(
+        db,
+        { id, name: 'Original', type: 'http', url: 'https://example.com/mcp', enabled: 1 },
+        { type: 'bearer', token: 'original-token' },
+      )
+
+      await updateMcpServerWithCredentials(db, id, { name: 'Renamed', url: 'https://new.example.com/mcp' })
+
+      const servers = await getAllMcpServers(db)
+      expect(servers[0]?.name).toBe('Renamed')
+      expect(servers[0]?.url).toBe('https://new.example.com/mcp')
+      expect(await getMcpServerCredentials(db, id)).toEqual({ type: 'bearer', token: 'original-token' })
+    })
+
+    it('replaces the credential when an object is given', async () => {
+      const db = getDb()
+      const id = uuidv7()
+      await createMcpServerWithCredentials(
+        db,
+        { id, name: 'Server', type: 'http', url: 'https://example.com/mcp', enabled: 1 },
+        { type: 'bearer', token: 'old-token' },
+      )
+
+      await updateMcpServerWithCredentials(db, id, { name: 'Server' }, { type: 'bearer', token: 'new-token' })
+
+      expect(await getMcpServerCredentials(db, id)).toEqual({ type: 'bearer', token: 'new-token' })
+    })
+
+    it('deletes the credential when null is given', async () => {
+      const db = getDb()
+      const id = uuidv7()
+      await createMcpServerWithCredentials(
+        db,
+        { id, name: 'Server', type: 'http', url: 'https://example.com/mcp', enabled: 1 },
+        { type: 'bearer', token: 'doomed' },
+      )
+
+      await updateMcpServerWithCredentials(db, id, { name: 'Server' }, null)
+
+      expect(await getMcpServerCredentials(db, id)).toBeNull()
+    })
+
+    it('adds a credential to a previously-uncredentialed server', async () => {
+      const db = getDb()
+      const id = uuidv7()
+      await createMcpServerWithCredentials(db, {
+        id,
+        name: 'Open Server',
+        type: 'http',
+        url: 'https://example.com/mcp',
+        enabled: 1,
+      })
+
+      await updateMcpServerWithCredentials(db, id, {}, { type: 'bearer', token: 'fresh' })
+
+      expect(await getMcpServerCredentials(db, id)).toEqual({ type: 'bearer', token: 'fresh' })
     })
   })
 

--- a/src/dal/mcp-servers.ts
+++ b/src/dal/mcp-servers.ts
@@ -6,7 +6,7 @@ import { and, eq, inArray, isNotNull, isNull } from 'drizzle-orm'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { mcpSecretsTable, mcpServersTable } from '../db/tables'
 import { clearNullableColumns, nowIso } from '../lib/utils'
-import { setMcpServerCredentials, type McpServerCredentials } from './mcp-secrets'
+import { deleteMcpServerCredentials, setMcpServerCredentials, type McpServerCredentials } from './mcp-secrets'
 import { type McpServer } from '@/types'
 import type { DrizzleQueryWithPromise } from '@/types'
 
@@ -78,6 +78,46 @@ export const createMcpServerWithCredentials = async (
       await setMcpServerCredentials(tx, data.id, credentials)
     }
     await createMcpServer(tx, data)
+  })
+}
+
+/**
+ * Patches an MCP server row (and bumps updatedAt). The patch must NOT include
+ * `id` or `createdAt`; touch only mutable columns. No-op when the id doesn't
+ * match (the update silently affects zero rows).
+ */
+export const updateMcpServer = async (
+  db: AnyDrizzleDatabase,
+  id: string,
+  patch: Partial<Omit<McpServer, 'id' | 'createdAt'>>,
+): Promise<void> => {
+  await db
+    .update(mcpServersTable)
+    .set({ ...patch, updatedAt: nowIso() })
+    .where(eq(mcpServersTable.id, id))
+}
+
+/**
+ * Updates an MCP server row and (optionally) its on-device credentials in a
+ * single transaction. Symmetric to {@link createMcpServerWithCredentials}.
+ * `credentials` semantics:
+ *   - `undefined`: leave existing credential alone (e.g. rename without touching the token)
+ *   - `null`: delete existing credential (user cleared the bearer field)
+ *   - object: replace existing credential
+ */
+export const updateMcpServerWithCredentials = async (
+  db: AnyDrizzleDatabase,
+  id: string,
+  patch: Partial<Omit<McpServer, 'id' | 'createdAt'>>,
+  credentials?: McpServerCredentials | null,
+): Promise<void> => {
+  await db.transaction(async (tx) => {
+    if (credentials === null) {
+      await deleteMcpServerCredentials(tx, id)
+    } else if (credentials) {
+      await setMcpServerCredentials(tx, id, credentials)
+    }
+    await updateMcpServer(tx, id, patch)
   })
 }
 

--- a/src/hooks/use-add-server-form.test.ts
+++ b/src/hooks/use-add-server-form.test.ts
@@ -206,6 +206,50 @@ describe('useAddServerForm', () => {
     expect(result.current.testResult.kind).toBe('needs-oauth')
   })
 
+  it('keeps a passing test result when only the name is edited', async () => {
+    const { result } = renderForm(makeDeps())
+
+    act(() => result.current.openDialog())
+    act(() => result.current.changeUrl('https://tools.example.com/mcp'))
+    await act(async () => {
+      getClock().tick(700)
+      await getClock().runAllAsync()
+    })
+    expect(result.current.testResult.kind).toBe('success')
+
+    // Renaming doesn't change what the probe verifies, so the success must survive —
+    // otherwise Save Changes gets stuck disabled with no obvious recovery.
+    act(() => result.current.changeName('My Server'))
+    expect(result.current.testResult.kind).toBe('success')
+  })
+
+  it('reports hasConnectionEdits only for connection-affecting fields in edit mode', () => {
+    const { result } = renderForm(makeDeps())
+
+    act(() =>
+      result.current.openEditDialog(
+        { id: 's1', name: 'GitHub', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 } as never,
+        'tok-1',
+      ),
+    )
+    expect(result.current.hasConnectionEdits).toBe(false)
+
+    // Name is metadata, not part of the probe — must not flip the flag.
+    act(() => result.current.changeName('Renamed'))
+    expect(result.current.hasConnectionEdits).toBe(false)
+
+    act(() => result.current.changeUrl('https://api.github.com/mcp/v2'))
+    expect(result.current.hasConnectionEdits).toBe(true)
+  })
+
+  it('hasConnectionEdits is true in Add mode (no original snapshot)', () => {
+    const { result } = renderForm(makeDeps())
+
+    act(() => result.current.openDialog())
+    // No original to diff against — Add must keep the existing test-success Save gate.
+    expect(result.current.hasConnectionEdits).toBe(true)
+  })
+
   it('resets all form state on resetAddDialog', async () => {
     const { result } = renderForm(makeDeps())
 

--- a/src/hooks/use-add-server-form.test.ts
+++ b/src/hooks/use-add-server-form.test.ts
@@ -299,6 +299,97 @@ describe('useAddServerForm', () => {
     expect(result.current.isClearingBearerOnly).toBe(false)
   })
 
+  it('reports isOAuthEdit for an OAuth-authorized server until the user types a bearer token', () => {
+    const { result } = renderForm(makeDeps())
+
+    // Open Edit on an OAuth server — the token field is deliberately empty
+    // (OAuth credentials aren't surfaced in the token input).
+    act(() =>
+      result.current.openEditDialog(
+        makeMcpServer({ id: 'oauth-1', name: 'GH', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 }),
+        null,
+        'oauth',
+      ),
+    )
+    expect(result.current.isOAuthEdit).toBe(true)
+
+    // A URL edit doesn't affect the flag — the server is still OAuth-with-empty-token.
+    act(() => result.current.changeUrl('https://api.github.com/mcp/v2'))
+    expect(result.current.isOAuthEdit).toBe(true)
+
+    // Typing a bearer converts the intent away from OAuth (mutation will replace
+    // OAuth credential with bearer), so the probe becomes actionable again.
+    act(() => result.current.changeToken('pat-123'))
+    expect(result.current.isOAuthEdit).toBe(false)
+  })
+
+  it('does not report isOAuthEdit for bearer or none-credential servers in Edit mode', () => {
+    const { result } = renderForm(makeDeps())
+
+    act(() =>
+      result.current.openEditDialog(
+        makeMcpServer({ id: 'bearer-1', name: 'GH', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 }),
+        'tok-1',
+        'bearer',
+      ),
+    )
+    // Bearer server, even after clearing the token — bearer is not OAuth.
+    expect(result.current.isOAuthEdit).toBe(false)
+    act(() => result.current.changeToken(''))
+    expect(result.current.isOAuthEdit).toBe(false)
+  })
+
+  it('does not report isOAuthEdit in Add mode (no original snapshot)', () => {
+    const { result } = renderForm(makeDeps())
+    act(() => result.current.openDialog())
+    expect(result.current.isOAuthEdit).toBe(false)
+  })
+
+  it('skips the auto-probe when opening Edit on an OAuth server (empty token stays empty)', async () => {
+    const probeMcpServerTools = mock(async () => ['tool']) as unknown as AddServerFormDeps['probeMcpServerTools']
+    const { result } = renderForm(makeDeps({ probeMcpServerTools }))
+
+    act(() =>
+      result.current.openEditDialog(
+        makeMcpServer({ id: 'oauth-1', name: 'GH', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 }),
+        null,
+        'oauth',
+      ),
+    )
+    // Advance past the debounce — the probe would fire here for a bearer/none
+    // server, but must not for an OAuth server with an empty token (the 401 would
+    // render a misleading "needs authorization" panel over an already-connected
+    // server, and burn a network round-trip on every Edit-open).
+    await act(async () => {
+      getClock().tick(1000)
+      await getClock().runAllAsync()
+    })
+    expect(probeMcpServerTools).not.toHaveBeenCalled()
+    expect(result.current.testResult.kind).toBe('idle')
+  })
+
+  it('probes once the user types a bearer on an OAuth-server edit (converts away from OAuth)', async () => {
+    const probeMcpServerTools = mock(async () => ['tool']) as unknown as AddServerFormDeps['probeMcpServerTools']
+    const { result } = renderForm(makeDeps({ probeMcpServerTools }))
+
+    act(() =>
+      result.current.openEditDialog(
+        makeMcpServer({ id: 'oauth-1', name: 'GH', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 }),
+        null,
+        'oauth',
+      ),
+    )
+    // Typing a bearer lifts the OAuth-skip guard: the probe can now succeed and
+    // is the confirmation the user needs before Save Changes unlocks.
+    act(() => result.current.changeToken('pat-123'))
+    await act(async () => {
+      getClock().tick(700)
+      await getClock().runAllAsync()
+    })
+    expect(probeMcpServerTools).toHaveBeenCalledTimes(1)
+    expect(result.current.testResult.kind).toBe('success')
+  })
+
   it('hasConnectionEdits is true in Add mode (no original snapshot)', () => {
     const { result } = renderForm(makeDeps())
 

--- a/src/hooks/use-add-server-form.test.ts
+++ b/src/hooks/use-add-server-form.test.ts
@@ -5,6 +5,7 @@
 import '@/testing-library'
 import { getClock } from '@/testing-library'
 import type { FetchFn } from '@/lib/proxy-fetch'
+import type { McpServer } from '@/types'
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { generateServerName, useAddServerForm, type AddServerFormDeps } from './use-add-server-form'
@@ -13,6 +14,22 @@ const fakeFetch = (async () => new Response()) as unknown as FetchFn
 
 /** A 401 shaped like the real transport error `isUnauthorizedError` recognizes. */
 const unauthorized = () => Object.assign(new Error('Unauthorized'), { code: 401 })
+
+/** Build a fully-typed McpServer for edit-dialog tests without an `as never` escape hatch. */
+const makeMcpServer = (overrides: Partial<McpServer> = {}): McpServer => ({
+  id: 's1',
+  name: 'default',
+  type: 'http',
+  enabled: 1,
+  url: null,
+  command: null,
+  args: null,
+  createdAt: null,
+  updatedAt: null,
+  deletedAt: null,
+  userId: null,
+  ...overrides,
+})
 
 const makeDeps = (overrides: Partial<AddServerFormDeps> = {}): AddServerFormDeps => ({
   probeMcpServerTools: mock(async () => ['search']) as unknown as AddServerFormDeps['probeMcpServerTools'],
@@ -228,8 +245,9 @@ describe('useAddServerForm', () => {
 
     act(() =>
       result.current.openEditDialog(
-        { id: 's1', name: 'GitHub', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 } as never,
+        makeMcpServer({ id: 's1', name: 'GitHub', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 }),
         'tok-1',
+        'bearer',
       ),
     )
     expect(result.current.hasConnectionEdits).toBe(false)
@@ -240,6 +258,45 @@ describe('useAddServerForm', () => {
 
     act(() => result.current.changeUrl('https://api.github.com/mcp/v2'))
     expect(result.current.hasConnectionEdits).toBe(true)
+  })
+
+  it('reports isClearingBearerOnly only when a stored bearer is cleared with URL/transport untouched', () => {
+    const { result } = renderForm(makeDeps())
+
+    // Bearer-authorized server: token is prefilled from mcp_secrets.
+    act(() =>
+      result.current.openEditDialog(
+        makeMcpServer({ id: 's1', name: 'GitHub', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 }),
+        'tok-1',
+        'bearer',
+      ),
+    )
+    expect(result.current.isClearingBearerOnly).toBe(false)
+
+    // Clearing the bearer flips it — the Save gate must recognize this so
+    // removing auth from a still-protected server doesn't get stuck disabled.
+    act(() => result.current.changeToken(''))
+    expect(result.current.hasConnectionEdits).toBe(true)
+    expect(result.current.isClearingBearerOnly).toBe(true)
+
+    // Also changing the URL is no longer a bearer-only clear — it's a real edit.
+    act(() => result.current.changeUrl('https://api.github.com/mcp/v2'))
+    expect(result.current.isClearingBearerOnly).toBe(false)
+  })
+
+  it('does not report isClearingBearerOnly when the original credential was OAuth or none', () => {
+    const { result } = renderForm(makeDeps())
+
+    act(() =>
+      result.current.openEditDialog(
+        makeMcpServer({ id: 's2', name: 'GitHub', url: 'https://api.github.com/mcp', type: 'http', enabled: 1 }),
+        null,
+        'oauth',
+      ),
+    )
+    // OAuth is managed via the Authorize buttons, not the token field, so a
+    // blank token here has always been the state — nothing to "clear".
+    expect(result.current.isClearingBearerOnly).toBe(false)
   })
 
   it('hasConnectionEdits is true in Add mode (no original snapshot)', () => {

--- a/src/hooks/use-add-server-form.ts
+++ b/src/hooks/use-add-server-form.ts
@@ -9,6 +9,7 @@ import type { probeMcpServerTools } from '@/lib/mcp-connection-test'
 import { buildMcpHeaders, createMcpTransport, type MCPTransportType } from '@/lib/mcp-transport'
 import { validateMcpServerUrl } from '@/lib/mcp-url-validation'
 import type { FetchFn } from '@/lib/proxy-fetch'
+import type { McpServer } from '@/types'
 import { useEffect, useReducer, useRef } from 'react'
 
 /**
@@ -44,6 +45,8 @@ export const generateServerName = (url: string): string => {
 
 type AddServerFormState = {
   isAddDialogOpen: boolean
+  /** Non-null when the dialog is editing an existing server (id) instead of adding one. */
+  editingServerId: string | null
   name: string
   /** True once the user edits the name field, so the URL stops re-deriving it. */
   nameManuallyEdited: boolean
@@ -56,6 +59,7 @@ type AddServerFormState = {
 
 type AddServerFormAction =
   | { type: 'open-dialog' }
+  | { type: 'open-edit-dialog'; server: McpServer; bearerToken: string | null }
   | { type: 'reset' }
   | { type: 'set-name'; value: string }
   | { type: 'set-url'; value: string; derivedName: string | null }
@@ -68,6 +72,7 @@ type AddServerFormAction =
 
 const initialState: AddServerFormState = {
   isAddDialogOpen: false,
+  editingServerId: null,
   name: '',
   nameManuallyEdited: false,
   url: '',
@@ -81,6 +86,19 @@ const addServerFormReducer = (state: AddServerFormState, action: AddServerFormAc
   switch (action.type) {
     case 'open-dialog':
       return { ...state, isAddDialogOpen: true }
+    case 'open-edit-dialog':
+      // Edit prefills every field from the existing row. `nameManuallyEdited`
+      // is set so a URL change during edit doesn't clobber the existing name.
+      return {
+        ...initialState,
+        isAddDialogOpen: true,
+        editingServerId: action.server.id,
+        name: action.server.name ?? '',
+        nameManuallyEdited: true,
+        url: action.server.url ?? '',
+        transport: action.server.type === 'sse' ? 'sse' : 'http',
+        token: action.bearerToken ?? '',
+      }
     case 'reset':
       return initialState
     case 'set-name':
@@ -119,7 +137,11 @@ export type AddServerFormDeps = {
 
 export type UseAddServerFormResult = {
   isAddDialogOpen: boolean
+  /** Id of the server being edited, or null when the dialog is in Add mode. */
+  editingServerId: string | null
   openDialog: () => void
+  /** Opens the dialog in Edit mode with all fields prefilled from the existing server. */
+  openEditDialog: (server: McpServer, bearerToken: string | null) => void
   /** Closes the dialog and clears all add-form state (Cancel / Escape / overlay). */
   resetAddDialog: () => void
   name: string
@@ -170,6 +192,17 @@ export const useAddServerForm = ({
   const lastAutoTestedUrlRef = useRef<string | null>(null)
 
   const openDialog = () => dispatch({ type: 'open-dialog' })
+
+  // Open the dialog with every field prefilled from an existing server row +
+  // its on-device bearer token (null for OAuth or no-cred). The auto-detect
+  // effect will probe the prefilled URL after the standard 700ms debounce, so
+  // the user must still pass Test Connection before saving — same gate as Add.
+  const openEditDialog = (server: McpServer, bearerToken: string | null) => {
+    probeIdRef.current += 1
+    lastAutoTestedUrlRef.current = null
+    onClearDialogError()
+    dispatch({ type: 'open-edit-dialog', server, bearerToken })
+  }
 
   // Closes the Add dialog and clears all add-form state. Bumps the probe id so an
   // in-flight connection probe can't land its result after the dialog is gone.
@@ -302,7 +335,9 @@ export const useAddServerForm = ({
 
   return {
     isAddDialogOpen: state.isAddDialogOpen,
+    editingServerId: state.editingServerId,
     openDialog,
+    openEditDialog,
     resetAddDialog,
     name: state.name,
     url: state.url,

--- a/src/hooks/use-add-server-form.ts
+++ b/src/hooks/use-add-server-form.ts
@@ -55,6 +55,11 @@ type AddServerFormState = {
   token: string
   isTestingConnection: boolean
   testResult: TestConnectionResult | { kind: 'idle' }
+  /** Snapshot of url/transport/token at edit-open. Used to detect whether the
+   *  user changed a connection-affecting field, so the Save gate can skip the
+   *  fresh-probe requirement on a metadata-only edit (e.g. rename) where the
+   *  existing credential — including OAuth — is presumed valid. Null in Add mode. */
+  originalConnection: { url: string; transport: MCPTransportType; token: string } | null
 }
 
 type AddServerFormAction =
@@ -80,25 +85,31 @@ const initialState: AddServerFormState = {
   token: '',
   isTestingConnection: false,
   testResult: { kind: 'idle' },
+  originalConnection: null,
 }
 
 const addServerFormReducer = (state: AddServerFormState, action: AddServerFormAction): AddServerFormState => {
   switch (action.type) {
     case 'open-dialog':
       return { ...state, isAddDialogOpen: true }
-    case 'open-edit-dialog':
+    case 'open-edit-dialog': {
       // Edit prefills every field from the existing row. `nameManuallyEdited`
       // is set so a URL change during edit doesn't clobber the existing name.
+      const url = action.server.url ?? ''
+      const transport: MCPTransportType = action.server.type === 'sse' ? 'sse' : 'http'
+      const token = action.bearerToken ?? ''
       return {
         ...initialState,
         isAddDialogOpen: true,
         editingServerId: action.server.id,
         name: action.server.name ?? '',
         nameManuallyEdited: true,
-        url: action.server.url ?? '',
-        transport: action.server.type === 'sse' ? 'sse' : 'http',
-        token: action.bearerToken ?? '',
+        url,
+        transport,
+        token,
+        originalConnection: { url, transport, token },
       }
+    }
     case 'reset':
       return initialState
     case 'set-name':
@@ -156,6 +167,12 @@ export type UseAddServerFormResult = {
   testResult: TestConnectionResult | { kind: 'idle' }
   isTestingConnection: boolean
   serverCapabilities: string[]
+  /** True when a connection-affecting field (url/transport/token) differs from
+   *  the value loaded at edit-open. Always true in Add mode (no original
+   *  snapshot). Callers gate the Save-Changes test-success requirement on this
+   *  so a metadata-only edit can save without re-probing — important for OAuth
+   *  servers, whose empty-token probe would classify as `needs-oauth`. */
+  hasConnectionEdits: boolean
   testConnection: () => Promise<void>
   /** Leaving the URL field probes immediately (unless the debounce already did). */
   handleUrlBlur: () => void
@@ -314,7 +331,9 @@ export const useAddServerForm = ({
   }
 
   const changeName = (value: string) => {
-    resetConnectionTest()
+    // Name doesn't participate in the probe (only url/transport/token do), so a
+    // rename must not invalidate a passing test — otherwise Save Changes gets
+    // stuck disabled until the user re-edits a connection field or retests.
     dispatch({ type: 'set-name', value })
   }
 
@@ -351,6 +370,11 @@ export const useAddServerForm = ({
     isTestingConnection: state.isTestingConnection,
     // Derived: the discovered tools live on a successful result — no separate state to keep in sync.
     serverCapabilities: state.testResult.kind === 'success' ? state.testResult.tools : [],
+    hasConnectionEdits:
+      !state.originalConnection ||
+      state.url !== state.originalConnection.url ||
+      state.transport !== state.originalConnection.transport ||
+      state.token !== state.originalConnection.token,
     testConnection,
     handleUrlBlur,
     resolveServerName,

--- a/src/hooks/use-add-server-form.ts
+++ b/src/hooks/use-add-server-form.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { decideTestConnectionResult, type TestConnectionResult } from '@/lib/mcp-auth/auth-decision'
+import {
+  decideTestConnectionResult,
+  type StoredCredentialType,
+  type TestConnectionResult,
+} from '@/lib/mcp-auth/auth-decision'
 import type { classifyMcpServerAuth } from '@/lib/mcp-auth/web-oauth-flow'
 import { isUnauthorizedError } from '@/lib/mcp-errors'
 import type { probeMcpServerTools } from '@/lib/mcp-connection-test'
@@ -55,16 +59,24 @@ type AddServerFormState = {
   token: string
   isTestingConnection: boolean
   testResult: TestConnectionResult | { kind: 'idle' }
-  /** Snapshot of url/transport/token at edit-open. Used to detect whether the
-   *  user changed a connection-affecting field, so the Save gate can skip the
-   *  fresh-probe requirement on a metadata-only edit (e.g. rename) where the
-   *  existing credential — including OAuth — is presumed valid. Null in Add mode. */
-  originalConnection: { url: string; transport: MCPTransportType; token: string } | null
+  /** Snapshot of url/transport/token/credentialType at edit-open. Used to detect
+   *  whether the user changed a connection-affecting field, so the Save gate can
+   *  skip the fresh-probe requirement on a metadata-only edit (e.g. rename) where
+   *  the existing credential — including OAuth — is presumed valid. `credentialType`
+   *  additionally lets the gate recognize a "clear bearer" edit, which can save
+   *  without a passing probe (removing auth from a still-protected server would
+   *  otherwise fail the probe and lock Save out). Null in Add mode. */
+  originalConnection: {
+    url: string
+    transport: MCPTransportType
+    token: string
+    credentialType: StoredCredentialType
+  } | null
 }
 
 type AddServerFormAction =
   | { type: 'open-dialog' }
-  | { type: 'open-edit-dialog'; server: McpServer; bearerToken: string | null }
+  | { type: 'open-edit-dialog'; server: McpServer; bearerToken: string | null; credentialType: StoredCredentialType }
   | { type: 'reset' }
   | { type: 'set-name'; value: string }
   | { type: 'set-url'; value: string; derivedName: string | null }
@@ -107,7 +119,7 @@ const addServerFormReducer = (state: AddServerFormState, action: AddServerFormAc
         url,
         transport,
         token,
-        originalConnection: { url, transport, token },
+        originalConnection: { url, transport, token, credentialType: action.credentialType },
       }
     }
     case 'reset':
@@ -152,7 +164,7 @@ export type UseAddServerFormResult = {
   editingServerId: string | null
   openDialog: () => void
   /** Opens the dialog in Edit mode with all fields prefilled from the existing server. */
-  openEditDialog: (server: McpServer, bearerToken: string | null) => void
+  openEditDialog: (server: McpServer, bearerToken: string | null, credentialType: StoredCredentialType) => void
   /** Closes the dialog and clears all add-form state (Cancel / Escape / overlay). */
   resetAddDialog: () => void
   name: string
@@ -173,6 +185,13 @@ export type UseAddServerFormResult = {
    *  so a metadata-only edit can save without re-probing — important for OAuth
    *  servers, whose empty-token probe would classify as `needs-oauth`. */
   hasConnectionEdits: boolean
+  /** True when the user's only connection change is clearing a previously-stored
+   *  bearer token (URL/transport unchanged). Removing auth from a still-protected
+   *  server would fail an unauthenticated probe, which would otherwise leave Save
+   *  Changes disabled — so this signals the Save gate can waive the probe
+   *  requirement. The mutation already interprets a blank token + `originalCredentialType === 'bearer'`
+   *  as "delete the credential." False in Add mode. */
+  isClearingBearerOnly: boolean
   testConnection: () => Promise<void>
   /** Leaving the URL field probes immediately (unless the debounce already did). */
   handleUrlBlur: () => void
@@ -214,11 +233,11 @@ export const useAddServerForm = ({
   // its on-device bearer token (null for OAuth or no-cred). The auto-detect
   // effect will probe the prefilled URL after the standard 700ms debounce, so
   // the user must still pass Test Connection before saving — same gate as Add.
-  const openEditDialog = (server: McpServer, bearerToken: string | null) => {
+  const openEditDialog = (server: McpServer, bearerToken: string | null, credentialType: StoredCredentialType) => {
     probeIdRef.current += 1
     lastAutoTestedUrlRef.current = null
     onClearDialogError()
-    dispatch({ type: 'open-edit-dialog', server, bearerToken })
+    dispatch({ type: 'open-edit-dialog', server, bearerToken, credentialType })
   }
 
   // Closes the Add dialog and clears all add-form state. Bumps the probe id so an
@@ -375,6 +394,12 @@ export const useAddServerForm = ({
       state.url !== state.originalConnection.url ||
       state.transport !== state.originalConnection.transport ||
       state.token !== state.originalConnection.token,
+    isClearingBearerOnly:
+      !!state.originalConnection &&
+      state.originalConnection.credentialType === 'bearer' &&
+      state.token === '' &&
+      state.url === state.originalConnection.url &&
+      state.transport === state.originalConnection.transport,
     testConnection,
     handleUrlBlur,
     resolveServerName,

--- a/src/hooks/use-add-server-form.ts
+++ b/src/hooks/use-add-server-form.ts
@@ -192,6 +192,15 @@ export type UseAddServerFormResult = {
    *  requirement. The mutation already interprets a blank token + `originalCredentialType === 'bearer'`
    *  as "delete the credential." False in Add mode. */
   isClearingBearerOnly: boolean
+  /** True when editing an OAuth-authorized server with the token field still empty
+   *  (its normal state — OAuth tokens aren't surfaced in the token input). Any
+   *  probe from this state would fail 401 (no bearer), classify as `needs-oauth`,
+   *  and lock Save Changes out for a URL/transport edit that would otherwise be
+   *  reasonable to persist (the stored OAuth token stays intact via the mutation's
+   *  `credentials: undefined` branch, and the card's existing needs-auth flow
+   *  handles a re-authorize at the new endpoint). False in Add mode and once the
+   *  user types a bearer token (converting the server away from OAuth). */
+  isOAuthEdit: boolean
   testConnection: () => Promise<void>
   /** Leaving the URL field probes immediately (unless the debounce already did). */
   handleUrlBlur: () => void
@@ -325,7 +334,18 @@ export const useAddServerForm = ({
   // from re-probing, so a credential change after a result lands needs the manual
   // "Test Connection".
   useEffect(() => {
-    if (!state.isAddDialogOpen || !validateMcpServerUrl(state.url).ok || state.url === lastAutoTestedUrlRef.current) {
+    // Skip the probe for an OAuth-authorized server as long as the token field is
+    // empty (its normal Edit-open state — OAuth tokens aren't surfaced). An
+    // unauthenticated probe against the OAuth endpoint would 401 and render a
+    // misleading "needs authorization" panel over an already-connected server;
+    // wait until the user actually types a bearer to convert away from OAuth.
+    const skipForOAuthEdit = state.originalConnection?.credentialType === 'oauth' && !state.token
+    if (
+      !state.isAddDialogOpen ||
+      !validateMcpServerUrl(state.url).ok ||
+      state.url === lastAutoTestedUrlRef.current ||
+      skipForOAuthEdit
+    ) {
       return
     }
     const timer = setTimeout(() => {
@@ -400,6 +420,7 @@ export const useAddServerForm = ({
       state.token === '' &&
       state.url === state.originalConnection.url &&
       state.transport === state.originalConnection.transport,
+    isOAuthEdit: state.originalConnection?.credentialType === 'oauth' && state.token === '',
     testConnection,
     handleUrlBlur,
     resolveServerName,

--- a/src/hooks/use-mcp-sync.tsx
+++ b/src/hooks/use-mcp-sync.tsx
@@ -11,7 +11,7 @@ import { useEffect } from 'react'
 
 export const useMcpSync = () => {
   const db = useDatabase()
-  const { servers, addServer, removeServer, updateServerStatus } = useMCP()
+  const { servers, addServer, removeServer, updateServer } = useMCP()
 
   const { data: dbServers = [] } = useQuery({
     queryKey: ['mcp-servers'],
@@ -45,17 +45,35 @@ export const useMcpSync = () => {
         }
       }
 
-      // Update server status for existing servers
+      // Patch any row whose name/url/type/enabled diverged from the in-memory
+      // entry. `updateServer` redials when enabled so a URL or transport change
+      // actually takes effect (the previous sync only handled enable toggles,
+      // leaving editors connected to the old endpoint).
       for (const dbServer of dbServers) {
         const providerServer = servers.find((s) => s.id === dbServer.id)
-        if (providerServer && providerServer.enabled !== (dbServer.enabled === 1)) {
-          updateServerStatus(dbServer.id, dbServer.enabled === 1)
+        if (!providerServer) {
+          continue
+        }
+        const next = {
+          id: dbServer.id,
+          name: dbServer.name ?? '',
+          url: dbServer.url || '',
+          type: dbServer.type === 'sse' ? ('sse' as const) : ('http' as const),
+          enabled: dbServer.enabled === 1,
+        }
+        if (
+          providerServer.name !== next.name ||
+          providerServer.url !== next.url ||
+          providerServer.type !== next.type ||
+          providerServer.enabled !== next.enabled
+        ) {
+          updateServer(next)
         }
       }
     }
 
     syncServers()
-  }, [dbServers, servers, addServer, removeServer, updateServerStatus])
+  }, [dbServers, servers, addServer, removeServer, updateServer])
 
   return { servers, dbServers }
 }

--- a/src/hooks/use-mcp-sync.tsx
+++ b/src/hooks/use-mcp-sync.tsx
@@ -7,7 +7,7 @@ import { getRemoteMcpServers } from '@/dal'
 import { useMCP } from '@/lib/mcp-provider'
 import { toCompilableQuery } from '@powersync/drizzle-driver'
 import { useQuery } from '@powersync/tanstack-react-query'
-import { useEffect } from 'react'
+import { useEffect, useEffectEvent } from 'react'
 
 export const useMcpSync = () => {
   const db = useDatabase()
@@ -18,62 +18,65 @@ export const useMcpSync = () => {
     query: toCompilableQuery(getRemoteMcpServers(db)),
   })
 
-  // Sync database servers with MCP provider
-  useEffect(() => {
-    const syncServers = async () => {
-      // Get current server IDs in the provider
-      const providerServerIds = new Set(servers.map((s) => s.id))
+  // Reconcile the provider from the DB snapshot: add missing rows, remove rows
+  // the DB no longer has, and patch rows whose name/url/type/enabled diverged.
+  // Wrapped in `useEffectEvent` so the effect below depends only on `dbServers`
+  // — otherwise the provider callbacks (which are re-created every render) and
+  // `servers` (which changes as reconcile itself commits) would re-fire the
+  // effect on every provider render and race against the async `updateServer`
+  // it just kicked off.
+  const reconcile = useEffectEvent(async () => {
+    const providerServerIds = new Set(servers.map((s) => s.id))
 
-      // Add new servers from database that aren't in provider
-      for (const dbServer of dbServers) {
-        if (!providerServerIds.has(dbServer.id)) {
-          await addServer({
-            id: dbServer.id,
-            name: dbServer.name ?? '',
-            url: dbServer.url || '',
-            type: dbServer.type === 'sse' ? 'sse' : 'http',
-            enabled: dbServer.enabled === 1,
-          })
-        }
-      }
-
-      // Remove servers from provider that aren't in database
-      const dbServerIds = new Set(dbServers.map((s) => s.id))
-      for (const providerServer of servers) {
-        if (!dbServerIds.has(providerServer.id)) {
-          removeServer(providerServer.id)
-        }
-      }
-
-      // Patch any row whose name/url/type/enabled diverged from the in-memory
-      // entry. `updateServer` redials when enabled so a URL or transport change
-      // actually takes effect (the previous sync only handled enable toggles,
-      // leaving editors connected to the old endpoint).
-      for (const dbServer of dbServers) {
-        const providerServer = servers.find((s) => s.id === dbServer.id)
-        if (!providerServer) {
-          continue
-        }
-        const next = {
+    for (const dbServer of dbServers) {
+      if (!providerServerIds.has(dbServer.id)) {
+        await addServer({
           id: dbServer.id,
           name: dbServer.name ?? '',
-          url: dbServer.url || '',
-          type: dbServer.type === 'sse' ? ('sse' as const) : ('http' as const),
+          url: dbServer.url ?? '',
+          type: dbServer.type === 'sse' ? 'sse' : 'http',
           enabled: dbServer.enabled === 1,
-        }
-        if (
-          providerServer.name !== next.name ||
-          providerServer.url !== next.url ||
-          providerServer.type !== next.type ||
-          providerServer.enabled !== next.enabled
-        ) {
-          updateServer(next)
-        }
+        })
       }
     }
 
-    syncServers()
-  }, [dbServers, servers, addServer, removeServer, updateServer])
+    const dbServerIds = new Set(dbServers.map((s) => s.id))
+    for (const providerServer of servers) {
+      if (!dbServerIds.has(providerServer.id)) {
+        removeServer(providerServer.id)
+      }
+    }
+
+    // `updateServer` redials when enabled so a URL or transport change actually
+    // takes effect (the previous sync only handled enable toggles, leaving
+    // editors connected to the old endpoint).
+    for (const dbServer of dbServers) {
+      const providerServer = servers.find((s) => s.id === dbServer.id)
+      if (!providerServer) {
+        continue
+      }
+      const next = {
+        id: dbServer.id,
+        name: dbServer.name ?? '',
+        url: dbServer.url ?? '',
+        type: dbServer.type === 'sse' ? ('sse' as const) : ('http' as const),
+        enabled: dbServer.enabled === 1,
+      }
+      if (
+        providerServer.name !== next.name ||
+        providerServer.url !== next.url ||
+        providerServer.type !== next.type ||
+        providerServer.enabled !== next.enabled
+      ) {
+        updateServer(next)
+      }
+    }
+  })
+
+  useEffect(() => {
+    reconcile()
+    // Effect Events don't get listed in deps; only DB changes trigger a reconcile.
+  }, [dbServers])
 
   return { servers, dbServers }
 }

--- a/src/lib/mcp-provider.test.tsx
+++ b/src/lib/mcp-provider.test.tsx
@@ -387,6 +387,70 @@ describe('MCPProvider reconnect', () => {
     expect(after?.isConnected).toBe(false)
   })
 
+  // Credential-only edits (same url + transport) saved while the initial
+  // connect is still in-flight must redial after that connect settles —
+  // otherwise the live client keeps using credentials captured at the start
+  // of the original connect, and the new bearer/OAuth value sits unused in
+  // `mcp_secrets`. The settings save path opts in via `forceRedial`; without
+  // it (the useMcpSync row-diff path) the in-flight guard still suppresses
+  // redundant connects.
+  it('redials after the in-flight connect settles when updateServer is called with forceRedial', async () => {
+    const initial = fakeClient()
+    const refreshed = fakeClient()
+    let calls = 0
+    const gate = deferred<void>()
+    const createClient = async (): Promise<MCPClient> => {
+      calls++
+      if (calls === 1) {
+        await gate.promise
+        return initial
+      }
+      return refreshed
+    }
+
+    const { result } = renderProvider(createClient)
+
+    await act(async () => {
+      const pending = result.current.addServer(server)
+      // Same url + type, simulating a credential-only edit during the connect window.
+      const reconciled = result.current.updateServer({ ...server }, { forceRedial: true })
+      gate.resolve()
+      await pending
+      await reconciled
+    })
+
+    expect(calls).toBe(2)
+    expect(initial.closeCount()).toBe(1)
+    const after = result.current.servers.find((s) => s.id === server.id)
+    expect(after?.client).toBe(refreshed as unknown as ProviderMCPClient)
+  })
+
+  // Without `forceRedial`, the in-flight guard keeps its original contract:
+  // a redundant updateServer during the connect window collapses to one
+  // createClient call (useMcpSync's row-diff path relies on this).
+  it('skips redial without forceRedial when url/type match an in-flight connect', async () => {
+    const created: Array<ReturnType<typeof fakeClient>> = []
+    const gate = deferred<void>()
+    const createClient = async (): Promise<MCPClient> => {
+      await gate.promise
+      const c = fakeClient()
+      created.push(c)
+      return c
+    }
+
+    const { result } = renderProvider(createClient)
+
+    await act(async () => {
+      const pending = result.current.addServer(server)
+      // No forceRedial → in-flight guard returns early.
+      result.current.updateServer({ ...server })
+      gate.resolve()
+      await pending
+    })
+
+    expect(created).toHaveLength(1)
+  })
+
   it('is a no-op when updateServer targets an unknown id', () => {
     const createClient = async (): Promise<MCPClient> => fakeClient()
     const { result } = renderProvider(createClient)

--- a/src/lib/mcp-provider.test.tsx
+++ b/src/lib/mcp-provider.test.tsx
@@ -511,12 +511,17 @@ describe('MCPProvider reconnect', () => {
     expect(created).toHaveLength(1)
   })
 
-  it('is a no-op when updateServer targets an unknown id', () => {
+  it('is a no-op when updateServer targets an unknown id', async () => {
     const createClient = async (): Promise<MCPClient> => fakeClient()
     const { result } = renderProvider(createClient)
 
-    // No throw, no spurious entry inserted.
-    act(() => result.current.updateServer({ ...server, id: 'unknown' }))
+    // No throw, no spurious entry inserted. Await the returned promise so its
+    // microtask settles inside act — leaving it dangling leaks into the next
+    // test file's setup (breaks framer-motion animation timing on unrelated
+    // component renders).
+    await act(async () => {
+      await result.current.updateServer({ ...server, id: 'unknown' })
+    })
     expect(result.current.servers.some((s) => s.id === 'unknown')).toBe(false)
   })
 })

--- a/src/lib/mcp-provider.test.tsx
+++ b/src/lib/mcp-provider.test.tsx
@@ -359,6 +359,66 @@ describe('MCPProvider reconnect', () => {
     expect(after?.client).toBe(refreshed as unknown as ProviderMCPClient)
   })
 
+  // A rename (or any pure metadata edit) on an already-connected server must
+  // NOT close the healthy client. The provider used to reconnect unconditionally
+  // whenever `updateServer` fired on the steady state, which bumped the client
+  // generation, refetched tools, and dropped any tool call in flight — all for
+  // a change that never touches the connection.
+  it('applies the row patch without reconnecting when only name changes on a connected server', async () => {
+    const initial = fakeClient()
+    let calls = 0
+    const createClient = async (): Promise<MCPClient> => {
+      calls++
+      return initial
+    }
+
+    const { result } = renderProvider(createClient)
+
+    await act(async () => {
+      await result.current.addServer(server)
+    })
+    expect(calls).toBe(1)
+
+    await act(async () => {
+      await result.current.updateServer({ ...server, name: 'Renamed' })
+    })
+
+    // Row patch applied, but the live client wasn't churned.
+    expect(calls).toBe(1)
+    expect(initial.closeCount()).toBe(0)
+    const after = result.current.servers.find((s) => s.id === server.id)
+    expect(after?.name).toBe('Renamed')
+    expect(after?.client).toBe(initial as unknown as ProviderMCPClient)
+  })
+
+  // Credential-only edits (same endpoint) DO need to redial so the new bearer /
+  // OAuth value gets picked up on the next connect; callers opt in via
+  // `forceRedial`. This is the settings Save path with token changes.
+  it('reconnects on same endpoint + forceRedial so a credential-only edit takes effect', async () => {
+    const initial = fakeClient()
+    const refreshed = fakeClient()
+    let calls = 0
+    const createClient = async (): Promise<MCPClient> => {
+      calls++
+      return calls === 1 ? initial : refreshed
+    }
+
+    const { result } = renderProvider(createClient)
+
+    await act(async () => {
+      await result.current.addServer(server)
+    })
+
+    await act(async () => {
+      await result.current.updateServer({ ...server }, { forceRedial: true })
+    })
+
+    expect(calls).toBe(2)
+    expect(initial.closeCount()).toBe(1)
+    const after = result.current.servers.find((s) => s.id === server.id)
+    expect(after?.client).toBe(refreshed as unknown as ProviderMCPClient)
+  })
+
   it('disconnects without redialing when updateServer flips enabled to false', async () => {
     const initial = fakeClient()
     let calls = 0

--- a/src/lib/mcp-provider.test.tsx
+++ b/src/lib/mcp-provider.test.tsx
@@ -207,7 +207,7 @@ describe('MCPProvider reconnect', () => {
     await act(async () => {
       const pending = result.current.addServer(server)
       // Disable the server while the initial connect's createClient is in flight.
-      result.current.updateServerStatus(server.id, false)
+      result.current.updateServer({ ...server, enabled: false })
       gate.resolve()
       await pending
     })
@@ -217,9 +217,9 @@ describe('MCPProvider reconnect', () => {
     expect(result.current.getEnabledClients()).toHaveLength(0)
   })
 
-  // UNIT 1 (#2): the addServer→connect vs updateServerStatus(enable)→connect
-  // race. Without coalescing the second connect would cacheClient over the
-  // first live client without closing it, leaking the first connection.
+  // UNIT 1 (#2): the addServer→connect vs updateServer(enable)→connect race.
+  // Without coalescing the second connect would cacheClient over the first
+  // live client without closing it, leaking the first connection.
   it('coalesces overlapping connects for the same server (no leaked client)', async () => {
     const created: Array<ReturnType<typeof fakeClient>> = []
     const gate = deferred<void>()
@@ -233,9 +233,9 @@ describe('MCPProvider reconnect', () => {
     const { result } = renderProvider(createClient)
 
     await act(async () => {
-      // addServer fires the first connect; a concurrent enable re-fires it.
+      // addServer fires the first connect; a concurrent enable patch re-fires it.
       const a = result.current.addServer(server)
-      result.current.updateServerStatus(server.id, true)
+      result.current.updateServer({ ...server, enabled: true })
       gate.resolve()
       await a
     })
@@ -276,7 +276,7 @@ describe('MCPProvider reconnect', () => {
     await act(async () => {
       const pending = result.current.reconnectServer(server.id)
       // Disable the server while the reconnect's createClient is still pending.
-      result.current.updateServerStatus(server.id, false)
+      result.current.updateServer({ ...server, enabled: false })
       gate.resolve()
       await pending
     })
@@ -319,6 +319,81 @@ describe('MCPProvider reconnect', () => {
     const after = useChatStore.getState().getMcpClients()
     expect(after[0].client).toBe(reconnected as unknown as ProviderMCPClient)
     expect(after[0].client).not.toBe(initial as unknown as ProviderMCPClient)
+  })
+
+  // Settings can edit a server in-place (rename, new url/transport, new bearer
+  // token). The provider had no patch path, so the live client kept dialing the
+  // old endpoint while the UI showed the new config — `updateServer` closes the
+  // stale client, patches state, and redials so a save actually takes effect.
+  it('patches url+name and reconnects the live client on updateServer', async () => {
+    const initial = fakeClient()
+    const refreshed = fakeClient()
+    let calls = 0
+    const seenArgs: Array<{ url: string }> = []
+    const createClient = async (_id: string, url: string): Promise<MCPClient> => {
+      calls++
+      seenArgs.push({ url })
+      return calls === 1 ? initial : refreshed
+    }
+
+    const { result } = renderProvider(createClient)
+
+    await act(async () => {
+      await result.current.addServer(server)
+    })
+    expect(seenArgs[0].url).toBe(server.url)
+
+    await act(async () => {
+      result.current.updateServer({ ...server, name: 'Renamed', url: 'https://new.test/mcp' })
+      // Reconnect kicks off synchronously; await its in-flight promise via a
+      // follow-up reconnectServer call (coalesces into the same promise).
+      await result.current.reconnectServer(server.id)
+    })
+
+    // Stale client closed, fresh one cached with the new URL fed to createClient.
+    expect(initial.closeCount()).toBe(1)
+    expect(seenArgs[1].url).toBe('https://new.test/mcp')
+    const after = result.current.servers.find((s) => s.id === server.id)
+    expect(after?.name).toBe('Renamed')
+    expect(after?.url).toBe('https://new.test/mcp')
+    expect(after?.client).toBe(refreshed as unknown as ProviderMCPClient)
+  })
+
+  it('disconnects without redialing when updateServer flips enabled to false', async () => {
+    const initial = fakeClient()
+    let calls = 0
+    const createClient = async (): Promise<MCPClient> => {
+      calls++
+      return initial
+    }
+
+    const { result } = renderProvider(createClient)
+
+    await act(async () => {
+      await result.current.addServer(server)
+    })
+    expect(calls).toBe(1)
+
+    await act(async () => {
+      result.current.updateServer({ ...server, enabled: false })
+    })
+
+    // No second createClient (no reconnect on a disabled patch) and the old client closed.
+    expect(calls).toBe(1)
+    expect(initial.closeCount()).toBe(1)
+    const after = result.current.servers.find((s) => s.id === server.id)
+    expect(after?.enabled).toBe(false)
+    expect(after?.client).toBeNull()
+    expect(after?.isConnected).toBe(false)
+  })
+
+  it('is a no-op when updateServer targets an unknown id', () => {
+    const createClient = async (): Promise<MCPClient> => fakeClient()
+    const { result } = renderProvider(createClient)
+
+    // No throw, no spurious entry inserted.
+    act(() => result.current.updateServer({ ...server, id: 'unknown' }))
+    expect(result.current.servers.some((s) => s.id === 'unknown')).toBe(false)
   })
 })
 

--- a/src/lib/mcp-provider.tsx
+++ b/src/lib/mcp-provider.tsx
@@ -55,8 +55,13 @@ type MCPContextType = {
    *  the stale client, redials with the new url/type and live credentials).
    *  Credentials (bearer or OAuth) live in `mcp_secrets`; `defaultCreateClient`
    *  re-reads them on every connect, so the redial picks up the new value too.
+   *  Set `forceRedial` when the caller just wrote credentials: the redial then
+   *  also chains onto any in-flight initial connect so the new credentials
+   *  aren't stranded behind a connect that read the old ones at its start.
+   *  Returns a promise that resolves once the reconcile (connect / reconnect /
+   *  chained reconnect) has settled — callers that don't care can ignore it.
    *  No-op when the id isn't tracked yet. */
-  updateServer: (server: MCPServer) => void
+  updateServer: (server: MCPServer, options?: { forceRedial?: boolean }) => Promise<void>
 }
 
 const MCPContext = createContext<MCPContextType | undefined>(undefined)
@@ -270,8 +275,10 @@ export const MCPProvider = ({ children, createClient: injectedCreateClient }: MC
    *  changes don't touch the row, so we always redial here even when fields
    *  are unchanged). The in-flight-with-matching-url guard suppresses a second
    *  createClient when an initial connect for the same target is already
-   *  underway. */
-  const updateServer = (server: MCPServer) => {
+   *  underway — unless `forceRedial` is set, in which case we chain a
+   *  reconnect onto the in-flight connect so a credential update written by
+   *  the caller before this call lands on the live client. */
+  const updateServer = async (server: MCPServer, options?: { forceRedial?: boolean }): Promise<void> => {
     const existing = serversRef.current.find((s) => s.id === server.id)
     if (!existing) {
       return
@@ -294,14 +301,19 @@ export const MCPProvider = ({ children, createClient: injectedCreateClient }: MC
     }
 
     if (!existing.enabled) {
-      void connectServer(server)
+      await connectServer(server)
       return
     }
 
-    if (connectsInFlight.current.has(server.id) && existing.url === server.url && existing.type === server.type) {
+    const inFlightConnect = connectsInFlight.current.get(server.id)
+    if (inFlightConnect && existing.url === server.url && existing.type === server.type) {
+      if (options?.forceRedial) {
+        await inFlightConnect
+        await reconnectServer(server.id)
+      }
       return
     }
-    void reconnectServer(server.id)
+    await reconnectServer(server.id)
   }
 
   /** Open a fresh connection for `serverId`, committing it only if the server is

--- a/src/lib/mcp-provider.tsx
+++ b/src/lib/mcp-provider.tsx
@@ -267,17 +267,7 @@ export const MCPProvider = ({ children, createClient: injectedCreateClient }: MC
     commitServers((prev) => prev.filter((s) => s.id !== serverId))
   }
 
-  /** Apply a row patch from settings or PowerSync sync and reconcile the live
-   *  connection. Disabled → disconnect; disabled→enabled → connectServer (so
-   *  it coalesces with an in-flight initial connect via `connectsInFlight`);
-   *  already-enabled → reconnectServer, which closes the stale client and
-   *  redials with the new url/type plus freshly-read credentials (mcp_secrets
-   *  changes don't touch the row, so we always redial here even when fields
-   *  are unchanged). The in-flight-with-matching-url guard suppresses a second
-   *  createClient when an initial connect for the same target is already
-   *  underway — unless `forceRedial` is set, in which case we chain a
-   *  reconnect onto the in-flight connect so a credential update written by
-   *  the caller before this call lands on the live client. */
+  /** See the `MCPContextType.updateServer` JSDoc for the full contract. */
   const updateServer = async (server: MCPServer, options?: { forceRedial?: boolean }): Promise<void> => {
     const existing = serversRef.current.find((s) => s.id === server.id)
     if (!existing) {

--- a/src/lib/mcp-provider.tsx
+++ b/src/lib/mcp-provider.tsx
@@ -49,7 +49,14 @@ type MCPContextType = {
   reconnectClient: ReconnectClient
   addServer: (server: MCPServer) => Promise<void>
   removeServer: (serverId: string) => void
-  updateServerStatus: (serverId: string, enabled: boolean) => void
+  /** Apply a row patch (rename / url / type / enabled) and reconcile the
+   *  connection: disabled → disconnect; disabled→enabled → connect (coalesces
+   *  with any in-flight initial connect); already-enabled → reconnect (closes
+   *  the stale client, redials with the new url/type and live credentials).
+   *  Credentials (bearer or OAuth) live in `mcp_secrets`; `defaultCreateClient`
+   *  re-reads them on every connect, so the redial picks up the new value too.
+   *  No-op when the id isn't tracked yet. */
+  updateServer: (server: MCPServer) => void
 }
 
 const MCPContext = createContext<MCPContextType | undefined>(undefined)
@@ -150,7 +157,7 @@ export const MCPProvider = ({ children, createClient: injectedCreateClient }: MC
 
     // Coalesce overlapping connects for the same server into one in-flight
     // promise. Two sync consumers can re-fire the enable→connect path before
-    // React flushes (the addServer→connect vs updateServerStatus(enable)→connect
+    // React flushes (the addServer→connect vs updateServer(enable)→connect
     // race), so without this a second createClient could cacheClient over a live
     // client without closing it — leaking the first connection.
     const inFlight = connectsInFlight.current.get(server.id)
@@ -255,22 +262,46 @@ export const MCPProvider = ({ children, createClient: injectedCreateClient }: MC
     commitServers((prev) => prev.filter((s) => s.id !== serverId))
   }
 
-  const updateServerStatus = (serverId: string, enabled: boolean) => {
-    const server = serversRef.current.find((s) => s.id === serverId)
-    if (!server) {
+  /** Apply a row patch from settings or PowerSync sync and reconcile the live
+   *  connection. Disabled → disconnect; disabled→enabled → connectServer (so
+   *  it coalesces with an in-flight initial connect via `connectsInFlight`);
+   *  already-enabled → reconnectServer, which closes the stale client and
+   *  redials with the new url/type plus freshly-read credentials (mcp_secrets
+   *  changes don't touch the row, so we always redial here even when fields
+   *  are unchanged). The in-flight-with-matching-url guard suppresses a second
+   *  createClient when an initial connect for the same target is already
+   *  underway. */
+  const updateServer = (server: MCPServer) => {
+    const existing = serversRef.current.find((s) => s.id === server.id)
+    if (!existing) {
       return
     }
 
-    if (enabled) {
-      connectServer({ ...server, enabled })
-    } else {
-      disconnectServer(serverId)
+    commitServers((prev) =>
+      prev.map((s) =>
+        s.id === server.id
+          ? { ...s, name: server.name, url: server.url, type: server.type, enabled: server.enabled }
+          : s,
+      ),
+    )
+
+    if (!server.enabled) {
+      disconnectServer(server.id)
       commitServers((prev) =>
-        prev.map((s) =>
-          s.id === serverId ? { ...s, client: null, isConnected: false, error: null, enabled: false } : s,
-        ),
+        prev.map((s) => (s.id === server.id ? { ...s, client: null, isConnected: false, error: null } : s)),
       )
+      return
     }
+
+    if (!existing.enabled) {
+      void connectServer(server)
+      return
+    }
+
+    if (connectsInFlight.current.has(server.id) && existing.url === server.url && existing.type === server.type) {
+      return
+    }
+    void reconnectServer(server.id)
   }
 
   /** Open a fresh connection for `serverId`, committing it only if the server is
@@ -373,7 +404,7 @@ export const MCPProvider = ({ children, createClient: injectedCreateClient }: MC
         reconnectClient,
         addServer,
         removeServer,
-        updateServerStatus,
+        updateServer,
       }}
     >
       {children}

--- a/src/lib/mcp-provider.tsx
+++ b/src/lib/mcp-provider.tsx
@@ -50,16 +50,20 @@ type MCPContextType = {
   addServer: (server: MCPServer) => Promise<void>
   removeServer: (serverId: string) => void
   /** Apply a row patch (rename / url / type / enabled) and reconcile the
-   *  connection: disabled → disconnect; disabled→enabled → connect (coalesces
-   *  with any in-flight initial connect); already-enabled → reconnect (closes
-   *  the stale client, redials with the new url/type and live credentials).
+   *  connection. The row patch is always applied; whether the live client
+   *  redials depends on what changed:
+   *    - disabled → disconnect;
+   *    - disabled→enabled → connect (coalesces with any in-flight initial connect);
+   *    - already-enabled + url or type changed → reconnect with the new endpoint;
+   *    - already-enabled + endpoint unchanged → no-op unless `forceRedial` is set,
+   *      because a pure metadata edit (rename) doesn't need to close a healthy client.
    *  Credentials (bearer or OAuth) live in `mcp_secrets`; `defaultCreateClient`
-   *  re-reads them on every connect, so the redial picks up the new value too.
-   *  Set `forceRedial` when the caller just wrote credentials: the redial then
-   *  also chains onto any in-flight initial connect so the new credentials
-   *  aren't stranded behind a connect that read the old ones at its start.
-   *  Returns a promise that resolves once the reconcile (connect / reconnect /
-   *  chained reconnect) has settled — callers that don't care can ignore it.
+   *  re-reads them on every connect. Set `forceRedial` when the caller just wrote
+   *  credentials so the redial fires even on the endpoint-unchanged path — and,
+   *  when an initial connect is still in-flight, chains onto it so the new
+   *  credentials aren't stranded behind a connect that read the old ones at its
+   *  start. Returns a promise that resolves once the reconcile (connect / reconnect /
+   *  chained reconnect / no-op) has settled — callers that don't care can ignore it.
    *  No-op when the id isn't tracked yet. */
   updateServer: (server: MCPServer, options?: { forceRedial?: boolean }) => Promise<void>
 }
@@ -295,13 +299,18 @@ export const MCPProvider = ({ children, createClient: injectedCreateClient }: MC
       return
     }
 
-    const inFlightConnect = connectsInFlight.current.get(server.id)
-    if (inFlightConnect && existing.url === server.url && existing.type === server.type) {
-      if (options?.forceRedial) {
-        await inFlightConnect
-        await reconnectServer(server.id)
-      }
+    const sameEndpoint = existing.url === server.url && existing.type === server.type
+    // Pure metadata edit (rename): the row patch above already applied — no need
+    // to churn the healthy client. Credentials-only edits opt back in via
+    // `forceRedial`, so the new bearer/OAuth value doesn't sit unused in mcp_secrets.
+    if (sameEndpoint && !options?.forceRedial) {
       return
+    }
+    // Chain onto an in-flight initial connect so a credentials write doesn't get
+    // stranded behind a connect that read the old credentials at its start.
+    const inFlightConnect = connectsInFlight.current.get(server.id)
+    if (inFlightConnect && sameEndpoint) {
+      await inFlightConnect
     }
     await reconnectServer(server.id)
   }

--- a/src/settings/mcp-servers.test.tsx
+++ b/src/settings/mcp-servers.test.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createMcpServer, getAllMcpServers } from '@/dal'
+import { createMcpServer, createMcpServerWithCredentials, getAllMcpServers, getMcpServerCredentials } from '@/dal'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
 import { renderWithReactivity, waitForElement } from '@/test-utils/powersync-reactivity-test'
@@ -281,6 +281,72 @@ describe('McpServersPage Add & Authorize', () => {
 
     // Dialog is gone — no lingering needs-oauth UI to trigger a duplicate add.
     expect(screen.queryByPlaceholderText('http://localhost:8000/mcp/')).not.toBeInTheDocument()
+  })
+})
+
+describe('McpServersPage Edit server', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('prefills the dialog from the existing server and persists the patch on Save', async () => {
+    const db = getDb()
+    const id = uuidv7()
+    await createMcpServerWithCredentials(
+      db,
+      { id, name: 'Original', type: 'http', url: 'https://old.example.com/mcp', enabled: 1 },
+      { type: 'bearer', token: 'original-token' },
+    )
+
+    renderWithReactivity(<McpServersPage deps={{ probeMcpServerTools: async () => ['search'] }} />, {
+      tables: ['mcp_servers', 'mcp_secrets'],
+      wrapper: McpProviderWrapper,
+    })
+
+    const editButton = await waitForElement(() => screen.queryByRole('button', { name: 'Edit server' }))
+    fireEvent.click(editButton)
+
+    // Dialog title flips to Edit and the existing values are surfaced — name in the
+    // visible input and token in the password field (URL stays read off the input).
+    expect(await waitForElement(() => screen.queryByText('Edit MCP Server'))).toBeInTheDocument()
+    const nameInput = screen.getByPlaceholderText('Server name (used to prefix tools)') as HTMLInputElement
+    const urlInput = screen.getByPlaceholderText('http://localhost:8000/mcp/') as HTMLInputElement
+    const tokenInput = screen.getByPlaceholderText('Bearer token or API key') as HTMLInputElement
+    expect(nameInput.value).toBe('Original')
+    expect(urlInput.value).toBe('https://old.example.com/mcp')
+    expect(tokenInput.value).toBe('original-token')
+    // Bulk-import toggle is hidden in Edit mode.
+    expect(screen.queryByRole('radio', { name: 'Advanced (JSON)' })).not.toBeInTheDocument()
+
+    // Rename and let the auto-probe fire so the success gate unlocks Save.
+    fireEvent.change(nameInput, { target: { value: 'Renamed' } })
+    await flushAutoProbe()
+    expect(screen.getByText('Connection successful!')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+      await getClock().runAllAsync()
+    })
+
+    const rows = await getAllMcpServers(db)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.id).toBe(id)
+    expect(rows[0]?.name).toBe('Renamed')
+    expect(rows[0]?.url).toBe('https://old.example.com/mcp')
+    // The prefilled bearer token survives an edit that doesn't touch it.
+    expect(await getMcpServerCredentials(db, id)).toEqual({ type: 'bearer', token: 'original-token' })
   })
 })
 

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -820,7 +820,13 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
                 <Button
                   onClick={handleUpdateServer}
                   disabled={
-                    !newServerUrl || !isUrlValid || testResult.kind !== 'success' || updateServerMutation.isPending
+                    !newServerUrl ||
+                    !isUrlValid ||
+                    // Connection-affecting fields untouched ⇒ existing credential
+                    // (including OAuth) is presumed valid; otherwise require a
+                    // fresh successful probe.
+                    (form.hasConnectionEdits && testResult.kind !== 'success') ||
+                    updateServerMutation.isPending
                   }
                 >
                   Save Changes

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -442,7 +442,11 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     // new url/type/credentials. useMcpSync would catch row changes eventually
     // via PowerSync, but credential-only edits don't touch the row at all —
     // updateServer's reconnect re-reads `mcp_secrets` so both paths converge.
-    updateServer({ id, name, url: newServerUrl, type: transport, enabled })
+    // forceRedial: the dialog may have just written new credentials. When the
+    // initial connect for this server is still in-flight, that connect read
+    // credentials at its start and would otherwise leave the new value
+    // stranded; the flag chains a reconnect onto it.
+    updateServer({ id, name, url: newServerUrl, type: transport, enabled }, { forceRedial: true })
     form.resetAddDialog()
     resetLocalDialogState()
   }

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -27,6 +27,7 @@ import {
   createMcpServerWithCredentials,
   deleteMcpServer,
   getRemoteMcpServers,
+  updateMcpServerWithCredentials,
 } from '@/dal'
 import type { McpServerCredentials } from '@/dal/mcp-secrets'
 import { useDatabase } from '@/contexts'
@@ -36,7 +37,7 @@ import { type McpServer } from '@/types'
 import { useMutation } from '@tanstack/react-query'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { eq } from 'drizzle-orm'
-import { Check, Copy, Globe, LockKeyhole, Plus, RefreshCw, Server, Trash2, X } from 'lucide-react'
+import { Check, Copy, Globe, LockKeyhole, Pencil, Plus, RefreshCw, Server, Trash2, X } from 'lucide-react'
 import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 import { v7 as uuidv7 } from 'uuid'
@@ -281,6 +282,19 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     return acc
   }, {})
 
+  // Prefill source for Edit: the on-device bearer token (if the stored credential
+  // is bearer). OAuth credentials are intentionally not surfaced — the token UI
+  // only accepts bearer values, and OAuth is managed via the Authorize buttons.
+  const bearerTokenById = mcpSecrets.reduce<Record<string, string>>((acc, row) => {
+    if (row.credentials) {
+      const cred = JSON.parse(row.credentials) as McpServerCredentials
+      if (cred.type === 'bearer') {
+        acc[row.id] = cred.token
+      }
+    }
+    return acc
+  }, {})
+
   // Tools for connected servers. The query keys on each CONNECTION's identity
   // (`id:generation`, where the generation changes whenever the provider swaps in
   // a fresh client instance) — keying on the id set alone would serve the dead
@@ -332,6 +346,36 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     },
   })
 
+  const updateServerMutation = useMutation({
+    mutationFn: async ({
+      id,
+      name,
+      url,
+      transport,
+      token,
+      originalCredentialType,
+    }: {
+      id: string
+      name: string
+      url: string
+      transport: MCPTransportType
+      token: string
+      originalCredentialType: StoredCredentialType
+    }) => {
+      // Credential semantics on edit:
+      //   - token filled → store as bearer (replaces any prior credential, OAuth included)
+      //   - token blank + originally bearer → delete the credential (user cleared the field)
+      //   - token blank + originally oauth/none → leave the credential alone, so a rename
+      //     of an OAuth-authorized server doesn't wipe its tokens
+      const credentials = token
+        ? ({ type: 'bearer', token } as const)
+        : originalCredentialType === 'bearer'
+          ? null
+          : undefined
+      await updateMcpServerWithCredentials(db, id, { name, url, type: transport }, credentials)
+    },
+  })
+
   const importServersMutation = useMutation({
     mutationFn: async (parsed: ParsedMcpServer[]): Promise<void> => {
       await createMcpServersWithCredentials(
@@ -372,6 +416,26 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     await addServerMutation.mutateAsync({ id: uuidv7(), name: resolveServerName(), url: newServerUrl })
     form.resetAddDialog()
     resetLocalDialogState()
+  }
+
+  const handleUpdateServer = async () => {
+    if (!form.editingServerId || !newServerUrl || !isUrlValid) {
+      return
+    }
+    await updateServerMutation.mutateAsync({
+      id: form.editingServerId,
+      name: resolveServerName(),
+      url: newServerUrl,
+      transport: newServerTransport,
+      token: newServerToken,
+      originalCredentialType: credentialTypeById[form.editingServerId] ?? 'none',
+    })
+    form.resetAddDialog()
+    resetLocalDialogState()
+  }
+
+  const handleEditClick = (server: McpServer) => {
+    form.openEditDialog(server, bearerTokenById[server.id] ?? null)
   }
 
   /**
@@ -431,8 +495,8 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
       if (testResult.kind === 'idle' && newServerUrl && isUrlValid) {
         testConnection()
       } else if (testResult.kind === 'success') {
-        handleAddServer()
-      } else if (testResult.kind === 'needs-oauth') {
+        form.editingServerId ? handleUpdateServer() : handleAddServer()
+      } else if (testResult.kind === 'needs-oauth' && !form.editingServerId) {
         handleAddAndAuthorize()
       }
     }
@@ -586,30 +650,35 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
           </DialogTrigger>
           <ResponsiveModalContentComposable className="sm:max-w-[500px] max-h-[85vh]">
             <ResponsiveModalHeader>
-              <ResponsiveModalTitle>Add MCP Server</ResponsiveModalTitle>
-              <ResponsiveModalDescription className="sr-only">Add a new MCP server</ResponsiveModalDescription>
+              <ResponsiveModalTitle>{form.editingServerId ? 'Edit MCP Server' : 'Add MCP Server'}</ResponsiveModalTitle>
+              <ResponsiveModalDescription className="sr-only">
+                {form.editingServerId ? 'Edit MCP server' : 'Add a new MCP server'}
+              </ResponsiveModalDescription>
             </ResponsiveModalHeader>
 
-            <ToggleGroup
-              type="single"
-              variant="outline"
-              value={mode}
-              onValueChange={(value) => {
-                if (value !== 'simple' && value !== 'advanced') {
-                  return
-                }
-                // Each mode owns a different error source (JSON import vs OAuth
-                // authorization). Clear both on switch so a stale message from the
-                // mode you're leaving can't surface under the new mode's UI.
-                setImportError(null)
-                clearDialogError()
-                setMode(value)
-              }}
-              className="w-full flex-shrink-0"
-            >
-              <ToggleGroupItem value="simple">Simple</ToggleGroupItem>
-              <ToggleGroupItem value="advanced">Advanced (JSON)</ToggleGroupItem>
-            </ToggleGroup>
+            {/* Advanced (JSON) is bulk-import only — irrelevant when editing a single server. */}
+            {!form.editingServerId && (
+              <ToggleGroup
+                type="single"
+                variant="outline"
+                value={mode}
+                onValueChange={(value) => {
+                  if (value !== 'simple' && value !== 'advanced') {
+                    return
+                  }
+                  // Each mode owns a different error source (JSON import vs OAuth
+                  // authorization). Clear both on switch so a stale message from the
+                  // mode you're leaving can't surface under the new mode's UI.
+                  setImportError(null)
+                  clearDialogError()
+                  setMode(value)
+                }}
+                className="w-full flex-shrink-0"
+              >
+                <ToggleGroupItem value="simple">Simple</ToggleGroupItem>
+                <ToggleGroupItem value="advanced">Advanced (JSON)</ToggleGroupItem>
+              </ToggleGroup>
+            )}
 
             <div className="flex-1 overflow-y-auto px-1 -mx-1">
               {mode === 'simple' ? (
@@ -747,7 +816,16 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
               >
                 Cancel
               </Button>
-              {mode === 'advanced' ? (
+              {form.editingServerId ? (
+                <Button
+                  onClick={handleUpdateServer}
+                  disabled={
+                    !newServerUrl || !isUrlValid || testResult.kind !== 'success' || updateServerMutation.isPending
+                  }
+                >
+                  Save Changes
+                </Button>
+              ) : mode === 'advanced' ? (
                 <Button onClick={handleImportConfig} disabled={!jsonText.trim() || importServersMutation.isPending}>
                   Import Servers
                 </Button>
@@ -906,6 +984,22 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
                       </TooltipTrigger>
                       <TooltipContent side="bottom">
                         <p>{isEnabled ? 'Disable server' : 'Enable server'}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          aria-label="Edit server"
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 w-8 p-0"
+                          onClick={() => handleEditClick(server)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        <p>Edit server</p>
                       </TooltipContent>
                     </Tooltip>
                     <Popover

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -38,7 +38,7 @@ import { useMutation } from '@tanstack/react-query'
 import { useQuery } from '@powersync/tanstack-react-query'
 import { eq } from 'drizzle-orm'
 import { Check, Copy, Globe, LockKeyhole, Pencil, Plus, RefreshCw, Server, Trash2, X } from 'lucide-react'
-import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 import { v7 as uuidv7 } from 'uuid'
 import { probeMcpServerTools } from '@/lib/mcp-connection-test'
@@ -198,6 +198,7 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
   const [mode, setMode] = useState<AddServerMode>('simple')
   const [jsonText, setJsonText] = useState('')
   const [importError, setImportError] = useState<string | null>(null)
+  const [updateError, setUpdateError] = useState<string | null>(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState<string | null>(null)
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null)
   const [retryingServerId, setRetryingServerId] = useState<string | null>(null)
@@ -251,16 +252,20 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
   // In simple mode the URL gates auto-detect / Add; advanced mode imports raw JSON.
   const urlValidation = newServerUrl ? validateMcpServerUrl(newServerUrl) : null
   const isUrlValid = urlValidation?.ok === true
+  const isUrlReady = !!newServerUrl && isUrlValid
 
-  // The add-dialog surfaces at most one error: a JSON import failure (advanced) or
-  // an OAuth authorization failure (simple). The title is derived from the error
-  // itself — not the current mode — so a message is always labeled by its own
-  // context (switching modes clears the other source, see the mode toggle).
+  // The add-dialog surfaces at most one error: a JSON import failure (advanced),
+  // an Edit save failure (Save Changes), or an OAuth authorization failure. The
+  // title is derived from the error itself — not the current mode — so a message
+  // is always labeled by its own context (switching modes clears the other
+  // sources, see the mode toggle).
   const addDialogError = importError
     ? { title: 'Import failed', body: importError }
-    : dialogError
-      ? { title: 'Authorization error', body: dialogError }
-      : null
+    : updateError
+      ? { title: 'Save failed', body: updateError }
+      : dialogError
+        ? { title: 'Authorization error', body: dialogError }
+        : null
 
   // TODO: Add support for stdio servers
   const { data: servers = [] } = useQuery({
@@ -268,32 +273,28 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     query: toCompilableQuery(getRemoteMcpServers(db)),
   })
 
-  // Reactively track the STORED credential type per server so the card can apply
-  // the auth precedence (oauth → authorized/needs-auth; bearer-401 → generic
-  // error; none-401 → needs-auth). Reads the local-only mcp_secrets table.
+  // Reactively track each server's stored credential in one pass. `type` drives
+  // the card's auth precedence (oauth → authorized/needs-auth; bearer-401 →
+  // generic error; none-401 → needs-auth). `bearerToken` prefills the Edit
+  // dialog's token field — OAuth credentials are intentionally not surfaced
+  // there, since the token UI only accepts bearer values and OAuth is managed
+  // via the Authorize buttons. Reads the local-only mcp_secrets table.
   const { data: mcpSecrets = [] } = useQuery({
     queryKey: ['mcp-secrets'],
     query: toCompilableQuery(db.select().from(mcpSecretsTable)),
   })
-  const credentialTypeById = mcpSecrets.reduce<Record<string, StoredCredentialType>>((acc, row) => {
-    if (row.credentials) {
-      acc[row.id] = (JSON.parse(row.credentials) as McpServerCredentials).type
-    }
-    return acc
-  }, {})
-
-  // Prefill source for Edit: the on-device bearer token (if the stored credential
-  // is bearer). OAuth credentials are intentionally not surfaced — the token UI
-  // only accepts bearer values, and OAuth is managed via the Authorize buttons.
-  const bearerTokenById = mcpSecrets.reduce<Record<string, string>>((acc, row) => {
-    if (row.credentials) {
-      const cred = JSON.parse(row.credentials) as McpServerCredentials
-      if (cred.type === 'bearer') {
-        acc[row.id] = cred.token
-      }
-    }
-    return acc
-  }, {})
+  const credentialsById = useMemo(
+    () =>
+      mcpSecrets.reduce<Record<string, { type: StoredCredentialType; bearerToken?: string }>>((acc, row) => {
+        if (!row.credentials) {
+          return acc
+        }
+        const cred = JSON.parse(row.credentials) as McpServerCredentials
+        acc[row.id] = cred.type === 'bearer' ? { type: 'bearer', bearerToken: cred.token } : { type: cred.type }
+        return acc
+      }, {}),
+    [mcpSecrets],
+  )
 
   // Tools for connected servers. The query keys on each CONNECTION's identity
   // (`id:generation`, where the generation changes whenever the provider swaps in
@@ -401,16 +402,17 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     },
   })
 
-  // Clears add-dialog local state (mode, JSON text, import error) in sync with
+  // Clears add-dialog local state (mode, JSON text, dialog errors) in sync with
   // the external form hook's resetAddDialog so a re-open always starts clean.
   const resetLocalDialogState = () => {
     setMode('simple')
     setJsonText('')
     setImportError(null)
+    setUpdateError(null)
   }
 
   const handleAddServer = async () => {
-    if (!newServerUrl || !isUrlValid) {
+    if (!isUrlReady) {
       return
     }
     await addServerMutation.mutateAsync({ id: uuidv7(), name: resolveServerName(), url: newServerUrl })
@@ -419,25 +421,36 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
   }
 
   const handleUpdateServer = async () => {
-    if (!form.editingServerId || !newServerUrl || !isUrlValid) {
+    if (!form.editingServerId || !isUrlReady) {
       return
     }
     const id = form.editingServerId
+    // Read enabled from the DB row (source of truth), not the provider's
+    // in-memory state — the provider can be briefly stale right after a toggle,
+    // and the dialog doesn't own the enabled bit. If the row disappeared
+    // between dialog open and save (e.g. deleted from another device), bail.
+    const dbRow = servers.find((s) => s.id === id)
+    if (!dbRow) {
+      return
+    }
     const name = resolveServerName()
     const transport = newServerTransport
-    // Carry the current enabled flag through. The row's enabled bit isn't part
-    // of this dialog, so we mirror the in-memory state to avoid an inadvertent
-    // toggle. Falls back to enabled=true for a defensively-missing entry.
-    const existing = mcpServers.find((s) => s.id === id)
-    const enabled = existing?.enabled ?? true
-    await updateServerMutation.mutateAsync({
-      id,
-      name,
-      url: newServerUrl,
-      transport,
-      token: newServerToken,
-      originalCredentialType: credentialTypeById[id] ?? 'none',
-    })
+    const enabled = dbRow.enabled === 1
+    setUpdateError(null)
+    try {
+      await updateServerMutation.mutateAsync({
+        id,
+        name,
+        url: newServerUrl,
+        transport,
+        token: newServerToken,
+        originalCredentialType: credentialsById[id]?.type ?? 'none',
+      })
+    } catch (error) {
+      console.error('Failed to update MCP server:', error)
+      setUpdateError('Could not save changes. Please try again.')
+      return
+    }
     // Push the patch into the MCP provider so the live client redials with the
     // new url/type/credentials. useMcpSync would catch row changes eventually
     // via PowerSync, but credential-only edits don't touch the row at all —
@@ -452,7 +465,8 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
   }
 
   const handleEditClick = (server: McpServer) => {
-    form.openEditDialog(server, bearerTokenById[server.id] ?? null)
+    const cred = credentialsById[server.id]
+    form.openEditDialog(server, cred?.bearerToken ?? null, cred?.type ?? 'none')
   }
 
   /**
@@ -487,7 +501,7 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
    * server row also surfaces an Authorize action on its card.
    */
   const handleAddAndAuthorize = async () => {
-    if (!newServerUrl || !isUrlValid) {
+    if (!isUrlReady) {
       return
     }
     const url = newServerUrl
@@ -511,19 +525,27 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
       return
     }
     e.preventDefault()
-    // Metadata-only edit (rename / no connection change): Save Changes is the
-    // button's enabled state regardless of testResult, so Enter must mirror it
-    // — otherwise pressing Enter after a rename does nothing while the button
-    // would have saved.
-    if (form.editingServerId && !form.hasConnectionEdits && newServerUrl && isUrlValid) {
+    // Edit-mode: Enter mirrors the Save Changes button's enabled state — save
+    // whenever the button would (metadata-only OR bearer-clear, both of which
+    // waive the probe requirement) so a rename or an auth removal doesn't fall
+    // through to the probe branches below.
+    if (form.editingServerId && isUrlReady && (!form.hasConnectionEdits || form.isClearingBearerOnly)) {
       handleUpdateServer()
       return
     }
-    if (testResult.kind === 'idle' && newServerUrl && isUrlValid) {
+    if (testResult.kind === 'idle' && isUrlReady) {
       testConnection()
-    } else if (testResult.kind === 'success') {
-      form.editingServerId ? handleUpdateServer() : handleAddServer()
-    } else if (testResult.kind === 'needs-oauth' && !form.editingServerId) {
+      return
+    }
+    if (testResult.kind === 'success') {
+      if (form.editingServerId) {
+        handleUpdateServer()
+      } else {
+        handleAddServer()
+      }
+      return
+    }
+    if (testResult.kind === 'needs-oauth' && !form.editingServerId) {
       handleAddAndAuthorize()
     }
   }
@@ -640,7 +662,7 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     const conn = mcpServers.find((s) => s.id === server.id)
     const decision = deriveOAuthCardDecision({
       isConnected: conn?.isConnected ?? false,
-      credentialType: credentialTypeById[server.id] ?? 'none',
+      credentialType: credentialsById[server.id]?.type ?? 'none',
       error: conn?.error,
       needsReauth: isNeedsReauthError(conn?.error),
     })
@@ -652,6 +674,9 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     }
     return null
   }
+
+  const dialogTitle = form.editingServerId ? 'Edit MCP Server' : 'Add MCP Server'
+  const dialogDescription = form.editingServerId ? 'Edit MCP server configuration' : 'Add a new MCP server'
 
   return (
     <div className="flex flex-col gap-6 p-4 w-full max-w-[760px] mx-auto">
@@ -676,10 +701,8 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
           </DialogTrigger>
           <ResponsiveModalContentComposable className="sm:max-w-[500px] max-h-[85vh]">
             <ResponsiveModalHeader>
-              <ResponsiveModalTitle>{form.editingServerId ? 'Edit MCP Server' : 'Add MCP Server'}</ResponsiveModalTitle>
-              <ResponsiveModalDescription className="sr-only">
-                {form.editingServerId ? 'Edit MCP server' : 'Add a new MCP server'}
-              </ResponsiveModalDescription>
+              <ResponsiveModalTitle>{dialogTitle}</ResponsiveModalTitle>
+              <ResponsiveModalDescription className="sr-only">{dialogDescription}</ResponsiveModalDescription>
             </ResponsiveModalHeader>
 
             {/* Advanced (JSON) is bulk-import only — irrelevant when editing a single server. */}
@@ -693,9 +716,11 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
                     return
                   }
                   // Each mode owns a different error source (JSON import vs OAuth
-                  // authorization). Clear both on switch so a stale message from the
-                  // mode you're leaving can't surface under the new mode's UI.
+                  // authorization vs Save-Changes). Clear all on switch so a stale
+                  // message from the mode you're leaving can't surface under the new
+                  // mode's UI.
                   setImportError(null)
+                  setUpdateError(null)
                   clearDialogError()
                   setMode(value)
                 }}
@@ -762,7 +787,7 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
                     />
                   </div>
 
-                  {newServerUrl && isUrlValid && (
+                  {isUrlReady && (
                     <Button
                       onClick={testConnection}
                       disabled={isTestingConnection}
@@ -846,12 +871,14 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
                 <Button
                   onClick={handleUpdateServer}
                   disabled={
-                    !newServerUrl ||
-                    !isUrlValid ||
+                    !isUrlReady ||
                     // Connection-affecting fields untouched ⇒ existing credential
-                    // (including OAuth) is presumed valid; otherwise require a
-                    // fresh successful probe.
-                    (form.hasConnectionEdits && testResult.kind !== 'success') ||
+                    // (including OAuth) is presumed valid — save without a fresh
+                    // probe. Same waiver for a bearer-removal edit: an unauth
+                    // probe would fail against a still-protected server, but the
+                    // mutation deletes the credential row on blank token, so the
+                    // save is exactly the intended action.
+                    (form.hasConnectionEdits && !form.isClearingBearerOnly && testResult.kind !== 'success') ||
                     updateServerMutation.isPending
                   }
                 >
@@ -862,18 +889,12 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
                   Import Servers
                 </Button>
               ) : testResult.kind === 'needs-oauth' ? (
-                <Button
-                  onClick={handleAddAndAuthorize}
-                  disabled={!newServerUrl || !isUrlValid || isAddAuthorizePending}
-                >
+                <Button onClick={handleAddAndAuthorize} disabled={!isUrlReady || isAddAuthorizePending}>
                   <LockKeyhole className="h-3.5 w-3.5 mr-1.5" />
                   Add &amp; Authorize
                 </Button>
               ) : (
-                <Button
-                  onClick={handleAddServer}
-                  disabled={!newServerUrl || !isUrlValid || testResult.kind !== 'success'}
-                >
+                <Button onClick={handleAddServer} disabled={!isUrlReady || testResult.kind !== 'success'}>
                   Add Server
                 </Button>
               )}

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -192,7 +192,7 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
   // Read provider connection state read-only for status display. Sync ownership
   // lives in the single global useMcpSync() in AppContent — running it here too
   // would re-run the reconciliation effect and double-register servers.
-  const { servers: mcpServers, reconnectServer } = useMCP()
+  const { servers: mcpServers, reconnectServer, updateServer } = useMCP()
   const location = useLocation()
   const navigate = useNavigate()
   const [mode, setMode] = useState<AddServerMode>('simple')
@@ -422,14 +422,27 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     if (!form.editingServerId || !newServerUrl || !isUrlValid) {
       return
     }
+    const id = form.editingServerId
+    const name = resolveServerName()
+    const transport = newServerTransport
+    // Carry the current enabled flag through. The row's enabled bit isn't part
+    // of this dialog, so we mirror the in-memory state to avoid an inadvertent
+    // toggle. Falls back to enabled=true for a defensively-missing entry.
+    const existing = mcpServers.find((s) => s.id === id)
+    const enabled = existing?.enabled ?? true
     await updateServerMutation.mutateAsync({
-      id: form.editingServerId,
-      name: resolveServerName(),
+      id,
+      name,
       url: newServerUrl,
-      transport: newServerTransport,
+      transport,
       token: newServerToken,
-      originalCredentialType: credentialTypeById[form.editingServerId] ?? 'none',
+      originalCredentialType: credentialTypeById[id] ?? 'none',
     })
+    // Push the patch into the MCP provider so the live client redials with the
+    // new url/type/credentials. useMcpSync would catch row changes eventually
+    // via PowerSync, but credential-only edits don't touch the row at all —
+    // updateServer's reconnect re-reads `mcp_secrets` so both paths converge.
+    updateServer({ id, name, url: newServerUrl, type: transport, enabled })
     form.resetAddDialog()
     resetLocalDialogState()
   }
@@ -490,15 +503,24 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
   }
 
   const handleUrlKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      if (testResult.kind === 'idle' && newServerUrl && isUrlValid) {
-        testConnection()
-      } else if (testResult.kind === 'success') {
-        form.editingServerId ? handleUpdateServer() : handleAddServer()
-      } else if (testResult.kind === 'needs-oauth' && !form.editingServerId) {
-        handleAddAndAuthorize()
-      }
+    if (e.key !== 'Enter') {
+      return
+    }
+    e.preventDefault()
+    // Metadata-only edit (rename / no connection change): Save Changes is the
+    // button's enabled state regardless of testResult, so Enter must mirror it
+    // — otherwise pressing Enter after a rename does nothing while the button
+    // would have saved.
+    if (form.editingServerId && !form.hasConnectionEdits && newServerUrl && isUrlValid) {
+      handleUpdateServer()
+      return
+    }
+    if (testResult.kind === 'idle' && newServerUrl && isUrlValid) {
+      testConnection()
+    } else if (testResult.kind === 'success') {
+      form.editingServerId ? handleUpdateServer() : handleAddServer()
+    } else if (testResult.kind === 'needs-oauth' && !form.editingServerId) {
+      handleAddAndAuthorize()
     }
   }
 

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -526,10 +526,14 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     }
     e.preventDefault()
     // Edit-mode: Enter mirrors the Save Changes button's enabled state — save
-    // whenever the button would (metadata-only OR bearer-clear, both of which
-    // waive the probe requirement) so a rename or an auth removal doesn't fall
-    // through to the probe branches below.
-    if (form.editingServerId && isUrlReady && (!form.hasConnectionEdits || form.isClearingBearerOnly)) {
+    // whenever the button would (metadata-only OR bearer-clear OR OAuth edit with
+    // empty token, all of which waive the probe requirement) so those cases don't
+    // fall through to the probe branches below.
+    if (
+      form.editingServerId &&
+      isUrlReady &&
+      (!form.hasConnectionEdits || form.isClearingBearerOnly || form.isOAuthEdit)
+    ) {
       handleUpdateServer()
       return
     }
@@ -874,11 +878,17 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
                     !isUrlReady ||
                     // Connection-affecting fields untouched ⇒ existing credential
                     // (including OAuth) is presumed valid — save without a fresh
-                    // probe. Same waiver for a bearer-removal edit: an unauth
-                    // probe would fail against a still-protected server, but the
-                    // mutation deletes the credential row on blank token, so the
-                    // save is exactly the intended action.
-                    (form.hasConnectionEdits && !form.isClearingBearerOnly && testResult.kind !== 'success') ||
+                    // probe. Same waiver for a bearer-removal edit (unauth probe
+                    // fails against a still-protected server; the mutation deletes
+                    // the credential row on blank token) and an OAuth-edit with
+                    // empty token (probe can never succeed without a bearer, and
+                    // the OAuth credential is preserved by the mutation — the
+                    // card's needs-auth flow handles a re-authorize at the new
+                    // endpoint post-save).
+                    (form.hasConnectionEdits &&
+                      !form.isClearingBearerOnly &&
+                      !form.isOAuthEdit &&
+                      testResult.kind !== 'success') ||
                     updateServerMutation.isPending
                   }
                 >

--- a/src/settings/mcp-servers.tsx
+++ b/src/settings/mcp-servers.tsx
@@ -455,11 +455,11 @@ export default function McpServersPage({ deps = {} }: { deps?: McpServersPageDep
     // new url/type/credentials. useMcpSync would catch row changes eventually
     // via PowerSync, but credential-only edits don't touch the row at all —
     // updateServer's reconnect re-reads `mcp_secrets` so both paths converge.
-    // forceRedial: the dialog may have just written new credentials. When the
-    // initial connect for this server is still in-flight, that connect read
-    // credentials at its start and would otherwise leave the new value
-    // stranded; the flag chains a reconnect onto it.
-    updateServer({ id, name, url: newServerUrl, type: transport, enabled }, { forceRedial: true })
+    // forceRedial only when a connection-affecting field was actually edited:
+    // for a pure metadata save (rename), skipping it lets the provider keep the
+    // healthy client and just apply the row patch, so an active tool call
+    // against this server isn't dropped by an unnecessary reconnect.
+    updateServer({ id, name, url: newServerUrl, type: transport, enabled }, { forceRedial: form.hasConnectionEdits })
     form.resetAddDialog()
     resetLocalDialogState()
   }


### PR DESCRIPTION
Adds an Edit action to the MCP servers settings page so users can update an existing server's config (name, URL, headers, credentials) without deleting and re-adding it.

- New `updateMcpServer` DAL helper + tests.
- `useAddServerForm` reused for both add and edit; the dialog opens prefilled when editing.

Fixes THU-618.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP connection lifecycle (reconnect, in-flight connect coalescing, credential writes) and local secret handling; well-covered by new tests but mis-sync could leave stale clients or wrong auth.
> 
> **Overview**
> Users can **edit** existing MCP servers from settings (pencil on each card) instead of delete-and-re-add. The shared add dialog runs in **Edit** mode with prefilled name, URL, transport, and bearer token; JSON bulk-import is hidden while editing.
> 
> **Persistence:** New DAL helpers `updateMcpServer` / `updateMcpServerWithCredentials` patch server rows and optionally replace, delete, or leave `mcp_secrets` credentials unchanged (so OAuth tokens aren’t wiped on rename-only saves).
> 
> **Save UX:** `useAddServerForm` tracks `hasConnectionEdits` so **metadata-only** changes (e.g. rename) can save without a new successful probe; renames no longer clear a passing test result. Connection field changes still require test success before save.
> 
> **Live connections:** `updateServerStatus` is replaced by **`updateServer`**, which patches in-memory config and reconnects when enabled (URL/transport/credential changes). Settings calls it with **`forceRedial`** after save so credential-only updates apply even if an initial connect is still in flight. **`useMcpSync`** now diffs name/url/type/enabled and calls `updateServer`, not just enable toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437a5db8a0285683ccc36fb474fde781df23c072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->