### PR TITLE
fix(THU-643): harden Android versionCode and CrabNebula upload

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -109,13 +109,16 @@ jobs:
       - name: Calculate versionCode from git history
         id: version_code
         run: |
+          # versionCode must be strictly monotonic across uploads: Play permanently
+          # burns any code it has accepted, so neither a re-dispatch nor a "Re-run"
+          # of the same workflow can reuse a code. RUN_NUMBER increments per new
+          # dispatch but not on re-runs, RUN_ATTEMPT increments on every re-run —
+          # combining them (RUN_NUMBER * 100 + RUN_ATTEMPT) covers both. See THU-643.
           COMMIT_COUNT=$(git rev-list --count HEAD)
-          # Base offset to ensure we stay above previous manual versionCode (1018)
-          # Using 1000 as base means we start at 2626 (2000 + 626 commits)
           BASE_OFFSET=2000
-          VERSION_CODE=$((BASE_OFFSET + COMMIT_COUNT))
+          VERSION_CODE=$((BASE_OFFSET + COMMIT_COUNT + GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT))
           echo "versionCode=$VERSION_CODE" >> $GITHUB_OUTPUT
-          echo "📱 Calculated versionCode: $VERSION_CODE (base $BASE_OFFSET + $COMMIT_COUNT commits)"
+          echo "📱 Calculated versionCode: $VERSION_CODE (base $BASE_OFFSET + $COMMIT_COUNT commits + run #$GITHUB_RUN_NUMBER attempt $GITHUB_RUN_ATTEMPT)"
 
       - name: Set build version and versionCode locally for Android
         run: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -347,13 +347,26 @@ jobs:
             src-tauri/target/x86_64-apple-darwin/release/bundle/macos/*.app.tar.gz
             src-tauri/target/x86_64-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
 
-      # Skip CrabNebula for nightly builds
+      # Skip CrabNebula for nightly builds.
+      # A late-running matrix job (e.g. macOS Apple Silicon queued behind other
+      # runners) can hit the CrabNebula release after it has flipped to published,
+      # which makes `cn release upload` fail with "release was already published".
+      # We tolerate that race — the GitHub Release already has the asset, the
+      # CrabNebula auto-updater for this platform just misses this version — and
+      # surface a loud warning so any other failure mode stays visible. See THU-643.
       - name: Upload to CrabNebula Cloud
         if: ${{ !inputs.nightly }}
+        id: cn_upload
+        continue-on-error: true
         uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
         with:
           command: release upload thunderbird/thunderbolt ${{ inputs.version }} --framework tauri
           api-key: ${{ secrets.CRABNEBULA_CLOUD_API_KEY }}
+
+      - name: Warn on CrabNebula upload failure
+        if: ${{ !inputs.nightly && steps.cn_upload.outcome == 'failure' }}
+        run: |
+          echo "::warning title=CrabNebula upload failed::Failed to upload ${{ matrix.build_name }} asset to CrabNebula for v${{ inputs.version }}. Auto-updater on this platform will miss this version. See THU-643."
 
   publish:
     name: Publish Release

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -365,8 +365,11 @@ jobs:
 
       - name: Warn on CrabNebula upload failure
         if: ${{ !inputs.nightly && steps.cn_upload.outcome == 'failure' }}
+        env:
+          BUILD_NAME: ${{ matrix.build_name }}
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "::warning title=CrabNebula upload failed::Failed to upload ${{ matrix.build_name }} asset to CrabNebula for v${{ inputs.version }}. Auto-updater on this platform will miss this version. See THU-643."
+          echo "::warning title=CrabNebula upload failed::Failed to upload $BUILD_NAME asset to CrabNebula for v$VERSION. Auto-updater on this platform will miss this version. See THU-643."
 
   publish:
     name: Publish Release


### PR DESCRIPTION
Fixes both failures from the v0.1.103 release run.

- **Android** — `versionCode` now incorporates `GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT`, so it's strictly monotonic across new dispatches and re-runs (Play permanently burns any code it accepts).
- **macOS** — `Upload to CrabNebula Cloud` is now `continue-on-error: true` with a follow-up `::warning::` annotation. A late-running matrix job (e.g. Apple Silicon stalled in the runner queue) no longer fails the release when CrabNebula's release has already flipped to published.

Closes [THU-643](https://linear.app/mozilla-thunderbolt/issue/THU-643).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release pipeline changes with no app runtime, auth, or data-handling impact; tradeoff is a possible missed CrabNebula auto-update for one platform if upload fails silently aside from the warning.
> 
> **Overview**
> Addresses release failures from v0.1.103 by making **Android** `versionCode` strictly monotonic for Play uploads and by **not failing desktop releases** when a late matrix job loses the CrabNebula upload race.
> 
> **Android** — `versionCode` is still `2000 + commit count`, but now also adds `GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT` so new workflow dispatches and re-runs never reuse a code Google Play has already accepted.
> 
> **Desktop (non-nightly)** — `Upload to CrabNebula Cloud` uses `continue-on-error: true` with a follow-up step that emits a `::warning::` when upload fails (e.g. release already published while Apple Silicon was still queued). GitHub Release assets still ship; only that platform’s CrabNebula auto-updater may skip the version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b0f5ebcd82f8be38c79a1d123c9dd7debd6d317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->