### PR TITLE
fix: enforce LF line endings for shell scripts on all platforms

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps maintain consistent coding styles across editors and OSes.
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+
+[*.{bat,cmd,ps1}]
+end_of_line = crlf
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml,lock}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Normalize line endings across platforms. Shell scripts and Makefiles must use LF
+# so bash/WSL/macOS/Linux can run them without CRLF errors.
+* text=auto
+
+*.sh text eol=lf
+Makefile text eol=lf
+
+# Windows-native scripts keep CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary assets
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.wasm binary


### PR DESCRIPTION
## Summary

- Add `.gitattributes` to force LF line endings for `*.sh` and `Makefile` on checkout across Windows, macOS, and Linux
- Add root `.editorconfig` so editors consistently use LF for cross-platform files

## Problem

On Windows/WSL, shell scripts checked out with CRLF line endings cause bash errors when running dev tooling:

```
scripts/thunderdoctor.sh: line 2: $'\r': command not found
set: pipefail: invalid option name
```

This blocks `make doctor` and other Makefile targets that invoke bash scripts.

## Solution

Git already stores these files with LF in the index; the missing piece is checkout normalization via `.gitattributes` (`eol=lf`) plus editor guidance via `.editorconfig`.

## Test plan

- [x] Fresh clone into WSL home filesystem (`~/thunderbolt-lf-test`) — `scripts/*.sh` and `Makefile` have LF line endings (no CRLF)
- [x] `make doctor` runs without CRLF/bash parse errors (fails later only on missing tools, as expected)
- [ ] Maintainer verifies on macOS/Linux clone

## Notes

Developers with existing Windows checkouts on `/mnt/c/` may need a one-time refresh after pulling:

```bash
git checkout -- scripts/ Makefile
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo-wide editor and Git checkout settings only; no runtime or application logic changes.
> 
> **Overview**
> Adds **`.gitattributes`** so `*.sh` and `Makefile` always check out with **LF**, fixing CRLF-related bash failures on Windows/WSL when running targets like `make doctor`. Windows script types (`*.bat`, `*.cmd`, `*.ps1`) stay **CRLF**; common binary extensions are marked binary.
> 
> Adds a root **`.editorconfig`** with LF defaults, tab indents for `Makefile`, CRLF for Windows scripts, and 2-space indent for JSON/YAML/lock files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30ea86f12b63dd462d229c5f969ffe689a0f9046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->