### PR TITLE
feat(settings): add tooltips to models page actions

### DIFF
--- a/src/settings/models/index.test.tsx
+++ b/src/settings/models/index.test.tsx
@@ -11,7 +11,7 @@ import '@testing-library/jest-dom'
 import { act, cleanup, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { v7 as uuidv7 } from 'uuid'
-import ModelsPage from './index'
+import ModelsPage, { modelEditTooltip, modelRemoveTooltip } from './index'
 
 describe('ModelsPage reactivity', () => {
   beforeAll(async () => {
@@ -65,5 +65,17 @@ describe('ModelsPage reactivity', () => {
     })
 
     expect(screen.getByText('Second Model')).toBeInTheDocument()
+  })
+})
+
+describe('model action tooltips', () => {
+  it('explains why built-in models cannot be edited or removed', () => {
+    expect(modelEditTooltip(true)).toBe("Built-in models can't be edited")
+    expect(modelRemoveTooltip(true)).toBe("Built-in models can't be removed")
+  })
+
+  it('uses action labels for user-added models', () => {
+    expect(modelEditTooltip(false)).toBe('Edit model')
+    expect(modelRemoveTooltip(false)).toBe('Remove model')
   })
 })

--- a/src/settings/models/index.test.tsx
+++ b/src/settings/models/index.test.tsx
@@ -11,7 +11,7 @@ import '@testing-library/jest-dom'
 import { act, cleanup, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { v7 as uuidv7 } from 'uuid'
-import ModelsPage, { modelEditTooltip, modelRemoveTooltip } from './index'
+import ModelsPage, { modelAddTooltip, modelEditTooltip, modelRemoveTooltip } from './index'
 
 describe('ModelsPage reactivity', () => {
   beforeAll(async () => {
@@ -77,5 +77,9 @@ describe('model action tooltips', () => {
   it('uses action labels for user-added models', () => {
     expect(modelEditTooltip(false)).toBe('Edit model')
     expect(modelRemoveTooltip(false)).toBe('Remove model')
+  })
+
+  it('labels the add model control', () => {
+    expect(modelAddTooltip()).toBe('Add model')
   })
 })

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -899,7 +899,7 @@ export default function ModelsPage() {
           <Tooltip>
             <TooltipTrigger asChild>
               <DialogTrigger asChild>
-                <Button variant="outline" size="icon" className="rounded-lg" aria-label="Add model">
+                <Button variant="outline" size="icon" className="rounded-lg" aria-label={modelAddTooltip()}>
                   <Plus />
                 </Button>
               </DialogTrigger>
@@ -1247,7 +1247,7 @@ export default function ModelsPage() {
                               variant="outline"
                               onClick={() => setEditingModel(model)}
                               disabled={isSystemModel}
-                              aria-label="Edit model"
+                              aria-label={modelEditTooltip(isSystemModel)}
                             >
                               <Pen className="h-3 w-3" />
                             </ButtonGroupItem>
@@ -1264,7 +1264,7 @@ export default function ModelsPage() {
                               variant="outline"
                               onClick={() => dispatch({ type: 'OPEN_DELETE_CONFIRM', modelId: model.id })}
                               disabled={isSystemModel}
-                              aria-label="Remove model"
+                              aria-label={modelRemoveTooltip(isSystemModel)}
                             >
                               <Trash2 className="h-3 w-3" />
                             </ButtonGroupItem>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -350,6 +350,8 @@ export const modelEditTooltip = (isSystemModel: boolean): string =>
 export const modelRemoveTooltip = (isSystemModel: boolean): string =>
   isSystemModel ? "Built-in models can't be removed" : 'Remove model'
 
+export const modelAddTooltip = (): string => 'Add model'
+
 export default function ModelsPage() {
   const db = useDatabase()
   const getProxyFetch = useProxyFetchGetter()
@@ -894,11 +896,18 @@ export default function ModelsPage() {
     <div className="flex flex-col gap-6 p-4 pb-12 w-full max-w-[760px] mx-auto">
       <PageHeader title="Models">
         <Dialog open={isAddDialogOpen} onOpenChange={handleDialogOpenChange}>
-          <DialogTrigger asChild>
-            <Button variant="outline" size="icon" className="rounded-lg">
-              <Plus />
-            </Button>
-          </DialogTrigger>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DialogTrigger asChild>
+                <Button variant="outline" size="icon" className="rounded-lg" aria-label="Add model">
+                  <Plus />
+                </Button>
+              </DialogTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p>{modelAddTooltip()}</p>
+            </TooltipContent>
+          </Tooltip>
           <ResponsiveModalContentComposable className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
             <ResponsiveModalHeader>
               <ResponsiveModalTitle>Add Model</ResponsiveModalTitle>

--- a/src/settings/models/index.tsx
+++ b/src/settings/models/index.tsx
@@ -343,6 +343,13 @@ const EditModelModal = ({
   </Dialog>
 )
 
+/** Tooltip copy for model row edit/remove actions. Exported for unit tests. */
+export const modelEditTooltip = (isSystemModel: boolean): string =>
+  isSystemModel ? "Built-in models can't be edited" : 'Edit model'
+
+export const modelRemoveTooltip = (isSystemModel: boolean): string =>
+  isSystemModel ? "Built-in models can't be removed" : 'Remove model'
+
 export default function ModelsPage() {
   const db = useDatabase()
   const getProxyFetch = useProxyFetchGetter()
@@ -1224,20 +1231,40 @@ export default function ModelsPage() {
                     </TooltipProvider>
 
                     <ButtonGroup size="icon">
-                      <ButtonGroupItem
-                        variant="outline"
-                        onClick={() => setEditingModel(model)}
-                        disabled={isSystemModel}
-                      >
-                        <Pen className="h-3 w-3" />
-                      </ButtonGroupItem>
-                      <ButtonGroupItem
-                        variant="outline"
-                        onClick={() => dispatch({ type: 'OPEN_DELETE_CONFIRM', modelId: model.id })}
-                        disabled={isSystemModel}
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </ButtonGroupItem>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <ButtonGroupItem
+                              variant="outline"
+                              onClick={() => setEditingModel(model)}
+                              disabled={isSystemModel}
+                              aria-label="Edit model"
+                            >
+                              <Pen className="h-3 w-3" />
+                            </ButtonGroupItem>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                          <p>{modelEditTooltip(isSystemModel)}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <ButtonGroupItem
+                              variant="outline"
+                              onClick={() => dispatch({ type: 'OPEN_DELETE_CONFIRM', modelId: model.id })}
+                              disabled={isSystemModel}
+                              aria-label="Remove model"
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </ButtonGroupItem>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                          <p>{modelRemoveTooltip(isSystemModel)}</p>
+                        </TooltipContent>
+                      </Tooltip>
                     </ButtonGroup>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Add hover tooltips on disabled edit/remove buttons for built-in models explaining they can't be edited or removed
- Add "Add model" tooltip on the header + button (icon-only control)
- Wrap disabled action buttons so tooltips still receive pointer events

## Test plan
- [x] `bun test src/settings/models/index.test.tsx`
- [x] Open Settings → Models and hover the + button — shows "Add model"
- [x] Hover disabled pen/trash on built-in models (Opus 4.8, Tinfoil models) — shows built-in restriction messages
- [x] Hover pen/trash on a user-added model — shows "Edit model" / "Remove model"


Made with [Cursor](https://cursor.com)