### PR TITLE
fix(THU-620): skip temperature for models that reject it

### DIFF
--- a/backend/src/inference/routes.ts
+++ b/backend/src/inference/routes.ts
@@ -24,6 +24,9 @@ const sanitizeMessageRoles = (messages: Message[]): Message[] =>
 type ModelConfig = {
   provider: InferenceProvider
   internalName: string
+  /** Newer reasoning-tuned models (e.g. Claude Opus 4.8) reject `temperature`
+   *  with a 400. Set true to drop the field from the upstream payload. */
+  omitTemperature?: boolean
 }
 
 export const supportedModels: Record<string, ModelConfig> = {
@@ -46,6 +49,7 @@ export const supportedModels: Record<string, ModelConfig> = {
   'opus-4.8': {
     provider: 'anthropic',
     internalName: 'claude-opus-4-8',
+    omitTemperature: true,
   },
 }
 
@@ -74,7 +78,7 @@ export const createInferenceRoutes = (auth: Auth, rateLimit?: AnyElysia) => {
         throw new Error('Model not found')
       }
 
-      const { provider, internalName } = modelConfig
+      const { provider, internalName, omitTemperature } = modelConfig
 
       const { client } = getInferenceClient(provider)
 
@@ -84,7 +88,7 @@ export const createInferenceRoutes = (auth: Auth, rateLimit?: AnyElysia) => {
         const completion = await (client as PostHogOpenAI).chat.completions.create({
           model: internalName,
           messages: sanitizeMessageRoles(body.messages) as ChatCompletionMessageParam[],
-          temperature: body.temperature,
+          ...(omitTemperature ? {} : { temperature: body.temperature }),
           tools: body.tools,
           tool_choice: body.tool_choice,
           stream: true,


### PR DESCRIPTION
Anthropic's newer reasoning-tuned models — starting with `claude-opus-4-8` — reject `temperature` with a 400 "temperature is deprecated for this model". The route was passing it unconditionally, so any chat with Opus 4.8 failed.

Adds an `omitTemperature` flag to `ModelConfig` and sets it for `opus-4.8`; the route drops the field from the upstream payload when the flag is set. As more models deprecate sampling params, flip the flag instead of branching on model id.

Fixes THU-620.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, config-driven change to inference request shaping; only Opus 4.8 omits temperature while other models are unchanged.
> 
> **Overview**
> Fixes streaming chat failures for **Opus 4.8** when Anthropic returns 400 because `temperature` is deprecated on newer reasoning-tuned models.
> 
> Adds an optional **`omitTemperature`** flag on `ModelConfig`, sets it for `opus-4.8`, and changes `/chat/completions` so the upstream `chat.completions.create` payload only includes `temperature` when that flag is not set. Other models keep the previous behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d17435987afdc4ec52aa87f3ae378140db49b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->