### PR TITLE
perf(chat): cut time to first token via prompt prefix cache, preflight dedupe, and Tinfoil prewarm

### DIFF
--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -88,20 +88,58 @@ export const ollama = createOpenAI({
 //
 // System cache is keyed by cloudUrl so a dev-tools URL switch hits the new
 // backend on the next call.
-const systemTinfoilClients = new Map<string, SecureClient>()
+const systemTinfoilClients = new Map<string, Promise<SecureClient>>()
 let userTinfoilClient: SecureClient | null = null
+
+/**
+ * Build a fresh system `SecureClient` promise and cache it synchronously
+ * (before the dynamic `import('tinfoil')` resolves) so a prewarm and an
+ * immediate first send share one client and attest once instead of racing into
+ * two attestations. On construction failure we drop the entry so the next call
+ * retries the import rather than inheriting a sticky rejection.
+ */
+const createSystemTinfoilClient = (cloudUrl: string): Promise<SecureClient> => {
+  const clientPromise = import('tinfoil').then(
+    ({ SecureClient }) => new SecureClient({ baseURL: `${cloudUrl}/tinfoil` }),
+  )
+  void clientPromise.catch(() => systemTinfoilClients.delete(cloudUrl))
+  systemTinfoilClients.set(cloudUrl, clientPromise)
+  return clientPromise
+}
 
 export const getSystemTinfoilClient = async (): Promise<SecureClient> => {
   // cloudUrl already ends in /v1 (shared with the OpenAI chat baseURL).
   const cloudUrl = getLocalSetting('cloudUrl').replace(/\/$/, '')
-  let client = systemTinfoilClients.get(cloudUrl)
-  if (!client) {
-    const { SecureClient } = await import('tinfoil')
-    client = new SecureClient({ baseURL: `${cloudUrl}/tinfoil` })
-    systemTinfoilClients.set(cloudUrl, client)
-  }
+  // Reuse the cached construction promise across concurrent callers; `ready()`
+  // is awaited per call below (idempotent once attested).
+  const client = await (systemTinfoilClients.get(cloudUrl) ?? createSystemTinfoilClient(cloudUrl))
   await client.ready()
   return client
+}
+
+/**
+ * Best-effort warm-up of the Tinfoil system enclave so the first chat send
+ * doesn't pay the attestation handshake on the critical path. Fired (fire-and-
+ * forget) from the chat-ready path for the built-in agent only — see
+ * {@link useHydrateChatStore}; ACP agents route over the wire and never reach
+ * {@link createModel}. No-op unless `model` is a Tinfoil *system* model (the
+ * only path that attests via {@link getSystemTinfoilClient}); BYO/other
+ * providers never attest here.
+ *
+ * Idempotent: `getSystemTinfoilClient` memoizes per cloudUrl, so repeated warm-
+ * ups and a concurrent real send share the same in-flight client. Errors are
+ * swallowed ONLY here because this is a speculative cache fill — the real send
+ * still surfaces attestation failures loudly through {@link createModel}.
+ */
+export const prewarmSystemModel = async (model: Pick<Model, 'provider' | 'isSystem'> | null | undefined) => {
+  if (!model || model.provider !== 'tinfoil' || !model.isSystem) {
+    return
+  }
+  try {
+    await getSystemTinfoilClient()
+  } catch (error) {
+    console.warn('prewarmSystemModel: warm-up skipped', error)
+  }
 }
 
 /** Drop the cached `SecureClient` so the next send constructs a fresh one with
@@ -446,6 +484,10 @@ export const aiFetchStreamingResponse = async ({
     time_format: '12h',
     currency: 'USD',
     integrations_do_not_ask_again: false,
+    // Also fetch the tool-availability gates here so `getAvailableTools` can
+    // reuse them (via ToolAvailabilityContext) instead of re-reading settings.
+    experimental_feature_tasks: false,
+    integrations_pro_is_enabled: false,
   })
 
   const integrationStatus = await getIntegrationStatus(db)
@@ -466,7 +508,7 @@ export const aiFetchStreamingResponse = async ({
   let mcpServersSummary: string | undefined
   let mcpToolsMetadata: UIMessageMetadata['mcpTools']
   if (supportsTools) {
-    const availableTools = await getAvailableTools(httpClient, sourceCollector)
+    const availableTools = await getAvailableTools(httpClient, sourceCollector, { settings, integrationStatus })
     toolset = { ...createToolset(availableTools) }
 
     const merged = await mergeMcpTools(toolset, mcpClients ?? [], reconnectClient ?? (async () => null))

--- a/src/ai/prompt.test.ts
+++ b/src/ai/prompt.test.ts
@@ -127,4 +127,29 @@ describe('createPrompt', () => {
     const result = createPrompt(baseParams)
     expect(result).not.toContain('# Active Mode')
   })
+
+  test('keeps the per-turn timestamp in the suffix (prefix-cache friendly)', () => {
+    const result = createPrompt(baseParams)
+    // The timestamp is the only per-turn-volatile field, so it comes after the
+    // whole static instruction block to leave a stable cacheable prefix.
+    expect(result.indexOf('Current date/time')).toBeGreaterThan(result.indexOf('# Output Format'))
+    expect(result.indexOf('Current date/time')).toBeGreaterThan(result.indexOf('# Tools'))
+  })
+
+  test('keeps the stable # Context block (user profile + integration status) in the prefix', () => {
+    const result = createPrompt(baseParams)
+    expect(result.indexOf('# Context')).toBeLessThan(result.indexOf('# Tools'))
+    expect(result.indexOf('Integration status:')).toBeLessThan(result.indexOf('# Tools'))
+  })
+
+  test('keeps user-controlled fields out of the trailing suffix (no injection-by-recency)', () => {
+    const result = createPrompt(baseParams)
+    expect(result.indexOf('User name:')).toBeLessThan(result.indexOf('Current date/time'))
+    expect(result.indexOf('User location:')).toBeLessThan(result.indexOf('Current date/time'))
+  })
+
+  test('appends the timestamp after the Active Mode block so it stays last', () => {
+    const result = createPrompt({ ...baseParams, modeSystemPrompt: 'Mode instructions' })
+    expect(result.indexOf('# Active Mode')).toBeLessThan(result.indexOf('Current date/time'))
+  })
 })

--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -53,17 +53,19 @@ export const createPrompt = ({
         : modeName === 'research'
           ? profile.researchModeAddendum
           : undefined
+  // The date/time changes every send; it goes in the suffix (see the ordering
+  // note on the returned template), while the stable context stays in the prefix.
+  const currentDateTime = `Current date/time: ${new Date().toLocaleString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short',
+  })}`
   const contextSection = [
-    `Current date/time: ${new Date().toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      second: '2-digit',
-      timeZoneName: 'short',
-    })}`,
     preferredName ? `User name: ${preferredName}` : '',
     location.name
       ? `User location: ${location.name}${location.lat && location.lng ? ` (${location.lat}, ${location.lng})` : ''}`
@@ -78,6 +80,15 @@ export const createPrompt = ({
   // `\(…\)` / `\[…\]`). The chat renderer (src/components/chat/memoized-markdown.tsx)
   // still normalizes `\(…\)` / `\[…\]` defensively because models drift — the two
   // are complementary, not redundant; don't drop either side.
+  //
+  // Ordering is prefix-cache-friendly: the per-turn-volatile timestamp is the
+  // ONLY part that changes every send, so it alone is appended LAST (the
+  // suffix). Everything before it — the static instruction block plus the
+  // stable `# Context` (user profile + integration status) — forms a prefix
+  // that prefix-caching backends (vLLM/Tinfoil, OpenAI) reuse across turns.
+  // Keeping the timestamp at the front would invalidate the cache on every
+  // send. User-controlled fields stay in `# Context` (not the trailing suffix)
+  // so settings text can't read as the most-recent instruction.
   return `You are an executive assistant using the **${modelName}** model. You ALWAYS cite sources with [N] — place each [N] once after the final sentence using that source, with a space before the bracket.
 Reasoning: low
 
@@ -129,5 +140,7 @@ Wrong: "Tokyo has 14 million residents. [1] The metro area has 37 million. [1]" 
 Wrong: "Tokyo has 14 million residents." (missing [N])
 Wrong: "| Tokyo | 14 million | [1] |" (citation in separate column)
 Format math as LaTeX with dollar delimiters: $…$ inline, $$…$$ for standalone equations. Never use \\(…\\) or \\[…\\].
-${modeSystemPrompt ? `\n# Active Mode (follow these instructions)\n${modeSystemPrompt}${modeAddendum ? `\n\n${modeAddendum}` : ''}` : ''}`
+${modeSystemPrompt ? `\n# Active Mode (follow these instructions)\n${modeSystemPrompt}${modeAddendum ? `\n\n${modeAddendum}` : ''}` : ''}
+
+${currentDateTime}`
 }

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -27,11 +27,13 @@ import { useMCP } from '@/lib/mcp-provider'
 import { trackEvent } from '@/lib/posthog'
 import { generateTitle } from '@/lib/title-generator'
 import { convertDbChatMessageToUIMessage } from '@/lib/utils'
-import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
+import type { Model, SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
+import type { Agent } from '@/types/acp'
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useChatStore } from './chat-store'
 import { createChatInstance } from './chat-instance'
+import { prewarmSystemModel } from '@/ai/fetch'
 
 type UseHydrateChatStoreParams = {
   id: string
@@ -46,6 +48,19 @@ const trackChatReadyOnce = () => {
   const chatReadyMs = markChatReady()
   if (chatReadyMs !== null) {
     trackEvent('app_chat_ready', { chat_ready_ms: Math.round(chatReadyMs) })
+  }
+}
+
+/**
+ * Warm the Tinfoil system enclave off the critical path so the first send skips
+ * the attestation handshake. Built-in agent only — ACP agents route over the
+ * wire and never touch the local model pipeline, so it's a no-op for them (and
+ * {@link prewarmSystemModel} further no-ops unless `model` is a Tinfoil *system*
+ * model). Fire-and-forget.
+ */
+const maybePrewarmBuiltInAgent = (agent: Agent, model: Model) => {
+  if (agent.type === 'built-in') {
+    void prewarmSystemModel(model)
   }
 }
 
@@ -133,6 +148,9 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
 
       setIsReady(true)
       trackChatReadyOnce()
+      // `sessions.has(id)` above guarantees the session is present.
+      const existingSession = sessions.get(id)!
+      maybePrewarmBuiltInAgent(existingSession.selectedAgent, existingSession.selectedModel)
 
       return
     }
@@ -249,6 +267,7 @@ export const useHydrateChatStore = ({ id, isNew }: UseHydrateChatStoreParams) =>
 
     setIsReady(true)
     trackChatReadyOnce()
+    maybePrewarmBuiltInAgent(selectedAgent, defaultModel)
   }
 
   return { hydrateChatStore, isReady, saveMessages }

--- a/src/lib/tools.test.ts
+++ b/src/lib/tools.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'bun:test'
+import type { HttpClient } from '@/contexts'
+import { getAvailableTools, type ToolAvailabilityContext } from './tools'
+
+// Tool config builders only capture the client inside their `execute` closures,
+// so an empty stub is enough to exercise the availability branching.
+const stubHttpClient = {} as HttpClient
+
+const integrationStatus = (
+  overrides: Partial<ToolAvailabilityContext['integrationStatus']> = {},
+): ToolAvailabilityContext['integrationStatus'] => ({
+  googleConnected: false,
+  googleEnabled: false,
+  googleEmail: null,
+  microsoftConnected: false,
+  microsoftEnabled: false,
+  microsoftEmail: null,
+  ...overrides,
+})
+
+const context = (overrides: Partial<ToolAvailabilityContext> = {}): ToolAvailabilityContext => ({
+  settings: { experimentalFeatureTasks: false, integrationsProIsEnabled: false },
+  integrationStatus: integrationStatus(),
+  ...overrides,
+})
+
+// These run WITHOUT a test database set up. The injected context must fully
+// drive availability, so any reintroduced `getSettings`/`getIntegrationStatus`
+// read (the duplicate the DI removed) would surface here. This locks in the
+// dedup from the hot send path (`aiFetchStreamingResponse`).
+describe('getAvailableTools (injected context)', () => {
+  it('returns no tools when every gate is disabled', async () => {
+    const tools = await getAvailableTools(stubHttpClient, undefined, context())
+    expect(tools).toEqual([])
+  })
+
+  it('includes task tools when experimentalFeatureTasks is enabled', async () => {
+    const tools = await getAvailableTools(
+      stubHttpClient,
+      undefined,
+      context({ settings: { experimentalFeatureTasks: true, integrationsProIsEnabled: false } }),
+    )
+    expect(tools.length).toBeGreaterThan(0)
+  })
+
+  it('includes Google tools only when the Google integration is enabled', async () => {
+    const tools = await getAvailableTools(
+      stubHttpClient,
+      undefined,
+      context({ integrationStatus: integrationStatus({ googleEnabled: true }) }),
+    )
+    expect(tools.some((tool) => tool.name.startsWith('google'))).toBe(true)
+  })
+
+  it('includes Microsoft tools only when the Microsoft integration is enabled', async () => {
+    const tools = await getAvailableTools(
+      stubHttpClient,
+      undefined,
+      context({ integrationStatus: integrationStatus({ microsoftEnabled: true }) }),
+    )
+    expect(tools.some((tool) => tool.name.startsWith('microsoft'))).toBe(true)
+  })
+
+  it('includes Pro tools when the Pro integration is enabled', async () => {
+    const tools = await getAvailableTools(
+      stubHttpClient,
+      undefined,
+      context({ settings: { experimentalFeatureTasks: false, integrationsProIsEnabled: true } }),
+    )
+    expect(tools.some((tool) => tool.name === 'search')).toBe(true)
+  })
+})

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -14,18 +14,35 @@ import type { ToolConfig } from '@/types'
 import type { SourceMetadata } from '@/types/source'
 import { tool, type Tool } from 'ai'
 
-export const getAvailableTools = async (
-  httpClient: HttpClient,
-  sourceCollector?: SourceMetadata[],
-): Promise<ToolConfig[]> => {
-  // Check Thunderbolt Pro access and integration enabled state
+/** Settings + integration status that gate which tools are exposed. */
+export type ToolAvailabilityContext = {
+  settings: { experimentalFeatureTasks: boolean; integrationsProIsEnabled: boolean }
+  integrationStatus: Awaited<ReturnType<typeof getIntegrationStatus>>
+}
+
+/** Read the settings + integration status that gate tool availability. The hot
+ *  send path (`aiFetchStreamingResponse`) already fetches both, so it injects
+ *  them to avoid duplicate DB round-trips; other callers let this self-fetch. */
+const loadToolAvailabilityContext = async (): Promise<ToolAvailabilityContext> => {
   const db = getDb()
-  const proEnabled = await hasProAccess()
-  const { experimentalFeatureTasks, integrationsProIsEnabled } = await getSettings(db, {
+  const settings = await getSettings(db, {
     experimental_feature_tasks: false,
     integrations_pro_is_enabled: false,
   })
   const integrationStatus = await getIntegrationStatus(db)
+  return { settings, integrationStatus }
+}
+
+export const getAvailableTools = async (
+  httpClient: HttpClient,
+  sourceCollector?: SourceMetadata[],
+  context?: ToolAvailabilityContext,
+): Promise<ToolConfig[]> => {
+  const proEnabled = await hasProAccess()
+  const {
+    settings: { experimentalFeatureTasks, integrationsProIsEnabled },
+    integrationStatus,
+  } = context ?? (await loadToolAvailabilityContext())
 
   const baseTools: ToolConfig[] = experimentalFeatureTasks ? [...Object.values(tasksTools)] : []
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Performance and prompt-ordering changes with tests; no auth or data-model changes, and Tinfoil prewarm failures are swallowed by design.
> 
> **Overview**
> Improves **time to first token** by overlapping slow work with chat load and making the system prompt easier for prefix-caching backends to reuse.
> 
> **System prompt layout** moves the per-turn `Current date/time` to the **end** of the prompt so the static instructions plus `# Context` stay a stable prefix; tests lock in ordering (timestamp last, user fields not in the trailing suffix).
> 
> **Tinfoil system clients** cache an in-flight `Promise<SecureClient>` (not a resolved client) so prewarm and the first send share one attestation. **`prewarmSystemModel`** runs fire-and-forget when the built-in agent’s chat becomes ready (Tinfoil system models only).
> 
> **Send path** passes already-loaded settings and integration status into **`getAvailableTools`** via `ToolAvailabilityContext`, dropping duplicate DB reads on each message send.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f59ae5ad39df27c9841401d0c82a57a4f0f447cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->