### PR TITLE
feat(chat): show a mode aware status label before the first token

### DIFF
--- a/src/components/chat/assistant-message.test.tsx
+++ b/src/components/chat/assistant-message.test.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { GroupedUIPart, ReasoningGroupUIPart } from '@/lib/assistant-message'
+import { render, screen } from '@testing-library/react'
 import type { ReasoningUIPart, TextUIPart, ToolUIPart } from 'ai'
 import { describe, expect, it } from 'bun:test'
 import { mountMessageParts } from './assistant-message'
@@ -50,6 +51,23 @@ describe('mountMessageParts', () => {
       expect(result).toHaveLength(1)
       // Check that it's the synthetic loading component by checking the result structure
       expect(result[0]).toBeDefined()
+    })
+
+    it('threads the mode-aware loading message into the synthetic loading part', () => {
+      const result = mountMessageParts(
+        [],
+        true,
+        testMessageId,
+        testReasoningTime,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'Searching the web…',
+      )
+
+      render(<>{result[0]}</>)
+      expect(screen.getByTestId('loading-status')).toHaveTextContent('Searching the web…')
     })
   })
 

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -24,6 +24,7 @@ type AssistantMessageProps = {
   isStreaming: boolean
   isLastMessage?: boolean
   isLastAssistantMessage?: boolean
+  loadingMessage?: string
 }
 
 // Viewport positioning constant - ensures enough space for scrolling user message to top
@@ -46,12 +47,13 @@ export const mountMessageParts = (
   sources?: SourceMetadata[],
   haystackReferences?: HaystackReferenceMeta[],
   mcpTools?: UIMessageMetadata['mcpTools'],
+  loadingMessage?: string,
 ) => {
   const partElements: ReactNode[] = []
 
   if (groupedParts.length === 0 && isStreaming) {
     // isStreaming should always be true because the next part will *replace* this one
-    partElements.push(<SyntheticLoadingPart isStreaming />)
+    partElements.push(<SyntheticLoadingPart isStreaming message={loadingMessage} />)
   }
 
   const hasTextPart = groupedParts.some((part) => {
@@ -96,7 +98,13 @@ export const mountMessageParts = (
 }
 
 export const AssistantMessage = memo(
-  ({ message, isStreaming, isLastMessage = false, isLastAssistantMessage = false }: AssistantMessageProps) => {
+  ({
+    message,
+    isStreaming,
+    isLastMessage = false,
+    isLastAssistantMessage = false,
+    loadingMessage,
+  }: AssistantMessageProps) => {
     // Memoize filtering and grouping to avoid recomputing on every render
     const groupedParts = useMemo(() => groupMessageParts(filterMessageParts(message.parts)), [message.parts])
 
@@ -144,6 +152,7 @@ export const AssistantMessage = memo(
           sources,
           haystackReferences,
           mcpTools,
+          loadingMessage,
         ),
       [
         groupedParts,
@@ -154,6 +163,7 @@ export const AssistantMessage = memo(
         sources,
         haystackReferences,
         mcpTools,
+        loadingMessage,
       ],
     )
 
@@ -209,7 +219,8 @@ export const AssistantMessage = memo(
       prevProps.message.metadata === nextProps.message.metadata &&
       prevProps.isStreaming === nextProps.isStreaming &&
       prevProps.isLastMessage === nextProps.isLastMessage &&
-      prevProps.isLastAssistantMessage === nextProps.isLastAssistantMessage
+      prevProps.isLastAssistantMessage === nextProps.isLastAssistantMessage &&
+      prevProps.loadingMessage === nextProps.loadingMessage
     )
   },
 )

--- a/src/components/chat/chat-messages.test.tsx
+++ b/src/components/chat/chat-messages.test.tsx
@@ -6,6 +6,7 @@ import { setupTestDatabase, teardownTestDatabase, resetTestDatabase } from '@/da
 import {
   createMockChatInstance,
   createMockChatThread,
+  createMockMode,
   createMockUseChat,
   hydrateStore,
   resetStore,
@@ -18,6 +19,8 @@ import { useChatStore } from '@/chats/chat-store'
 import { ChatMessages } from './chat-messages'
 import { ExternalLinkDialogProvider } from './markdown-utils'
 import type { ThunderboltUIMessage } from '@/types'
+import type { Agent } from '@/types/acp'
+import { builtInAgent } from '@/defaults/agents'
 import { type ReactNode } from 'react'
 
 const createTestWrapper = () => {
@@ -411,6 +414,64 @@ describe('ChatMessages', () => {
       ]
       const { container } = setup('submitted', messages)
       expect(container.querySelector('.animate-spin')).toBeNull()
+    })
+  })
+
+  describe('mode-aware loading label', () => {
+    const setupWithMode = (modeName: string, agent?: Agent) => {
+      const messages: ThunderboltUIMessage[] = [
+        createTestMessage({ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }),
+      ]
+      const mockChatInstance = createMockChatInstance(messages, 'submitted')
+      const mockUseChat = createMockUseChat(mockChatInstance)
+      hydrateStore({
+        chatInstance: mockChatInstance,
+        chatThread: createMockChatThread(),
+        id: 'thread-1',
+        mcpClients: [],
+        models: [],
+        selectedMode: createMockMode({ name: modeName }),
+        selectedModel: null,
+        triggerData: null,
+      })
+      // `hydrateStore` always assigns the built-in agent; patch the session for
+      // tests that need a non-built-in (ACP) agent.
+      if (agent) {
+        useChatStore.setState((state) => {
+          const session = state.sessions.get('thread-1')
+          if (!session) {
+            return state
+          }
+          const nextSessions = new Map(state.sessions)
+          nextSessions.set('thread-1', { ...session, selectedAgent: agent })
+          return { sessions: nextSessions }
+        })
+      }
+      return render(<ChatMessages useChat={mockUseChat} />, { wrapper: createTestWrapper() })
+    }
+
+    it('shows a specific label in search mode', () => {
+      setupWithMode('search')
+      expect(screen.getByTestId('loading-status')).toHaveTextContent('Searching the web…')
+    })
+
+    it('shows a specific label in research mode', () => {
+      setupWithMode('research')
+      expect(screen.getByTestId('loading-status')).toHaveTextContent('Researching…')
+    })
+
+    it('keeps a plain spinner (no specific label) in chat mode', () => {
+      const { container } = setupWithMode('chat')
+      // The plain spinner still renders, but with no specific status text.
+      expect(container.querySelector('.animate-spin')).not.toBeNull()
+      expect(screen.getByTestId('loading-status').textContent?.trim()).toBe('')
+    })
+
+    it('keeps a plain spinner for ACP agents even when a search mode is stale-selected', () => {
+      const acpAgent: Agent = { ...builtInAgent, id: 'acp-1', name: 'Some ACP', type: 'remote-acp' }
+      setupWithMode('search', acpAgent)
+      // ACP agents own their mode upstream — never leak a false "Searching…" label.
+      expect(screen.getByTestId('loading-status').textContent?.trim()).toBe('')
     })
   })
 })

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -11,16 +11,25 @@ import { useCurrentChatSession } from '@/chats/chat-store'
 import { useChat as useChat_default } from '@ai-sdk/react'
 import { shouldUseViewportPositioning } from '@/chats/use-chat-scroll-handler'
 import { useHaptics } from '@/hooks/use-haptics'
+import { getLoadingLabel } from '@/lib/loading-labels'
+import { isBuiltInAgent } from '@/defaults/agents'
 
 type ChatMessagesProps = {
   useChat?: typeof useChat_default
 }
 
 export const ChatMessages = ({ useChat = useChat_default }: ChatMessagesProps) => {
-  const { chatInstance, retryCount, retriesExhausted } = useCurrentChatSession()
+  const { chatInstance, retryCount, retriesExhausted, selectedAgent, selectedMode } = useCurrentChatSession()
 
   const { error: chatError, status, messages, regenerate } = useChat({ chat: chatInstance })
   const { triggerNotification } = useHaptics()
+
+  // Mode-aware status shown in the loading window before the first token. Pure
+  // render-time derive — search/research get a specific label, chat keeps the
+  // plain spinner (undefined). ACP agents own their conversation mode upstream
+  // and ignore `selectedMode` (mirroring ChatModePicker), so a stale built-in
+  // mode must not leak a false "Searching the web…" label onto an ACP chat.
+  const loadingMessage = isBuiltInAgent(selectedAgent) ? getLoadingLabel(selectedMode.name) : undefined
 
   const isStreaming = status === 'streaming'
   const wasStreaming = useRef(false)
@@ -77,6 +86,7 @@ export const ChatMessages = ({ useChat = useChat_default }: ChatMessagesProps) =
               isStreaming={isStreaming && isLast}
               isLastMessage={shouldApplyViewport}
               isLastAssistantMessage={message === lastAssistantMessage}
+              loadingMessage={loadingMessage}
             />
           )
         }
@@ -87,7 +97,7 @@ export const ChatMessages = ({ useChat = useChat_default }: ChatMessagesProps) =
         return null
       })}
 
-      {showSubmittedLoading && <SyntheticLoadingPart isStreaming />}
+      {showSubmittedLoading && <SyntheticLoadingPart isStreaming message={loadingMessage} />}
 
       {/* Show error message if there's an error */}
       {hasError && (

--- a/src/components/chat/chat-mode-picker.tsx
+++ b/src/components/chat/chat-mode-picker.tsx
@@ -5,6 +5,7 @@
 import { useChatStore, useCurrentChatSession } from '@/chats/chat-store'
 import { useHaptics } from '@/hooks/use-haptics'
 import { ModeSelector } from '@/components/ui/mode-selector'
+import { isBuiltInAgent } from '@/defaults/agents'
 import { useCallback } from 'react'
 
 type ChatModePickerProps = {
@@ -33,7 +34,7 @@ export const ChatModePicker = ({ iconOnly = false }: ChatModePickerProps) => {
     [chatThreadId, setSelectedMode, triggerSelection],
   )
 
-  if (selectedAgent.type !== 'built-in' || modes.length === 0) {
+  if (!isBuiltInAgent(selectedAgent) || modes.length === 0) {
     return null
   }
 

--- a/src/components/chat/reasoning-group-title.tsx
+++ b/src/components/chat/reasoning-group-title.tsx
@@ -50,7 +50,10 @@ export const ReasoningGroupTitle = ({ totalDuration, isGroupReasoning, tools, mc
               transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
               className="w-full"
             >
-              <span className="text-xs text-muted-foreground italic animate-pulse truncate min-w-0">
+              <span
+                data-testid="tool-status"
+                className="text-xs text-muted-foreground italic animate-pulse truncate min-w-0"
+              >
                 {loadingLabel}
               </span>
             </m.div>

--- a/src/components/chat/reasoning-group.test.tsx
+++ b/src/components/chat/reasoning-group.test.tsx
@@ -138,6 +138,43 @@ describe('ReasoningGroup', () => {
       const loader = container.querySelector('.animate-spin')
       expect(loader).toBeInTheDocument()
     })
+
+    it('should expose the active tool status (window #2) while streaming', () => {
+      const toolPart = createMockToolPart('search', 'input-streaming')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={true}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
+        { wrapper: TestWrapper },
+      )
+
+      // The tool-derived status span carries the harness testid and a non-empty verb.
+      const status = screen.getByTestId('tool-status')
+      expect(status).toBeInTheDocument()
+      expect(status.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    })
+
+    it('should not expose the active tool status once streaming completes', () => {
+      const toolPart = createMockToolPart('search')
+      const parts: ReasoningGroupItem[] = [{ type: 'tool', content: toolPart, id: toolPart.toolCallId }]
+      render(
+        <ReasoningGroup
+          parts={parts}
+          isStreaming={false}
+          isLastPartInMessage={true}
+          hasTextPart={false}
+          reasoningTime={testReasoningTime}
+        />,
+        { wrapper: TestWrapper },
+      )
+
+      expect(screen.queryByTestId('tool-status')).not.toBeInTheDocument()
+    })
   })
 
   describe('isGroupReasoning logic', () => {

--- a/src/components/chat/synthetic-loading-part.tsx
+++ b/src/components/chat/synthetic-loading-part.tsx
@@ -17,7 +17,11 @@ export const SyntheticLoadingPart = ({ message = '', isStreaming }: SyntheticLoa
 
   const displayMessage = message && message.trim().length > 0 ? message : '\u00A0'
 
-  const titleNode = <span className="text-sm text-secondary-foreground">{displayMessage}</span>
+  const titleNode = (
+    <span data-testid="loading-status" className="text-sm text-secondary-foreground">
+      {displayMessage}
+    </span>
+  )
 
   return (
     <Expandable

--- a/src/defaults/agents.ts
+++ b/src/defaults/agents.ts
@@ -24,3 +24,10 @@ export const builtInAgent: Agent = {
   deletedAt: null,
   userId: null,
 }
+
+/**
+ * Whether an agent is the in-process built-in Thunderbolt agent (vs. an ACP
+ * agent). Built-in-only chat affordances — the mode picker and the mode-aware
+ * loading label — gate on this; ACP agents own their conversation mode upstream.
+ */
+export const isBuiltInAgent = (agent: Agent): boolean => agent.type === 'built-in'

--- a/src/lib/loading-labels.test.ts
+++ b/src/lib/loading-labels.test.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'bun:test'
+import { getLoadingLabel } from './loading-labels'
+
+describe('getLoadingLabel', () => {
+  it('returns a specific label for search mode', () => {
+    expect(getLoadingLabel('search')).toBe('Searching the web…')
+  })
+
+  it('returns a specific label for research mode', () => {
+    expect(getLoadingLabel('research')).toBe('Researching…')
+  })
+
+  it('returns undefined for chat mode (keeps the plain spinner)', () => {
+    expect(getLoadingLabel('chat')).toBeUndefined()
+  })
+
+  it('returns undefined for unknown/custom modes (no fabricated label)', () => {
+    expect(getLoadingLabel('my-custom-mode')).toBeUndefined()
+    expect(getLoadingLabel('')).toBeUndefined()
+  })
+})

--- a/src/lib/loading-labels.ts
+++ b/src/lib/loading-labels.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Maps a chat mode name to the status label shown in the "submitted" window —
+ * after the user sends a message but before the model emits its first token.
+ *
+ * Only modes whose pre-token action is known and truthful return a label:
+ * - `search`   → "Searching the web…"
+ * - `research` → "Researching…"
+ *
+ * Plain chat (and any custom mode) has no specific, honest action to describe
+ * before the first token, so it returns `undefined` and the caller keeps the
+ * plain spinner. Generic filler ("Thinking…") is intentionally avoided — vendor
+ * and community UX guidance rates it worse than a bare spinner.
+ *
+ * @param modeName - The selected mode's `name` (e.g. `selectedMode.name`).
+ * @returns A specific, static status label, or `undefined` to keep the spinner.
+ */
+export const getLoadingLabel = (modeName: string): string | undefined => {
+  if (modeName === 'search') {
+    return 'Searching the web…'
+  }
+  if (modeName === 'research') {
+    return 'Researching…'
+  }
+  return undefined
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only copy and test hooks in chat loading; behavior is gated to the built-in agent with no auth or data-path changes.
> 
> **Overview**
> Adds **mode-aware loading text** in the gap after send and before the first assistant token, for the built-in agent only.
> 
> `ChatMessages` derives a label via new `getLoadingLabel(selectedMode.name)` (**"Searching the web…"** / **"Researching…"** for search/research; **no label** for chat or unknown modes so the spinner stays plain). That value is passed into **`SyntheticLoadingPart`** for the submitted state and into **`AssistantMessage`** / **`mountMessageParts`** when streaming with empty parts. **ACP agents** skip mode-based labels (same gating as the mode picker) so a stale search/research selection does not show misleading copy.
> 
> Introduces shared **`isBuiltInAgent`** (used by **`ChatModePicker`** and loading logic). **`SyntheticLoadingPart`** and reasoning **tool status** spans get **`data-testid`** hooks for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9839d1ed1c63bbb92aef82ca2aa6d65033cdbc39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->