### PR TITLE
fix(sidebar): smooth the mobile close by dropping the animated backdrop blur

### DIFF
--- a/src/components/ui/mobile-sidebar.test.tsx
+++ b/src/components/ui/mobile-sidebar.test.tsx
@@ -2,20 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Import for side effect: registers the framer-motion `mock.module` so `animate` resolves
-// synchronously and `useMotionValue`/`useTransform` return inert values in jsdom.
-import '@/test-utils/framer-motion-mock'
+// Registers the framer-motion `mock.module` (side effect) so `animate` resolves synchronously
+// and `useMotionValue`/`useTransform`/`useReducedMotion` return inert values in jsdom. The named
+// imports also let us drive the reduced-motion flag and inspect the transition passed to `animate`.
+import { animateSpy, setMockReducedMotion } from '@/test-utils/framer-motion-mock'
 
 import { act, cleanup, fireEvent, render } from '@testing-library/react'
-import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { PanInfo } from 'framer-motion'
 import { useState } from 'react'
 
 import { getClock } from '@/testing-library'
-import { MobileSidebar, shouldCloseOnDragEnd } from './mobile-sidebar'
+
+// Import the component dynamically — after the framer-motion mock above has registered — so the
+// shared `mock.module('framer-motion')` actually intercepts its `animate`/`useReducedMotion`
+// imports. A top-level static import links the real framer-motion before the mock applies, which
+// would leave `animateSpy` empty and run the suite against the real animation runtime.
+const { MobileSidebar, shouldCloseOnDragEnd } = await import('./mobile-sidebar')
+
+beforeEach(() => {
+  animateSpy.mockClear()
+  setMockReducedMotion(false)
+})
 
 afterEach(() => {
   cleanup()
+  // Reset here too (not just beforeEach): the framer-motion mock's flag persists across files, so
+  // a reduced-motion test running last under --randomize must not leak `true` to the next file.
+  setMockReducedMotion(false)
 })
 
 const makeDragInfo = (offsetX: number, velocityX: number): PanInfo => ({
@@ -84,6 +98,21 @@ describe('MobileSidebar', () => {
     await flushAnimations()
 
     expect(onOpenChange).toHaveBeenCalledWith(false)
+    // Default (motion allowed): the close rides the spring.
+    expect(animateSpy.mock.calls.at(-1)?.[2]).toMatchObject({ type: 'spring' })
+  })
+
+  it('closes instantly (no spring) under prefers-reduced-motion, still firing onOpenChange', async () => {
+    setMockReducedMotion(true)
+    const onOpenChange = mock()
+    render(<Harness onOpenChange={onOpenChange} />)
+
+    fireEvent.click(getOverlay())
+    await flushAnimations()
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    // Reduced motion: the close uses an instant transition instead of the spring.
+    expect(animateSpy.mock.calls.at(-1)?.[2]).toEqual({ duration: 0 })
   })
 
   it('ignores a second overlay tap while the close is already running (isAnimating guard)', async () => {

--- a/src/components/ui/mobile-sidebar.test.tsx
+++ b/src/components/ui/mobile-sidebar.test.tsx
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Import for side effect: registers the framer-motion `mock.module` so `animate` resolves
+// synchronously and `useMotionValue`/`useTransform` return inert values in jsdom.
+import '@/test-utils/framer-motion-mock'
+
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import type { PanInfo } from 'framer-motion'
+import { useState } from 'react'
+
+import { getClock } from '@/testing-library'
+import { MobileSidebar, shouldCloseOnDragEnd } from './mobile-sidebar'
+
+afterEach(() => {
+  cleanup()
+})
+
+const makeDragInfo = (offsetX: number, velocityX: number): PanInfo => ({
+  point: { x: 0, y: 0 },
+  delta: { x: 0, y: 0 },
+  offset: { x: offsetX, y: 0 },
+  velocity: { x: velocityX, y: 0 },
+})
+
+describe('shouldCloseOnDragEnd', () => {
+  it('closes a left drawer dragged past the -50px threshold', () => {
+    expect(shouldCloseOnDragEnd('left', makeDragInfo(-60, 0))).toBe(true)
+  })
+
+  it('closes a left drawer flicked left fast enough', () => {
+    expect(shouldCloseOnDragEnd('left', makeDragInfo(-10, -600))).toBe(true)
+  })
+
+  it('keeps a left drawer open below both thresholds', () => {
+    expect(shouldCloseOnDragEnd('left', makeDragInfo(-10, -100))).toBe(false)
+  })
+
+  it('closes a right drawer dragged past the +50px threshold', () => {
+    expect(shouldCloseOnDragEnd('right', makeDragInfo(60, 0))).toBe(true)
+  })
+
+  it('closes a right drawer flicked right fast enough', () => {
+    expect(shouldCloseOnDragEnd('right', makeDragInfo(10, 600))).toBe(true)
+  })
+
+  it('keeps a right drawer open below both thresholds', () => {
+    expect(shouldCloseOnDragEnd('right', makeDragInfo(10, 100))).toBe(false)
+  })
+})
+
+/** Controlled wrapper mirroring how `Sidebar` drives the drawer (open is parent-owned). */
+const Harness = ({ onOpenChange }: { onOpenChange: (open: boolean) => void }) => {
+  const [open, setOpen] = useState(true)
+  return (
+    <MobileSidebar
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        onOpenChange(next)
+      }}
+    >
+      <div>sidebar content</div>
+    </MobileSidebar>
+  )
+}
+
+const getOverlay = () => document.querySelector('[data-slot="sidebar-overlay"]')!
+
+const flushAnimations = async () => {
+  await act(async () => {
+    await getClock().runAllAsync()
+  })
+}
+
+describe('MobileSidebar', () => {
+  it('closes via onOpenChange(false) when the overlay is tapped', async () => {
+    const onOpenChange = mock()
+    render(<Harness onOpenChange={onOpenChange} />)
+
+    fireEvent.click(getOverlay())
+    await flushAnimations()
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('ignores a second overlay tap while the close is already running (isAnimating guard)', async () => {
+    const onOpenChange = mock()
+    render(<Harness onOpenChange={onOpenChange} />)
+
+    const overlay = getOverlay()
+    fireEvent.click(overlay)
+    fireEvent.click(overlay)
+    await flushAnimations()
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ui/mobile-sidebar.tsx
+++ b/src/components/ui/mobile-sidebar.tsx
@@ -3,10 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useHaptics } from '@/hooks/use-haptics'
+import { mobileSidebarWidthRatio } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { animate, m, useMotionValue, useTransform, type PanInfo } from 'framer-motion'
-import { useEffect, useState, type CSSProperties, type ReactNode } from 'react'
+import { useEffect, useState, useSyncExternalStore, type CSSProperties, type ReactNode } from 'react'
 
 type MobileSidebarProps = {
   open: boolean
@@ -16,6 +17,29 @@ type MobileSidebarProps = {
   className?: string
   style?: CSSProperties
 }
+
+/**
+ * Spring shared by every drawer transition (open, close, drag snap-back). High damping and
+ * stiffness with low mass keep it near-critically-damped: it settles quickly without
+ * overshoot and stays interruptible for the drag-to-close gesture.
+ */
+const drawerSpring = { type: 'spring', damping: 35, stiffness: 400, mass: 0.8 } as const
+
+/** Slide distance for the drawer (its rendered width, 80vw), or a sane fallback off-DOM. */
+const readSidebarWidth = () => (typeof window !== 'undefined' ? window.innerWidth * mobileSidebarWidthRatio : 300)
+
+const subscribeToResize = (onResize: () => void) => {
+  window.addEventListener('resize', onResize)
+  return () => window.removeEventListener('resize', onResize)
+}
+
+/**
+ * Decides whether a drag-end gesture should dismiss the drawer: closes when it has been
+ * dragged past the 50px threshold toward its edge, or flicked there fast enough (velocity
+ * beyond 500px/s) in the closing direction.
+ */
+export const shouldCloseOnDragEnd = (side: 'left' | 'right', info: PanInfo): boolean =>
+  side === 'left' ? info.offset.x < -50 || info.velocity.x < -500 : info.offset.x > 50 || info.velocity.x > 500
 
 export const MobileSidebar = ({
   open,
@@ -30,12 +54,13 @@ export const MobileSidebar = ({
   const x = useMotionValue(0)
   const { triggerImpact } = useHaptics()
 
-  const getSidebarWidth = () => (typeof window !== 'undefined' ? window.innerWidth * 0.8 : 300)
+  // The drawer renders at w-[80vw]; track that slide distance live so the off-screen
+  // animation target and drag constraints stay correct across viewport resizes/rotations.
+  // useSyncExternalStore reads window.innerWidth once per render (vs the old 3x) plus on
+  // resize — the house pattern (see use-mobile.ts), no extra effect.
+  const sidebarWidth = useSyncExternalStore(subscribeToResize, readSidebarWidth, readSidebarWidth)
 
-  // Transform x position to overlay opacity (fade out as sidebar moves away).
-  // Output [0, 1] so backdrop-blur and bg dimming render at full strength when open
-  // (opacity multiplies the whole composited layer including backdrop-filter).
-  const sidebarWidth = getSidebarWidth()
+  // Fade the dim overlay as the sidebar slides: full opacity when open, transparent when off-screen.
   const overlayOpacity = useTransform(
     x,
     side === 'left' ? [-sidebarWidth, 0] : [0, sidebarWidth],
@@ -44,44 +69,28 @@ export const MobileSidebar = ({
 
   // Handle external open/close requests
   useEffect(() => {
-    const width = getSidebarWidth()
     if (open && !internalOpen) {
       // Opening: set position first, then animate in
       // Set position synchronously before rendering to avoid flicker
-      x.set(side === 'left' ? -width : width)
+      x.set(side === 'left' ? -sidebarWidth : sidebarWidth)
       setInternalOpen(true)
 
       // Animate to position after render
       const animateOpen = async () => {
-        await animate(x, 0, {
-          type: 'spring',
-          // Performance-optimized spring physics:
-          // - Higher damping (35) = fewer oscillations, settles faster, less computation
-          // - Higher stiffness (400) = snappier response, shorter animation duration
-          // - Lower mass (0.8) = lighter feel, more responsive, better for mobile
-          damping: 35,
-          stiffness: 400,
-          mass: 0.8,
-        })
+        await animate(x, 0, drawerSpring)
       }
       animateOpen()
     } else if (!open && internalOpen && !isAnimating) {
       // Closing: animate first, then close
       const animateClose = async () => {
         setIsAnimating(true)
-        await animate(x, side === 'left' ? -width : width, {
-          type: 'spring',
-          // Same optimized spring physics for consistent feel across all animations
-          damping: 35,
-          stiffness: 400,
-          mass: 0.8,
-        })
+        await animate(x, side === 'left' ? -sidebarWidth : sidebarWidth, drawerSpring)
         setIsAnimating(false)
         setInternalOpen(false)
       }
       animateClose()
     }
-  }, [open, internalOpen, isAnimating, x, side])
+  }, [open, internalOpen, isAnimating, x, side, sidebarWidth])
 
   const handleClose = async () => {
     if (isAnimating) {
@@ -89,49 +98,33 @@ export const MobileSidebar = ({
     }
 
     triggerImpact('light')
-    const width = getSidebarWidth()
     setIsAnimating(true)
-    await animate(x, side === 'left' ? -width : width, {
-      type: 'spring',
-      // Same optimized spring physics for consistent feel across all animations
-      damping: 35,
-      stiffness: 400,
-      mass: 0.8,
-    })
+    await animate(x, side === 'left' ? -sidebarWidth : sidebarWidth, drawerSpring)
     setIsAnimating(false)
     setInternalOpen(false)
     onOpenChange(false)
   }
 
   const handleDragEnd = async (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
-    const shouldClose =
-      side === 'left' ? info.offset.x < -50 || info.velocity.x < -500 : info.offset.x > 50 || info.velocity.x > 500
-
-    if (shouldClose) {
+    if (shouldCloseOnDragEnd(side, info)) {
       await handleClose()
     } else {
-      // Snap back to position with animation
-      await animate(x, 0, {
-        type: 'spring',
-        // Same optimized spring physics for consistent feel across all animations
-        damping: 35,
-        stiffness: 400,
-        mass: 0.8,
-      })
+      // Snap back to the open position
+      await animate(x, 0, drawerSpring)
     }
   }
 
   return (
     <DialogPrimitive.Root open={internalOpen}>
       <DialogPrimitive.Portal>
-        {/* Animated overlay with blur */}
+        {/* Dim overlay — plain opacity fade (compositor-only). Intentionally NOT blurred:
+            unlike the app's Radix sheet/dialog overlays (bg-black/50 backdrop-blur-md), this
+            skips backdrop-filter because animating opacity on a blur layer forces a per-frame
+            re-blur of the scene behind it — the main source of close-animation jank on mobile. */}
         <m.div
-          className="fixed inset-0 z-50 bg-black/40 backdrop-blur-lg"
-          style={{
-            opacity: overlayOpacity,
-            // willChange hints to browser this property will animate, enabling GPU acceleration
-            willChange: 'opacity',
-          }}
+          data-slot="sidebar-overlay"
+          className="fixed inset-0 z-50 bg-black/40"
+          style={{ opacity: overlayOpacity }}
           onClick={handleClose}
         />
 
@@ -139,18 +132,12 @@ export const MobileSidebar = ({
         <m.div
           drag="x"
           dragConstraints={{
-            left: side === 'left' ? -getSidebarWidth() : 0,
-            right: side === 'left' ? 0 : getSidebarWidth(),
+            left: side === 'left' ? -sidebarWidth : 0,
+            right: side === 'left' ? 0 : sidebarWidth,
           }}
           dragElastic={0.2}
           onDragEnd={handleDragEnd}
-          style={{
-            x,
-            // willChange hints to browser this property will animate, enabling GPU acceleration
-            // This promotes the element to its own compositing layer for smoother 60fps animations
-            willChange: 'transform',
-            ...style,
-          }}
+          style={{ x, ...style }}
           className={cn(
             'bg-sidebar text-sidebar-foreground fixed inset-y-0 z-50 h-full w-[80vw] border-r shadow-lg flex flex-col',
             side === 'left' ? 'left-0' : 'right-0',

--- a/src/components/ui/mobile-sidebar.tsx
+++ b/src/components/ui/mobile-sidebar.tsx
@@ -6,7 +6,7 @@ import { useHaptics } from '@/hooks/use-haptics'
 import { mobileSidebarWidthRatio } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { animate, m, useMotionValue, useTransform, type PanInfo } from 'framer-motion'
+import { animate, m, useMotionValue, useReducedMotion, useTransform, type PanInfo } from 'framer-motion'
 import { useEffect, useState, useSyncExternalStore, type CSSProperties, type ReactNode } from 'react'
 
 type MobileSidebarProps = {
@@ -24,6 +24,9 @@ type MobileSidebarProps = {
  * overshoot and stays interruptible for the drag-to-close gesture.
  */
 const drawerSpring = { type: 'spring', damping: 35, stiffness: 400, mass: 0.8 } as const
+
+/** Instant transition used under `prefers-reduced-motion`: jumps to the target with no spring travel. */
+const instantTransition = { duration: 0 } as const
 
 /** Slide distance for the drawer (its rendered width, 80vw), or a sane fallback off-DOM. */
 const readSidebarWidth = () => (typeof window !== 'undefined' ? window.innerWidth * mobileSidebarWidthRatio : 300)
@@ -54,6 +57,12 @@ export const MobileSidebar = ({
   const x = useMotionValue(0)
   const { triggerImpact } = useHaptics()
 
+  // Honor prefers-reduced-motion: drive every open/close/snap-back with an instant transition
+  // (no spring travel) while keeping drag-to-dismiss and the overlay dim intact. Derived during
+  // render — both branches are stable module constants, so this stays referentially safe in deps.
+  const reducedMotion = useReducedMotion()
+  const transition = reducedMotion ? instantTransition : drawerSpring
+
   // The drawer renders at w-[80vw]; track that slide distance live so the off-screen
   // animation target and drag constraints stay correct across viewport resizes/rotations.
   // useSyncExternalStore reads window.innerWidth once per render (vs the old 3x) plus on
@@ -77,20 +86,20 @@ export const MobileSidebar = ({
 
       // Animate to position after render
       const animateOpen = async () => {
-        await animate(x, 0, drawerSpring)
+        await animate(x, 0, transition)
       }
       animateOpen()
     } else if (!open && internalOpen && !isAnimating) {
       // Closing: animate first, then close
       const animateClose = async () => {
         setIsAnimating(true)
-        await animate(x, side === 'left' ? -sidebarWidth : sidebarWidth, drawerSpring)
+        await animate(x, side === 'left' ? -sidebarWidth : sidebarWidth, transition)
         setIsAnimating(false)
         setInternalOpen(false)
       }
       animateClose()
     }
-  }, [open, internalOpen, isAnimating, x, side, sidebarWidth])
+  }, [open, internalOpen, isAnimating, x, side, sidebarWidth, transition])
 
   const handleClose = async () => {
     if (isAnimating) {
@@ -99,7 +108,7 @@ export const MobileSidebar = ({
 
     triggerImpact('light')
     setIsAnimating(true)
-    await animate(x, side === 'left' ? -sidebarWidth : sidebarWidth, drawerSpring)
+    await animate(x, side === 'left' ? -sidebarWidth : sidebarWidth, transition)
     setIsAnimating(false)
     setInternalOpen(false)
     onOpenChange(false)
@@ -110,7 +119,7 @@ export const MobileSidebar = ({
       await handleClose()
     } else {
       // Snap back to the open position
-      await animate(x, 0, drawerSpring)
+      await animate(x, 0, transition)
     }
   }
 

--- a/src/test-utils/framer-motion-mock.ts
+++ b/src/test-utils/framer-motion-mock.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { mock } from 'bun:test'
-import { createElement, type ReactNode } from 'react'
+import { createElement, useRef, type ReactNode } from 'react'
 
 /**
  * Process-global stub for `framer-motion`. Bun's `mock.module` persists
@@ -42,6 +42,39 @@ const motionTagProxy = new Proxy(
   },
 )
 
+/**
+ * Minimal stand-in for a framer-motion `MotionValue`. Holds a value and exposes the
+ * surface our components touch (`get`/`set`); subscriptions and teardown are no-ops since
+ * the mock never drives a real animation loop.
+ */
+type MockMotionValue = {
+  get: () => unknown
+  set: (value: unknown) => void
+  on: () => () => void
+  destroy: () => void
+}
+
+const createMotionValue = (initial: unknown): MockMotionValue => {
+  let current = initial
+  return {
+    get: () => current,
+    set: (value) => {
+      current = value
+    },
+    on: () => () => {},
+    destroy: () => {},
+  }
+}
+
+/** Stable `MotionValue` per component instance (mirrors framer's ref-backed hooks). */
+const useStableMotionValue = (initial: unknown): MockMotionValue => {
+  const ref = useRef<MockMotionValue | null>(null)
+  if (ref.current === null) {
+    ref.current = createMotionValue(initial)
+  }
+  return ref.current
+}
+
 mock.module('framer-motion', () => ({
   AnimatePresence: ({ children }: { children: ReactNode }) => children,
   LayoutGroup: ({ children }: { children: ReactNode }) => children,
@@ -50,4 +83,11 @@ mock.module('framer-motion', () => ({
   domMax: {},
   m: motionTagProxy,
   motion: motionTagProxy,
+  // Resolve synchronously to the target so awaited `animate()` end-states are deterministic.
+  animate: (value: MockMotionValue, target: unknown) => {
+    value.set(target)
+    return Promise.resolve()
+  },
+  useMotionValue: (initial: unknown) => useStableMotionValue(initial),
+  useTransform: () => useStableMotionValue(0),
 }))

--- a/src/test-utils/framer-motion-mock.ts
+++ b/src/test-utils/framer-motion-mock.ts
@@ -75,6 +75,24 @@ const useStableMotionValue = (initial: unknown): MockMotionValue => {
   return ref.current
 }
 
+/**
+ * Spy standing in for framer-motion's `animate`. Resolves synchronously to the target so
+ * awaited `animate()` end-states are deterministic; exposed as a spy so tests can assert the
+ * transition argument (e.g. the instant `prefers-reduced-motion` transition). Call
+ * `animateSpy.mockClear()` in a `beforeEach` to isolate per-test call history.
+ */
+export const animateSpy = mock((value: MockMotionValue, target: unknown, _transition?: unknown) => {
+  value.set(target)
+  return Promise.resolve()
+})
+
+let reducedMotion = false
+
+/** Test hook: force `useReducedMotion()` to report (un)reduced motion. Reset per test. */
+export const setMockReducedMotion = (value: boolean) => {
+  reducedMotion = value
+}
+
 mock.module('framer-motion', () => ({
   AnimatePresence: ({ children }: { children: ReactNode }) => children,
   LayoutGroup: ({ children }: { children: ReactNode }) => children,
@@ -83,11 +101,8 @@ mock.module('framer-motion', () => ({
   domMax: {},
   m: motionTagProxy,
   motion: motionTagProxy,
-  // Resolve synchronously to the target so awaited `animate()` end-states are deterministic.
-  animate: (value: MockMotionValue, target: unknown) => {
-    value.set(target)
-    return Promise.resolve()
-  },
+  animate: animateSpy,
   useMotionValue: (initial: unknown) => useStableMotionValue(initial),
+  useReducedMotion: () => reducedMotion,
   useTransform: () => useStableMotionValue(0),
 }))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only animation and overlay styling with added unit tests; no security, data, or API surface changes.
> 
> **Overview**
> Improves **mobile drawer close performance** by removing **`backdrop-blur`** from the dim overlay so the fade is opacity-only (avoids per-frame re-blur jank). The overlay is still a simple `bg-black/40` fade tied to slide position, with **`data-slot="sidebar-overlay"`** for tests.
> 
> **Animation behavior** is consolidated: shared **`drawerSpring`** vs **`instantTransition`** when **`prefers-reduced-motion`** is on (open/close/snap-back all use the same transition). Drawer travel distance now follows **`mobileSidebarWidthRatio`** via **`useSyncExternalStore`** on resize instead of repeated width reads.
> 
> Drag-to-dismiss logic is extracted as exported **`shouldCloseOnDragEnd`**. New **`mobile-sidebar.test.tsx`** covers thresholds, overlay close, reduced-motion transitions, and the **`isAnimating`** double-tap guard. **`framer-motion-mock`** gains **`animateSpy`**, motion hooks, and **`setMockReducedMotion`** to support those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9786be06af287ecb68d205a1086def7b53c84a5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->