### PR TITLE
fix(THU-646): unblock nightly macOS build on macos-26 runner

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -164,9 +164,11 @@ jobs:
           security unlock-keychain -p "build" build.keychain
           security list-keychains -d user -s build.keychain login.keychain
 
-          # Convert certificate to macOS-compatible format (using older encryption algorithms)
-          openssl pkcs12 -in certificate.p12 -out temp_cert.pem -clcerts -nokeys -passin pass:"$APPLE_DEVELOPER_CERTIFICATE_PASSWORD"
-          openssl pkcs12 -in certificate.p12 -out temp_key.pem -nocerts -nodes -passin pass:"$APPLE_DEVELOPER_CERTIFICATE_PASSWORD"
+          # Convert certificate to macOS-compatible format (using older encryption algorithms).
+          # -legacy loads OpenSSL 3's legacy provider so we can read p12s that Apple Developer
+          # exports with RC2-40-CBC; safe for modern p12s too (both providers stay available).
+          openssl pkcs12 -in certificate.p12 -out temp_cert.pem -clcerts -nokeys -legacy -passin pass:"$APPLE_DEVELOPER_CERTIFICATE_PASSWORD"
+          openssl pkcs12 -in certificate.p12 -out temp_key.pem -nocerts -nodes -legacy -passin pass:"$APPLE_DEVELOPER_CERTIFICATE_PASSWORD"
           openssl pkcs12 -export -out macos_certificate.p12 -inkey temp_key.pem -in temp_cert.pem -passout pass:"$APPLE_DEVELOPER_CERTIFICATE_PASSWORD" -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1
 
           # Import the converted certificate


### PR DESCRIPTION
GitHub rotated `macos-latest` from macOS 15 to macOS 26 between yesterday's manual release and today's nightly. On the new image OpenSSL 3 won't load the legacy provider by default, so `openssl pkcs12 -in certificate.p12` rejects the `APPLE_DEVELOPER_CERTIFICATE` secret (which Apple Developer exports with RC2-40-CBC) and the macOS matrix exits before signing.

Adds `-legacy` to the two p12 reads in `desktop-release.yml`. Works for both legacy- and modern-exported p12s, so we're not coupled to which Apple tool produced the secret. The export step is unchanged — PBE-SHA1-3DES stays in the default provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to certificate conversion flags; no app runtime or secret handling logic changes beyond fixing p12 parsing on newer runners.
> 
> **Overview**
> **Unblocks macOS desktop signing** on newer GitHub `macos-latest` runners (macOS 26 / OpenSSL 3), where reading the `APPLE_DEVELOPER_CERTIFICATE` p12 failed before codesign could run.
> 
> In `desktop-release.yml`, the two `openssl pkcs12` extract steps now pass **`-legacy`** so OpenSSL loads the legacy provider and accepts Apple Developer exports that use **RC2-40-CBC**. Inline comments document why. The re-export step is unchanged (still **PBE-SHA1-3DES** via the default provider).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17160fe786b01b02a9f41ecf4ebeb0cdb05b4ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->