### PR TITLE
chore(THU-633): import/export UI tweaks

### DIFF
--- a/src/lib/export-download.test.ts
+++ b/src/lib/export-download.test.ts
@@ -7,32 +7,25 @@ import { getClock } from '@/testing-library'
 import { downloadJson, exportFilenameFor } from './export-download'
 
 describe('exportFilenameFor', () => {
-  it('formats the filename as YYYY-MM-DD.json.gz in local time', () => {
+  it('formats the filename as YYYY-MM-DD.json in local time', () => {
     // Using local-TZ constructor so the test is timezone-independent —
     // whatever the runner's TZ is, getFullYear/getMonth/getDate match.
     const date = new Date(2026, 5, 16, 12, 34, 56)
-    expect(exportFilenameFor(date)).toBe('thunderbolt-export-2026-06-16.json.gz')
+    expect(exportFilenameFor(date)).toBe('thunderbolt-export-2026-06-16.json')
   })
 
   it('zero-pads month and day', () => {
     const date = new Date(2026, 0, 3, 0, 0, 0)
-    expect(exportFilenameFor(date)).toBe('thunderbolt-export-2026-01-03.json.gz')
+    expect(exportFilenameFor(date)).toBe('thunderbolt-export-2026-01-03.json')
   })
 
   it('reflects the local calendar day even on the UTC boundary', () => {
     // 23:30 on the 16th locally is still the 16th in the filename, regardless
     // of whether that's a different UTC day for the runner.
     const date = new Date(2026, 5, 16, 23, 30, 0)
-    expect(exportFilenameFor(date)).toBe('thunderbolt-export-2026-06-16.json.gz')
+    expect(exportFilenameFor(date)).toBe('thunderbolt-export-2026-06-16.json')
   })
 })
-
-/** Reverse the gzip round-trip so the test can read back what `downloadJson` packed. */
-const gunzipToJson = async (blob: Blob): Promise<unknown> => {
-  const stream = blob.stream().pipeThrough(new DecompressionStream('gzip'))
-  const text = await new Response(stream).text()
-  return JSON.parse(text)
-}
 
 describe('downloadJson', () => {
   let createSpy: ReturnType<typeof spyOn>
@@ -48,45 +41,37 @@ describe('downloadJson', () => {
     revokeSpy.mockRestore()
   })
 
-  it('clicks an anchor with download + href and removes it afterwards', async () => {
+  it('clicks an anchor with download + href and removes it afterwards', () => {
     const removeChildSpy = spyOn(document.body, 'removeChild')
 
-    await downloadJson('export.json.gz', { hello: 'world' })
+    downloadJson('export.json', { hello: 'world' })
 
     expect(createSpy).toHaveBeenCalledTimes(1)
     const blob = createSpy.mock.calls[0]?.[0] as Blob
     expect(blob).toBeInstanceOf(Blob)
-    expect(blob.type).toBe('application/gzip')
+    expect(blob.type).toBe('application/json')
     // The anchor only lives for one tick — assert it was appended then removed.
     expect(removeChildSpy).toHaveBeenCalledTimes(1)
 
     removeChildSpy.mockRestore()
   })
 
-  it('does NOT revoke the blob URL synchronously (WebKit cancels in-flight downloads otherwise)', async () => {
-    await downloadJson('export.json.gz', { hello: 'world' })
+  it('does NOT revoke the blob URL synchronously (WebKit cancels in-flight downloads otherwise)', () => {
+    downloadJson('export.json', { hello: 'world' })
     expect(revokeSpy).not.toHaveBeenCalled()
   })
 
   it('revokes the blob URL on the next macrotask', async () => {
-    await downloadJson('export.json.gz', { hello: 'world' })
+    downloadJson('export.json', { hello: 'world' })
     await getClock().tickAsync(0)
     expect(revokeSpy).toHaveBeenCalledTimes(1)
     expect(revokeSpy).toHaveBeenCalledWith('blob:test/abc-123')
   })
 
-  it('round-trips the payload through gzip → JSON', async () => {
+  it('serializes the payload as JSON', async () => {
     const payload = { hello: 'world', list: [1, 2, 3], nested: { a: true, b: null } }
-    await downloadJson('export.json.gz', payload)
+    downloadJson('export.json', payload)
     const blob = createSpy.mock.calls[0]?.[0] as Blob
-    expect(await gunzipToJson(blob)).toEqual(payload)
-  })
-
-  it('serializes without indentation (gzip is a poor fit for whitespace anyway)', async () => {
-    await downloadJson('export.json.gz', { hello: 'world', list: [1, 2, 3] })
-    const blob = createSpy.mock.calls[0]?.[0] as Blob
-    const stream = blob.stream().pipeThrough(new DecompressionStream('gzip'))
-    const text = await new Response(stream).text()
-    expect(text).not.toContain('\n')
+    expect(JSON.parse(await blob.text())).toEqual(payload)
   })
 })

--- a/src/lib/export-download.ts
+++ b/src/lib/export-download.ts
@@ -3,15 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * Compresses the payload to gzip and triggers a browser download.
- *
- * Why gzip: chat-message JSON compresses to ~10-15% of the original. A heavy
- * user's export drops from tens of MB to a few — the file is faster to write,
- * cheaper to keep around, and stays well under the importer's 200 MB cap.
- *
- * The JSON is serialized without indentation; a backup file is consumed by the
- * matching importer, not eyeballed in a text editor, and `gunzip -c | jq` (or
- * any JSON tool) re-pretty-prints it for inspection if needed.
+ * Serializes the payload to JSON and triggers a browser download.
  *
  * Works on both web and Tauri's WebView via the universal `<a download>` blob-
  * URL pattern. The blob URL is revoked on the next macrotask, not synchronously
@@ -19,12 +11,9 @@
  * cancel the download if the URL is revoked before the browser starts streaming
  * the blob to disk.
  */
-export const downloadJson = async (filename: string, payload: unknown): Promise<void> => {
-  const json = JSON.stringify(payload)
-  const stream = new Blob([json]).stream().pipeThrough(new CompressionStream('gzip'))
-  const blob = await new Response(stream).blob()
-  const gzipped = new Blob([blob], { type: 'application/gzip' })
-  const url = URL.createObjectURL(gzipped)
+export const downloadJson = (filename: string, payload: unknown): void => {
+  const blob = new Blob([JSON.stringify(payload)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
   const anchor = document.createElement('a')
   anchor.href = url
   anchor.download = filename
@@ -36,14 +25,12 @@ export const downloadJson = async (filename: string, payload: unknown): Promise<
 
 /**
  * Returns the canonical export filename for a given timestamp.
- * Format: `thunderbolt-export-YYYY-MM-DD.json.gz` in the user's local timezone
- * so the filename matches the calendar day they hit "Export" on. The `.json.gz`
- * suffix mirrors what `gunzip` produces — `gunzip thunderbolt-export-…json.gz`
- * yields a `.json` file inspectable with any tool.
+ * Format: `thunderbolt-export-YYYY-MM-DD.json` in the user's local timezone so
+ * the filename matches the calendar day they hit "Export" on.
  */
 export const exportFilenameFor = (date: Date): string => {
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')
-  return `thunderbolt-export-${year}-${month}-${day}.json.gz`
+  return `thunderbolt-export-${year}-${month}-${day}.json`
 }

--- a/src/lib/import-upload.test.ts
+++ b/src/lib/import-upload.test.ts
@@ -8,13 +8,6 @@ import { readJsonFile } from './import-upload'
 
 const fileOf = (name: string, content: string): File => new File([content], name, { type: 'application/json' })
 
-/** Gzip the given JSON string, then wrap it in a `File` so it looks like a real upload. */
-const gzipFileOf = async (name: string, content: string): Promise<File> => {
-  const stream = new Blob([content]).stream().pipeThrough(new CompressionStream('gzip'))
-  const blob = await new Response(stream).blob()
-  return new File([blob], name, { type: 'application/gzip' })
-}
-
 /** Build a File whose `.size` reports `bytes` without actually allocating that much memory. */
 const oversizedFile = (name: string, bytes: number): File => {
   const file = new File(['{}'], name, { type: 'application/json' })
@@ -37,32 +30,10 @@ describe('readJsonFile', () => {
     await expect(readJsonFile(str)).resolves.toBe('hi')
   })
 
-  it('transparently decompresses gzipped exports (the canonical .json.gz format)', async () => {
-    const payload = { hello: 'world', list: [1, 2, 3], nested: { a: true } }
-    const file = await gzipFileOf('export.json.gz', JSON.stringify(payload))
-    await expect(readJsonFile(file)).resolves.toEqual(payload)
-  })
-
-  it('detects gzip by magic bytes, not by file extension', async () => {
-    // Gzipped content with a misleading `.json` filename still decompresses.
-    const payload = { kind: 'gzipped-with-json-extension' }
-    const gzipped = await gzipFileOf('mislabeled.json', JSON.stringify(payload))
-    await expect(readJsonFile(gzipped)).resolves.toEqual(payload)
-  })
-
   it('throws a SyntaxError mentioning the file name on malformed JSON', async () => {
     const file = fileOf('bad.json', '{ not: valid }')
     await expect(readJsonFile(file)).rejects.toBeInstanceOf(SyntaxError)
     await expect(readJsonFile(file)).rejects.toThrow(/bad\.json/)
-  })
-
-  it('throws ImportFormatError when a gzipped file is truncated / corrupted', async () => {
-    // Cut the gzip stream after the magic bytes — DecompressionStream rejects mid-stream.
-    const truncated = new File([new Uint8Array([0x1f, 0x8b, 0x08, 0x00])], 'truncated.json.gz', {
-      type: 'application/gzip',
-    })
-    await expect(readJsonFile(truncated)).rejects.toBeInstanceOf(ImportFormatError)
-    await expect(readJsonFile(truncated)).rejects.toThrow(/truncated\.json\.gz/)
   })
 
   it('rejects oversized files with ImportFormatError before reading them into memory', async () => {

--- a/src/lib/import-upload.ts
+++ b/src/lib/import-upload.ts
@@ -5,30 +5,21 @@
 import { ImportFormatError } from '@/dal'
 
 /**
- * Hard ceiling on the size of an import file we'll attempt to read into
- * memory. Applies to the *on-disk* size — a gzipped export at ~200 MB
- * decompresses to a few GB of JSON, which the importer wouldn't survive
- * anyway. Anything larger almost certainly isn't a Thunderbolt export, so we
- * refuse it before paying the `file.arrayBuffer()` allocation: picking the
- * wrong file on Tauri iOS would otherwise freeze or OOM the WebView.
+ * Hard ceiling on the size of an import file we'll read into memory. Anything
+ * larger almost certainly isn't a Thunderbolt export, so we refuse it before
+ * paying the `file.text()` allocation: picking the wrong file on Tauri iOS
+ * would otherwise freeze or OOM the WebView.
  */
 const maxImportBytes = 200 * 1024 * 1024
 
-/** Gzip magic bytes (RFC 1952 §2.3.1 — `1f 8b`). */
-const isGzip = (bytes: Uint8Array): boolean => bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b
-
 /**
  * Reads a `File` (from an `<input type="file">`) and parses it as JSON.
- * Detects gzip via magic bytes and decompresses transparently — exports are
- * gzipped (`.json.gz`); a hand-decompressed `.json` from the same envelope
- * still imports cleanly. Returns `unknown` so the caller validates the shape
- * before using it.
+ * Returns `unknown` so the caller validates the shape before using it.
  *
  * Throws an {@link ImportFormatError} when the file exceeds
- * {@link maxImportBytes} or when gzip decompression fails (truncated /
- * corrupted archive), and a `SyntaxError` with the original file name in
- * the message when the JSON doesn't parse — easier to surface in the UI
- * than the raw parser error.
+ * {@link maxImportBytes}, and a `SyntaxError` with the original file name in
+ * the message when the JSON doesn't parse — easier to surface in the UI than
+ * the raw parser error.
  */
 export const readJsonFile = async (file: File): Promise<unknown> => {
   if (file.size > maxImportBytes) {
@@ -38,24 +29,11 @@ export const readJsonFile = async (file: File): Promise<unknown> => {
       `"${file.name}" is too large (${sizeMb} MB). Maximum supported import size is ${maxMb} MB.`,
     )
   }
-  const buffer = await file.arrayBuffer()
-  const text = isGzip(new Uint8Array(buffer, 0, Math.min(2, buffer.byteLength)))
-    ? await gunzipToText(buffer, file.name)
-    : new TextDecoder('utf-8').decode(buffer)
+  const text = await file.text()
   try {
     return JSON.parse(text)
   } catch (error) {
     const reason = error instanceof Error ? error.message : 'Unknown parse error'
     throw new SyntaxError(`Could not parse "${file.name}" as JSON: ${reason}`, { cause: error })
-  }
-}
-
-const gunzipToText = async (buffer: ArrayBuffer, filename: string): Promise<string> => {
-  try {
-    const stream = new Blob([buffer]).stream().pipeThrough(new DecompressionStream('gzip'))
-    return await new Response(stream).text()
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : 'Unknown decompression error'
-    throw new ImportFormatError(`Could not decompress "${filename}": ${reason}`)
   }
 }

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -415,7 +415,7 @@ export default function PreferencesSettingsPage() {
         id: userId,
         email: session.user.email ?? null,
       })
-      await downloadJson(exportFilenameFor(new Date()), payload)
+      downloadJson(exportFilenameFor(new Date()), payload)
       trackEvent('settings_data_export')
     } catch (error) {
       console.error('Failed to export data:', error)
@@ -889,10 +889,7 @@ export default function PreferencesSettingsPage() {
                   Export Your Data
                 </label>
                 <p id="export-data-description" className="text-sm text-muted-foreground">
-                  Download a JSON snapshot of your chats, tasks, models, and the credentials you've entered (model API
-                  keys, MCP server tokens, agent keys). Treat the file like a password vault — anyone who can read it
-                  can use any of those credentials. Google and Microsoft sign-ins aren't included; you'll reconnect
-                  those after importing.
+                  Export all of your data as JSON.
                 </p>
                 {exportError && (
                   <p id="export-data-error" className="text-sm text-destructive" role="alert">
@@ -918,8 +915,7 @@ export default function PreferencesSettingsPage() {
                   Import Your Data
                 </label>
                 <p id="import-data-description" className="text-sm text-muted-foreground">
-                  Restore from a Thunderbolt export file. Rows that share an ID with existing data are overwritten with
-                  the imported version and synced to your other devices. Everything else is left alone.
+                  Import your data from previously exported JSON.
                 </p>
                 {importError && (
                   <p id="import-data-error" className="text-sm text-destructive" role="alert">
@@ -934,8 +930,7 @@ export default function PreferencesSettingsPage() {
                 <input
                   ref={importFileInputRef}
                   type="file"
-                  // `.gz` is listed separately because some file dialogs only honor a single trailing extension.
-                  accept="application/gzip,application/json,.json.gz,.gz,.json"
+                  accept="application/json,.json"
                   className="hidden"
                   onChange={handleImportFileSelected}
                 />


### PR DESCRIPTION
- Reword export/import helper text per [THU-633](https://linear.app/mozilla-thunderbolt/issue/THU-633/importexport-ui-tweaks).
- Drop gzip end-to-end: exports are plain `.json`, importer reads JSON directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk backup format and removes automatic import of legacy `.json.gz` exports; larger plain JSON may approach the 200 MB import cap sooner for heavy users.
> 
> **Overview**
> **Data export/import now uses uncompressed JSON** instead of gzip end-to-end. Exports download as `thunderbolt-export-YYYY-MM-DD.json` via a synchronous `downloadJson` that writes an `application/json` blob; imports read the file with `file.text()` and no longer detect or decompress gzip (magic bytes, `DecompressionStream`, and related errors/tests are removed).
> 
> **Preferences “Data” section copy and file picker** are simplified per THU-633: shorter export/import helper text (including removal of the long credential/security warning on export), and the import input `accept` is limited to `application/json,.json` instead of gzip variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87213b72ec4fd8c900e636d3dcbd93f9e29edea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->