### PR TITLE
fix(THU-625): surface IndexedDB failures when attaching files

### DIFF
--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -374,14 +374,24 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             continue
           }
           const localFileId = crypto.randomUUID()
-          await putAttachment({
-            id: localFileId,
-            filename: file.name,
-            mimeType: file.type,
-            size: file.size,
-            createdAt: Date.now(),
-            blob: file,
-          })
+          try {
+            await putAttachment({
+              id: localFileId,
+              filename: file.name,
+              mimeType: file.type,
+              size: file.size,
+              createdAt: Date.now(),
+              blob: file,
+            })
+          } catch (error) {
+            // IndexedDB can reject when storage is full or unavailable (e.g. a
+            // private window). Surface it instead of letting the `void`-called
+            // promise reject silently — otherwise no chip appears and no banner
+            // shows. Stop here: subsequent writes would hit the same failure.
+            console.error('Failed to store attachment locally:', error)
+            setAttachError(`Couldn't attach "${file.name}" — your browser may be out of storage or in private mode.`)
+            break
+          }
           setAttachments((prev) => [...prev, { localFileId, filename: file.name, mimeType: file.type }])
           count++
         }

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -384,12 +384,12 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
               blob: file,
             })
           } catch (error) {
-            // IndexedDB can reject when storage is full or unavailable (e.g. a
-            // private window). Surface it instead of letting the `void`-called
+            // IndexedDB can reject when its storage quota is exceeded or it's
+            // unavailable. Surface it instead of letting the `void`-called
             // promise reject silently — otherwise no chip appears and no banner
             // shows. Stop here: subsequent writes would hit the same failure.
             console.error('Failed to store attachment locally:', error)
-            setAttachError(`Couldn't attach "${file.name}" — your browser may be out of storage or in private mode.`)
+            setAttachError(`Couldn't attach "${file.name}" — your browser's storage is full or unavailable.`)
             break
           }
           setAttachments((prev) => [...prev, { localFileId, filename: file.name, mimeType: file.type }])


### PR DESCRIPTION
## What

Hotfix for the merged #1041. `addFiles` is invoked as `void addFiles(...)` by both the drop handler and the file-input `onChange`. If `putAttachment` rejects — IndexedDB full, or blocked in a private window — the loop throws, the promise rejects **unhandled**, and the user gets no feedback: no chip appears and no error banner shows (unlike the size/type checks, this path never called `setAttachError`).

## Fix

Wrap the `putAttachment` call in a try/catch that surfaces the failure via `setAttachError` (matching the existing size/type loud-failure paths), then `break` — subsequent writes in the same batch would hit the same storage failure.

```
Couldn't attach "<name>" — your browser may be out of storage or in private mode.
```

## Notes

- Bytes still never enter a message part; this only affects the local IndexedDB staging write.
- No partial-state leak: the chip is only appended *after* a successful put, so a failed file leaves nothing behind.

tsc + lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX/error-handling around local attachment staging; no auth, send path, or message payload changes.
> 
> **Overview**
> **Chat file attachments** now handle **IndexedDB staging failures** the same way as size/type validation: quota exceeded or unavailable storage no longer fails silently when `addFiles` is fired with `void`.
> 
> `putAttachment` is wrapped in **try/catch**; on reject the UI sets **`attachError`** with a user-facing message, logs the error, and **`break`s** the batch loop so later files aren’t written into the same broken store. Attachment chips are still added **only after** a successful put, so a failed file doesn’t leave partial UI state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1263a217b41ebc1a3db9afa834ea3d02bbbb11f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->