### PR TITLE
fix: restore pinned skill chip sizing on desktop

### DIFF
--- a/src/components/chat/chat-skills-bar.tsx
+++ b/src/components/chat/chat-skills-bar.tsx
@@ -156,7 +156,7 @@ export const ChatSkillsBar = ({
                   size="icon-sm"
                   aria-label="Pin a skill"
                   disabled={addDisabled}
-                  className={`size-[var(--touch-height-control)] shrink-0 cursor-pointer rounded-full bg-card transition-opacity disabled:cursor-not-allowed disabled:opacity-40 ${
+                  className={`shrink-0 cursor-pointer rounded-full bg-card transition-opacity disabled:cursor-not-allowed disabled:opacity-40 ${
                     openChipId ? 'opacity-40' : ''
                   }`}
                 >

--- a/src/skills/suggestion-chip.tsx
+++ b/src/skills/suggestion-chip.tsx
@@ -107,7 +107,7 @@ export const SuggestionChip = ({
             clearLongPress()
             handleOpenChange(true)
           }}
-          // `h-[var(--touch-height-control)]` resolves to 40px on mobile, 28px on
+          // `h-[var(--touch-height-sm)]` resolves to 40px on mobile, 32px on
           // desktop — keeps the compact desktop look while meeting the
           // 40px-min touch target the rest of the app uses on touch devices.
           //
@@ -117,7 +117,7 @@ export const SuggestionChip = ({
           // share/copy callout pops) while our long-press timer is waiting
           // to open the action menu. Leaving `touch-action` at its default
           // so the chip strip's horizontal scroll on mobile still works.
-          className={`h-[var(--touch-height-control)] shrink-0 cursor-pointer select-none rounded-full bg-card px-2 text-sm font-normal transition-opacity [-webkit-touch-callout:none] ${
+          className={`h-[var(--touch-height-sm)] shrink-0 cursor-pointer select-none rounded-full bg-card px-3 text-sm font-normal transition-opacity [-webkit-touch-callout:none] ${
             dimmed ? 'opacity-40' : ''
           }`}
           aria-label={`Pinned skill /${label}`}


### PR DESCRIPTION
## What

Chris flagged the pinned skill chips reading too small on desktop/web. THU-587 (#981, ~Jun 15) shrank them two ways and added an explicit size to the pin button. This reverts **only** the skill-chip + pin-button hunks back to their original sizing.

- **Chip** (`suggestion-chip.tsx`): height `--touch-height-control` (28px) → `--touch-height-sm` (32px desktop); padding `px-2` → `px-3`.
- **`+` pin button** (`chat-skills-bar.tsx`): drop the explicit `size-[…]`, back to `icon-sm`.
- **Mobile unchanged** (40px). `--touch-height-sm` holds the 40px min touch target.

The rest of THU-587 (mode/model selectors, prompt input) is **left intact** — Chris confirmed those are fine now.

## Notes

- `src/skills/suggestion-chip.tsx` is now byte-identical to its pre-THU-587 state.
- `tsc` + lint clean; `chat-skills-bar` tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic class tweaks in the chat skills bar with no auth, data, or API impact.
> 
> **Overview**
> Restores **desktop** sizing for pinned skill chips and the **Pin a skill** (`+`) control after THU-587 made them feel too small on web.
> 
> **`SuggestionChip`** again uses `h-[var(--touch-height-sm)]` (32px on desktop, still 40px on mobile) and `px-3` instead of `--touch-height-control` / `px-2`. **`ChatSkillsBar`** drops the explicit `size-[var(--touch-height-control)]` on the pin button so it relies on `size="icon-sm"` like before.
> 
> No behavior or logic changes—only Tailwind classes and the related comment update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 999c27ca43d19595b21b7eec4525fe3421dd56a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->