### PR TITLE
chore(THU-621): bump Tinfoil GLM default to 5.2

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -102,6 +102,15 @@ export const getSystemTinfoilClient = async (): Promise<SecureClient> => {
   return client
 }
 
+/** Drop the cached `SecureClient` so the next send constructs a fresh one with
+ *  a new attestation context. Use when a key-config error keeps repeating
+ *  inside the SDK's own reset+retry — the cached client's transport is wedged
+ *  and only a brand-new instance breaks the cycle. */
+const evictSystemTinfoilClient = (): void => {
+  const cloudUrl = getLocalSetting('cloudUrl').replace(/\/$/, '')
+  systemTinfoilClients.delete(cloudUrl)
+}
+
 export const getTinfoilClient = async (): Promise<SecureClient> => {
   if (!userTinfoilClient) {
     const { SecureClient } = await import('tinfoil')
@@ -110,6 +119,16 @@ export const getTinfoilClient = async (): Promise<SecureClient> => {
   await userTinfoilClient.ready()
   return userTinfoilClient
 }
+
+const evictUserTinfoilClient = (): void => {
+  userTinfoilClient = null
+}
+
+/** A KeyConfigMismatchError that survives the SDK's internal reset+retry means
+ *  our cached `SecureClient` has a wedged transport. Evict it so the next call
+ *  builds a fresh instance with a brand-new attestation context. */
+const isKeyConfigMismatchError = (err: unknown): boolean =>
+  err instanceof Error && err.name === 'KeyConfigMismatchError'
 
 /** Reconnect a dropped MCP client; returns a fresh client or null. Supplied by
  *  the MCP provider via the chat store. See `src/lib/mcp-provider.tsx`. */
@@ -334,7 +353,7 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
         const sso = isSsoMode()
         const token = getAuthToken()
         const wrappedFetch: typeof fetch = Object.assign(
-          (input: RequestInfo | URL, init?: RequestInit) => {
+          async (input: RequestInfo | URL, init?: RequestInit) => {
             const headers = new Headers(init?.headers)
             const upstreamInit: RequestInit = { ...init, headers }
             if (sso && !token) {
@@ -343,7 +362,14 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
             } else if (token) {
               headers.set('Authorization', `Bearer ${token}`)
             }
-            return client.fetch(input, upstreamInit)
+            try {
+              return await client.fetch(input, upstreamInit)
+            } catch (err) {
+              if (isKeyConfigMismatchError(err)) {
+                evictSystemTinfoilClient()
+              }
+              throw err
+            }
           },
           { preconnect: fetch.preconnect },
         )
@@ -359,11 +385,24 @@ export const createModel = async (modelConfig: Model, getProxyFetch: () => Fetch
         throw new Error('No API key provided')
       }
       const client = await getTinfoilClient()
+      const evictingFetch: typeof fetch = Object.assign(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          try {
+            return await client.fetch(input, init)
+          } catch (err) {
+            if (isKeyConfigMismatchError(err)) {
+              evictUserTinfoilClient()
+            }
+            throw err
+          }
+        },
+        { preconnect: fetch.preconnect },
+      )
       const tinfoil = createOpenAICompatible({
         name: 'tinfoil',
         baseURL: client.getBaseURL()!,
         apiKey: modelConfig.apiKey,
-        fetch: client.fetch,
+        fetch: evictingFetch,
       })
       return tinfoil(modelConfig.model)
     }

--- a/src/defaults/model-profiles.ts
+++ b/src/defaults/model-profiles.ts
@@ -4,7 +4,7 @@
 
 export {
   defaultModelProfileDeepseekV4Pro,
-  defaultModelProfileGlm51,
+  defaultModelProfileGlm52,
   defaultModelProfileKimiK26,
   defaultModelProfileOpus48,
   defaultModelProfiles,

--- a/src/defaults/model-profiles/glm.ts
+++ b/src/defaults/model-profiles/glm.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { ModelProfile } from '@/types'
-import { defaultModelGlm51 } from '@/defaults/models'
+import { defaultModelGlm52 } from '@/defaults/models'
 
-export const defaultModelProfileGlm51: ModelProfile = {
-  modelId: defaultModelGlm51.id,
+export const defaultModelProfileGlm52: ModelProfile = {
+  modelId: defaultModelGlm52.id,
   temperature: 0.2,
   maxSteps: 20,
   maxAttempts: 2,

--- a/src/defaults/model-profiles/index.ts
+++ b/src/defaults/model-profiles/index.ts
@@ -5,12 +5,12 @@
 import { hashValues } from '@/lib/utils'
 import type { ModelProfile } from '@/types'
 import { defaultModelProfileDeepseekV4Pro } from './deepseek'
-import { defaultModelProfileGlm51 } from './glm'
+import { defaultModelProfileGlm52 } from './glm'
 import { defaultModelProfileKimiK26 } from './kimi'
 import { defaultModelProfileOpus48 } from './opus'
 
 export { defaultModelProfileDeepseekV4Pro } from './deepseek'
-export { defaultModelProfileGlm51 } from './glm'
+export { defaultModelProfileGlm52 } from './glm'
 export { defaultModelProfileKimiK26 } from './kimi'
 export { defaultModelProfileOpus48 } from './opus'
 
@@ -48,5 +48,5 @@ export const defaultModelProfiles: ReadonlyArray<ModelProfile> = [
   defaultModelProfileOpus48,
   defaultModelProfileDeepseekV4Pro,
   defaultModelProfileKimiK26,
-  defaultModelProfileGlm51,
+  defaultModelProfileGlm52,
 ] as const

--- a/src/defaults/models.ts
+++ b/src/defaults/models.ts
@@ -100,11 +100,11 @@ export const defaultModelKimiK26: Model = {
   userId: null,
 }
 
-export const defaultModelGlm51: Model = {
+export const defaultModelGlm52: Model = {
   id: '019e7580-2b0e-719c-a43f-d2b56e7f31b4',
-  name: 'GLM 5.1',
+  name: 'GLM 5.2',
   provider: 'tinfoil',
-  model: 'glm-5-1',
+  model: 'glm-5-2',
   isSystem: 1,
   enabled: 1,
   isConfidential: 1,
@@ -129,5 +129,5 @@ export const defaultModels: ReadonlyArray<Model> = [
   defaultModelOpus48,
   defaultModelDeepseekV4Pro,
   defaultModelKimiK26,
-  defaultModelGlm51,
+  defaultModelGlm52,
 ] as const


### PR DESCRIPTION
## Summary
- Bump the bundled Tinfoil GLM default from 5.1 to 5.2. Row id is reused so reconciliation upgrades unmodified user rows in place. `qwen3-vl-30b` is not in defaults; BYOK users on it would need to switch to `gemma4-31b` manually.
- Evict the cached `SecureClient` when a `KeyConfigMismatchError` survives the SDK's internal reset+retry. Without this, the wedged transport keeps returning 422 across the chat-instance auto-retries until something else (timeout, page reload) breaks the cycle; the next send now builds a brand-new client with a fresh attestation context.

## Test plan
- [ ] Switch to GLM 5.2 in the model picker; send a few messages and confirm streaming starts immediately (no long thinking pause).
- [ ] Reproduce a 422 cycle (it's intermittent — happens after some idle time); confirm the chat-instance auto-retry now recovers on the first follow-up attempt instead of burning all three.