### PR TITLE
fix(map): graceful fallback when WebGL is unavailable

### DIFF
--- a/src/widgets/map/widget.tsx
+++ b/src/widgets/map/widget.tsx
@@ -75,6 +75,28 @@ export const MapWidgetSkeleton = () => (
   </div>
 )
 
+/** Friendly message shown when the browser can't give MapLibre a WebGL context. */
+const webglUnavailableMessage = 'Maps can’t be displayed here — WebGL is disabled or unavailable in this browser.'
+
+/** Generic message for any other map load failure (style/tiles/network). */
+const mapLoadFailedMessage = 'The map couldn’t be loaded.'
+
+/**
+ * Cheap synchronous probe: can this browser create a WebGL context at all?
+ * MapLibre requires one, and when WebGL is off (Firefox with hardware accel /
+ * `resistFingerprinting` disabled, a blocklisted GPU, headless, etc.) it throws
+ * a verbose `webglcontextcreationerror`. We detect up front and show a clean
+ * message instead of dumping MapLibre's raw error JSON at the user.
+ */
+const isWebglAvailable = (): boolean => {
+  try {
+    const canvas = document.createElement('canvas')
+    return Boolean(canvas.getContext('webgl2') || canvas.getContext('webgl'))
+  } catch {
+    return false
+  }
+}
+
 /**
  * Generic GeoJSON map widget: renders a FeatureCollection (points / lines /
  * polygons) on an interactive map, fits the view to the data, and shows a
@@ -100,6 +122,12 @@ export const MapWidget = ({ data, title }: MapWidgetProps) => {
     // a stale "Couldn't load the map" message.
     setReady(false)
     setError(null)
+    // MapLibre needs WebGL; probe before loading it so a WebGL-disabled browser
+    // gets a clean message instead of MapLibre's raw context-creation error.
+    if (!isWebglAvailable()) {
+      setError(webglUnavailableMessage)
+      return
+    }
     let map: MaplibreMap | null = null
     let cancelled = false
     // Whether the map reached `load`, so the `error` handler can tell a fatal
@@ -130,7 +158,10 @@ export const MapWidget = ({ data, title }: MapWidgetProps) => {
         if (cancelled || loaded) {
           return
         }
-        setError(event.error?.message ?? 'Failed to load map')
+        // Log the raw MapLibre detail (e.g. the verbose webglcontextcreationerror
+        // object) for debugging, but show the user a clean message.
+        console.warn('MapLibre failed to load:', event.error)
+        setError(mapLoadFailedMessage)
       })
 
       // The currently-open popup, so clicking marker after marker replaces it
@@ -264,7 +295,8 @@ export const MapWidget = ({ data, title }: MapWidgetProps) => {
 
     init().catch((err) => {
       if (!cancelled) {
-        setError(err instanceof Error ? err.message : 'Failed to load map')
+        console.warn('MapLibre failed to load:', err)
+        setError(mapLoadFailedMessage)
       }
     })
 
@@ -285,12 +317,12 @@ export const MapWidget = ({ data, title }: MapWidgetProps) => {
       <div className="relative h-80 w-full overflow-hidden rounded-lg border border-border">
         <div ref={containerRef} className="h-full w-full" />
         {!ready && !error && <MapSkeleton />}
+        {error && (
+          <div className="absolute inset-0 flex items-center justify-center p-6 text-center">
+            <p className="text-[length:var(--font-size-sm)] text-muted-foreground">{error}</p>
+          </div>
+        )}
       </div>
-      {error && (
-        <p className="mt-1 px-1 text-[length:var(--font-size-xs)] text-muted-foreground">
-          Couldn’t load the map: {error}
-        </p>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Problem

In a browser where WebGL can't initialize (e.g. Firefox with hardware acceleration / `resistFingerprinting` off, a blocklisted GPU, or headless), the map widget dumped MapLibre's **raw `webglcontextcreationerror` JSON** at the user:

> Couldn't load the map: {"requestedAttributes":{"antialias":false,…},"type":"webglcontextcreationerror","message":"Failed to initialize WebGL"}

Reported by Chris in Firefox. Reproducible by setting `webgl.disabled=true` in `about:config` and rendering any map.

## Fix (`src/widgets/map/widget.tsx`)

MapLibre requires WebGL; we can't make it exist, but we shouldn't leak a raw GL error.

1. **Probe WebGL before loading MapLibre** — if a `webgl2`/`webgl` context can't be created, skip init and show a clean message: *"Maps can't be displayed here — WebGL is disabled or unavailable in this browser."*
2. **Sanitize the other failure paths** — `map.on('error')` and the init `catch` now `console.warn` the raw MapLibre detail (for debugging) and surface a generic *"The map couldn't be loaded."* instead of the raw object.
3. **Render the message centered inside the map box** rather than dumping text below an empty frame.

## Verify

With `webgl.disabled=true` in Firefox, render a map (Storybook → Map story, or ask the chat for one): you now get the clean centered message instead of the JSON. Flip the pref back → map renders normally.

tsc + eslint clean; 12/12 map widget tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only error handling in the map widget; no auth, data, or API changes.
> 
> **Overview**
> Fixes map load failures surfacing **raw MapLibre/WebGL error JSON** (e.g. `webglcontextcreationerror`) to users when WebGL is disabled or unavailable.
> 
> **`MapWidget`** now runs a synchronous **`isWebglAvailable()`** probe before lazy-loading MapLibre; if WebGL cannot be created, init is skipped and a dedicated message is shown: *Maps can't be displayed here — WebGL is disabled or unavailable in this browser.*
> 
> Other failure paths (`map.on('error')` and init **`catch`**) **`console.warn`** the raw error for debugging but set a generic *The map couldn't be loaded.* instead of exposing `event.error.message` or thrown details.
> 
> Error UI is **centered inside the map frame** (overlay on the bordered box) rather than a caption below the empty map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a92a1898e7a9bba737743b53ad95cfc93bc9fb52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->