### PR TITLE
feat(THU-634): add App Version section to settings

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,19 +36,9 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ],
+    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
     "iOS": {
-      "frameworks": [
-        "MetalPerformanceShaders.framework",
-        "MetalKit.framework",
-        "Metal.framework"
-      ],
+      "frameworks": ["MetalPerformanceShaders.framework", "MetalKit.framework", "Metal.framework"],
       "developmentTeam": "BUMSKVQ3D9"
     },
     "android": {
@@ -59,14 +49,9 @@
     "deep-link": {
       "mobile": [
         {
-          "scheme": [
-            "https"
-          ],
+          "scheme": ["https"],
           "host": "app.thunderbolt.io",
-          "pathPrefix": [
-            "/oauth/callback",
-            "/auth/verify"
-          ],
+          "pathPrefix": ["/oauth/callback", "/auth/verify"],
           "appLink": true
         }
       ]

--- a/src/components/update-notification.tsx
+++ b/src/components/update-notification.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button'
 import { isDesktop } from '@/lib/platform'
 
 const statusConfig: Record<UpdateStatus, { icon: typeof Download; message: string; showActions: boolean }> = {
+  initial: { icon: CheckCircle, message: '', showActions: false },
   idle: { icon: CheckCircle, message: '', showActions: false },
   checking: { icon: Loader2, message: 'Checking for updates...', showActions: false },
   available: { icon: Download, message: 'A new version is available!', showActions: true },
@@ -27,7 +28,7 @@ export const UpdateNotification = () => {
     return null
   }
 
-  const isVisible = !dismissed && status !== 'idle' && status !== 'checking'
+  const isVisible = !dismissed && status !== 'initial' && status !== 'idle' && status !== 'checking'
   const config = statusConfig[status]
   const Icon = config.icon
 

--- a/src/hooks/use-desktop-update.test.ts
+++ b/src/hooks/use-desktop-update.test.ts
@@ -87,10 +87,11 @@ describe('updateReducer', () => {
     it('should set status to error with message', () => {
       const state: UpdateState = { ...initialUpdateState, status: 'downloading' }
 
-      const result = updateReducer(state, { type: 'ERROR', error: 'Download failed' })
+      const result = updateReducer(state, { type: 'ERROR', error: 'Download failed', phase: 'download' })
 
       expect(result.status).toBe('error')
       expect(result.error).toBe('Download failed')
+      expect(result.errorPhase).toBe('download')
     })
 
     it('should preserve other state when erroring', () => {
@@ -102,7 +103,7 @@ describe('updateReducer', () => {
         downloadProgress: 50,
       }
 
-      const result = updateReducer(state, { type: 'ERROR', error: 'Network error' })
+      const result = updateReducer(state, { type: 'ERROR', error: 'Network error', phase: 'download' })
 
       expect(result.update).toBe(mockUpdate)
       expect(result.downloadProgress).toBe(50)
@@ -114,7 +115,7 @@ describe('updateReducer', () => {
       const mockUpdate = { version: '2.0.0' } as UpdateState['update']
 
       let state = initialUpdateState
-      expect(state.status).toBe('idle')
+      expect(state.status).toBe('initial')
 
       state = updateReducer(state, { type: 'CHECK_START' })
       expect(state.status).toBe('checking')
@@ -136,12 +137,14 @@ describe('updateReducer', () => {
 
     it('should handle error recovery flow', () => {
       let state = updateReducer(initialUpdateState, { type: 'CHECK_START' })
-      state = updateReducer(state, { type: 'ERROR', error: 'Network error' })
+      state = updateReducer(state, { type: 'ERROR', error: 'Network error', phase: 'check' })
       expect(state.status).toBe('error')
+      expect(state.errorPhase).toBe('check')
 
       state = updateReducer(state, { type: 'CHECK_START' })
       expect(state.status).toBe('checking')
       expect(state.error).toBeNull()
+      expect(state.errorPhase).toBeNull()
     })
   })
 })

--- a/src/hooks/use-desktop-update.ts
+++ b/src/hooks/use-desktop-update.ts
@@ -10,12 +10,15 @@ import { isDesktop } from '@/lib/platform'
 import { getPowerSyncInstance } from '@/db/powersync/sync-state'
 import { setPostUpdateFlag, clearPostUpdateFlag } from '@/lib/post-update-redirect'
 
-export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error'
+export type UpdateStatus = 'initial' | 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error'
+
+export type UpdateErrorPhase = 'check' | 'download' | 'restart'
 
 export type UpdateState = {
   status: UpdateStatus
   update: Update | null
   error: string | null
+  errorPhase: UpdateErrorPhase | null
   downloadProgress: number
 }
 
@@ -25,19 +28,20 @@ export type UpdateAction =
   | { type: 'DOWNLOAD_START' }
   | { type: 'DOWNLOAD_PROGRESS'; progress: number }
   | { type: 'DOWNLOAD_SUCCESS' }
-  | { type: 'ERROR'; error: string }
+  | { type: 'ERROR'; error: string; phase: UpdateErrorPhase }
 
 export const initialUpdateState: UpdateState = {
-  status: 'idle',
+  status: 'initial',
   update: null,
   error: null,
+  errorPhase: null,
   downloadProgress: 0,
 }
 
 export const updateReducer = (state: UpdateState, action: UpdateAction): UpdateState => {
   switch (action.type) {
     case 'CHECK_START':
-      return { ...state, status: 'checking', error: null }
+      return { ...state, status: 'checking', error: null, errorPhase: null }
     case 'CHECK_SUCCESS':
       return {
         ...state,
@@ -51,7 +55,7 @@ export const updateReducer = (state: UpdateState, action: UpdateAction): UpdateS
     case 'DOWNLOAD_SUCCESS':
       return { ...state, status: 'ready', downloadProgress: 100 }
     case 'ERROR':
-      return { ...state, status: 'error', error: action.error }
+      return { ...state, status: 'error', error: action.error, errorPhase: action.phase }
   }
 }
 
@@ -100,10 +104,17 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
   const status = useUpdateStore((s) => s.status)
   const update = useUpdateStore((s) => s.update)
   const error = useUpdateStore((s) => s.error)
+  const errorPhase = useUpdateStore((s) => s.errorPhase)
   const downloadProgress = useUpdateStore((s) => s.downloadProgress)
 
   const checkForUpdates = useCallback(async () => {
     if (!isDesktop()) {
+      return
+    }
+
+    // Don't interrupt an in-flight check, download, or post-download ready state.
+    const current = useUpdateStore.getState().status
+    if (current === 'checking' || current === 'downloading' || current === 'ready') {
       return
     }
 
@@ -115,9 +126,11 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
       dispatch({ type: 'CHECK_SUCCESS', update: availableUpdate })
     } catch (err) {
       console.error('Failed to check for updates:', err)
-      useUpdateStore
-        .getState()
-        .dispatch({ type: 'ERROR', error: extractErrorMessage(err, 'Failed to check for updates') })
+      useUpdateStore.getState().dispatch({
+        type: 'ERROR',
+        error: extractErrorMessage(err, 'Failed to check for updates'),
+        phase: 'check',
+      })
     }
   }, [])
 
@@ -152,9 +165,11 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
       useUpdateStore.getState().dispatch({ type: 'DOWNLOAD_SUCCESS' })
     } catch (err) {
       console.error('Failed to download update:', err)
-      useUpdateStore
-        .getState()
-        .dispatch({ type: 'ERROR', error: extractErrorMessage(err, 'Failed to download update') })
+      useUpdateStore.getState().dispatch({
+        type: 'ERROR',
+        error: extractErrorMessage(err, 'Failed to download update'),
+        phase: 'download',
+      })
     }
   }, [])
 
@@ -173,19 +188,25 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
       // Clear the flag so a stale flag doesn't force-redirect on next manual launch
       clearPostUpdateFlag()
       console.error('Failed to restart app:', err)
-      useUpdateStore.getState().dispatch({ type: 'ERROR', error: extractErrorMessage(err, 'Failed to restart app') })
+      useUpdateStore.getState().dispatch({
+        type: 'ERROR',
+        error: extractErrorMessage(err, 'Failed to restart app'),
+        phase: 'restart',
+      })
     }
   }, [])
 
   // Auto-check once per session on desktop. Guarded so mounting the hook in
-  // multiple places (toast + Settings) doesn't fire repeat checks.
+  // multiple places (toast + Settings) doesn't fire repeat checks. The guard
+  // is set inside the timeout so an early unmount re-arms the check on the
+  // next mount instead of silently swallowing it for the session.
   useEffect(() => {
     if (!isDesktop() || didAutoCheck) {
       return
     }
-    didAutoCheck = true
 
     const timeout = setTimeout(() => {
+      didAutoCheck = true
       checkForUpdates()
     }, 5000)
 
@@ -196,6 +217,7 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
     status,
     update,
     error,
+    errorPhase,
     downloadProgress,
     checkForUpdates,
     downloadAndInstall,

--- a/src/hooks/use-desktop-update.ts
+++ b/src/hooks/use-desktop-update.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useReducer, useEffect, useCallback } from 'react'
+import { useEffect, useCallback } from 'react'
+import { create } from 'zustand'
 import { check, type Update } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
 import { isDesktop } from '@/lib/platform'
@@ -54,24 +55,59 @@ export const updateReducer = (state: UpdateState, action: UpdateAction): UpdateS
   }
 }
 
+const extractErrorMessage = (err: unknown, fallback: string): string => {
+  if (err instanceof Error) {
+    return err.message
+  }
+  if (typeof err === 'string') {
+    return err
+  }
+  if (err && typeof err === 'object' && 'message' in err && typeof err.message === 'string') {
+    return err.message
+  }
+  try {
+    const serialized = JSON.stringify(err)
+    return serialized && serialized !== '{}' ? serialized : fallback
+  } catch {
+    return fallback
+  }
+}
+
+type UpdateStore = UpdateState & {
+  dispatch: (action: UpdateAction) => void
+}
+
+const useUpdateStore = create<UpdateStore>((set) => ({
+  ...initialUpdateState,
+  dispatch: (action) => set((state) => updateReducer(state, action)),
+}))
+
 export type DesktopUpdateState = UpdateState & {
   checkForUpdates: () => Promise<void>
   downloadAndInstall: () => Promise<void>
   restartApp: () => Promise<void>
 }
 
+let didAutoCheck = false
+
 /**
  * Hook to manage desktop application updates using Tauri's updater plugin.
  * Only active on desktop platforms (macOS, Windows, Linux).
+ * State lives in a shared zustand store so multiple call sites (toast,
+ * Settings page) stay in sync.
  */
 export const useDesktopUpdate = (): DesktopUpdateState => {
-  const [state, dispatch] = useReducer(updateReducer, initialUpdateState)
+  const status = useUpdateStore((s) => s.status)
+  const update = useUpdateStore((s) => s.update)
+  const error = useUpdateStore((s) => s.error)
+  const downloadProgress = useUpdateStore((s) => s.downloadProgress)
 
   const checkForUpdates = useCallback(async () => {
     if (!isDesktop()) {
       return
     }
 
+    const { dispatch } = useUpdateStore.getState()
     dispatch({ type: 'CHECK_START' })
 
     try {
@@ -79,22 +115,26 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
       dispatch({ type: 'CHECK_SUCCESS', update: availableUpdate })
     } catch (err) {
       console.error('Failed to check for updates:', err)
-      dispatch({ type: 'ERROR', error: err instanceof Error ? err.message : 'Failed to check for updates' })
+      useUpdateStore
+        .getState()
+        .dispatch({ type: 'ERROR', error: extractErrorMessage(err, 'Failed to check for updates') })
     }
   }, [])
 
   const downloadAndInstall = useCallback(async () => {
-    if (!state.update) {
+    const current = useUpdateStore.getState().update
+    if (!current) {
       return
     }
 
+    const { dispatch } = useUpdateStore.getState()
     dispatch({ type: 'DOWNLOAD_START' })
 
     let contentLength = 0
     let bytesDownloaded = 0
 
     try {
-      await state.update.downloadAndInstall((event) => {
+      await current.downloadAndInstall((event) => {
         if (event.event === 'Started' && event.data.contentLength) {
           contentLength = event.data.contentLength
           bytesDownloaded = 0
@@ -102,19 +142,21 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
           bytesDownloaded += event.data.chunkLength
           if (contentLength > 0) {
             const percentage = Math.round((bytesDownloaded / contentLength) * 100)
-            dispatch({ type: 'DOWNLOAD_PROGRESS', progress: Math.min(percentage, 100) })
+            useUpdateStore.getState().dispatch({ type: 'DOWNLOAD_PROGRESS', progress: Math.min(percentage, 100) })
           }
         } else if (event.event === 'Finished') {
-          dispatch({ type: 'DOWNLOAD_PROGRESS', progress: 100 })
+          useUpdateStore.getState().dispatch({ type: 'DOWNLOAD_PROGRESS', progress: 100 })
         }
       })
 
-      dispatch({ type: 'DOWNLOAD_SUCCESS' })
+      useUpdateStore.getState().dispatch({ type: 'DOWNLOAD_SUCCESS' })
     } catch (err) {
       console.error('Failed to download update:', err)
-      dispatch({ type: 'ERROR', error: err instanceof Error ? err.message : 'Failed to download update' })
+      useUpdateStore
+        .getState()
+        .dispatch({ type: 'ERROR', error: extractErrorMessage(err, 'Failed to download update') })
     }
-  }, [state.update])
+  }, [])
 
   const restartApp = useCallback(async () => {
     try {
@@ -131,17 +173,18 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
       // Clear the flag so a stale flag doesn't force-redirect on next manual launch
       clearPostUpdateFlag()
       console.error('Failed to restart app:', err)
-      dispatch({ type: 'ERROR', error: err instanceof Error ? err.message : 'Failed to restart app' })
+      useUpdateStore.getState().dispatch({ type: 'ERROR', error: extractErrorMessage(err, 'Failed to restart app') })
     }
   }, [])
 
-  // Check for updates on mount (desktop only)
+  // Auto-check once per session on desktop. Guarded so mounting the hook in
+  // multiple places (toast + Settings) doesn't fire repeat checks.
   useEffect(() => {
-    if (!isDesktop()) {
+    if (!isDesktop() || didAutoCheck) {
       return
     }
+    didAutoCheck = true
 
-    // Delay initial check to not block app startup
     const timeout = setTimeout(() => {
       checkForUpdates()
     }, 5000)
@@ -150,7 +193,10 @@ export const useDesktopUpdate = (): DesktopUpdateState => {
   }, [checkForUpdates])
 
   return {
-    ...state,
+    status,
+    update,
+    error,
+    downloadProgress,
     checkForUpdates,
     downloadAndInstall,
     restartApp,

--- a/src/settings/app-version-section.tsx
+++ b/src/settings/app-version-section.tsx
@@ -5,17 +5,32 @@
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { Button } from '@/components/ui/button'
 import { SectionCard } from '@/components/ui/section-card'
-import { useDesktopUpdate, type UpdateStatus } from '@/hooks/use-desktop-update'
+import { useDesktopUpdate, type UpdateErrorPhase, type UpdateStatus } from '@/hooks/use-desktop-update'
 import { downloadLinks } from '@/lib/download-links'
 import { getPlatform, isDesktop, isMobile, isTauri } from '@/lib/platform'
+
+const errorPrefix = (phase: UpdateErrorPhase | null): string => {
+  switch (phase) {
+    case 'download':
+      return "Couldn't download the update"
+    case 'restart':
+      return "Couldn't restart to apply the update"
+    case 'check':
+    case null:
+      return "Couldn't check for updates"
+  }
+}
 
 const desktopStatusText = (
   status: UpdateStatus,
   updateVersion: string | undefined,
   downloadProgress: number,
   error: string | null,
+  errorPhase: UpdateErrorPhase | null,
 ): string => {
   switch (status) {
+    case 'initial':
+      return 'Tap to check for updates.'
     case 'idle':
       return "You're on the latest version."
     case 'checking':
@@ -28,8 +43,10 @@ const desktopStatusText = (
       return `Downloading update... ${downloadProgress}%`
     case 'ready':
       return 'Update ready. Restart to apply.'
-    case 'error':
-      return error ? `Couldn't check for updates: ${error}` : "Couldn't check for updates."
+    case 'error': {
+      const prefix = errorPrefix(errorPhase)
+      return error ? `${prefix}: ${error}` : `${prefix}.`
+    }
   }
 }
 
@@ -39,7 +56,8 @@ export const AppVersionSection = () => {
   const mobile = isMobile()
   const showCheckButton = isTauri() && (desktop || mobile)
 
-  const { status, update, error, downloadProgress, checkForUpdates } = useDesktopUpdate()
+  const { status, update, error, errorPhase, downloadProgress, checkForUpdates } = useDesktopUpdate()
+  const checkDisabled = desktop && (status === 'checking' || status === 'downloading' || status === 'ready')
 
   const handleDesktopCheck = () => {
     checkForUpdates()
@@ -68,12 +86,12 @@ export const AppVersionSection = () => {
               <label className="text-sm font-medium">Updates</label>
               <p className="text-sm text-muted-foreground">
                 {desktop
-                  ? desktopStatusText(status, update?.version, downloadProgress, error)
+                  ? desktopStatusText(status, update?.version, downloadProgress, error, errorPhase)
                   : 'Open the store to check for updates.'}
               </p>
               <Button
                 variant="secondary"
-                disabled={desktop && status === 'checking'}
+                disabled={checkDisabled}
                 onClick={desktop ? handleDesktopCheck : handleMobileCheck}
               >
                 {desktop && status === 'checking' ? 'Checking...' : 'Check for updates'}

--- a/src/settings/app-version-section.tsx
+++ b/src/settings/app-version-section.tsx
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { Button } from '@/components/ui/button'
+import { SectionCard } from '@/components/ui/section-card'
+import { useDesktopUpdate, type UpdateStatus } from '@/hooks/use-desktop-update'
+import { downloadLinks } from '@/lib/download-links'
+import { getPlatform, isDesktop, isMobile, isTauri } from '@/lib/platform'
+
+const desktopStatusText = (
+  status: UpdateStatus,
+  updateVersion: string | undefined,
+  downloadProgress: number,
+  error: string | null,
+): string => {
+  switch (status) {
+    case 'idle':
+      return "You're on the latest version."
+    case 'checking':
+      return 'Checking for updates...'
+    case 'available':
+      return updateVersion
+        ? `Version ${updateVersion} is available. See the update prompt to install.`
+        : 'A new version is available. See the update prompt to install.'
+    case 'downloading':
+      return `Downloading update... ${downloadProgress}%`
+    case 'ready':
+      return 'Update ready. Restart to apply.'
+    case 'error':
+      return error ? `Couldn't check for updates: ${error}` : "Couldn't check for updates."
+  }
+}
+
+export const AppVersionSection = () => {
+  const appVersion = import.meta.env.VITE_APP_VERSION ?? 'unknown'
+  const desktop = isDesktop()
+  const mobile = isMobile()
+  const showCheckButton = isTauri() && (desktop || mobile)
+
+  const { status, update, error, downloadProgress, checkForUpdates } = useDesktopUpdate()
+
+  const handleDesktopCheck = () => {
+    checkForUpdates()
+  }
+
+  const handleMobileCheck = () => {
+    const url = getPlatform() === 'ios' ? downloadLinks.ios : downloadLinks.android
+    openUrl(url)
+  }
+
+  return (
+    <SectionCard title="App Version">
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-row items-center justify-between gap-4">
+          <div>
+            <label className="text-sm font-medium">Current version</label>
+            <p className="text-sm text-muted-foreground">{appVersion}</p>
+          </div>
+        </div>
+
+        {showCheckButton && (
+          <>
+            <div className="h-px bg-border -mx-6" />
+
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">Updates</label>
+              <p className="text-sm text-muted-foreground">
+                {desktop
+                  ? desktopStatusText(status, update?.version, downloadProgress, error)
+                  : 'Open the store to check for updates.'}
+              </p>
+              <Button
+                variant="secondary"
+                disabled={desktop && status === 'checking'}
+                onClick={desktop ? handleDesktopCheck : handleMobileCheck}
+              >
+                {desktop && status === 'checking' ? 'Checking...' : 'Check for updates'}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </SectionCard>
+  )
+}

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -39,6 +39,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
+import { AppVersionSection } from './app-version-section'
 import { SyncSetupModal } from '@/components/sync-setup/sync-setup-modal'
 import { Button } from '@/components/ui/button'
 import { Combobox } from '@/components/ui/combobox'
@@ -1033,6 +1034,10 @@ export default function PreferencesSettingsPage() {
           )}
         </div>
       </SectionCard>
+
+      <div className="h-6" />
+
+      <AppVersionSection />
 
       <SyncSetupModal open={syncSetupOpen} onOpenChange={setSyncSetupOpen} onComplete={handleSyncSetupComplete} />
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches app restart, PowerSync disconnect, and Tauri updater flows; regressions could affect update installs or duplicate checks, but scope is limited to desktop update UX.
> 
> **Overview**
> Adds an **App Version** card to Preferences that shows the current build (`VITE_APP_VERSION`) and, on Tauri desktop/mobile, a **Check for updates** control with live status text (checking, up to date, download progress, errors by phase). Desktop checks reuse the same updater flow as the toast; mobile opens the iOS/Android store links.
> 
> **Desktop update plumbing** moves from per-hook `useReducer` to a **Zustand** store so the notification toast and Settings stay in sync. Introduces an **`initial`** status (no check yet), **`errorPhase`** on failures (`check` / `download` / `restart`), richer error messaging, guards that skip overlapping checks/downloads, and a **once-per-session** delayed auto-check when the hook mounts in multiple places.
> 
> The update toast now stays hidden during **`initial`** as well as idle/checking. `tauri.conf.json` changes are formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae7808423e37cc7e3de50dbdc1a147f393f7510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<img width="750" src="https://github.com/user-attachments/assets/328673ba-fdfe-43b9-aac9-43ab06ca4dbc" />

