### PR TITLE
feat(THU-626): core client-side transformer registry (pdf→text, docx→text)

### DIFF
--- a/src/files/transformers/docx-to-html.ts
+++ b/src/files/transformers/docx-to-html.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Converts a DOCX blob to HTML via a lazily-imported mammoth. Used by the
+ * document preview pane. mammoth stays out of the entry bundle because this
+ * import only runs on the DOCX path.
+ *
+ * This is the preview sibling of {@link docxToText} — both live here so the
+ * viewer and the delivery pipeline share one mammoth dependency and one code
+ * path for DOCX handling.
+ */
+export const docxToHtml = async (blob: Blob): Promise<string> => {
+  const mammoth = await import('mammoth')
+  const arrayBuffer = await blob.arrayBuffer()
+  const result = await mammoth.convertToHtml({ arrayBuffer })
+  return result.value
+}

--- a/src/files/transformers/docx-to-text.ts
+++ b/src/files/transformers/docx-to-text.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { StoredFile } from '@/lib/file-blob-storage'
+
+/**
+ * Extracts plain text from a DOCX blob via a lazily-imported mammoth. This is
+ * the delivery counterpart to the preview's {@link docxToHtml}: the model
+ * wants prose, not markup, so we use mammoth's raw-text path and drop the HTML
+ * styling entirely.
+ */
+export const docxToText = async (file: StoredFile): Promise<{ text: string }> => {
+  const mammoth = await import('mammoth')
+  const arrayBuffer = await file.blob.arrayBuffer()
+  const result = await mammoth.extractRawText({ arrayBuffer })
+  return { text: result.value.trim() }
+}

--- a/src/files/transformers/index.test.ts
+++ b/src/files/transformers/index.test.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+
+import { docxMime, getTransformer, hasTransformer } from './index'
+
+describe('transformer registry', () => {
+  test('hasTransformer reports registered source→text pairs', () => {
+    expect(hasTransformer('application/pdf', 'text')).toBe(true)
+    expect(hasTransformer(docxMime, 'text')).toBe(true)
+  })
+
+  test('hasTransformer is false for unregistered MIME types', () => {
+    expect(hasTransformer('image/png', 'text')).toBe(false)
+    expect(hasTransformer('text/plain', 'text')).toBe(false)
+    expect(hasTransformer('', 'text')).toBe(false)
+  })
+
+  test('getTransformer lazy-loads a callable transformer for a known type', async () => {
+    const pdf = await getTransformer('application/pdf', 'text')
+    const docx = await getTransformer(docxMime, 'text')
+    expect(typeof pdf).toBe('function')
+    expect(typeof docx).toBe('function')
+  })
+
+  test('getTransformer resolves to null for an unknown type', async () => {
+    expect(await getTransformer('image/png', 'text')).toBeNull()
+  })
+})

--- a/src/files/transformers/index.ts
+++ b/src/files/transformers/index.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { StoredFile } from '@/lib/file-blob-storage'
+
+/**
+ * Client-side transformer registry: turns a stored attachment into a form a
+ * model can consume when its transport can't accept the raw bytes (e.g. a PDF
+ * for a text-only pipeline). Transformers run entirely on-device — the blobs
+ * never leave IndexedDB unless a delivery plan says so.
+ *
+ * Each transformer is lazy-imported so its heavy dependency (pdfjs, mammoth)
+ * stays out of the entry bundle and only loads when an attachment of that type
+ * actually needs converting.
+ */
+
+/** What a transformer produces. Image output (pdf→images, OCR) lands in THU-630. */
+export type TransformOutput = { text: string }
+
+export type Transformer = (file: StoredFile) => Promise<TransformOutput>
+
+/** Conversion target. `'images'` is added alongside the image transformers in THU-630. */
+export type TransformTarget = 'text'
+
+export type TransformerKey = `${string}->${TransformTarget}`
+
+/** MIME type for `.docx` (OOXML Word documents). */
+export const docxMime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+
+/**
+ * Lazy loaders keyed by `"<source-mime>-><target>"`. Adding a transformer is a
+ * one-line entry here plus its module — nothing else in the pipeline needs to
+ * know the concrete type.
+ */
+const loaders: Partial<Record<TransformerKey, () => Promise<Transformer>>> = {
+  'application/pdf->text': async () => (await import('./pdf-to-text')).pdfToText,
+  [`${docxMime}->text`]: async () => (await import('./docx-to-text')).docxToText,
+}
+
+/** True if a transformer exists for this source MIME → target. Sync, for routing decisions. */
+export const hasTransformer = (sourceMime: string, target: TransformTarget): boolean =>
+  `${sourceMime}->${target}` in loaders
+
+/** Lazy-load the matching transformer, or `null` if none is registered. */
+export const getTransformer = async (sourceMime: string, target: TransformTarget): Promise<Transformer | null> => {
+  const loader = loaders[`${sourceMime}->${target}` as TransformerKey]
+  return loader ? loader() : null
+}

--- a/src/files/transformers/pdf-to-text.ts
+++ b/src/files/transformers/pdf-to-text.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { StoredFile } from '@/lib/file-blob-storage'
+
+/**
+ * Extracts a PDF's embedded text layer via pdfjs (lazy-imported — pdfjs is
+ * heavy and only this path needs it). Pages are joined with a blank line so
+ * paragraph boundaries survive into the model context.
+ *
+ * Scanned / image-only PDFs carry no text layer and yield little or nothing
+ * here — OCR (THU-630) is the fallback for those.
+ */
+export const pdfToText = async (file: StoredFile): Promise<{ text: string }> => {
+  const pdfjs = await import('pdfjs-dist')
+  // Mirror the viewer's Vite worker-URL pattern so both share one worker build.
+  pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString()
+
+  const data = await file.blob.arrayBuffer()
+  const doc = await pdfjs.getDocument({ data }).promise
+
+  const pages: string[] = []
+  for (let pageNum = 1; pageNum <= doc.numPages; pageNum++) {
+    const page = await doc.getPage(pageNum)
+    const content = await page.getTextContent()
+    pages.push(content.items.map((item) => ('str' in item ? item.str : '')).join(' '))
+  }
+  await doc.destroy()
+
+  return { text: pages.join('\n\n').trim() }
+}

--- a/src/widgets/document-result/use-document-blob.ts
+++ b/src/widgets/document-result/use-document-blob.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { HttpClient } from '@/contexts'
+import { docxToHtml } from '@/files/transformers/docx-to-html'
 import { getAttachment } from '@/lib/file-blob-storage'
 import { useEffect, useReducer, useRef } from 'react'
 
@@ -31,18 +32,10 @@ const reducer = (_state: DocumentBlobState, action: DocumentBlobAction): Documen
   }
 }
 
-/** Converts a DOCX blob to HTML via a lazily-imported mammoth. PDFs and other
- *  types skip conversion and return null. mammoth stays out of the main bundle
- *  because the import only runs on the DOCX path. */
-const convertDocxIfNeeded = async (blob: Blob, fileType: FileType): Promise<string | null> => {
-  if (fileType !== 'docx') {
-    return null
-  }
-  const mammoth = await import('mammoth')
-  const arrayBuffer = await blob.arrayBuffer()
-  const result = await mammoth.convertToHtml({ arrayBuffer })
-  return result.value
-}
+/** Renders DOCX previews to HTML via the shared {@link docxToHtml} transformer.
+ *  PDFs and other types skip conversion and return null. */
+const convertDocxIfNeeded = async (blob: Blob, fileType: FileType): Promise<string | null> =>
+  fileType === 'docx' ? docxToHtml(blob) : null
 
 /**
  * Shared blob-preview loader: resolves a Blob via `loadBlob`, exposes the load


### PR DESCRIPTION
## THU-626 — Core client-side transformers

Adds a lazy-loaded, client-side transformer registry that converts a stored attachment into a model-consumable form when a transport can't accept the raw bytes (e.g. a PDF for a text-only pipeline). Transforms run entirely on-device.

### What's here
- **`src/files/transformers/index.ts`** — registry keyed `"<source-mime>-><target>"`. `hasTransformer()` is a sync routing check; `getTransformer()` lazy-loads the matching transformer (or `null`). Each transformer is dynamically imported so its heavy dep (pdfjs / mammoth) stays out of the entry bundle.
- **`pdf-to-text.ts`** — extracts the PDF text layer via pdfjs; worker URL mirrors the existing viewer so both share one worker build. (Scanned/image-only PDFs need OCR — THU-630.)
- **`docx-to-text.ts`** — mammoth `extractRawText` (prose, not markup).
- **`docx-to-html.ts`** — promotes the document viewer's previously-inline mammoth conversion into the shared transformers module. `use-document-blob.ts` now imports it, so **preview and delivery share one DOCX/mammoth code path**.
- **`index.test.ts`** — registry routing tests (registered vs unknown MIME, lazy load returns a callable).

### Scope notes
- Text transformers only. Image output (pdf→images, OCR) and the `'images'` target land in **THU-630** — the `TransformTarget`/`TransformOutput` types are shaped to widen there without churn.
- Actual pdf/docx extraction is integration-tested downstream (resolver/executor, THU-625/627) and verified manually; the unit tests cover the deterministic registry routing.

### Stacking
Based on **THU-623** (#1023) — depends on `StoredFile` (`src/lib/file-blob-storage.ts`) and the viewer's mammoth path, both of which live on that branch. Merge #1023 first; this PR's base will retarget to `main` automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New attachment-to-text conversion on the client (pdfjs/mammoth) affects how files reach model context, though processing stays on-device; the document preview change should be behavior-preserving but touches a shared loading path.
> 
> **Overview**
> Introduces **`src/files/transformers`**, a lazy-loaded on-device registry for turning stored attachments into **text** when a pipeline cannot send raw bytes. Routing is keyed by `"<mime>->text"` via sync **`hasTransformer`** and async **`getTransformer`**, with **pdfjs** and **mammoth** loaded only when a matching transform runs.
> 
> **PDF** and **DOCX** delivery paths add **`pdfToText`** (embedded text layer, shared pdfjs worker URL with the viewer) and **`docxToText`** (raw prose via mammoth). **`docxToHtml`** is extracted for previews; **`use-document-blob`** now calls it instead of inlining mammoth, so preview and delivery share one DOCX conversion module. Unit tests cover registry registration and lazy loading only; extraction is left to downstream integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb118a560f41ff5bbe430ae05f172c145897fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->