### PR TITLE
ci: rebuild thunder-deep-review diff from Files API to survive large PRs

### DIFF
--- a/.github/scripts/review-orchestrator.mjs
+++ b/.github/scripts/review-orchestrator.mjs
@@ -489,20 +489,31 @@ const buildSkipList = async () => {
 // UNCHANGED by the inline-review redesign.
 // =============================================================================
 
-const computeDeepMode = async () => {
-  let fileCount = 0;
-  let changedLines = 0;
-  let truncated = false;
+/**
+ * Fetch the PR's changed files ONCE (paginated, capped at the 3000-file cliff) —
+ * the single source that feeds BOTH the deep-mode size gate and the reconstructed
+ * unified diff. Best-effort like the rest of the advisory bot: a hard failure
+ * after retries yields an empty set, degrading the run to an empty-diff / non-deep
+ * no-op instead of a red check (the next push retries).
+ */
+const fetchPrFiles = async () => {
   try {
     const url = apiUrl(`/pulls/${env.prNumber}/files?per_page=100`);
-    const { items, truncated: t } = await paginateAll(url, { cap: PR_FILES_TRUNCATION_CAP });
-    truncated = t;
-    fileCount = items.length;
-    for (const f of items) changedLines += (f.additions ?? 0) + (f.deletions ?? 0);
+    return await paginateAll(url, { cap: PR_FILES_TRUNCATION_CAP });
   } catch (err) {
-    log('deep-mode: file list failed, defaulting to non-deep bounded:', err.message);
+    log('pre: PR files fetch failed — degrading to empty diff / non-deep:', err.message);
+    return { items: [], truncated: false };
   }
+};
 
+/**
+ * Deterministic deep-mode gate over the already-fetched file list: code, never
+ * the model, decides when to spend on deep mode. `truncated` (past the 3000-file
+ * cliff) flips bounded mode so the diff is clipped to a reviewable subset.
+ */
+const computeDeepMode = (files, truncated) => {
+  const fileCount = files.length;
+  const changedLines = files.reduce((n, f) => n + (f.additions ?? 0) + (f.deletions ?? 0), 0);
   const sizeTriggered = changedLines >= DEEP_MODE_CHANGED_LINES || fileCount >= DEEP_MODE_FILE_COUNT;
   return {
     deepMode: env.hasDeepLabel || sizeTriggered,
@@ -787,43 +798,43 @@ const loadDiffIndex = async () => {
 };
 
 /**
- * Deterministically clip a unified diff to its first `limit` per-file sections.
- * Each file section starts at a `diff --git ` line, so cutting on that boundary
- * always yields a still-valid patch (no half-file/half-hunk). Returns the
- * original patch unchanged when it has `limit` files or fewer.
+ * Reconstruct one file's section of a git unified diff from a List-pull-request-
+ * files entry. The API's `patch` is the HUNK BODY ONLY (`@@ … @@` + content
+ * lines); we prepend the `diff --git` + `---`/`+++` headers parseUnifiedDiff (and
+ * GitHub's own review-anchor validator) key on, so the rebuilt section is faithful
+ * enough that the SAME (path, line, side) anchors POST /pulls/{n}/reviews
+ * validates round-trip exactly.
+ *
+ * `added`/`removed` carry `/dev/null` on the absent side, so a deleted file is
+ * correctly NON-anchorable at head — parity with the real v3.diff. A file with no
+ * `patch` (binary, or a text file GitHub omitted as too large — lockfiles,
+ * generated snapshots) yields a HEADER-ONLY section: recorded as changed, but
+ * with no commentable lines, exactly as the real diff truncates it.
  */
-const clipDiffToFileLimit = (patch, limit) => {
-  const lines = patch.split('\n');
-  let fileCount = 0;
-  const kept = [];
-  for (const line of lines) {
-    if (line.startsWith('diff --git ')) {
-      fileCount += 1;
-      if (fileCount > limit) break;
-    }
-    kept.push(line);
-  }
-  return { clipped: fileCount > limit, fileCount: Math.min(fileCount, limit), text: kept.join('\n') };
+const fileSectionToDiff = (file) => {
+  const newPath = file.filename;
+  const oldPath = file.previous_filename ?? newPath;
+  const header = `diff --git a/${oldPath} b/${newPath}`;
+  if (!file.patch) return header;
+  const fromTo =
+    file.status === 'added'
+      ? ['--- /dev/null', `+++ b/${newPath}`]
+      : file.status === 'removed'
+        ? [`--- a/${oldPath}`, '+++ /dev/null']
+        : [`--- a/${oldPath}`, `+++ b/${newPath}`];
+  return [header, ...fromTo, file.patch].join('\n');
 };
 
 /**
- * In bounded mode, rewrite DIFF_FILE in place to its first
- * BOUNDED_MODE_FILE_LIMIT file sections so the model gets a REAL, deterministic
- * scope — not just a prompt asking it to self-limit. No-op when not bounded or
- * the diff already fits. Best-effort: a read/write failure leaves the full diff.
+ * Reconstruct the PR's FULL unified diff from the List-pull-request-files API —
+ * the path GitHub itself recommends when the `.diff` media type 406s past its
+ * 20k-line / 1 MB cap (which silently broke this whole job on large PRs). The
+ * files endpoint paginates and has no per-diff line cap, so it covers PRs the
+ * `.diff` endpoint refuses; the only ceiling is the 3000-file cliff, already
+ * handled by bounded mode. Concatenated `diff --git` sections — the exact shape
+ * parseUnifiedDiff consumes.
  */
-const enforceBoundedDiff = async (boundedMode) => {
-  if (!boundedMode) return;
-  try {
-    const patch = await readFile(DIFF_FILE, 'utf8');
-    const { clipped, fileCount, text } = clipDiffToFileLimit(patch, BOUNDED_MODE_FILE_LIMIT);
-    if (!clipped) return;
-    await writeFile(DIFF_FILE, text);
-    log(`pre: bounded mode — clipped diff to first ${fileCount} files (${BOUNDED_MODE_FILE_LIMIT} cap).`);
-  } catch (err) {
-    log('pre: bounded-diff clip failed (continuing with full diff):', err.message);
-  }
-};
+const buildUnifiedDiff = (files) => `${files.map(fileSectionToDiff).join('\n')}\n`;
 
 /**
  * Classify each finding against the diff index and attach its convergence keys:
@@ -1354,8 +1365,15 @@ const selectFindingsToPost = (findings, { openHashes, humanResolvedHashes, summa
  * runPost calls this (rather than inlining the branch) so logic and tests share
  * one source and can't drift.
  */
-const decideTerminalAction = ({ findingCount, eventAction, ownReviewBodies, openThreadsRemain }) => {
+const decideTerminalAction = ({ findingCount, eventAction, ownReviewBodies, openThreadsRemain, diffAvailable = true }) => {
   if (findingCount === 0) {
+    // Never affirm "no issues" when we never actually had a diff to review. A
+    // real PR always has ≥1 changed file, so an empty file set means the Files
+    // API fetch failed (persistent 403/429/5xx) and runPre wrote an empty diff —
+    // posting a clean review there would launder a broken run into fake green,
+    // exactly the failure mode the loud-fail persist guards exist to prevent.
+    // Skip silently; the next push retries with a real diff.
+    if (!diffAvailable) return { action: 'skip', reason: 'diff-unavailable' };
     if (eventAction === 'reopened') return { action: 'skip', reason: 'reopened-no-findings' };
     if (openThreadsRemain) return { action: 'skip', reason: 'open-threads-remain' };
     if (latestOwnReviewIsNoIssues(ownReviewBodies)) return { action: 'skip', reason: 'already-no-issues' };
@@ -1371,16 +1389,22 @@ const decideTerminalAction = ({ findingCount, eventAction, ownReviewBodies, open
 /** PRE phase: poll A's bots, then write the skip-list + deep-mode flag for the model step. */
 const runPre = async () => {
   await pollForBots();
-  const [skipList, deepInfo] = await Promise.all([buildSkipList(), computeDeepMode()]);
-  await writeFile(SKIPLIST_FILE, JSON.stringify({ headSha: env.headSha, skipList }, null, 2));
-  await writeFile(DEEPMODE_FILE, JSON.stringify(deepInfo, null, 2));
-  // The DIFF_FILE itself is produced by a separate deterministic workflow step
-  // (the GitHub API's PR diff, Accept: v3.diff — the exact merge-base..head set
-  // GitHub validates review anchors against). This script never shells out to
-  // git; it only does GitHub REST I/O. But when the PR overran the file cap we
-  // clip that diff here so bounded mode is an ENFORCED scope, not a prompt hint.
-  await enforceBoundedDiff(deepInfo.boundedMode);
-  log(`pre: wrote ${skipList.length} skip-list entries; deepMode=${deepInfo.deepMode} (${deepInfo.reason}).`);
+  const [skipList, prFiles] = await Promise.all([buildSkipList(), fetchPrFiles()]);
+  const deepInfo = computeDeepMode(prFiles.items, prFiles.truncated);
+  // Build the unified diff IN-SCRIPT from the List-pull-request-files API. The
+  // `.diff` media type caps at 20k lines / 1 MB and returns 406 on large PRs (the
+  // failure this fixes), so we reconstruct from /pulls/{n}/files — the same
+  // merge-base..head "Files changed" set GitHub validates review anchors against,
+  // just delivered per-file and paginated. In bounded mode (past the 3000-file
+  // cliff) we clip to the first BOUNDED_MODE_FILE_LIMIT files so the model's scope
+  // is a REAL, enforced limit, not just a prompt hint.
+  const diffFiles = deepInfo.boundedMode ? prFiles.items.slice(0, BOUNDED_MODE_FILE_LIMIT) : prFiles.items;
+  await Promise.all([
+    writeFile(DIFF_FILE, buildUnifiedDiff(diffFiles)),
+    writeFile(SKIPLIST_FILE, JSON.stringify({ headSha: env.headSha, skipList }, null, 2)),
+    writeFile(DEEPMODE_FILE, JSON.stringify(deepInfo, null, 2)),
+  ]);
+  log(`pre: wrote ${diffFiles.length}-file diff, ${skipList.length} skip-list entries; deepMode=${deepInfo.deepMode} (${deepInfo.reason}).`);
 };
 
 /**
@@ -1477,6 +1501,10 @@ const runPost = async () => {
     eventAction: env.eventAction,
     ownReviewBodies,
     openThreadsRemain,
+    // A real PR always has ≥1 changed file; fileCount 0 (or a missing deep-mode
+    // file) means the Files API fetch failed and the diff is empty — don't post
+    // an affirmative "no issues" review off a diff we never actually got.
+    diffAvailable: (deepInfo.fileCount ?? 0) > 0,
   });
   if (decision.action === 'no-issues') {
     await postNoIssuesReview(buildNoIssuesPayload({ deepInfo, skipCount }));
@@ -1519,6 +1547,8 @@ if (argv[1] && fileURLToPath(import.meta.url) === argv[1]) main();
 // convergence + precision-gate terminal logic lives here — keep it covered.
 export {
   parseUnifiedDiff,
+  buildUnifiedDiff,
+  computeDeepMode,
   normalizeDiffText,
   findingHash,
   classifyFindings,

--- a/.github/scripts/review-orchestrator.test.mjs
+++ b/.github/scripts/review-orchestrator.test.mjs
@@ -18,6 +18,8 @@ import { describe, test, expect } from 'bun:test';
 
 import {
   parseUnifiedDiff,
+  buildUnifiedDiff,
+  computeDeepMode,
   normalizeDiffText,
   classifyFindings,
   selectFindingsToPost,
@@ -414,5 +416,121 @@ describe('file-level + degenerate-window findings key on the file path', () => {
     // open; the file-path key resolves because the file is gone.
     const unrelated = normalizedDiff(['diff --git a/src/z.ts b/src/z.ts', '+++ b/src/z.ts', '@@ -1,1 +1,2 @@', ' const z = 1;', '+if (z) { go(); }'].join('\n'));
     expect(shouldResolveThread(threadFromFinding(f), unrelated)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SCENARIO 6 — diff reconstruction from the List-pull-request-files API. The
+// `.diff` media type 406s past 20k lines, so the orchestrator rebuilds the diff
+// from per-file `patch` bodies. These prove the rebuilt diff round-trips through
+// parseUnifiedDiff into the SAME (path, line, side) anchors a real v3.diff yields.
+// ---------------------------------------------------------------------------
+
+// A files-API `patch` is the HUNK BODY ONLY — no `diff --git`/`---`/`+++` headers.
+const MODIFIED_PATCH = ['@@ -1,1 +1,2 @@', ' const a = 1;', '+const danger = useUnsafe();'].join('\n');
+
+describe('buildUnifiedDiff: reconstruct a git diff from /pulls/{n}/files entries', () => {
+  test('a modified file gets the git headers so its added line is commentable', () => {
+    const patch = buildUnifiedDiff([{ filename: 'src/a.ts', status: 'modified', patch: MODIFIED_PATCH, additions: 1, deletions: 0 }]);
+    expect(patch).toContain('diff --git a/src/a.ts b/src/a.ts');
+    expect(patch).toContain('--- a/src/a.ts');
+    expect(patch).toContain('+++ b/src/a.ts');
+    // Round-trip: the added line (right line 2) must be anchorable inline.
+    const f = classifyFindings([inlineFinding({ file: 'src/a.ts', line: 2 })], parseUnifiedDiff(patch))[0];
+    expect(f.placement).toBe('inline');
+  });
+
+  test('an added file uses --- /dev/null as the from-side', () => {
+    const patch = buildUnifiedDiff([{ filename: 'src/new.ts', status: 'added', patch: ['@@ -0,0 +1,1 @@', '+const x = born();'].join('\n'), additions: 1, deletions: 0 }]);
+    expect(patch).toContain('diff --git a/src/new.ts b/src/new.ts');
+    expect(patch).toContain('--- /dev/null');
+    expect(patch).toContain('+++ b/src/new.ts');
+    expect(classifyFindings([inlineFinding({ file: 'src/new.ts', line: 1 })], parseUnifiedDiff(patch))[0].placement).toBe('inline');
+  });
+
+  test('a removed file uses +++ /dev/null and is NOT anchorable at head', () => {
+    const patch = buildUnifiedDiff([{ filename: 'src/gone.ts', status: 'removed', patch: ['@@ -1,1 +0,0 @@', '-const x = dead();'].join('\n'), additions: 0, deletions: 1 }]);
+    expect(patch).toContain('--- a/src/gone.ts');
+    expect(patch).toContain('+++ /dev/null');
+    // parseUnifiedDiff drops a /dev/null head side → the file has no RIGHT-side
+    // commentable lines, so a finding on it demotes to a summary (parity with v3.diff).
+    expect(parseUnifiedDiff(patch).has('src/gone.ts')).toBe(false);
+  });
+
+  test('a renamed file anchors the old path on the from-side', () => {
+    const patch = buildUnifiedDiff([{ filename: 'src/new-name.ts', previous_filename: 'src/old-name.ts', status: 'renamed', patch: MODIFIED_PATCH, additions: 1, deletions: 0 }]);
+    expect(patch).toContain('diff --git a/src/old-name.ts b/src/new-name.ts');
+    expect(patch).toContain('--- a/src/old-name.ts');
+    expect(patch).toContain('+++ b/src/new-name.ts');
+  });
+
+  test('a file with no patch (binary / large lockfile) is a header-only section', () => {
+    const patch = buildUnifiedDiff([{ filename: 'bun.lock', status: 'modified', patch: undefined, additions: 422, deletions: 5 }]);
+    expect(patch).toContain('diff --git a/bun.lock b/bun.lock');
+    expect(patch).not.toContain('@@'); // no hunks → nothing to anchor
+    expect(parseUnifiedDiff(patch).has('bun.lock')).toBe(false);
+  });
+
+  test('multiple files concatenate into one parseable diff', () => {
+    const patch = buildUnifiedDiff([
+      { filename: 'src/a.ts', status: 'modified', patch: MODIFIED_PATCH, additions: 1, deletions: 0 },
+      { filename: 'bin.wasm', status: 'added', patch: undefined, additions: 0, deletions: 0 },
+      { filename: 'src/b.ts', status: 'added', patch: ['@@ -0,0 +1,1 @@', '+const b = make();'].join('\n'), additions: 1, deletions: 0 },
+    ]);
+    const index = parseUnifiedDiff(patch);
+    expect([...index.keys()]).toEqual(['src/a.ts', 'src/b.ts']); // the binary contributes no hunk
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SCENARIO 7 — the deterministic deep-mode gate over the fetched file list.
+// ---------------------------------------------------------------------------
+
+describe('computeDeepMode: size gate + bounded-mode flag', () => {
+  const file = (additions) => ({ additions, deletions: 0 });
+
+  test('a small diff stays single-pass', () => {
+    const info = computeDeepMode([file(10), file(20)], false);
+    expect(info.deepMode).toBe(false);
+    expect(info.changedLines).toBe(30);
+    expect(info.boundedMode).toBe(false);
+    expect(info.reason).toBe('default single fan-out');
+  });
+
+  test('crossing the changed-line threshold triggers deep mode', () => {
+    const info = computeDeepMode([file(700)], false);
+    expect(info.deepMode).toBe(true);
+    expect(info.reason).toBe('size gate');
+  });
+
+  test('the 3000-file truncation flag flips bounded mode independently of the size gate', () => {
+    const info = computeDeepMode([file(1)], true);
+    expect(info.boundedMode).toBe(true); // driven by the truncation flag…
+    expect(info.deepMode).toBe(false); // …not coupled to deep mode (a real truncation also trips the file-count gate)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SCENARIO 8 — diff-availability guard: a failed Files API fetch (empty diff)
+// must NOT launder into a false affirmative "no issues" review.
+// ---------------------------------------------------------------------------
+
+describe('decideTerminalAction: never affirms no-issues without a diff', () => {
+  const clean = { findingCount: 0, eventAction: 'synchronize', ownReviewBodies: [], openThreadsRemain: false };
+
+  test('skips with reason diff-unavailable when no diff was fetched', () => {
+    expect(decideTerminalAction({ ...clean, diffAvailable: false })).toEqual({ action: 'skip', reason: 'diff-unavailable' });
+  });
+
+  test('still affirms no-issues on a real (available) clean diff', () => {
+    expect(decideTerminalAction({ ...clean, diffAvailable: true }).action).toBe('no-issues');
+  });
+
+  test('defaults to available (no behavior change for callers that omit it)', () => {
+    expect(decideTerminalAction(clean).action).toBe('no-issues');
+  });
+
+  test('a diff-unavailable run with findings still posts them (does not silently drop)', () => {
+    expect(decideTerminalAction({ ...clean, findingCount: 2, diffAvailable: false }).action).toBe('post-findings');
   });
 });

--- a/.github/workflows/thunder-deep-review.yml
+++ b/.github/workflows/thunder-deep-review.yml
@@ -101,44 +101,35 @@ jobs:
 
       # ─────────────────────────────────────────────────────────────────────
       # Checkout. persist-credentials:false (don't leave a usable token on disk
-      # for the model step), check out the HEAD sha shallow. The diff itself is
-      # fetched from the GitHub API (next step), so we need NO base/head fetch
-      # and NOT fetch-depth:0 — the working tree is only here for the model's
-      # Read/Grep/Glob tools and the .claude symlink-prune step. SHA pinned to
-      # v7.0.0.
+      # for the model step), check out the HEAD sha shallow. The diff is
+      # reconstructed from the GitHub API by the orchestrator `pre` phase, so we
+      # need NO base/head fetch and NOT fetch-depth:0 — the working tree is only
+      # here for the model's Read/Grep/Glob tools and the .claude symlink-prune
+      # step. SHA pinned to v7.0.0.
       # ─────────────────────────────────────────────────────────────────────
       - name: Checkout (head, shallow)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }} # review the head sha
-          fetch-depth: 1 # shallow; the diff comes from the API, not local git
+          fetch-depth: 1 # shallow; the diff is rebuilt from the API, not local git
 
       # ─────────────────────────────────────────────────────────────────────
-      # Pre-compute the diff DETERMINISTICALLY (no model, no Bash tool in
-      # the model step). The model reads this file via `Read`.
+      # The unified diff is pre-computed DETERMINISTICALLY (no model, no Bash tool
+      # in the model step) by the orchestrator's `pre` phase below, which writes
+      # ${THUNDER_DIFF_FILE} for the model to `Read`.
       #
-      # It MUST equal GitHub's REAL PR diff — the same merge-base..head ("Files
-      # changed") set that `POST /pulls/{n}/reviews` validates inline `comments[]`
-      # against — so we fetch it straight from the API (Accept: v3.diff) instead
-      # of a local `git diff`. A local TWO-DOT `git diff base..head` is WRONG:
-      # base.sha is the CURRENT tip of the base branch, not the merge-base, so
-      # when the PR branch is behind base it injects base-only commits as REVERSE
-      # diffs. The model then anchors findings to files NOT in the real PR diff,
-      # and `POST /pulls/{n}/reviews` 422s ("Path could not be resolved"),
-      # dropping the whole review.
-      #
-      # GITHUB_TOKEN is in the job env; this is NOT the read-only model step, so
-      # using it here is fine. `set -o pipefail` so an API error fails loudly
-      # instead of writing a truncated/empty diff that silently reviews nothing.
-      # ─────────────────────────────────────────────────────────────────────
-      - name: Compute diff to a bounded file
-        run: |
-          set -o pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
-            -H "Accept: application/vnd.github.v3.diff" > "$THUNDER_DIFF_FILE"
-          echo "diff bytes: $(wc -c < "$THUNDER_DIFF_FILE")"
-
+      # We do NOT fetch the `Accept: v3.diff` media type: it caps at 20,000 lines /
+      # 1 MB and returns HTTP 406 on large PRs, which hard-failed this whole job
+      # (e.g. PR #1032 at ~24k changed lines). Instead the orchestrator
+      # reconstructs the diff from the List-pull-request-files API — GitHub's
+      # recommended large-PR path — which paginates and has no per-diff line cap.
+      # That endpoint returns the SAME merge-base..head ("Files changed") set
+      # `POST /pulls/{n}/reviews` validates inline `comments[]` against (it is in
+      # fact the view the reviews API cross-references), so the reconstructed diff
+      # anchors findings exactly. A local `git diff` is deliberately avoided: a
+      # two-dot `base..head` uses base's CURRENT tip, not the merge-base, injecting
+      # base-only commits as reverse diffs that 422 the review.
       # ─────────────────────────────────────────────────────────────────────
       # The repo commits `.claude/{commands,agents}/thunderbot*` as symlinks into
       # a local-only `.thunderbot/` dir that is NOT checked out in CI, so they are
@@ -153,7 +144,8 @@ jobs:
           done
 
       # ─────────────────────────────────────────────────────────────────────
-      # (PRE phase): poll A's bots, build the skip-list, compute the
+      # (PRE phase): poll A's bots, build the skip-list, reconstruct the unified
+      # diff from the Files API (writing ${THUNDER_DIFF_FILE}), and compute the
       # deterministic deep-mode flag. ALL GitHub I/O is in this script.
       # This step touches untrusted PR metadata but holds no model credentials.
       # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the advisory bot obtains the PR diff and when it posts “no issues,” which is on the critical path for every same-repo PR review; behavior is heavily unit-tested but large-PR and API-failure edge cases deserve a quick sanity check in CI.
> 
> **Overview**
> Large PRs were hard-failing **thunder-deep-review** when GitHub’s `Accept: v3.diff` response hit the ~20k-line / 1 MB cap (HTTP 406). This PR **stops fetching that media type in the workflow** and instead has the orchestrator **`pre` phase** paginate **`/pulls/{n}/files` once**, then **rebuild a unified diff** from each entry’s hunk `patch` plus `diff --git` / `---` / `+++` headers so **`parseUnifiedDiff` and inline review anchors** stay aligned with the “Files changed” set.
> 
> **Deep-mode sizing** and **bounded mode** (3000-file cliff) now share that same file list; bounded reviews **slice the file list** to the first cap before writing the diff, replacing in-place clipping of a pre-fetched patch file.
> 
> A **`diffAvailable` guard** blocks posting an affirmative **“no issues”** review when the Files API fetch failed and the diff is empty (while still allowing **post-findings** when the model returned issues). **Unit tests** cover reconstruction (add/modify/remove/rename, header-only files), `computeDeepMode`, and the no-diff skip path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 753067d3722b18d167ef12e51abc886f738c2c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->