### PR TITLE
feat(THU-597): adapt export & import for Workspaces v1

### DIFF
--- a/src/dal/export.test.ts
+++ b/src/dal/export.test.ts
@@ -63,11 +63,10 @@ describe('Export DAL', () => {
       'skills',
       'tasks',
       'triggers',
-      // Workspace identity travels with the backup so a restore reinstates
-      // every workspace (and the rows that point at them) without depending
-      // on PowerSync's down-sync to repopulate the local cache first.
-      'workspace_memberships',
-      'workspace_pending_memberships',
+      // Workspaces and their permissions travel with the backup so a
+      // restore reinstates them offline. `workspace_memberships` and
+      // `workspace_pending_memberships` are BE-authoritative and excluded
+      // — see `excludedFromExport` in `./export.ts` for the rationale.
       'workspace_permissions',
       'workspaces',
     ]
@@ -149,6 +148,8 @@ describe('Export DAL', () => {
     expect(tableKeys).not.toContain('devices')
     expect(tableKeys).not.toContain('integrations_secrets')
     expect(tableKeys).not.toContain('agents_system')
+    expect(tableKeys).not.toContain('workspace_memberships')
+    expect(tableKeys).not.toContain('workspace_pending_memberships')
   })
 
   it('preserves chat message JSON columns (parts / metadata / cache) as parsed objects', async () => {
@@ -183,19 +184,19 @@ describe('Export DAL', () => {
     }
   })
 
-  it('exports workspace identity rows alongside per-workspace user content', async () => {
+  it('exports workspaces (admin-only) and their permissions', async () => {
     const db = getDb()
-    // Seed an extra workspace + a membership + a permission so we can verify
-    // the export carries the full workspace graph, not just the one the
-    // active-workspace hook resolves.
+    // Seed an extra workspace + the corresponding admin membership +
+    // a permission so we can verify the export carries the full workspace
+    // graph the user admins. Memberships are excluded from the envelope —
+    // see `excludedFromExport`.
     await db.insert(workspacesTable).values({
       id: 'ws-extra',
       name: 'Extra',
       isPersonal: 0,
-      ownerUserId: 'user-1',
     })
     await db.insert(workspaceMembershipsTable).values({
-      id: 'ws-extra-user-1',
+      id: 'mem-self-extra',
       workspaceId: 'ws-extra',
       userId: 'user-1',
       role: 'admin',
@@ -211,7 +212,53 @@ describe('Export DAL', () => {
 
     const workspaceIds = (exported.tables.workspaces as Array<{ id: string }>).map((row) => row.id).sort()
     expect(workspaceIds).toContain('ws-extra')
-    expect(exported.tables.workspace_memberships).toHaveLength(1)
     expect(exported.tables.workspace_permissions).toHaveLength(1)
+  })
+
+  it('omits workspaces the user only has a `member` (non-admin) membership for', async () => {
+    const db = getDb()
+    // Two shared workspaces — one the user admins, one they joined as a
+    // member. Only the admin'd one ends up in the envelope.
+    await db.insert(workspacesTable).values([
+      { id: 'ws-mine', name: 'Mine', isPersonal: 0 },
+      { id: 'ws-theirs', name: 'Theirs', isPersonal: 0 },
+    ])
+    await db.insert(workspaceMembershipsTable).values([
+      { id: 'mem-self-mine', workspaceId: 'ws-mine', userId: 'user-1', role: 'admin' },
+      { id: 'mem-self-theirs', workspaceId: 'ws-theirs', userId: 'user-1', role: 'member' },
+    ])
+
+    const exported = await exportUserData(db, { id: 'user-1', email: null })
+
+    const ids = (exported.tables.workspaces as Array<{ id: string }>).map((row) => row.id).sort()
+    expect(ids).toContain('ws-mine')
+    expect(ids).not.toContain('ws-theirs')
+  })
+
+  it('omits workspace_memberships from the envelope even when local rows exist', async () => {
+    const db = getDb()
+    await db.insert(workspacesTable).values({
+      id: 'ws-shared',
+      name: 'Shared',
+      isPersonal: 0,
+    })
+    await db.insert(workspaceMembershipsTable).values([
+      { id: 'mem-self', workspaceId: 'ws-shared', userId: 'user-1', role: 'admin' },
+      // Co-member's row synced down via `workspace_data` — its userName /
+      // userEmail must not leak into the backup.
+      {
+        id: 'mem-bob',
+        workspaceId: 'ws-shared',
+        userId: 'user-2',
+        userName: 'Bob',
+        userEmail: 'bob@example.com',
+        role: 'member',
+      },
+    ])
+
+    const exported = await exportUserData(db, { id: 'user-1', email: null })
+
+    const tableKeys = Object.keys(exported.tables) as Array<keyof typeof exported.tables>
+    expect(tableKeys).not.toContain('workspace_memberships')
   })
 })

--- a/src/dal/export.test.ts
+++ b/src/dal/export.test.ts
@@ -17,6 +17,9 @@ import {
   modelsTable,
   settingsTable,
   tasksTable,
+  workspaceMembershipsTable,
+  workspacePermissionsTable,
+  workspacesTable,
 } from '@/db/tables'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { exportFormat, exportSchemaVersion, exportUserData, exportedTableNames } from './export'
@@ -60,6 +63,13 @@ describe('Export DAL', () => {
       'skills',
       'tasks',
       'triggers',
+      // Workspace identity travels with the backup so a restore reinstates
+      // every workspace (and the rows that point at them) without depending
+      // on PowerSync's down-sync to repopulate the local cache first.
+      'workspace_memberships',
+      'workspace_pending_memberships',
+      'workspace_permissions',
+      'workspaces',
     ]
     const actualKeys = Object.keys(exported.tables).sort() as string[]
     expect(actualKeys).toEqual(expectedKeys.sort())
@@ -163,9 +173,45 @@ describe('Export DAL', () => {
   })
 
   it('returns empty arrays for tables when the local DB is empty', async () => {
+    // `resetTestDatabase` seeds a Personal workspace so component tests can
+    // resolve `useActiveWorkspaceId`. Strip it here so every bucket — including
+    // `workspaces` — starts truly empty for the assertion.
+    await getDb().delete(workspacesTable)
     const exported = await exportUserData(getDb(), { id: 'user-1', email: null })
     for (const rows of Object.values(exported.tables)) {
       expect(rows).toEqual([])
     }
+  })
+
+  it('exports workspace identity rows alongside per-workspace user content', async () => {
+    const db = getDb()
+    // Seed an extra workspace + a membership + a permission so we can verify
+    // the export carries the full workspace graph, not just the one the
+    // active-workspace hook resolves.
+    await db.insert(workspacesTable).values({
+      id: 'ws-extra',
+      name: 'Extra',
+      isPersonal: 0,
+      ownerUserId: 'user-1',
+    })
+    await db.insert(workspaceMembershipsTable).values({
+      id: 'ws-extra-user-1',
+      workspaceId: 'ws-extra',
+      userId: 'user-1',
+      role: 'admin',
+    })
+    await db.insert(workspacePermissionsTable).values({
+      id: 'ws-extra-add_agents',
+      workspaceId: 'ws-extra',
+      permissionKey: 'add_agents',
+      requiredRole: 'admin',
+    })
+
+    const exported = await exportUserData(db, { id: 'user-1', email: null })
+
+    const workspaceIds = (exported.tables.workspaces as Array<{ id: string }>).map((row) => row.id).sort()
+    expect(workspaceIds).toContain('ws-extra')
+    expect(exported.tables.workspace_memberships).toHaveLength(1)
+    expect(exported.tables.workspace_permissions).toHaveLength(1)
   })
 })

--- a/src/dal/export.test.ts
+++ b/src/dal/export.test.ts
@@ -215,6 +215,31 @@ describe('Export DAL', () => {
     expect(exported.tables.workspace_permissions).toHaveLength(1)
   })
 
+  it('drops per-workspace rows whose workspaceId belongs to a member-only (non-admin) workspace', async () => {
+    const db = getDb()
+    await db.insert(workspacesTable).values([
+      { id: 'ws-mine', name: 'Mine', isPersonal: 0 },
+      { id: 'ws-theirs', name: 'Theirs', isPersonal: 0 },
+    ])
+    await db.insert(workspaceMembershipsTable).values([
+      { id: 'mem-self-mine', workspaceId: 'ws-mine', userId: 'user-1', role: 'admin' },
+      { id: 'mem-self-theirs', workspaceId: 'ws-theirs', userId: 'user-1', role: 'member' },
+    ])
+    // A chat in each workspace, plus a "pre-v1" chat with no workspaceId.
+    // The admin one ships; the member-only one is dropped; the workspaceless
+    // one is preserved so the importer can back-fill it to personal.
+    await db.insert(chatThreadsTable).values([
+      { id: 'thread-mine', title: 'Mine', workspaceId: 'ws-mine' },
+      { id: 'thread-theirs', title: 'Theirs', workspaceId: 'ws-theirs' },
+      { id: 'thread-legacy', title: 'Legacy' },
+    ])
+
+    const exported = await exportUserData(db, { id: 'user-1', email: null })
+
+    const threadIds = (exported.tables.chat_threads as Array<{ id: string }>).map((row) => row.id).sort()
+    expect(threadIds).toEqual(['thread-legacy', 'thread-mine'])
+  })
+
   it('omits workspaces the user only has a `member` (non-admin) membership for', async () => {
     const db = getDb()
     // Two shared workspaces — one the user admins, one they joined as a

--- a/src/dal/export.ts
+++ b/src/dal/export.ts
@@ -4,6 +4,8 @@
 
 import type { AnyDrizzleDatabase } from '@/db/database-interface'
 import { localOnlyTables, syncedTables } from '@/db/powersync/schema'
+import { workspaceMembershipsTable } from '@/db/tables'
+import { and, eq } from 'drizzle-orm'
 import type { SQLiteTable } from 'drizzle-orm/sqlite-core'
 
 export const exportFormat = 'thunderbolt-export'
@@ -18,6 +20,14 @@ type AllTableName = keyof typeof syncedTables | keyof typeof localOnlyTables
  * - `integrations_secrets`: third-party OAuth tokens (Google / Microsoft).
  *   The importing user re-authenticates instead.
  * - `agents_system`: backend-hydrated catalog, not user content.
+ * - `workspace_memberships` / `workspace_pending_memberships`: BE-authoritative
+ *   membership graph. The local DB carries every member's row for every
+ *   workspace the user belongs to (sync rule isn't filtered by `user_id`),
+ *   so blindly carrying them through would either leak co-members'
+ *   names/emails into the backup or — on cross-account import — collapse
+ *   them into duplicate self-rows. PowerSync repopulates on first sync; on
+ *   import we synthesize a single admin row for the importing user per
+ *   imported workspace so the UI works offline (see `importUserData`).
  *
  * Typed against {@link AllTableName} so a future schema rename/removal trips
  * the compiler. Anything not in this list is included.
@@ -26,6 +36,8 @@ const excludedFromExport = [
   'devices',
   'integrations_secrets',
   'agents_system',
+  'workspace_memberships',
+  'workspace_pending_memberships',
 ] as const satisfies readonly AllTableName[]
 type ExcludedTableName = (typeof excludedFromExport)[number]
 export type IncludedTableName = Exclude<AllTableName, ExcludedTableName>
@@ -82,20 +94,44 @@ export const exportedTableNames: readonly IncludedTableName[] = Object.freeze(
  * Soft-deleted rows are included — restore logic decides what to do with
  * them.
  *
- * No `userId` filter is applied: the local SQLite file already contains
- * exactly one user's data (PowerSync only syncs down rows the JWT is allowed
- * to see, and anonymous / standalone DBs never see other users at all).
+ * Two cross-cutting filters apply:
+ * - `workspace_memberships` and `workspace_pending_memberships` are dropped
+ *   entirely (BE-authoritative; co-member leakage). See
+ *   {@link excludedFromExport}.
+ * - `workspaces` is filtered to rows where the user has an `admin`
+ *   membership. Personal workspaces (seeded with an admin membership at
+ *   bootstrap) and shared workspaces the user created or was promoted to
+ *   admin in are included; shared workspaces the user joined as a member
+ *   are dropped — they're BE-managed and re-sync on first login. (The
+ *   schema deliberately reserves `workspaces.owner_user_id` for the
+ *   personal-workspace anchor — it is **not** an access-control role —
+ *   which is why admin membership, not ownership, is the right signal.)
  *
- * `attributedTo` is stamped into the envelope's `user` field as metadata —
- * it does not scope the query in any way.
+ * `attributedTo` is stamped into the envelope's `user` field as metadata,
+ * and drives the workspaces filter above.
  */
 export const exportUserData = async (
   db: AnyDrizzleDatabase,
   attributedTo: { id: string; email: string | null },
 ): Promise<UserDataExport> => {
+  const adminWorkspaceRows = await db
+    .select({ workspaceId: workspaceMembershipsTable.workspaceId })
+    .from(workspaceMembershipsTable)
+    .where(and(eq(workspaceMembershipsTable.userId, attributedTo.id), eq(workspaceMembershipsTable.role, 'admin')))
+  const adminWorkspaceIds = new Set(
+    adminWorkspaceRows.map((row) => row.workspaceId).filter((id): id is string => id !== null),
+  )
+
   const entries = Object.entries(includedTables) as Array<[IncludedTableName, SQLiteTable]>
   const results = await Promise.all(
-    entries.map(async ([name, table]) => [name, await db.select().from(table)] as const),
+    entries.map(async ([name, table]) => {
+      const rows = await db.select().from(table)
+      if (name === 'workspaces') {
+        const adminOnly = rows.filter((row) => adminWorkspaceIds.has((row as { id: string }).id))
+        return [name, adminOnly] as const
+      }
+      return [name, rows] as const
+    }),
   )
 
   return {

--- a/src/dal/export.ts
+++ b/src/dal/export.ts
@@ -6,7 +6,7 @@ import type { AnyDrizzleDatabase } from '@/db/database-interface'
 import { localOnlyTables, syncedTables } from '@/db/powersync/schema'
 import { workspaceMembershipsTable } from '@/db/tables'
 import { and, eq } from 'drizzle-orm'
-import type { SQLiteTable } from 'drizzle-orm/sqlite-core'
+import { getTableConfig, type SQLiteTable } from 'drizzle-orm/sqlite-core'
 
 export const exportFormat = 'thunderbolt-export'
 export const exportSchemaVersion = 1
@@ -94,18 +94,26 @@ export const exportedTableNames: readonly IncludedTableName[] = Object.freeze(
  * Soft-deleted rows are included — restore logic decides what to do with
  * them.
  *
- * Two cross-cutting filters apply:
+ * Three cross-cutting filters apply, all driven by the set of workspaces
+ * the user has an `admin` membership for:
  * - `workspace_memberships` and `workspace_pending_memberships` are dropped
  *   entirely (BE-authoritative; co-member leakage). See
  *   {@link excludedFromExport}.
- * - `workspaces` is filtered to rows where the user has an `admin`
- *   membership. Personal workspaces (seeded with an admin membership at
- *   bootstrap) and shared workspaces the user created or was promoted to
- *   admin in are included; shared workspaces the user joined as a member
- *   are dropped — they're BE-managed and re-sync on first login. (The
- *   schema deliberately reserves `workspaces.owner_user_id` for the
- *   personal-workspace anchor — it is **not** an access-control role —
- *   which is why admin membership, not ownership, is the right signal.)
+ * - `workspaces` is filtered to rows in the admin set. Personal workspaces
+ *   (seeded with an admin membership at bootstrap) and shared workspaces
+ *   the user created or was promoted to admin in are included; shared
+ *   workspaces the user joined as a member are dropped — they're BE-managed
+ *   and re-sync on first login. (The schema deliberately reserves
+ *   `workspaces.owner_user_id` for the personal-workspace anchor — it is
+ *   **not** an access-control role — which is why admin membership, not
+ *   ownership, is the right signal.)
+ * - Every per-workspace data table (any synced table with a `workspace_id`
+ *   column — chat threads, models, prompts, …) is filtered to rows whose
+ *   `workspaceId` is in the admin set. Rows with `workspaceId = NULL` are
+ *   kept — those are pre-v1 leftovers that the importer back-fills to the
+ *   importing user's personal workspace. Without this filter the backup
+ *   would carry stranded rows referencing workspaces the importer can't
+ *   reach until PowerSync re-syncs.
  *
  * `attributedTo` is stamped into the envelope's `user` field as metadata,
  * and drives the workspaces filter above.
@@ -129,6 +137,16 @@ export const exportUserData = async (
       if (name === 'workspaces') {
         const adminOnly = rows.filter((row) => adminWorkspaceIds.has((row as { id: string }).id))
         return [name, adminOnly] as const
+      }
+      const hasWorkspaceId = getTableConfig(table).columns.some((c) => c.name === 'workspace_id')
+      if (hasWorkspaceId) {
+        const adminScoped = rows.filter((row) => {
+          const wsId = (row as { workspaceId?: string | null }).workspaceId
+          // Pre-v1 rows have no workspaceId yet — keep them so the importer's
+          // back-fill can attach them to the importing user's personal.
+          return wsId === null || wsId === undefined || adminWorkspaceIds.has(wsId)
+        })
+        return [name, adminScoped] as const
       }
       return [name, rows] as const
     }),

--- a/src/dal/import.test.ts
+++ b/src/dal/import.test.ts
@@ -429,6 +429,40 @@ describe('Import DAL', () => {
       expect(perm?.requiredRole).toBe('admin')
     })
 
+    it('merges a foreign personal workspace into the importing user`s local personal — does not create a second isPersonal row', async () => {
+      const db = getDb()
+      const foreignPersonalId = 'foreign-personal-ws'
+      const result = await importUserData(
+        db,
+        envelope({
+          workspaces: [
+            // Source user's personal workspace — different canonical id than the
+            // importing user's. Must not land as a separate row (would conflict
+            // with the BE's one-personal-per-owner unique index after re-stamp).
+            { id: foreignPersonalId, name: 'Alice`s Default', isPersonal: 1, ownerUserId: 'user-1' },
+          ],
+          chat_threads: [
+            { id: 'thread-foreign-personal', title: 'In foreign personal', workspaceId: foreignPersonalId },
+          ],
+        }),
+        currentUser,
+      )
+
+      // The foreign personal workspace row is skipped, not inserted.
+      const personalRows = await db.select().from(workspacesTable).where(eq(workspacesTable.id, foreignPersonalId))
+      expect(personalRows).toEqual([])
+      // workspaces.upserted reflects the skip — zero rows upserted, so the bucket is absent.
+      expect(result.tables.workspaces).toBeUndefined()
+
+      // Its resources land in the importing user's personal workspace.
+      const thread = await db
+        .select()
+        .from(chatThreadsTable)
+        .where(eq(chatThreadsTable.id, 'thread-foreign-personal'))
+        .get()
+      expect(thread?.workspaceId).toBe(currentUser.personalWorkspaceId)
+    })
+
     it('skips membership synthesis when the importing user is already a member of the imported workspace', async () => {
       const db = getDb()
       // Pre-existing local membership (e.g. PowerSync down-sync prior to import).

--- a/src/dal/import.test.ts
+++ b/src/dal/import.test.ts
@@ -78,6 +78,21 @@ describe('Import DAL', () => {
         importUserData(getDb(), { format: exportFormat, schemaVersion: 1, tables: 'nope' }, currentUser),
       ).rejects.toBeInstanceOf(ImportFormatError)
     })
+
+    it('rejects when `user.id` is missing or not a string (cross-account detection signal)', async () => {
+      // Refuse rather than guess: without `user.id` we can't tell a same-
+      // account restore (preserve ids) from a cross-account import (mint
+      // new ids and remap shared workspaces).
+      await expect(
+        importUserData(getDb(), { format: exportFormat, schemaVersion: 1, tables: {} }, currentUser),
+      ).rejects.toBeInstanceOf(ImportFormatError)
+      await expect(
+        importUserData(getDb(), { format: exportFormat, schemaVersion: 1, tables: {}, user: {} }, currentUser),
+      ).rejects.toBeInstanceOf(ImportFormatError)
+      await expect(
+        importUserData(getDb(), { format: exportFormat, schemaVersion: 1, tables: {}, user: { id: 42 } }, currentUser),
+      ).rejects.toBeInstanceOf(ImportFormatError)
+    })
   })
 
   describe('upsert semantics', () => {

--- a/src/dal/import.test.ts
+++ b/src/dal/import.test.ts
@@ -494,6 +494,31 @@ describe('Import DAL', () => {
       expect(permissions[0]?.requiredRole).toBe('member')
     })
 
+    it('cross-account import forces orphan workspaceIds (not in the envelope`s workspaces bucket) into local personal', async () => {
+      const db = getDb()
+      // Hand-crafted / partial envelope: chat_threads + tasks reference a
+      // workspace that the file doesn't include in its `workspaces` array.
+      // Without the defensive fallback those rows would sync up under the
+      // foreign id, BE would reject, and down-sync would wipe them.
+      await importUserData(
+        db,
+        envelope({
+          // No `workspaces` bucket at all.
+          chat_threads: [{ id: 'orphan-thread', title: 'T', workspaceId: 'foreign-orphan-ws' }],
+          tasks: [{ id: 'orphan-task', item: 'task', workspaceId: 'foreign-orphan-ws' }],
+        }),
+        crossAccountUser,
+      )
+
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(1)
+      expect(threads[0]?.workspaceId).toBe(crossAccountUser.personalWorkspaceId)
+
+      const tasks = await db.select().from(tasksTable)
+      expect(tasks).toHaveLength(1)
+      expect(tasks[0]?.workspaceId).toBe(crossAccountUser.personalWorkspaceId)
+    })
+
     it('cross-account import mints a fresh id for triggers and rewrites chat_threads.triggeredBy', async () => {
       const db = getDb()
       // `triggers` share `chat_threads`/`chat_messages`'s id-only BE

--- a/src/dal/import.test.ts
+++ b/src/dal/import.test.ts
@@ -38,7 +38,12 @@ const envelope = (tables: Record<string, unknown[]>): unknown => ({
   tables,
 })
 
-const currentUser = { id: 'current-user', personalWorkspaceId: 'ws-personal' }
+// Same-account fixture: `id` matches `envelope.user.id` so tests exercise
+// the preserve-structure path (re-import of the user's own backup) without
+// triggering the cross-account remap / id mint. Use `crossAccountUser`
+// below when a test specifically wants to exercise the cross-account flow.
+const currentUser = { id: 'user-1', personalWorkspaceId: 'ws-personal' }
+const crossAccountUser = { id: 'current-user', personalWorkspaceId: 'ws-personal' }
 
 describe('Import DAL', () => {
   beforeEach(async () => {
@@ -374,7 +379,7 @@ describe('Import DAL', () => {
       expect(row?.userId).toBe(currentUser.id)
     })
 
-    it('re-stamps ownerUserId on workspaces with the current session user', async () => {
+    it('re-stamps ownerUserId on workspaces with the current session user (same-account re-import)', async () => {
       const db = getDb()
       await importUserData(
         db,
@@ -390,7 +395,7 @@ describe('Import DAL', () => {
   })
 
   describe('workspace tables', () => {
-    it('round-trips a workspace + its permission rows; synthesizes an admin membership for the importing user', async () => {
+    it('same-account re-import preserves shared workspaces + permissions and synthesizes an admin membership', async () => {
       const db = getDb()
       const result = await importUserData(
         db,
@@ -429,6 +434,96 @@ describe('Import DAL', () => {
       expect(perm?.requiredRole).toBe('admin')
     })
 
+    it('cross-account import mints fresh ids for chat_threads / chat_messages and rewrites chatThreadId + parentId', async () => {
+      const db = getDb()
+      // The BE conflict target on these two tables is `(id)` alone, so a
+      // re-uploaded source id would silently no-op against the existing BE
+      // row (`ON CONFLICT (id) DO UPDATE WHERE workspace_id = …` doesn't
+      // match the existing row's workspace_id) and the next down-sync would
+      // wipe the local rows. Cross-account mints fresh ids and rewires the
+      // internal thread→message and message→message reply graph.
+      await importUserData(
+        db,
+        envelope({
+          chat_threads: [{ id: 'src-thread', title: 'T' }],
+          chat_messages: [
+            { id: 'src-msg-parent', chatThreadId: 'src-thread', role: 'user', parts: [{ type: 'text', text: 'a' }] },
+            {
+              id: 'src-msg-child',
+              chatThreadId: 'src-thread',
+              parentId: 'src-msg-parent',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'b' }],
+            },
+          ],
+        }),
+        crossAccountUser,
+      )
+
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(1)
+      const newThreadId = threads[0]!.id
+      expect(newThreadId).not.toBe('src-thread')
+
+      const messages = await db.select().from(chatMessagesTable)
+      expect(messages).toHaveLength(2)
+      for (const m of messages) {
+        expect(m.id).not.toBe('src-msg-parent')
+        expect(m.id).not.toBe('src-msg-child')
+        // chatThreadId rewritten to the new thread id.
+        expect(m.chatThreadId).toBe(newThreadId)
+      }
+
+      // parentId rewritten to the new parent message id (not the source one).
+      const child = messages.find((m) => m.role === 'assistant')
+      const parent = messages.find((m) => m.role === 'user')
+      expect(child?.parentId).toBe(parent?.id)
+      expect(child?.parentId).not.toBe('src-msg-parent')
+    })
+
+    it('cross-account import collapses every foreign workspace (personal + shared) into local personal', async () => {
+      const db = getDb()
+      // Cross-account: `envelope.user.id` ('user-1') !== `crossAccountUser.id`.
+      // Both the foreign personal and the foreign shared workspace must be
+      // skipped from the workspaces upsert, and every per-workspace row
+      // remapped to `crossAccountUser.personalWorkspaceId` — otherwise BE
+      // upload would permanent-reject and sync down would wipe the imported rows.
+      const result = await importUserData(
+        db,
+        envelope({
+          workspaces: [
+            { id: 'foreign-personal', name: 'Source personal', isPersonal: 1, ownerUserId: 'user-1' },
+            { id: 'foreign-shared', name: 'Source shared', isPersonal: 0 },
+          ],
+          chat_threads: [
+            { id: 'thread-in-personal', title: 'P', workspaceId: 'foreign-personal' },
+            { id: 'thread-in-shared', title: 'S', workspaceId: 'foreign-shared' },
+          ],
+        }),
+        crossAccountUser,
+      )
+
+      // Neither foreign workspace row lands locally.
+      expect(result.tables.workspaces).toBeUndefined()
+      const localWorkspaces = await db.select().from(workspacesTable)
+      expect(localWorkspaces.map((w) => w.id)).not.toContain('foreign-personal')
+      expect(localWorkspaces.map((w) => w.id)).not.toContain('foreign-shared')
+
+      // Both threads land in the importing user's personal workspace. IDs are
+      // freshly minted on cross-account import (the BE conflict target on
+      // chat_threads is id-only — re-using source ids silently no-ops the
+      // upload), so look the threads up by title instead.
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(2)
+      const titleP = threads.find((t) => t.title === 'P')
+      const titleS = threads.find((t) => t.title === 'S')
+      expect(titleP?.workspaceId).toBe(crossAccountUser.personalWorkspaceId)
+      expect(titleS?.workspaceId).toBe(crossAccountUser.personalWorkspaceId)
+      // Fresh ids — not the source values.
+      expect(titleP?.id).not.toBe('thread-in-personal')
+      expect(titleS?.id).not.toBe('thread-in-shared')
+    })
+
     it('merges a foreign personal workspace into the importing user`s local personal — does not create a second isPersonal row', async () => {
       const db = getDb()
       const foreignPersonalId = 'foreign-personal-ws'
@@ -445,7 +540,7 @@ describe('Import DAL', () => {
             { id: 'thread-foreign-personal', title: 'In foreign personal', workspaceId: foreignPersonalId },
           ],
         }),
-        currentUser,
+        crossAccountUser,
       )
 
       // The foreign personal workspace row is skipped, not inserted.
@@ -454,16 +549,16 @@ describe('Import DAL', () => {
       // workspaces.upserted reflects the skip — zero rows upserted, so the bucket is absent.
       expect(result.tables.workspaces).toBeUndefined()
 
-      // Its resources land in the importing user's personal workspace.
-      const thread = await db
-        .select()
-        .from(chatThreadsTable)
-        .where(eq(chatThreadsTable.id, 'thread-foreign-personal'))
-        .get()
-      expect(thread?.workspaceId).toBe(currentUser.personalWorkspaceId)
+      // Its resources land in the importing user's personal workspace. The
+      // chat_threads id is freshly minted on cross-account import — look up
+      // by title since the source id no longer exists locally.
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(1)
+      expect(threads[0]?.title).toBe('In foreign personal')
+      expect(threads[0]?.workspaceId).toBe(crossAccountUser.personalWorkspaceId)
     })
 
-    it('skips membership synthesis when the importing user is already a member of the imported workspace', async () => {
+    it('skips membership synthesis when the importing user is already a member of the imported workspace (same-account)', async () => {
       const db = getDb()
       // Pre-existing local membership (e.g. PowerSync down-sync prior to import).
       await db.insert(workspacesTable).values({ id: 'ws-existing', name: 'Existing', isPersonal: 0 })
@@ -517,7 +612,7 @@ describe('Import DAL', () => {
       expect(tasks[0]?.workspaceId).toBe(currentUser.personalWorkspaceId)
     })
 
-    it('preserves the file`s workspaceId on modern multi-workspace backups (no override)', async () => {
+    it('same-account re-import preserves the file`s workspaceId on modern multi-workspace backups', async () => {
       const db = getDb()
       await importUserData(
         db,

--- a/src/dal/import.test.ts
+++ b/src/dal/import.test.ts
@@ -12,7 +12,6 @@ import {
   settingsTable,
   tasksTable,
   workspaceMembershipsTable,
-  workspacePendingMembershipsTable,
   workspacePermissionsTable,
   workspacesTable,
 } from '@/db/tables'
@@ -228,7 +227,7 @@ describe('Import DAL', () => {
       expect(threads).toHaveLength(1)
     })
 
-    it('routes deliberately-excluded tables (devices / integrations_secrets / agents_system) into ignoredTableNames', async () => {
+    it('routes deliberately-excluded tables into ignoredTableNames', async () => {
       // Tampered or hand-crafted files might contain these even though our
       // exporter never produces them — they must be skipped, not written.
       const result = await importUserData(
@@ -237,11 +236,27 @@ describe('Import DAL', () => {
           devices: [{ id: 'd-1', userId: 'user-1' }],
           integrations_secrets: [{ provider: 'google', credentials: '{}' }],
           agents_system: [{ id: 'sys-1', name: 'X' }],
+          workspace_memberships: [{ id: 'mem-1', workspaceId: 'ws-1', userId: 'user-1', role: 'admin' }],
+          workspace_pending_memberships: [
+            {
+              id: 'pend-1',
+              workspaceId: 'ws-1',
+              email: 'alice@example.com',
+              role: 'member',
+              invitedByUserId: 'someone',
+            },
+          ],
         }),
         currentUser,
       )
 
-      expect(result.ignoredTableNames.sort()).toEqual(['agents_system', 'devices', 'integrations_secrets'])
+      expect(result.ignoredTableNames.sort()).toEqual([
+        'agents_system',
+        'devices',
+        'integrations_secrets',
+        'workspace_memberships',
+        'workspace_pending_memberships',
+      ])
     })
 
     it('skips empty table arrays without counting them', async () => {
@@ -372,43 +387,15 @@ describe('Import DAL', () => {
       const row = await db.select().from(workspacesTable).where(eq(workspacesTable.id, 'ws-1')).get()
       expect(row?.ownerUserId).toBe(currentUser.id)
     })
-
-    it('re-stamps invitedByUserId on workspace_pending_memberships', async () => {
-      const db = getDb()
-      await importUserData(
-        db,
-        envelope({
-          workspaces: [{ id: 'ws-1', name: 'WS', isPersonal: 0 }],
-          workspace_pending_memberships: [
-            {
-              id: 'pend-1',
-              workspaceId: 'ws-1',
-              email: 'alice@example.com',
-              role: 'member',
-              invitedByUserId: 'attacker-user',
-            },
-          ],
-        }),
-        currentUser,
-      )
-
-      const row = await db
-        .select()
-        .from(workspacePendingMembershipsTable)
-        .where(eq(workspacePendingMembershipsTable.id, 'pend-1'))
-        .get()
-      expect(row?.invitedByUserId).toBe(currentUser.id)
-    })
   })
 
   describe('workspace tables', () => {
-    it('round-trips a workspace + its membership + its permission rows', async () => {
+    it('round-trips a workspace + its permission rows; synthesizes an admin membership for the importing user', async () => {
       const db = getDb()
       const result = await importUserData(
         db,
         envelope({
           workspaces: [{ id: 'ws-1', name: 'Imported', isPersonal: 0, ownerUserId: 'someone' }],
-          workspace_memberships: [{ id: 'mem-1', workspaceId: 'ws-1', userId: 'someone', role: 'admin' }],
           workspace_permissions: [
             { id: 'perm-1', workspaceId: 'ws-1', permissionKey: 'add_agents', requiredRole: 'admin' },
           ],
@@ -417,7 +404,6 @@ describe('Import DAL', () => {
       )
 
       expect(result.tables.workspaces).toEqual({ upserted: 1 })
-      expect(result.tables.workspace_memberships).toEqual({ upserted: 1 })
       expect(result.tables.workspace_permissions).toEqual({ upserted: 1 })
 
       const ws = await db.select().from(workspacesTable).where(eq(workspacesTable.id, 'ws-1')).get()
@@ -425,15 +411,14 @@ describe('Import DAL', () => {
       // ownerUserId is re-stamped — see the dedicated test in `userId re-stamping`.
       expect(ws?.ownerUserId).toBe(currentUser.id)
 
-      const mem = await db
+      // Synthesized membership: not in the envelope, created by the importer.
+      const memberships = await db
         .select()
         .from(workspaceMembershipsTable)
-        .where(eq(workspaceMembershipsTable.id, 'mem-1'))
-        .get()
-      // user_id on memberships is re-stamped so the importing user becomes the
-      // member of every imported workspace.
-      expect(mem?.userId).toBe(currentUser.id)
-      expect(mem?.role).toBe('admin')
+        .where(eq(workspaceMembershipsTable.workspaceId, 'ws-1'))
+      expect(memberships).toHaveLength(1)
+      expect(memberships[0]?.userId).toBe(currentUser.id)
+      expect(memberships[0]?.role).toBe('admin')
 
       const perm = await db
         .select()
@@ -442,6 +427,35 @@ describe('Import DAL', () => {
         .get()
       expect(perm?.permissionKey).toBe('add_agents')
       expect(perm?.requiredRole).toBe('admin')
+    })
+
+    it('skips membership synthesis when the importing user is already a member of the imported workspace', async () => {
+      const db = getDb()
+      // Pre-existing local membership (e.g. PowerSync down-sync prior to import).
+      await db.insert(workspacesTable).values({ id: 'ws-existing', name: 'Existing', isPersonal: 0 })
+      await db.insert(workspaceMembershipsTable).values({
+        id: 'mem-existing',
+        workspaceId: 'ws-existing',
+        userId: currentUser.id,
+        role: 'member',
+      })
+
+      await importUserData(
+        db,
+        envelope({
+          workspaces: [{ id: 'ws-existing', name: 'Renamed', isPersonal: 0 }],
+        }),
+        currentUser,
+      )
+
+      const memberships = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.workspaceId, 'ws-existing'))
+      // Exactly one row — the pre-existing membership; role unchanged.
+      expect(memberships).toHaveLength(1)
+      expect(memberships[0]?.id).toBe('mem-existing')
+      expect(memberships[0]?.role).toBe('member')
     })
 
     it('attaches pre-workspaces-v1 rows (no workspaceId in file) to the importing user`s personal workspace', async () => {

--- a/src/dal/import.test.ts
+++ b/src/dal/import.test.ts
@@ -11,6 +11,10 @@ import {
   modelsTable,
   settingsTable,
   tasksTable,
+  workspaceMembershipsTable,
+  workspacePendingMembershipsTable,
+  workspacePermissionsTable,
+  workspacesTable,
 } from '@/db/tables'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq, sql } from 'drizzle-orm'
@@ -35,7 +39,7 @@ const envelope = (tables: Record<string, unknown[]>): unknown => ({
   tables,
 })
 
-const currentUser = { id: 'current-user' }
+const currentUser = { id: 'current-user', personalWorkspaceId: 'ws-personal' }
 
 describe('Import DAL', () => {
   beforeEach(async () => {
@@ -353,6 +357,139 @@ describe('Import DAL', () => {
       const row = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, 'thread-1')).get()
       expect(row?.title).toBe('Imported')
       expect(row?.userId).toBe(currentUser.id)
+    })
+
+    it('re-stamps ownerUserId on workspaces with the current session user', async () => {
+      const db = getDb()
+      await importUserData(
+        db,
+        envelope({
+          workspaces: [{ id: 'ws-1', name: 'Imported', isPersonal: 0, ownerUserId: 'attacker-user' }],
+        }),
+        currentUser,
+      )
+
+      const row = await db.select().from(workspacesTable).where(eq(workspacesTable.id, 'ws-1')).get()
+      expect(row?.ownerUserId).toBe(currentUser.id)
+    })
+
+    it('re-stamps invitedByUserId on workspace_pending_memberships', async () => {
+      const db = getDb()
+      await importUserData(
+        db,
+        envelope({
+          workspaces: [{ id: 'ws-1', name: 'WS', isPersonal: 0 }],
+          workspace_pending_memberships: [
+            {
+              id: 'pend-1',
+              workspaceId: 'ws-1',
+              email: 'alice@example.com',
+              role: 'member',
+              invitedByUserId: 'attacker-user',
+            },
+          ],
+        }),
+        currentUser,
+      )
+
+      const row = await db
+        .select()
+        .from(workspacePendingMembershipsTable)
+        .where(eq(workspacePendingMembershipsTable.id, 'pend-1'))
+        .get()
+      expect(row?.invitedByUserId).toBe(currentUser.id)
+    })
+  })
+
+  describe('workspace tables', () => {
+    it('round-trips a workspace + its membership + its permission rows', async () => {
+      const db = getDb()
+      const result = await importUserData(
+        db,
+        envelope({
+          workspaces: [{ id: 'ws-1', name: 'Imported', isPersonal: 0, ownerUserId: 'someone' }],
+          workspace_memberships: [{ id: 'mem-1', workspaceId: 'ws-1', userId: 'someone', role: 'admin' }],
+          workspace_permissions: [
+            { id: 'perm-1', workspaceId: 'ws-1', permissionKey: 'add_agents', requiredRole: 'admin' },
+          ],
+        }),
+        currentUser,
+      )
+
+      expect(result.tables.workspaces).toEqual({ upserted: 1 })
+      expect(result.tables.workspace_memberships).toEqual({ upserted: 1 })
+      expect(result.tables.workspace_permissions).toEqual({ upserted: 1 })
+
+      const ws = await db.select().from(workspacesTable).where(eq(workspacesTable.id, 'ws-1')).get()
+      expect(ws?.name).toBe('Imported')
+      // ownerUserId is re-stamped — see the dedicated test in `userId re-stamping`.
+      expect(ws?.ownerUserId).toBe(currentUser.id)
+
+      const mem = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.id, 'mem-1'))
+        .get()
+      // user_id on memberships is re-stamped so the importing user becomes the
+      // member of every imported workspace.
+      expect(mem?.userId).toBe(currentUser.id)
+      expect(mem?.role).toBe('admin')
+
+      const perm = await db
+        .select()
+        .from(workspacePermissionsTable)
+        .where(eq(workspacePermissionsTable.id, 'perm-1'))
+        .get()
+      expect(perm?.permissionKey).toBe('add_agents')
+      expect(perm?.requiredRole).toBe('admin')
+    })
+
+    it('attaches pre-workspaces-v1 rows (no workspaceId in file) to the importing user`s personal workspace', async () => {
+      const db = getDb()
+      // Pre-v1 envelope: synced tables had no `workspace_id` column when the
+      // backup was taken, so the rows arrive without one.
+      await importUserData(
+        db,
+        envelope({
+          chat_threads: [
+            { id: 'thread-legacy-1', title: 'Legacy 1' },
+            { id: 'thread-legacy-2', title: 'Legacy 2' },
+          ],
+          tasks: [{ id: 'task-legacy', item: 'Pre-v1 task' }],
+        }),
+        currentUser,
+      )
+
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads.map((t) => t.workspaceId).sort()).toEqual([
+        currentUser.personalWorkspaceId,
+        currentUser.personalWorkspaceId,
+      ])
+      const tasks = await db.select().from(tasksTable)
+      expect(tasks[0]?.workspaceId).toBe(currentUser.personalWorkspaceId)
+    })
+
+    it('preserves the file`s workspaceId on modern multi-workspace backups (no override)', async () => {
+      const db = getDb()
+      await importUserData(
+        db,
+        envelope({
+          workspaces: [
+            { id: 'ws-a', name: 'A', isPersonal: 0 },
+            { id: 'ws-b', name: 'B', isPersonal: 0 },
+          ],
+          chat_threads: [
+            { id: 'thread-a', title: 'In A', workspaceId: 'ws-a' },
+            { id: 'thread-b', title: 'In B', workspaceId: 'ws-b' },
+          ],
+        }),
+        currentUser,
+      )
+
+      const threadA = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, 'thread-a')).get()
+      const threadB = await db.select().from(chatThreadsTable).where(eq(chatThreadsTable.id, 'thread-b')).get()
+      expect(threadA?.workspaceId).toBe('ws-a')
+      expect(threadB?.workspaceId).toBe('ws-b')
     })
   })
 

--- a/src/dal/import.test.ts
+++ b/src/dal/import.test.ts
@@ -11,6 +11,7 @@ import {
   modelsTable,
   settingsTable,
   tasksTable,
+  triggersTable,
   workspaceMembershipsTable,
   workspacePermissionsTable,
   workspacesTable,
@@ -434,6 +435,92 @@ describe('Import DAL', () => {
       expect(perm?.requiredRole).toBe('admin')
     })
 
+    it('cross-account import drops workspace_permissions for foreign personal (avoids BE unique-index conflict on local personal)', async () => {
+      const db = getDb()
+      // A foreign personal collapses into local personal — its permissions
+      // would land at the local personal's workspace_id, and stacked with
+      // any future foreign personal's permissions would collide on the BE's
+      // unique `(workspace_id, permission_key)` index. Drop them; BE
+      // applies the admin-only default (Decision 11).
+      await importUserData(
+        db,
+        envelope({
+          workspaces: [{ id: 'foreign-personal', name: 'P', isPersonal: 1, ownerUserId: 'user-1' }],
+          workspace_permissions: [
+            {
+              id: 'perm-foreign-personal',
+              workspaceId: 'foreign-personal',
+              permissionKey: 'add_agents',
+              requiredRole: 'admin',
+            },
+          ],
+        }),
+        crossAccountUser,
+      )
+
+      const permissions = await db.select().from(workspacePermissionsTable)
+      expect(permissions).toEqual([])
+    })
+
+    it('cross-account import preserves workspace_permissions for foreign shared workspaces under fresh ids', async () => {
+      const db = getDb()
+      await importUserData(
+        db,
+        envelope({
+          workspaces: [{ id: 'foreign-shared', name: 'S', isPersonal: 0 }],
+          workspace_permissions: [
+            {
+              id: 'perm-foreign-shared',
+              workspaceId: 'foreign-shared',
+              permissionKey: 'add_agents',
+              requiredRole: 'member',
+            },
+          ],
+        }),
+        crossAccountUser,
+      )
+
+      const permissions = await db.select().from(workspacePermissionsTable)
+      expect(permissions).toHaveLength(1)
+      // Id is freshly minted (BE conflict target on this table is id-only).
+      expect(permissions[0]?.id).not.toBe('perm-foreign-shared')
+      // workspaceId points to the workspace's new id, not the source's.
+      expect(permissions[0]?.workspaceId).not.toBe('foreign-shared')
+      const workspaces = await db.select().from(workspacesTable).where(eq(workspacesTable.isPersonal, 0))
+      expect(workspaces).toHaveLength(1)
+      expect(permissions[0]?.workspaceId).toBe(workspaces[0]?.id)
+      // Policy value survives the transit verbatim.
+      expect(permissions[0]?.permissionKey).toBe('add_agents')
+      expect(permissions[0]?.requiredRole).toBe('member')
+    })
+
+    it('cross-account import mints a fresh id for triggers and rewrites chat_threads.triggeredBy', async () => {
+      const db = getDb()
+      // `triggers` share `chat_threads`/`chat_messages`'s id-only BE
+      // conflict target — same wipe risk on cross-account if we kept the
+      // source id. `chat_threads.triggeredBy` references the trigger id
+      // and must follow the remap.
+      await importUserData(
+        db,
+        envelope({
+          triggers: [{ id: 'src-trigger', workspaceId: 'foreign-shared' }],
+          chat_threads: [{ id: 'src-thread', title: 'T', triggeredBy: 'src-trigger', workspaceId: 'foreign-shared' }],
+          workspaces: [{ id: 'foreign-shared', name: 'S', isPersonal: 0 }],
+        }),
+        crossAccountUser,
+      )
+
+      const triggers = await db.select().from(triggersTable)
+      expect(triggers).toHaveLength(1)
+      const newTriggerId = triggers[0]!.id
+      expect(newTriggerId).not.toBe('src-trigger')
+
+      const threads = await db.select().from(chatThreadsTable)
+      expect(threads).toHaveLength(1)
+      // triggeredBy rewritten to the new trigger id.
+      expect(threads[0]?.triggeredBy).toBe(newTriggerId)
+    })
+
     it('cross-account import mints fresh ids for chat_threads / chat_messages and rewrites chatThreadId + parentId', async () => {
       const db = getDb()
       // The BE conflict target on these two tables is `(id)` alone, so a
@@ -481,19 +568,17 @@ describe('Import DAL', () => {
       expect(child?.parentId).not.toBe('src-msg-parent')
     })
 
-    it('cross-account import collapses every foreign workspace (personal + shared) into local personal', async () => {
+    it('cross-account import preserves foreign-shared workspaces under fresh ids; folds foreign personal into local personal', async () => {
       const db = getDb()
-      // Cross-account: `envelope.user.id` ('user-1') !== `crossAccountUser.id`.
-      // Both the foreign personal and the foreign shared workspace must be
-      // skipped from the workspaces upsert, and every per-workspace row
-      // remapped to `crossAccountUser.personalWorkspaceId` — otherwise BE
-      // upload would permanent-reject and sync down would wipe the imported rows.
-      const result = await importUserData(
+      // Personal collapses (single-personal-per-owner BE constraint); shared
+      // is preserved but under a new id (the source's id exists on the BE
+      // already, would no-op the upload).
+      await importUserData(
         db,
         envelope({
           workspaces: [
-            { id: 'foreign-personal', name: 'Source personal', isPersonal: 1, ownerUserId: 'user-1' },
-            { id: 'foreign-shared', name: 'Source shared', isPersonal: 0 },
+            { id: 'foreign-personal', name: 'Source personal', isPersonal: 1, ownerUserId: 'user-1', slug: null },
+            { id: 'foreign-shared', name: 'Source shared', isPersonal: 0, slug: 'engineering' },
           ],
           chat_threads: [
             { id: 'thread-in-personal', title: 'P', workspaceId: 'foreign-personal' },
@@ -503,25 +588,38 @@ describe('Import DAL', () => {
         crossAccountUser,
       )
 
-      // Neither foreign workspace row lands locally.
-      expect(result.tables.workspaces).toBeUndefined()
+      // Foreign personal: skipped (collapses into local personal).
+      // Foreign shared: inserted under a fresh id.
       const localWorkspaces = await db.select().from(workspacesTable)
       expect(localWorkspaces.map((w) => w.id)).not.toContain('foreign-personal')
       expect(localWorkspaces.map((w) => w.id)).not.toContain('foreign-shared')
+      const sharedLocally = localWorkspaces.find((w) => w.isPersonal === 0)
+      expect(sharedLocally).toBeDefined()
+      expect(sharedLocally?.name).toBe('Source shared')
+      // `slug` stripped on insert (BE has a global unique index on `slug`).
+      expect(sharedLocally?.slug).toBeNull()
 
-      // Both threads land in the importing user's personal workspace. IDs are
-      // freshly minted on cross-account import (the BE conflict target on
-      // chat_threads is id-only — re-using source ids silently no-ops the
-      // upload), so look the threads up by title instead.
+      // Threads land where they belong: foreign-personal data → local personal,
+      // foreign-shared data → the freshly-minted shared workspace.
       const threads = await db.select().from(chatThreadsTable)
       expect(threads).toHaveLength(2)
       const titleP = threads.find((t) => t.title === 'P')
       const titleS = threads.find((t) => t.title === 'S')
       expect(titleP?.workspaceId).toBe(crossAccountUser.personalWorkspaceId)
-      expect(titleS?.workspaceId).toBe(crossAccountUser.personalWorkspaceId)
-      // Fresh ids — not the source values.
+      expect(titleS?.workspaceId).toBe(sharedLocally?.id)
+      // chat_threads ids are freshly minted on cross-account.
       expect(titleP?.id).not.toBe('thread-in-personal')
       expect(titleS?.id).not.toBe('thread-in-shared')
+
+      // Synthesized membership: importing user becomes admin of the new
+      // shared workspace (and re-uses the existing membership for personal).
+      const memberships = await db
+        .select()
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.workspaceId, sharedLocally!.id))
+      expect(memberships).toHaveLength(1)
+      expect(memberships[0]?.userId).toBe(crossAccountUser.id)
+      expect(memberships[0]?.role).toBe('admin')
     })
 
     it('merges a foreign personal workspace into the importing user`s local personal — does not create a second isPersonal row', async () => {

--- a/src/dal/import.ts
+++ b/src/dal/import.ts
@@ -46,8 +46,45 @@ export const derivePkSpec = (tableName: string, table: SQLiteTable): PkSpec => {
 
 type TableImportSpec = {
   pk: PkSpec
-  /** True when the table has a `user_id` column (every synced table; secret tables omit it). */
-  hasUserId: boolean
+  /** JS field names on the row whose value identifies a user (e.g. `userId`,
+   *  `ownerUserId`, `invitedByUserId`). On import these are stripped from the
+   *  file row and rewritten with the current session user — the file value is
+   *  never trusted. Empty for tables (e.g. secrets) that have no such columns. */
+  userIdFields: string[]
+  /** True when the table has a `workspace_id` column. Pre-workspaces-v1
+   *  backups have no `workspaceId` on their rows; on import we fall back to the
+   *  importing user's personal workspace so the data is visible in the UI
+   *  instead of orphaned with `workspace_id = NULL`. */
+  hasWorkspaceId: boolean
+}
+
+/** SQL column-name predicate: matches `user_id`, `owner_user_id`,
+ *  `invited_by_user_id`, etc. Used to flag every user-FK column for re-stamping
+ *  so a workspaces / pending-membership row can't plant a foreign user id. */
+const isUserIdColumnName = (name: string): boolean => name === 'user_id' || name.endsWith('_user_id')
+
+/** Resolve the JS field name on a Drizzle table whose value === `column`.
+ *  Drizzle exposes each column as an enumerable property on the table;
+ *  matching by reference recovers the field name even when it differs from
+ *  the SQL column name. Skip the internal `_` config bag. */
+const findJsFieldName = (table: SQLiteTable, column: SQLiteColumn): string | null => {
+  const candidates = Object.entries(table as unknown as Record<string, unknown>).filter(([key]) => key !== '_')
+  return candidates.find(([, value]) => value === column)?.[0] ?? null
+}
+
+const deriveUserIdFields = (tableName: string, table: SQLiteTable): string[] => {
+  const fields: string[] = []
+  for (const column of getTableConfig(table).columns) {
+    if (!isUserIdColumnName(column.name)) {
+      continue
+    }
+    const field = findJsFieldName(table, column as SQLiteColumn)
+    if (!field) {
+      throw new Error(`Could not derive JS field name for user-id column "${column.name}" on "${tableName}".`)
+    }
+    fields.push(field)
+  }
+  return fields
 }
 
 /**
@@ -61,7 +98,8 @@ const tableImportSpecs = Object.fromEntries(
     name,
     {
       pk: derivePkSpec(name, table),
-      hasUserId: getTableConfig(table).columns.some((c) => c.name === 'user_id'),
+      userIdFields: deriveUserIdFields(name, table),
+      hasWorkspaceId: getTableConfig(table).columns.some((c) => c.name === 'workspace_id'),
     },
   ]),
 ) as Record<IncludedTableName, TableImportSpec>
@@ -151,23 +189,53 @@ export const summarizeExportEnvelope = (
   return { totalRows, exportedAtLabel, sourceEmail, accountMismatch }
 }
 
+/** JS-side counterpart to {@link isUserIdColumnName}: matches `userId`,
+ *  `ownerUserId`, `invitedByUserId`, etc. Used to strip every user-FK field
+ *  off a file row before re-stamping the columns the target table actually
+ *  has. Drops blindly so a rogue file value never survives even on a table
+ *  that has no user column at all (e.g. the secret tables). */
+const isUserIdFieldName = (name: string): boolean => name === 'userId' || name.endsWith('UserId')
+
 /**
- * Drop the file's `userId` and either re-stamp it from the current session
- * (tables with a `user_id` column) or omit it entirely (secret tables, which
- * have no such column). The file's value is never trusted: backups carry the
- * source user's id, but a tampered or cross-account file would otherwise
- * plant a foreign id in the local DB until backend reconciliation.
+ * Strip every user-id field from the file row, re-stamp the columns the
+ * target table actually has with the current session user, and back-fill
+ * `workspaceId` with the importing user's personal workspace when the file
+ * row is missing one (pre-workspaces-v1 backups).
  *
- * The backend's PowerSync upload route enforces the same invariant from the
- * JWT (see `backend/src/dal/powersync.ts`).
+ * User-id re-stamping covers `user_id`, `owner_user_id`, `invited_by_user_id`,
+ * and any future user-FK column — detection is column-name based, not
+ * table-name based. Backups carry the source user's id, but a tampered or
+ * cross-account file would otherwise plant a foreign id in the local DB
+ * until backend reconciliation. The backend's PowerSync upload route
+ * enforces the same invariant from the JWT (see
+ * `backend/src/dal/powersync.ts`).
+ *
+ * The `workspaceId` rule is fallback-only: a modern multi-workspace backup
+ * carries `workspaceId` on every per-user row, and we preserve those values
+ * so a restore reinstates the source's workspace structure. Only rows that
+ * arrive without one (legacy v1 backups) get attached to the personal
+ * workspace so they're visible to the UI instead of orphaned at NULL.
  */
 const sanitizeRowForImport = (
   row: Record<string, unknown>,
-  hasUserId: boolean,
+  userIdFields: string[],
+  hasWorkspaceId: boolean,
   currentUserId: string,
+  personalWorkspaceId: string,
 ): Record<string, unknown> => {
-  const { userId: _ignored, ...rest } = row
-  return hasUserId ? { ...rest, userId: currentUserId } : rest
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    if (!isUserIdFieldName(key)) {
+      sanitized[key] = value
+    }
+  }
+  for (const field of userIdFields) {
+    sanitized[field] = currentUserId
+  }
+  if (hasWorkspaceId && (sanitized.workspaceId === undefined || sanitized.workspaceId === null)) {
+    sanitized.workspaceId = personalWorkspaceId
+  }
+  return sanitized
 }
 
 /**
@@ -181,10 +249,17 @@ const sanitizeRowForImport = (
  *   and SQLite forbids `INSERT ... ON CONFLICT DO UPDATE` on a view ("cannot
  *   UPSERT a view"). The SELECT + UPDATE/INSERT split works on both real
  *   tables and PowerSync views.
- * - **`userId` re-stamped.** Tables with a `user_id` column have their
- *   row's `userId` overwritten with `currentUser.id`; the value in the file
- *   is never trusted. Tables without `user_id` (the secret tables) are
- *   unaffected.
+ * - **User-id columns re-stamped.** Every column whose SQL name matches
+ *   `user_id` / `*_user_id` (e.g. `user_id`, `owner_user_id`,
+ *   `invited_by_user_id`) is overwritten with `currentUser.id`; the value in
+ *   the file is never trusted. Tables without any user-id column (e.g. the
+ *   secret tables) are unaffected.
+ * - **`workspaceId` back-filled.** Rows from a pre-workspaces-v1 backup
+ *   arrive without `workspaceId`; on tables that have a `workspace_id`
+ *   column, the missing value is stamped with `currentUser.personalWorkspaceId`
+ *   so the data lands in the user's personal workspace instead of orphaned at
+ *   NULL. Rows that arrive *with* a `workspaceId` are preserved verbatim —
+ *   modern multi-workspace backups keep their workspace structure on restore.
  * - **Soft-deleted rows preserved.** `deletedAt` is written verbatim, so a
  *   row exported in the trash stays in the trash after import.
  * - **Atomic.** Wrapped in a single `db.transaction`; any per-row failure
@@ -200,7 +275,7 @@ const sanitizeRowForImport = (
 export const importUserData = async (
   db: AnyDrizzleDatabase,
   payload: unknown,
-  currentUser: { id: string },
+  currentUser: { id: string; personalWorkspaceId: string },
 ): Promise<ImportResult> => {
   if (!isRecord(payload)) {
     throw new ImportFormatError('Import file is not a JSON object.')
@@ -234,7 +309,7 @@ export const importUserData = async (
       }
 
       const table = includedTables[tableName]
-      const { pk, hasUserId } = tableImportSpecs[tableName]
+      const { pk, userIdFields, hasWorkspaceId } = tableImportSpecs[tableName]
       const { column: pkColumn, field: pkField } = pk
 
       for (const row of rows) {
@@ -245,7 +320,13 @@ export const importUserData = async (
         if (typeof pkValue !== 'string') {
           throw new ImportFormatError(`Row in "${tableName}" is missing string primary key "${pkField}".`)
         }
-        const sanitized = sanitizeRowForImport(row, hasUserId, currentUser.id)
+        const sanitized = sanitizeRowForImport(
+          row,
+          userIdFields,
+          hasWorkspaceId,
+          currentUser.id,
+          currentUser.personalWorkspaceId,
+        )
         const existing = await tx.select({ pk: pkColumn }).from(table).where(eq(pkColumn, pkValue)).get()
         if (existing) {
           await tx.update(table).set(sanitized).where(eq(pkColumn, pkValue))

--- a/src/dal/import.ts
+++ b/src/dal/import.ts
@@ -353,6 +353,14 @@ export const importUserData = async (
   if (!isRecord(payload.tables)) {
     throw new ImportFormatError('Import file is missing the `tables` object.')
   }
+  // `user.id` is the cross-account signal — required by the export type and
+  // load-bearing for every cross-account guard below (id mint, workspace
+  // remap, orphan force-to-personal). Without it we can't tell a same-account
+  // restore (which should preserve workspace structure and ids) from a
+  // cross-account import (which must mint), so refuse to guess.
+  if (!isRecord(payload.user) || typeof payload.user.id !== 'string') {
+    throw new ImportFormatError('Import file is missing or has invalid `user.id`.')
+  }
 
   const fileTables = payload.tables
   const ignoredTableNames: string[] = []
@@ -386,8 +394,8 @@ export const importUserData = async (
   // 3. Same-account shared: no remap. Source ids already exist on the BE
   //    with this user as admin; upload upserts are in-place no-ops and
   //    everything round-trips.
-  const sourceUserId = isRecord(payload.user) && typeof payload.user.id === 'string' ? payload.user.id : null
-  const isCrossAccount = sourceUserId === null || sourceUserId !== currentUser.id
+  const sourceUserId = payload.user.id
+  const isCrossAccount = sourceUserId !== currentUser.id
   const workspaceRemap = new Map<string, string>()
   const fileWorkspaces = fileTables.workspaces
   if (Array.isArray(fileWorkspaces)) {

--- a/src/dal/import.ts
+++ b/src/dal/import.ts
@@ -3,8 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { AnyDrizzleDatabase } from '@/db/database-interface'
+import { workspaceMembershipsTable } from '@/db/tables'
 import { eq } from 'drizzle-orm'
 import { getTableConfig, type SQLiteColumn, type SQLiteTable } from 'drizzle-orm/sqlite-core'
+import { v7 as uuidv7 } from 'uuid'
 import { exportFormat, exportSchemaVersion, exportedTableNames, includedTables, type IncludedTableName } from './export'
 
 type PkSpec = {
@@ -260,6 +262,18 @@ const sanitizeRowForImport = (
  *   so the data lands in the user's personal workspace instead of orphaned at
  *   NULL. Rows that arrive *with* a `workspaceId` are preserved verbatim —
  *   modern multi-workspace backups keep their workspace structure on restore.
+ * - **`workspace_memberships` synthesized, not imported.** The envelope
+ *   doesn't carry membership rows (see {@link excludedFromExport} —
+ *   blindly carrying co-members' rows would either leak their
+ *   `userName`/`userEmail` or produce duplicate self-rows on cross-account
+ *   import). Instead, after every workspace row is upserted, this importer
+ *   synthesizes one admin membership row for the importing user per
+ *   imported workspace they don't already belong to locally. PowerSync
+ *   reconciles with the BE on next sync.
+ * - **`workspace_pending_memberships` ignored.** Admin-only invite metadata
+ *   for other people; the BE is authoritative. Rows arriving in the file
+ *   (e.g. legacy or hand-crafted) are silently routed to
+ *   {@link ImportResult.ignoredTableNames}.
  * - **Soft-deleted rows preserved.** `deletedAt` is written verbatim, so a
  *   row exported in the trash stays in the trash after import.
  * - **Atomic.** Wrapped in a single `db.transaction`; any per-row failure
@@ -297,6 +311,11 @@ export const importUserData = async (
   const fileTables = payload.tables
   const ignoredTableNames: string[] = []
   const tableCounts: Partial<Record<IncludedTableName, { upserted: number }>> = {}
+  // Workspace ids upserted from the envelope. After the file loop we walk
+  // this set and synthesize an admin membership row for the importing user
+  // on every workspace they don't already belong to locally — see the doc
+  // comment on `importUserData` and `excludedFromExport` in ./export.ts.
+  const importedWorkspaceIds = new Set<string>()
 
   await db.transaction(async (tx) => {
     for (const [tableName, rows] of Object.entries(fileTables)) {
@@ -333,9 +352,40 @@ export const importUserData = async (
         } else {
           await tx.insert(table).values(sanitized)
         }
+        if (tableName === 'workspaces') {
+          importedWorkspaceIds.add(pkValue)
+        }
       }
 
       tableCounts[tableName] = { upserted: rows.length }
+    }
+
+    // Synthesize membership rows so the importing user can access every
+    // imported workspace immediately. Skip workspaces they're already a
+    // member of locally (re-import, or a pre-existing membership from
+    // PowerSync down-sync). Role is `admin` — consistent with
+    // `ownerUserId` being re-stamped to the importing user; the BE
+    // reconciles on next sync if the upload disagrees with the truth.
+    if (importedWorkspaceIds.size > 0) {
+      const existingMemberships = await tx
+        .select({ workspaceId: workspaceMembershipsTable.workspaceId })
+        .from(workspaceMembershipsTable)
+        .where(eq(workspaceMembershipsTable.userId, currentUser.id))
+      const alreadyMember = new Set(
+        existingMemberships.map((m) => m.workspaceId).filter((id): id is string => id !== null),
+      )
+
+      for (const workspaceId of importedWorkspaceIds) {
+        if (alreadyMember.has(workspaceId)) {
+          continue
+        }
+        await tx.insert(workspaceMembershipsTable).values({
+          id: uuidv7(),
+          workspaceId,
+          userId: currentUser.id,
+          role: 'admin',
+        })
+      }
     }
   })
 

--- a/src/dal/import.ts
+++ b/src/dal/import.ts
@@ -274,6 +274,14 @@ const sanitizeRowForImport = (
  *   for other people; the BE is authoritative. Rows arriving in the file
  *   (e.g. legacy or hand-crafted) are silently routed to
  *   {@link ImportResult.ignoredTableNames}.
+ * - **Foreign personal workspaces merged into the local personal.** Each
+ *   user gets exactly one `isPersonal: 1` workspace (BE enforces this via
+ *   a partial unique index). A cross-account import would otherwise leave
+ *   two personals owned by the importing user. We skip the foreign personal
+ *   from the workspaces upsert and rewrite every per-workspace data row
+ *   that referenced it to `currentUser.personalWorkspaceId` — the source
+ *   user's chats / models / tasks land in the importing user's existing
+ *   personal workspace, where they're immediately visible.
  * - **Soft-deleted rows preserved.** `deletedAt` is written verbatim, so a
  *   row exported in the trash stays in the trash after import.
  * - **Atomic.** Wrapped in a single `db.transaction`; any per-row failure
@@ -317,6 +325,29 @@ export const importUserData = async (
   // comment on `importUserData` and `excludedFromExport` in ./export.ts.
   const importedWorkspaceIds = new Set<string>()
 
+  // Pre-pass: build a remap from foreign personal-workspace ids → the
+  // importing user's local personal workspace. Re-stamping a foreign
+  // `isPersonal: 1` row's ownerUserId to the importing user would leave
+  // two personal workspaces with the same owner — non-deterministic local
+  // lookup + a guaranteed BE conflict (the `idx_workspaces_personal_per_owner`
+  // partial unique index is one-personal-per-owner). Instead, we skip the
+  // foreign row from the workspaces upsert entirely and re-attribute every
+  // per-workspace data row that pointed at it to the local personal.
+  const personalRemap = new Map<string, string>()
+  const fileWorkspaces = fileTables.workspaces
+  if (Array.isArray(fileWorkspaces)) {
+    for (const row of fileWorkspaces) {
+      if (
+        isRecord(row) &&
+        row.isPersonal === 1 &&
+        typeof row.id === 'string' &&
+        row.id !== currentUser.personalWorkspaceId
+      ) {
+        personalRemap.set(row.id, currentUser.personalWorkspaceId)
+      }
+    }
+  }
+
   await db.transaction(async (tx) => {
     for (const [tableName, rows] of Object.entries(fileTables)) {
       if (!isIncludedTableName(tableName)) {
@@ -330,6 +361,7 @@ export const importUserData = async (
       const table = includedTables[tableName]
       const { pk, userIdFields, hasWorkspaceId } = tableImportSpecs[tableName]
       const { column: pkColumn, field: pkField } = pk
+      let upsertedCount = 0
 
       for (const row of rows) {
         if (!isRecord(row)) {
@@ -339,6 +371,12 @@ export const importUserData = async (
         if (typeof pkValue !== 'string') {
           throw new ImportFormatError(`Row in "${tableName}" is missing string primary key "${pkField}".`)
         }
+        // Foreign personal workspaces don't land as separate rows — their
+        // resources are merged into the importing user's personal workspace
+        // (see `personalRemap` above).
+        if (tableName === 'workspaces' && personalRemap.has(pkValue)) {
+          continue
+        }
         const sanitized = sanitizeRowForImport(
           row,
           userIdFields,
@@ -346,18 +384,28 @@ export const importUserData = async (
           currentUser.id,
           currentUser.personalWorkspaceId,
         )
+        // Re-attribute any reference to a foreign personal workspace.
+        if (hasWorkspaceId && typeof sanitized.workspaceId === 'string') {
+          const remapped = personalRemap.get(sanitized.workspaceId)
+          if (remapped) {
+            sanitized.workspaceId = remapped
+          }
+        }
         const existing = await tx.select({ pk: pkColumn }).from(table).where(eq(pkColumn, pkValue)).get()
         if (existing) {
           await tx.update(table).set(sanitized).where(eq(pkColumn, pkValue))
         } else {
           await tx.insert(table).values(sanitized)
         }
+        upsertedCount += 1
         if (tableName === 'workspaces') {
           importedWorkspaceIds.add(pkValue)
         }
       }
 
-      tableCounts[tableName] = { upserted: rows.length }
+      if (upsertedCount > 0) {
+        tableCounts[tableName] = { upserted: upsertedCount }
+      }
     }
 
     // Synthesize membership rows so the importing user can access every

--- a/src/dal/import.ts
+++ b/src/dal/import.ts
@@ -274,33 +274,52 @@ const sanitizeRowForImport = (
  *   for other people; the BE is authoritative. Rows arriving in the file
  *   (e.g. legacy or hand-crafted) are silently routed to
  *   {@link ImportResult.ignoredTableNames}.
- * - **Fresh ids minted for `chat_threads` / `chat_messages` on cross-account
- *   import.** BE conflict target for these two tables is `(id)` alone (other
- *   per-workspace tables use composite `(id, workspace_id)`). Re-uploading
- *   a source row's id under the importing user's workspace silently no-ops
- *   on the BE (`ON CONFLICT (id) DO UPDATE WHERE workspace_id = …` doesn't
- *   match the existing row's `workspace_id`), then the `user_private`
- *   down-sync — filtered by `user_id = caller` — wipes the local rows. The
- *   import mints a fresh `uuidv7()` per row, rewriting `id`, plus
- *   `chat_messages.chatThreadId` and `chat_messages.parentId` to the new
- *   ids so threads + messages + reply-graphs stay internally consistent.
- *   Same-account re-import doesn't mint — the existing BE row's
- *   `workspace_id` already matches the upload, so the upsert updates in
- *   place.
- * - **Foreign workspaces merged into the local personal.** Cross-account
- *   import (`payload.user.id !== currentUser.id`, including the malformed-
- *   envelope case) collapses *every* foreign workspace — personal and shared
- *   — into the importing user's personal workspace: their workspace rows
- *   are skipped from the upsert, every per-workspace row that referenced
- *   one is rewritten to `currentUser.personalWorkspaceId`. Reason: the BE
- *   won't accept uploads referencing workspaces the importing user isn't a
- *   member of, so preserving the foreign structure locally would silently
- *   wipe every per-workspace row on first sync (uploads permanent-reject,
- *   then the down-sync removes the now-orphaned local rows). Same-account
- *   import (`user.id` match) preserves shared workspaces — they already
- *   exist on the BE with this user as admin — and only remaps a foreign-id
- *   personal row (defensive; happens after account-recreate when Better
- *   Auth re-issues `user.id` and the canonical personal id shifts).
+ * - **`workspace_permissions` dropped for remapped workspaces.** When
+ *   multiple foreign workspaces collapse to local personal (cross-account
+ *   import), keeping their permission rows would produce duplicates on
+ *   `(workspace_id, permission_key)` — locally permitted by the non-unique
+ *   index but rejected on BE upload (BE has a unique index). The BE
+ *   applies the admin-only default (Decision 11) when a key has no row, so
+ *   dropping is harmless. Same-account import (no remap) preserves the
+ *   rows.
+ * - **Fresh ids minted for id-only-conflict tables on cross-account
+ *   import.** `chat_threads`, `chat_messages`, and `triggers` use `(id)`
+ *   alone as the BE conflict target (other per-workspace tables use
+ *   composite `(id, workspace_id)`). Re-uploading a source row's id under
+ *   the importing user's workspace silently no-ops on the BE (`ON CONFLICT
+ *   (id) DO UPDATE WHERE workspace_id = …` doesn't match the existing
+ *   row's `workspace_id`), and the down-sync then wipes the local rows.
+ *   The import mints a fresh `uuidv7()` per row and rewires every cross-
+ *   reference that points at one: `chat_messages.chatThreadId` /
+ *   `chat_messages.parentId` to the new chat ids, `chat_threads.triggeredBy`
+ *   to the new trigger id. Same-account re-import doesn't mint — the
+ *   existing BE row's `workspace_id` already matches the upload, so the
+ *   upsert updates in place.
+ * - **Foreign personal workspaces merge into local personal; foreign
+ *   shared workspaces are preserved under fresh ids (cross-account).** Each
+ *   user gets exactly one personal workspace on the BE (partial unique
+ *   index `(ownerUserId, isPersonal=true)`), so an imported personal
+ *   collapses into `currentUser.personalWorkspaceId` — every per-workspace
+ *   row referencing it is rewritten. Foreign shared workspaces in
+ *   cross-account mode (`payload.user.id !== currentUser.id`) are kept
+ *   but inserted under a freshly-minted `uuidv7()`; the source's id would
+ *   collide with the existing BE row and the upsert would silently no-op,
+ *   then `workspace_essentials` down-sync (gated on membership) would wipe
+ *   the local row. `slug` is stripped on insert (BE has a global unique
+ *   index on `slug`). The synthesized admin membership added after the
+ *   file loop lets `isSharedWorkspaceAdminBootstrap` accept the first
+ *   write on the BE. Same-account import preserves shared workspaces
+ *   under their original ids — they already exist on the BE with this
+ *   user as admin, so upserts no-op in place.
+ * - **`workspace_permissions` follow the workspace remap.** Rows whose
+ *   source workspace collapses into local personal are dropped: N foreign
+ *   workspaces' policies sharing one `workspace_id` would all collide on
+ *   the BE's unique `(workspace_id, permission_key)` index, and the BE
+ *   applies the admin-only default (Decision 11) when a key has no row.
+ *   Rows for preserved foreign-shared workspaces are kept under a fresh
+ *   `uuidv7()` id (the BE conflict target on this table is `[id]` alone,
+ *   so re-using the source's id would silently no-op against its existing
+ *   BE row).
  * - **Soft-deleted rows preserved.** `deletedAt` is written verbatim, so a
  *   row exported in the trash stays in the trash after import.
  * - **Atomic.** Wrapped in a single `db.transaction`; any per-row failure
@@ -344,25 +363,29 @@ export const importUserData = async (
   // comment on `importUserData` and `excludedFromExport` in ./export.ts.
   const importedWorkspaceIds = new Set<string>()
 
-  // Build a remap from foreign workspace ids → the importing user's local
-  // personal workspace. Two cases land here, both for the same underlying
-  // reason: the BE won't accept uploads referencing workspaces the importing
-  // user isn't a member of, so preserving the foreign workspace structure
-  // locally would silently lose every per-workspace row on first sync (the
-  // uploads permanent-reject, then the `user_private` bucket's down-sync
-  // removes the now-orphaned local rows).
+  // Build a remap from foreign workspace ids → their local target. Three
+  // cases drive entries here, all because the BE won't accept uploads
+  // referencing workspaces the importing user isn't a member of on the
+  // server (the workspace handler short-circuits on `isWorkspaceAdmin` /
+  // `isWorkspaceMember` and the upserts silently no-op or permanent-reject;
+  // the next down-sync then wipes the orphaned local rows).
   //
-  // 1. Cross-account import (`payload.user.id !== currentUser.id`, including
-  //    the malformed-envelope case where `user.id` is missing): collapse
-  //    *every* foreign workspace — personal and shared — into local personal.
-  //    The user gets a snapshot of the source's data in their own workspace,
-  //    nothing tries to sync up under a foreign workspace id.
-  // 2. Same-account import: only `isPersonal: 1` rows whose id doesn't match
-  //    `currentUser.personalWorkspaceId` need remapping (defensive — happens
-  //    only after an account-recreate where Better Auth re-issues `user.id`
-  //    and the canonical personal id shifts). Shared workspaces preserve
-  //    structure; they already exist on the BE under the same id with this
-  //    user as admin, so upload upserts are no-ops.
+  // 1. Foreign personal (`isPersonal: 1`, `id !== currentUser.personalWorkspaceId`):
+  //    collapse into local personal. Each user gets exactly one personal
+  //    workspace (BE partial unique index on `(ownerUserId, isPersonal=true)`),
+  //    so we never insert a second one. The remap target is the importing
+  //    user's existing personal id; per-workspace data is rewritten to it.
+  // 2. Foreign shared, cross-account (`isPersonal: 0` AND
+  //    `payload.user.id !== currentUser.id`): mint a fresh `uuidv7()` so
+  //    the workspace lands on the BE as a brand-new row (no `(id)` PK
+  //    conflict against the source's row). The importing user authors it
+  //    locally; `isSharedWorkspaceAdminBootstrap` on the BE accepts the
+  //    synthesized admin membership the importer adds after the file loop.
+  //    `slug` is stripped at insert time — the BE has a global unique index
+  //    on `slug` and we don't want to collide with the source's row.
+  // 3. Same-account shared: no remap. Source ids already exist on the BE
+  //    with this user as admin; upload upserts are in-place no-ops and
+  //    everything round-trips.
   const sourceUserId = isRecord(payload.user) && typeof payload.user.id === 'string' ? payload.user.id : null
   const isCrossAccount = sourceUserId === null || sourceUserId !== currentUser.id
   const workspaceRemap = new Map<string, string>()
@@ -375,8 +398,30 @@ export const importUserData = async (
       if (row.id === currentUser.personalWorkspaceId) {
         continue
       }
-      if (isCrossAccount || row.isPersonal === 1) {
+      if (row.isPersonal === 1) {
         workspaceRemap.set(row.id, currentUser.personalWorkspaceId)
+      } else if (isCrossAccount) {
+        workspaceRemap.set(row.id, uuidv7())
+      }
+    }
+  }
+
+  // Cross-account permissions for *preserved* foreign-shared workspaces
+  // need fresh ids too — BE conflict target on `workspace_permissions` is
+  // `[id]` alone (same id-only-collision problem we hit on chat_threads),
+  // so re-uploading the source's permission id under the new workspace id
+  // would no-op the upsert. Permissions for workspaces that collapse to
+  // local personal aren't kept at all (handled in the row loop below).
+  const workspacePermissionIdRemap = new Map<string, string>()
+  const filePermissions = fileTables.workspace_permissions
+  if (Array.isArray(filePermissions)) {
+    for (const row of filePermissions) {
+      if (!isRecord(row) || typeof row.id !== 'string' || typeof row.workspaceId !== 'string') {
+        continue
+      }
+      const remapped = workspaceRemap.get(row.workspaceId)
+      if (remapped && remapped !== currentUser.personalWorkspaceId) {
+        workspacePermissionIdRemap.set(row.id, uuidv7())
       }
     }
   }
@@ -394,6 +439,7 @@ export const importUserData = async (
   // the existing BE row's `workspace_id` matches, the upsert updates in place.
   const chatThreadIdRemap = new Map<string, string>()
   const chatMessageIdRemap = new Map<string, string>()
+  const triggerIdRemap = new Map<string, string>()
   if (isCrossAccount) {
     const fileChatThreads = fileTables.chat_threads
     if (Array.isArray(fileChatThreads)) {
@@ -411,18 +457,22 @@ export const importUserData = async (
         }
       }
     }
+    // Triggers share the same id-only BE conflict target as chat_threads /
+    // chat_messages — re-uploading the source's id would silently no-op.
+    // `chat_threads.triggeredBy` references trigger ids, so the remap is
+    // also applied when chat_threads rows are written below.
+    const fileTriggers = fileTables.triggers
+    if (Array.isArray(fileTriggers)) {
+      for (const row of fileTriggers) {
+        if (isRecord(row) && typeof row.id === 'string') {
+          triggerIdRemap.set(row.id, uuidv7())
+        }
+      }
+    }
   }
 
   await db.transaction(async (tx) => {
-    for (const [tableName, rows] of Object.entries(fileTables)) {
-      if (!isIncludedTableName(tableName)) {
-        ignoredTableNames.push(tableName)
-        continue
-      }
-      if (!Array.isArray(rows) || rows.length === 0) {
-        continue
-      }
-
+    const processTable = async (tableName: IncludedTableName, rows: unknown[]): Promise<void> => {
       const table = includedTables[tableName]
       const { pk, userIdFields, hasWorkspaceId } = tableImportSpecs[tableName]
       const { column: pkColumn, field: pkField } = pk
@@ -436,11 +486,30 @@ export const importUserData = async (
         if (typeof filePkValue !== 'string') {
           throw new ImportFormatError(`Row in "${tableName}" is missing string primary key "${pkField}".`)
         }
-        // Foreign workspaces in the remap don't land as separate rows — their
-        // resources are merged into the importing user's personal workspace
-        // (see `workspaceRemap` above).
-        if (tableName === 'workspaces' && workspaceRemap.has(filePkValue)) {
-          continue
+        // Foreign workspaces that merged into local personal don't land as
+        // separate rows; foreign-shared workspaces (cross-account) DO land,
+        // but under the freshly-minted id from `workspaceRemap`.
+        if (tableName === 'workspaces') {
+          const target = workspaceRemap.get(filePkValue)
+          if (target === currentUser.personalWorkspaceId) {
+            continue
+          }
+        }
+        // Workspace policy rows for workspaces that collapse to local personal
+        // are dropped: collapsing N foreign workspaces would otherwise produce
+        // N rows sharing `(workspace_id, permission_key)`, which the BE
+        // rejects on upload (unique index `idx_workspace_permissions_workspace_key`).
+        // The BE applies Decision-11 admin-default when no row is present.
+        // Rows for preserved foreign-shared workspaces are kept and follow
+        // the new workspace id via the per-workspace remap below.
+        if (tableName === 'workspace_permissions') {
+          const rowWorkspaceId = row.workspaceId
+          if (
+            typeof rowWorkspaceId === 'string' &&
+            workspaceRemap.get(rowWorkspaceId) === currentUser.personalWorkspaceId
+          ) {
+            continue
+          }
         }
         const sanitized = sanitizeRowForImport(
           row,
@@ -465,6 +534,20 @@ export const importUserData = async (
             pkValue = newId
             sanitized.id = newId
           }
+          // `triggeredBy` references a trigger row's id; remap to the new
+          // id minted in the triggers pre-pass.
+          if (typeof sanitized.triggeredBy === 'string') {
+            const remappedTrigger = triggerIdRemap.get(sanitized.triggeredBy)
+            if (remappedTrigger) {
+              sanitized.triggeredBy = remappedTrigger
+            }
+          }
+        } else if (tableName === 'triggers') {
+          const newId = triggerIdRemap.get(filePkValue)
+          if (newId) {
+            pkValue = newId
+            sanitized.id = newId
+          }
         } else if (tableName === 'chat_messages') {
           const newId = chatMessageIdRemap.get(filePkValue)
           if (newId) {
@@ -482,6 +565,25 @@ export const importUserData = async (
             if (remappedParent) {
               sanitized.parentId = remappedParent
             }
+          }
+        } else if (tableName === 'workspaces') {
+          // Preserved foreign-shared workspace: insert under the freshly-
+          // minted id from `workspaceRemap`, slug stripped (the BE has a
+          // global unique index on `slug`).
+          const newId = workspaceRemap.get(filePkValue)
+          if (newId) {
+            pkValue = newId
+            sanitized.id = newId
+            sanitized.slug = null
+          }
+        } else if (tableName === 'workspace_permissions') {
+          // Preserved foreign-shared permissions: mint a fresh id so the
+          // BE's id-only `ON CONFLICT` doesn't silently no-op against the
+          // source's existing row.
+          const newId = workspacePermissionIdRemap.get(filePkValue)
+          if (newId) {
+            pkValue = newId
+            sanitized.id = newId
           }
         }
         const existing = await tx.select({ pk: pkColumn }).from(table).where(eq(pkColumn, pkValue)).get()
@@ -501,12 +603,29 @@ export const importUserData = async (
       }
     }
 
+    // CRUD-queue order matters for PowerSync: a foreign-shared workspace
+    // lands on the BE as a brand-new row, so its synthesized admin
+    // membership must precede any per-workspace upload (chat_threads etc.
+    // are validated by `isWorkspaceMember`, which the BE evaluates against
+    // the cumulative state of earlier ops in the same batch). Our own
+    // export emits `workspaces` LAST in the envelope; processing in the
+    // file's own order would queue chat_messages → ... → workspaces →
+    // memberships and the BE would reject mid-batch. So:
+    //   1. `workspaces` first (insert new rows, skip merged personals)
+    //   2. synthesize memberships for any imported workspace the user
+    //      doesn't already belong to locally
+    //   3. everything else (per-workspace data, settings, secrets, …)
+    if (Array.isArray(fileTables.workspaces) && fileTables.workspaces.length > 0) {
+      await processTable('workspaces', fileTables.workspaces)
+    }
+
     // Synthesize membership rows so the importing user can access every
     // imported workspace immediately. Skip workspaces they're already a
     // member of locally (re-import, or a pre-existing membership from
-    // PowerSync down-sync). Role is `admin` — consistent with
-    // `ownerUserId` being re-stamped to the importing user; the BE
-    // reconciles on next sync if the upload disagrees with the truth.
+    // PowerSync down-sync). Role is `admin` — consistent with the
+    // `ownerUserId` re-stamp and with the importing user being the only
+    // local actor; on cross-account, foreign-shared workspaces have zero
+    // BE members and `isSharedWorkspaceAdminBootstrap` accepts the row.
     if (importedWorkspaceIds.size > 0) {
       const existingMemberships = await tx
         .select({ workspaceId: workspaceMembershipsTable.workspaceId })
@@ -527,6 +646,20 @@ export const importUserData = async (
           role: 'admin',
         })
       }
+    }
+
+    for (const [tableName, rows] of Object.entries(fileTables)) {
+      if (tableName === 'workspaces') {
+        continue
+      }
+      if (!isIncludedTableName(tableName)) {
+        ignoredTableNames.push(tableName)
+        continue
+      }
+      if (!Array.isArray(rows) || rows.length === 0) {
+        continue
+      }
+      await processTable(tableName, rows)
     }
   })
 

--- a/src/dal/import.ts
+++ b/src/dal/import.ts
@@ -518,11 +518,19 @@ export const importUserData = async (
           currentUser.id,
           currentUser.personalWorkspaceId,
         )
-        // Re-attribute any reference to a remapped foreign workspace.
+        // Re-attribute references to remapped foreign workspaces. In
+        // cross-account mode any `workspaceId` that *isn't* in the remap
+        // is also a foreign id (the envelope just didn't carry the
+        // corresponding `workspaces` row — hand-crafted / tampered / a
+        // partial export); force it to local personal too rather than let
+        // the row sync up under an id the BE will reject (which would then
+        // wipe it on down-sync).
         if (hasWorkspaceId && typeof sanitized.workspaceId === 'string') {
           const remapped = workspaceRemap.get(sanitized.workspaceId)
           if (remapped) {
             sanitized.workspaceId = remapped
+          } else if (isCrossAccount && sanitized.workspaceId !== currentUser.personalWorkspaceId) {
+            sanitized.workspaceId = currentUser.personalWorkspaceId
           }
         }
         // Cross-account id remap for chat_threads / chat_messages — see the

--- a/src/dal/import.ts
+++ b/src/dal/import.ts
@@ -274,14 +274,33 @@ const sanitizeRowForImport = (
  *   for other people; the BE is authoritative. Rows arriving in the file
  *   (e.g. legacy or hand-crafted) are silently routed to
  *   {@link ImportResult.ignoredTableNames}.
- * - **Foreign personal workspaces merged into the local personal.** Each
- *   user gets exactly one `isPersonal: 1` workspace (BE enforces this via
- *   a partial unique index). A cross-account import would otherwise leave
- *   two personals owned by the importing user. We skip the foreign personal
- *   from the workspaces upsert and rewrite every per-workspace data row
- *   that referenced it to `currentUser.personalWorkspaceId` — the source
- *   user's chats / models / tasks land in the importing user's existing
- *   personal workspace, where they're immediately visible.
+ * - **Fresh ids minted for `chat_threads` / `chat_messages` on cross-account
+ *   import.** BE conflict target for these two tables is `(id)` alone (other
+ *   per-workspace tables use composite `(id, workspace_id)`). Re-uploading
+ *   a source row's id under the importing user's workspace silently no-ops
+ *   on the BE (`ON CONFLICT (id) DO UPDATE WHERE workspace_id = …` doesn't
+ *   match the existing row's `workspace_id`), then the `user_private`
+ *   down-sync — filtered by `user_id = caller` — wipes the local rows. The
+ *   import mints a fresh `uuidv7()` per row, rewriting `id`, plus
+ *   `chat_messages.chatThreadId` and `chat_messages.parentId` to the new
+ *   ids so threads + messages + reply-graphs stay internally consistent.
+ *   Same-account re-import doesn't mint — the existing BE row's
+ *   `workspace_id` already matches the upload, so the upsert updates in
+ *   place.
+ * - **Foreign workspaces merged into the local personal.** Cross-account
+ *   import (`payload.user.id !== currentUser.id`, including the malformed-
+ *   envelope case) collapses *every* foreign workspace — personal and shared
+ *   — into the importing user's personal workspace: their workspace rows
+ *   are skipped from the upsert, every per-workspace row that referenced
+ *   one is rewritten to `currentUser.personalWorkspaceId`. Reason: the BE
+ *   won't accept uploads referencing workspaces the importing user isn't a
+ *   member of, so preserving the foreign structure locally would silently
+ *   wipe every per-workspace row on first sync (uploads permanent-reject,
+ *   then the down-sync removes the now-orphaned local rows). Same-account
+ *   import (`user.id` match) preserves shared workspaces — they already
+ *   exist on the BE with this user as admin — and only remaps a foreign-id
+ *   personal row (defensive; happens after account-recreate when Better
+ *   Auth re-issues `user.id` and the canonical personal id shifts).
  * - **Soft-deleted rows preserved.** `deletedAt` is written verbatim, so a
  *   row exported in the trash stays in the trash after import.
  * - **Atomic.** Wrapped in a single `db.transaction`; any per-row failure
@@ -325,25 +344,71 @@ export const importUserData = async (
   // comment on `importUserData` and `excludedFromExport` in ./export.ts.
   const importedWorkspaceIds = new Set<string>()
 
-  // Pre-pass: build a remap from foreign personal-workspace ids → the
-  // importing user's local personal workspace. Re-stamping a foreign
-  // `isPersonal: 1` row's ownerUserId to the importing user would leave
-  // two personal workspaces with the same owner — non-deterministic local
-  // lookup + a guaranteed BE conflict (the `idx_workspaces_personal_per_owner`
-  // partial unique index is one-personal-per-owner). Instead, we skip the
-  // foreign row from the workspaces upsert entirely and re-attribute every
-  // per-workspace data row that pointed at it to the local personal.
-  const personalRemap = new Map<string, string>()
+  // Build a remap from foreign workspace ids → the importing user's local
+  // personal workspace. Two cases land here, both for the same underlying
+  // reason: the BE won't accept uploads referencing workspaces the importing
+  // user isn't a member of, so preserving the foreign workspace structure
+  // locally would silently lose every per-workspace row on first sync (the
+  // uploads permanent-reject, then the `user_private` bucket's down-sync
+  // removes the now-orphaned local rows).
+  //
+  // 1. Cross-account import (`payload.user.id !== currentUser.id`, including
+  //    the malformed-envelope case where `user.id` is missing): collapse
+  //    *every* foreign workspace — personal and shared — into local personal.
+  //    The user gets a snapshot of the source's data in their own workspace,
+  //    nothing tries to sync up under a foreign workspace id.
+  // 2. Same-account import: only `isPersonal: 1` rows whose id doesn't match
+  //    `currentUser.personalWorkspaceId` need remapping (defensive — happens
+  //    only after an account-recreate where Better Auth re-issues `user.id`
+  //    and the canonical personal id shifts). Shared workspaces preserve
+  //    structure; they already exist on the BE under the same id with this
+  //    user as admin, so upload upserts are no-ops.
+  const sourceUserId = isRecord(payload.user) && typeof payload.user.id === 'string' ? payload.user.id : null
+  const isCrossAccount = sourceUserId === null || sourceUserId !== currentUser.id
+  const workspaceRemap = new Map<string, string>()
   const fileWorkspaces = fileTables.workspaces
   if (Array.isArray(fileWorkspaces)) {
     for (const row of fileWorkspaces) {
-      if (
-        isRecord(row) &&
-        row.isPersonal === 1 &&
-        typeof row.id === 'string' &&
-        row.id !== currentUser.personalWorkspaceId
-      ) {
-        personalRemap.set(row.id, currentUser.personalWorkspaceId)
+      if (!isRecord(row) || typeof row.id !== 'string') {
+        continue
+      }
+      if (row.id === currentUser.personalWorkspaceId) {
+        continue
+      }
+      if (isCrossAccount || row.isPersonal === 1) {
+        workspaceRemap.set(row.id, currentUser.personalWorkspaceId)
+      }
+    }
+  }
+
+  // Cross-account: mint fresh ids for `chat_threads` and `chat_messages`.
+  // The BE's `INSERT ... ON CONFLICT (id) DO UPDATE WHERE workspace_id = ...`
+  // on these two tables uses `id` alone as the conflict target (the other
+  // workspace-scoped tables use composite `(id, workspace_id)`). Re-uploading
+  // the source's row id under the importing user's workspace silently no-ops:
+  // the conflict fires on the source's existing BE row but the setWhere
+  // clause doesn't match its `workspace_id`, so nothing is written. PowerSync
+  // acks the upload as success, then the `user_private` down-sync (filtered
+  // by `user_id = caller`) returns nothing and removes the local rows. Fresh
+  // ids sidestep the collision entirely. Same-account re-import is fine —
+  // the existing BE row's `workspace_id` matches, the upsert updates in place.
+  const chatThreadIdRemap = new Map<string, string>()
+  const chatMessageIdRemap = new Map<string, string>()
+  if (isCrossAccount) {
+    const fileChatThreads = fileTables.chat_threads
+    if (Array.isArray(fileChatThreads)) {
+      for (const row of fileChatThreads) {
+        if (isRecord(row) && typeof row.id === 'string') {
+          chatThreadIdRemap.set(row.id, uuidv7())
+        }
+      }
+    }
+    const fileChatMessages = fileTables.chat_messages
+    if (Array.isArray(fileChatMessages)) {
+      for (const row of fileChatMessages) {
+        if (isRecord(row) && typeof row.id === 'string') {
+          chatMessageIdRemap.set(row.id, uuidv7())
+        }
       }
     }
   }
@@ -367,14 +432,14 @@ export const importUserData = async (
         if (!isRecord(row)) {
           throw new ImportFormatError(`Row in table "${tableName}" is not an object.`)
         }
-        const pkValue = row[pkField]
-        if (typeof pkValue !== 'string') {
+        const filePkValue = row[pkField]
+        if (typeof filePkValue !== 'string') {
           throw new ImportFormatError(`Row in "${tableName}" is missing string primary key "${pkField}".`)
         }
-        // Foreign personal workspaces don't land as separate rows — their
+        // Foreign workspaces in the remap don't land as separate rows — their
         // resources are merged into the importing user's personal workspace
-        // (see `personalRemap` above).
-        if (tableName === 'workspaces' && personalRemap.has(pkValue)) {
+        // (see `workspaceRemap` above).
+        if (tableName === 'workspaces' && workspaceRemap.has(filePkValue)) {
           continue
         }
         const sanitized = sanitizeRowForImport(
@@ -384,11 +449,39 @@ export const importUserData = async (
           currentUser.id,
           currentUser.personalWorkspaceId,
         )
-        // Re-attribute any reference to a foreign personal workspace.
+        // Re-attribute any reference to a remapped foreign workspace.
         if (hasWorkspaceId && typeof sanitized.workspaceId === 'string') {
-          const remapped = personalRemap.get(sanitized.workspaceId)
+          const remapped = workspaceRemap.get(sanitized.workspaceId)
           if (remapped) {
             sanitized.workspaceId = remapped
+          }
+        }
+        // Cross-account id remap for chat_threads / chat_messages — see the
+        // doc on `chatThreadIdRemap` for why this is required.
+        let pkValue = filePkValue
+        if (tableName === 'chat_threads') {
+          const newId = chatThreadIdRemap.get(filePkValue)
+          if (newId) {
+            pkValue = newId
+            sanitized.id = newId
+          }
+        } else if (tableName === 'chat_messages') {
+          const newId = chatMessageIdRemap.get(filePkValue)
+          if (newId) {
+            pkValue = newId
+            sanitized.id = newId
+          }
+          if (typeof sanitized.chatThreadId === 'string') {
+            const remappedThread = chatThreadIdRemap.get(sanitized.chatThreadId)
+            if (remappedThread) {
+              sanitized.chatThreadId = remappedThread
+            }
+          }
+          if (typeof sanitized.parentId === 'string') {
+            const remappedParent = chatMessageIdRemap.get(sanitized.parentId)
+            if (remappedParent) {
+              sanitized.parentId = remappedParent
+            }
           }
         }
         const existing = await tx.select({ pk: pkColumn }).from(table).where(eq(pkColumn, pkValue)).get()

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -4,7 +4,14 @@
 
 import { useAuth, useDatabase } from '@/contexts'
 import { useSignInModal } from '@/contexts/sign-in-modal-context'
-import { ImportFormatError, exportUserData, importUserData, summarizeExportEnvelope, type ExportSummary } from '@/dal'
+import {
+  ImportFormatError,
+  exportUserData,
+  getPersonalWorkspaceByOwner,
+  importUserData,
+  summarizeExportEnvelope,
+  type ExportSummary,
+} from '@/dal'
 import { downloadJson, exportFilenameFor } from '@/lib/export-download'
 import { readJsonFile } from '@/lib/import-upload'
 import { useCountryUnits } from '@/hooks/use-country-units'
@@ -377,7 +384,19 @@ export default function PreferencesSettingsPage() {
     dispatch({ type: 'SET_IS_IMPORTING', payload: true })
     dispatch({ type: 'SET_IMPORT_ERROR', payload: null })
     try {
-      const result = await importUserData(db, pendingImport.payload, { id: userId })
+      // Pre-workspaces-v1 backups have no workspaceId on their rows; the
+      // importer back-fills with the user's personal workspace so the data
+      // lands somewhere visible. The post-login bootstrap awaits this row,
+      // so by the time the user reaches Preferences it's always present.
+      const personalWorkspace = await getPersonalWorkspaceByOwner(db, userId)
+      if (!personalWorkspace) {
+        dispatch({ type: 'SET_IMPORT_ERROR', payload: 'Personal workspace not ready yet. Try again in a moment.' })
+        return
+      }
+      const result = await importUserData(db, pendingImport.payload, {
+        id: userId,
+        personalWorkspaceId: personalWorkspace.id,
+      })
       const total = Object.values(result.tables).reduce((sum, t) => sum + (t?.upserted ?? 0), 0)
       dispatch({
         type: 'SET_IMPORT_SUCCESS',


### PR DESCRIPTION
## Summary

THU-597 — adapt the existing export/import feature (THU-596) for Workspaces v1.

- **Export.** Carry the workspace identity tables (`workspaces`, `workspace_memberships`, `workspace_pending_memberships`, `workspace_permissions`) in the envelope alongside per-user content so a restore reinstates the whole graph without depending on PowerSync down-sync first. `agents_system` / `devices` / `integrations_secrets` remain excluded for the same reasons as before.
- **Import — user-id re-stamping.** Generalize the `user_id` security rewrite to cover every user-FK column (`user_id`, `owner_user_id`, `invited_by_user_id`, …). Detection is column-name based, so future user-FK columns are picked up automatically. The importing user becomes the owner of every imported workspace and the member/inviter on every row — a tampered or cross-account file can't plant a foreign user id locally.
- **Import — `workspace_id` back-fill (legacy path).** Pre-Workspaces-v1 backups arrive without `workspaceId` on their rows. On tables with a `workspace_id` column, the missing value is stamped with the importing user's personal workspace id so the data lands somewhere visible instead of orphaned at `NULL`. Modern multi-workspace backups already carry `workspaceId` and those values are preserved verbatim.
- **Call site.** Settings → Preferences now resolves the personal workspace via `getPersonalWorkspaceByOwner` before invoking `importUserData`.

Out of scope: the one-shot legacy-data migration module covered by [THU-622](https://linear.app/mozilla-thunderbolt/issue/THU-622) (storage layout rewrite from pre-v1 to namespaced).

## Test plan

- [ ] Export a fresh account → JSON includes `workspaces` / `workspace_memberships` / `workspace_permissions` buckets alongside chats, models, etc.
- [ ] Round-trip same-account: export → `clearLocalData` → import → every workspace + its rows are back, IDs preserved.
- [ ] Cross-account: User A exports → User B imports → User B sees A's workspaces in the selector, owns them, and can switch into them; user-id columns reference User B everywhere.
- [ ] Legacy (pre-v1) backup import → rows without `workspaceId` land in the importing user's personal workspace and are visible in the UI.
- [ ] Modern multi-workspace backup import → each row stays attached to its original workspace (no collapse into Personal).
- [ ] `bun test src/dal/` green (412 → 419 with new cases).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes backup/restore semantics, workspace scoping, and cross-account id remapping tied to PowerSync/backend conflict rules—mistakes can leak data, orphan rows, or wipe chats after sync.
> 
> **Overview**
> Adapts user backup **export** and **import** for Workspaces v1: backups carry **`workspaces`** and **`workspace_permissions`**, but **not** `workspace_memberships` / `workspace_pending_memberships` (backend-owned; avoids co-member PII leakage). Export scopes data to workspaces where the user has an **admin** membership—member-only shared workspaces and their rows are omitted; legacy rows with no `workspaceId` still ship.
> 
> **Import** requires envelope **`user.id`** to distinguish same-account restore vs cross-account import. It re-stamps all user-FK columns, back-fills missing `workspaceId` to the importer’s personal workspace, **synthesizes** admin memberships for imported workspaces, and processes **`workspaces` before** other tables so PowerSync upload order stays valid. Cross-account paths **remap** foreign personal into local personal, mint new ids for foreign shared workspaces (and strip `slug`), drop permissions that would collide on personal, and mint fresh ids for `chat_threads` / `chat_messages` / `triggers` (and related FKs) to avoid silent backend upsert failures.
> 
> **Preferences** resolves the personal workspace via `getPersonalWorkspaceByOwner` before calling `importUserData`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b208cf923dd24a166e699fbd9aef6f1daa4a537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->