### PR TITLE
feat(THU-651): quote-reply — quote a passage from a response into the composer

### DIFF
--- a/src/acp/acp-adapter.ts
+++ b/src/acp/acp-adapter.ts
@@ -46,6 +46,7 @@ import { ClientSideConnection as ClientSideConnectionImpl } from '@agentclientpr
 import type { Agent, AgentAdapter, AgentAdapterContext, AgentCapabilities, EnsureSessionContext } from '@/types/acp'
 import type { ThunderboltUIMessage } from '@/types'
 import { blobToBase64, getAttachments, type HydratedAttachment } from '@/lib/attachments'
+import { renderMessageQuotesAsText } from '@/lib/quotes'
 import { getTransformer } from '@/files/transformers'
 import { getAttachment } from '@/lib/file-blob-storage'
 import { openTransport } from './transports'
@@ -147,10 +148,16 @@ export const buildPromptBlocks = async (
   if (!lastUser) {
     throw new Error('ACP adapter: no user message in request body')
   }
-  const userText = lastUser.parts
+  const replyText = lastUser.parts
     .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
     .map((p) => p.text)
     .join('\n')
+  // Quotes flatten to a leading Markdown blockquote — ACP builds a plain-text
+  // prompt, so unlike the AI SDK path we fold them in here rather than passing a
+  // structured data-quote part through hydrateQuotesAsText. Ordered ahead of the
+  // reply, mirroring the composer (quote chip above the typed text).
+  const quotesText = renderMessageQuotesAsText(lastUser)
+  const userText = [quotesText, replyText].filter(Boolean).join('\n\n')
   // Skill instructions ride the text block (ACP has no system channel) — see composeAcpPrompt.
   const text = composeAcpPrompt(skillInstructions, userText)
 

--- a/src/acp/acp-prompt-blocks.test.ts
+++ b/src/acp/acp-prompt-blocks.test.ts
@@ -16,6 +16,7 @@
 import { describe, expect, test } from 'bun:test'
 import type { StoredFile } from '@/lib/file-blob-storage'
 import { buildAttachmentPart } from '@/lib/attachments'
+import { buildQuotePart } from '@/lib/quotes'
 import { buildPromptBlocks, type PromptBlockDeps } from './acp-adapter'
 
 // PDF has a text transformer; everything else (e.g. images) has none. The
@@ -117,5 +118,40 @@ describe('buildPromptBlocks — embeddedContext', () => {
     expect(blocks).toHaveLength(1)
     expect(blocks[0]?.text).toContain('hi')
     expect(blocks[0]?.text).toContain('[Attachment "doc.pdf" could not be delivered to this agent]')
+  })
+})
+
+describe('buildPromptBlocks — quotes', () => {
+  const quote = (text: string) => buildQuotePart({ text, sourceMessageId: 'm0' })
+
+  test('prepends the quoted passage as a Markdown blockquote ahead of the reply text', async () => {
+    const blocks = (await buildPromptBlocks(
+      initWith([quote('the mitochondria is the powerhouse of the cell'), textPart('is this right?')]),
+      undefined,
+      false,
+      deps,
+    )) as Block[]
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]?.text).toBe('> the mitochondria is the powerhouse of the cell\n\nis this right?')
+  })
+
+  test('sends a quote-only reply (no typed text) as the blockquote alone', async () => {
+    const blocks = (await buildPromptBlocks(initWith([quote('quoted line')]), undefined, false, deps)) as Block[]
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]?.text).toBe('> quoted line')
+  })
+
+  test('carries quotes through the embeddedContext path alongside attachments', async () => {
+    const blocks = (await buildPromptBlocks(
+      initWith([quote('context'), textPart('summarize'), pdf()]),
+      undefined,
+      true,
+      deps,
+    )) as Block[]
+
+    expect(blocks[0]?.text).toBe('> context\n\nsummarize')
+    expect(blocks[1]?.type).toBe('resource')
   })
 })

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -19,6 +19,7 @@ import { collectAskEntriesFromCache, formatAskResponsesNote } from '@/widgets/as
 import { getDb } from '@/db/database'
 import { getLocalSetting } from '@/stores/local-settings-store'
 import { hydrateAttachmentsAsFileParts } from '@/lib/attachments'
+import { hydrateQuotesAsText } from '@/lib/quotes'
 import { isSsoMode } from '@/lib/auth-mode'
 import { getAuthToken } from '@/lib/auth-token'
 import { fetch as baseFetch } from '@/lib/fetch'
@@ -760,7 +761,10 @@ export const aiFetchStreamingResponse = async ({
         // Hydrate reference-only PDF attachments into AI SDK file parts (bytes
         // read from IndexedDB) so the model receives them. Only the reference is
         // persisted/synced; the bytes are inlined here, in-flight to the model.
-        const baseMessages = await convertToModelMessages(await hydrateAttachmentsAsFileParts(messages))
+        // Quote parts are likewise flattened to Markdown blockquote text parts.
+        const baseMessages = await convertToModelMessages(
+          hydrateQuotesAsText(await hydrateAttachmentsAsFileParts(messages)),
+        )
         let currentMessages: typeof baseMessages = [
           ...systemNotes.map((content) => ({ role: 'system' as const, content })),
           ...baseMessages,

--- a/src/chats/pending-quotes-store.test.ts
+++ b/src/chats/pending-quotes-store.test.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { usePendingQuotesStore } from './pending-quotes-store'
+
+const { getState, setState } = usePendingQuotesStore
+
+afterEach(() => setState({ quotesByThread: {} }))
+
+describe('pending-quotes-store', () => {
+  test('addQuote appends per thread without touching other threads', () => {
+    getState().addQuote('t1', { text: 'a' })
+    getState().addQuote('t1', { text: 'b' })
+    getState().addQuote('t2', { text: 'c' })
+    expect(getState().quotesByThread.t1.map((q) => q.text)).toEqual(['a', 'b'])
+    expect(getState().quotesByThread.t2.map((q) => q.text)).toEqual(['c'])
+  })
+
+  test('removeQuote drops the passage at the given index', () => {
+    getState().setQuotes('t1', [{ text: 'a' }, { text: 'b' }, { text: 'c' }])
+    getState().removeQuote('t1', 1)
+    expect(getState().quotesByThread.t1.map((q) => q.text)).toEqual(['a', 'c'])
+  })
+
+  test('clearQuotes removes the thread entry entirely', () => {
+    getState().setQuotes('t1', [{ text: 'a' }])
+    getState().clearQuotes('t1')
+    expect(getState().quotesByThread.t1).toBeUndefined()
+  })
+})

--- a/src/chats/pending-quotes-store.test.ts
+++ b/src/chats/pending-quotes-store.test.ts
@@ -14,14 +14,22 @@ describe('pending-quotes-store', () => {
     getState().addQuote('t1', { text: 'a' })
     getState().addQuote('t1', { text: 'b' })
     getState().addQuote('t2', { text: 'c' })
-    expect(getState().quotesByThread.t1.map((q) => q.text)).toEqual(['a', 'b'])
-    expect(getState().quotesByThread.t2.map((q) => q.text)).toEqual(['c'])
+    expect(getState().quotesByThread.t1.map((q) => q.data.text)).toEqual(['a', 'b'])
+    expect(getState().quotesByThread.t2.map((q) => q.data.text)).toEqual(['c'])
   })
 
-  test('removeQuote drops the passage at the given index', () => {
+  test('addQuote assigns each pending quote a distinct stable id', () => {
+    getState().addQuote('t1', { text: 'a' })
+    getState().addQuote('t1', { text: 'a' })
+    const [first, second] = getState().quotesByThread.t1
+    expect(first.id).not.toBe(second.id)
+  })
+
+  test('removeQuote drops the passage with the matching id', () => {
     getState().setQuotes('t1', [{ text: 'a' }, { text: 'b' }, { text: 'c' }])
-    getState().removeQuote('t1', 1)
-    expect(getState().quotesByThread.t1.map((q) => q.text)).toEqual(['a', 'c'])
+    const middleId = getState().quotesByThread.t1[1].id
+    getState().removeQuote('t1', middleId)
+    expect(getState().quotesByThread.t1.map((q) => q.data.text)).toEqual(['a', 'c'])
   })
 
   test('clearQuotes removes the thread entry entirely', () => {

--- a/src/chats/pending-quotes-store.ts
+++ b/src/chats/pending-quotes-store.ts
@@ -6,6 +6,17 @@ import type { QuoteData } from '@/types'
 import { create } from 'zustand'
 
 /**
+ * A pending quote plus a stable UI-only id. The id (not the array index) keys the
+ * composer chips, so removing a middle chip doesn't reconcile survivors onto the
+ * wrong DOM nodes. It's transient composer state and never serialized — only the
+ * inner {@link QuoteData} is sent, so the id stays out of the persisted type.
+ */
+export type PendingQuote = {
+  id: string
+  data: QuoteData
+}
+
+/**
  * Pending quote-reply passages for the composer, keyed by chat thread id.
  *
  * This is the channel between the "Reply" button — which lives deep in the
@@ -16,9 +27,9 @@ import { create } from 'zustand'
  * bleed across threads while the composer stays mounted.
  */
 type PendingQuotesStore = {
-  quotesByThread: Record<string, QuoteData[]>
+  quotesByThread: Record<string, PendingQuote[]>
   addQuote: (threadId: string, quote: QuoteData) => void
-  removeQuote: (threadId: string, index: number) => void
+  removeQuote: (threadId: string, id: string) => void
   setQuotes: (threadId: string, quotes: QuoteData[]) => void
   clearQuotes: (threadId: string) => void
 }
@@ -29,18 +40,23 @@ export const usePendingQuotesStore = create<PendingQuotesStore>((set) => ({
     set((state) => ({
       quotesByThread: {
         ...state.quotesByThread,
-        [threadId]: [...(state.quotesByThread[threadId] ?? []), quote],
+        [threadId]: [...(state.quotesByThread[threadId] ?? []), { id: crypto.randomUUID(), data: quote }],
       },
     })),
-  removeQuote: (threadId, index) =>
+  removeQuote: (threadId, id) =>
     set((state) => ({
       quotesByThread: {
         ...state.quotesByThread,
-        [threadId]: (state.quotesByThread[threadId] ?? []).filter((_, i) => i !== index),
+        [threadId]: (state.quotesByThread[threadId] ?? []).filter((quote) => quote.id !== id),
       },
     })),
   setQuotes: (threadId, quotes) =>
-    set((state) => ({ quotesByThread: { ...state.quotesByThread, [threadId]: quotes } })),
+    set((state) => ({
+      quotesByThread: {
+        ...state.quotesByThread,
+        [threadId]: quotes.map((data) => ({ id: crypto.randomUUID(), data })),
+      },
+    })),
   clearQuotes: (threadId) =>
     set((state) => {
       const next = { ...state.quotesByThread }
@@ -50,8 +66,8 @@ export const usePendingQuotesStore = create<PendingQuotesStore>((set) => ({
 }))
 
 /** Stable empty reference so threads with no quotes don't churn selector snapshots. */
-const emptyQuotes: QuoteData[] = []
+const emptyQuotes: PendingQuote[] = []
 
 /** The pending quotes for one thread (referentially stable while empty). */
-export const usePendingQuotes = (threadId: string): QuoteData[] =>
+export const usePendingQuotes = (threadId: string): PendingQuote[] =>
   usePendingQuotesStore((state) => state.quotesByThread[threadId] ?? emptyQuotes)

--- a/src/chats/pending-quotes-store.ts
+++ b/src/chats/pending-quotes-store.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { QuoteData } from '@/types'
+import { create } from 'zustand'
+
+/**
+ * Pending quote-reply passages for the composer, keyed by chat thread id.
+ *
+ * This is the channel between the "Reply" button — which lives deep in the
+ * assistant message list — and the composer, which owns the send. Both address
+ * the same thread via `useCurrentChatSession().id`, so neither has to know about
+ * the other. In-memory (not persisted): a pending quote is transient composer
+ * state, like the pending attachment chips. Keyed by thread so quotes don't
+ * bleed across threads while the composer stays mounted.
+ */
+type PendingQuotesStore = {
+  quotesByThread: Record<string, QuoteData[]>
+  addQuote: (threadId: string, quote: QuoteData) => void
+  removeQuote: (threadId: string, index: number) => void
+  setQuotes: (threadId: string, quotes: QuoteData[]) => void
+  clearQuotes: (threadId: string) => void
+}
+
+export const usePendingQuotesStore = create<PendingQuotesStore>((set) => ({
+  quotesByThread: {},
+  addQuote: (threadId, quote) =>
+    set((state) => ({
+      quotesByThread: {
+        ...state.quotesByThread,
+        [threadId]: [...(state.quotesByThread[threadId] ?? []), quote],
+      },
+    })),
+  removeQuote: (threadId, index) =>
+    set((state) => ({
+      quotesByThread: {
+        ...state.quotesByThread,
+        [threadId]: (state.quotesByThread[threadId] ?? []).filter((_, i) => i !== index),
+      },
+    })),
+  setQuotes: (threadId, quotes) =>
+    set((state) => ({ quotesByThread: { ...state.quotesByThread, [threadId]: quotes } })),
+  clearQuotes: (threadId) =>
+    set((state) => {
+      const next = { ...state.quotesByThread }
+      delete next[threadId]
+      return { quotesByThread: next }
+    }),
+}))
+
+/** Stable empty reference so threads with no quotes don't churn selector snapshots. */
+const emptyQuotes: QuoteData[] = []
+
+/** The pending quotes for one thread (referentially stable while empty). */
+export const usePendingQuotes = (threadId: string): QuoteData[] =>
+  usePendingQuotesStore((state) => state.quotesByThread[threadId] ?? emptyQuotes)

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -191,6 +191,7 @@ export const AssistantMessage = memo(
     return (
       <div
         data-message-id={message.id}
+        data-quotable-message-id={message.id}
         className={showCopyOnHover ? 'group' : undefined}
         style={isLastMessage ? { minHeight: lastMessageMinHeight } : undefined}
       >

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -15,6 +15,7 @@ import { useHaptics } from '@/hooks/use-haptics'
 import { useAttachmentRemediation } from './use-attachment-remediation'
 import { getLoadingLabel } from '@/lib/loading-labels'
 import { isBuiltInAgent } from '@/defaults/agents'
+import { QuoteReplyButton } from './quote-reply-button'
 
 type ChatMessagesProps = {
   useChat?: typeof useChat_default
@@ -159,6 +160,9 @@ export const ChatMessages = ({ useChat = useChat_default }: ChatMessagesProps) =
           deliveryExhausted={deliveryExhausted}
         />
       )}
+
+      {/* Floating "Reply" button over any text selection within a response. */}
+      <QuoteReplyButton />
     </div>
   )
 }

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -4,6 +4,7 @@
 
 import { isAgentAvailable as isAgentAvailable_default } from '@/acp/agent-availability'
 import { useCurrentChatSession } from '@/chats/chat-store'
+import { usePendingQuotes, usePendingQuotesStore } from '@/chats/pending-quotes-store'
 import { estimateTokensForText } from '@/ai/tokenizers'
 import { useContextTracking as useContextTracking_default } from '@/hooks/use-context-tracking'
 import { useIsMobile as useIsMobile_default } from '@/hooks/use-mobile'
@@ -35,6 +36,8 @@ import { PromptInput } from '../ui/prompt-input'
 import { ChatModePicker } from './chat-mode-picker'
 import { ChatModelPicker } from './chat-model-picker'
 import { buildAttachmentPart } from '@/lib/attachments'
+import { buildQuotePart } from '@/lib/quotes'
+import { QuoteChip } from './quote-chip'
 import { deleteAttachment, putAttachment } from '@/lib/file-blob-storage'
 import { FileCard } from './file-card'
 
@@ -206,6 +209,13 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
     const [input, setInput, clearDraft] = useDraftInput(draftKey, { persist: !isNewChat })
     const [attachments, setAttachments] = useState<AttachmentData[]>([])
     const [attachError, setAttachError] = useState<string | null>(null)
+    // Quote-reply passages pulled in from the "Reply" button on a response. Held
+    // in a per-thread store (not local state) so that button — which lives deep
+    // in the message list — can add to the composer without prop-drilling.
+    const quotes = usePendingQuotes(chatThreadId)
+    const removeQuote = usePendingQuotesStore((s) => s.removeQuote)
+    const setQuotes = usePendingQuotesStore((s) => s.setQuotes)
+    const clearQuotes = usePendingQuotesStore((s) => s.clearQuotes)
     const [isDragging, setIsDragging] = useState(false)
     const fileInputRef = useRef<HTMLInputElement>(null)
     // Latest-input ref so deferred callers (e.g. the `runSkill` microtask
@@ -406,9 +416,9 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
 
     const handleSubmit = async () => {
       try {
-        // Prevent submitting while streaming, or with neither text nor attachments
+        // Prevent submitting while streaming, or with no text, attachments, or quotes
         const textToSend = input.trim()
-        if (isStreaming || (!textToSend && attachments.length === 0)) {
+        if (isStreaming || (!textToSend && attachments.length === 0 && quotes.length === 0)) {
           return
         }
 
@@ -420,20 +430,28 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
         // Reference-only attachment parts — bytes stay in IndexedDB and are
         // hydrated per-agent at send time (see the file transports).
         const attachmentParts = attachments.map(buildAttachmentPart)
+        // Quote parts render as blockquotes and hydrate to `> …` text for the model.
+        const quoteParts = quotes.map(buildQuotePart)
 
-        // Clear input, draft, and pending attachments immediately for responsive UX
+        // Clear input, draft, pending attachments, and quotes immediately for responsive UX
         clearDraft()
         setAttachments([])
+        clearQuotes(chatThreadId)
         setAttachError(null)
 
         await sendMessage({
-          parts: [...(textToSend ? [{ type: 'text' as const, text: textToSend }] : []), ...attachmentParts],
+          parts: [
+            ...quoteParts,
+            ...(textToSend ? [{ type: 'text' as const, text: textToSend }] : []),
+            ...attachmentParts,
+          ],
         })
       } catch (error) {
         console.error('Error submitting message:', error)
         // Send failed — the chips were cleared optimistically but the blobs are
         // still in IndexedDB, so restore them rather than orphaning the bytes.
         setAttachments(attachments)
+        setQuotes(chatThreadId, quotes)
       }
     }
 
@@ -624,17 +642,32 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
           <PromptInput
             ref={formRef}
             headerSlot={
-              attachments.length > 0 ? (
-                <div className="flex flex-wrap items-start gap-2 pb-2">
-                  {attachments.map((attachment) => (
-                    <FileCard
-                      key={attachment.localFileId}
-                      localFileId={attachment.localFileId}
-                      filename={attachment.filename}
-                      mimeType={attachment.mimeType}
-                      onRemove={() => removeAttachment(attachment.localFileId)}
-                    />
-                  ))}
+              attachments.length > 0 || quotes.length > 0 ? (
+                <div className="flex flex-col gap-2 pb-2">
+                  {quotes.length > 0 && (
+                    <div className="flex flex-col gap-1.5">
+                      {quotes.map((quote, index) => (
+                        <QuoteChip
+                          key={`${index}-${quote.sourceMessageId ?? ''}`}
+                          text={quote.text}
+                          onRemove={() => removeQuote(chatThreadId, index)}
+                        />
+                      ))}
+                    </div>
+                  )}
+                  {attachments.length > 0 && (
+                    <div className="flex flex-wrap items-start gap-2">
+                      {attachments.map((attachment) => (
+                        <FileCard
+                          key={attachment.localFileId}
+                          localFileId={attachment.localFileId}
+                          filename={attachment.filename}
+                          mimeType={attachment.mimeType}
+                          onRemove={() => removeAttachment(attachment.localFileId)}
+                        />
+                      ))}
+                    </div>
+                  )}
                 </div>
               ) : undefined
             }
@@ -644,7 +677,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             showSubmitButton
             onSubmit={handleSubmit}
             // Allow sending an attachment even with no typed text (matches the Enter behavior).
-            canSubmit={input.trim().length > 0 || attachments.length > 0}
+            canSubmit={input.trim().length > 0 || attachments.length > 0 || quotes.length > 0}
             isLoading={isStreaming || isConnecting}
             isStreaming={isStreaming}
             onStop={stop}

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -342,17 +342,23 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
       return map
     }, [library, isEnabled])
 
-    // Estimate the token cost of resolved skill instructions so the
-    // overflow modal fires correctly when /name tokens push the send past
-    // the model's context window — Skills v1 Open Q #5.
+    // Estimate the token cost of resolved skill instructions and pending
+    // quote passages so the overflow modal fires correctly when /name tokens
+    // or large quoted selections push the send past the model's context window
+    // — Skills v1 Open Q #5. Quotes are injected into the send (as `> …`
+    // blockquotes) but aren't part of `currentInput`, so they'd otherwise be
+    // invisible to the estimate.
     const additionalInputTokens = useMemo(() => {
       const instructions = resolveSkillTokenInstructions(input, enabledInstructionBySlug)
       let total = 0
       for (const instruction of instructions) {
         total += estimateTokensForText(instruction)
       }
+      for (const quote of quotes) {
+        total += estimateTokensForText(quote.data.text)
+      }
       return total
-    }, [input, enabledInstructionBySlug])
+    }, [input, enabledInstructionBySlug, quotes])
 
     const { usedTokens, maxTokens, isContextKnown, isOverflowing } = useContextTracking({
       model: selectedModel,

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -431,7 +431,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
         // hydrated per-agent at send time (see the file transports).
         const attachmentParts = attachments.map(buildAttachmentPart)
         // Quote parts render as blockquotes and hydrate to `> …` text for the model.
-        const quoteParts = quotes.map(buildQuotePart)
+        const quoteParts = quotes.map((quote) => buildQuotePart(quote.data))
 
         // Clear input, draft, pending attachments, and quotes immediately for responsive UX
         clearDraft()
@@ -451,7 +451,10 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
         // Send failed — the chips were cleared optimistically but the blobs are
         // still in IndexedDB, so restore them rather than orphaning the bytes.
         setAttachments(attachments)
-        setQuotes(chatThreadId, quotes)
+        setQuotes(
+          chatThreadId,
+          quotes.map((quote) => quote.data),
+        )
       }
     }
 
@@ -646,11 +649,11 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
                 <div className="flex flex-col gap-2 pb-2">
                   {quotes.length > 0 && (
                     <div className="flex flex-col gap-1.5">
-                      {quotes.map((quote, index) => (
+                      {quotes.map((quote) => (
                         <QuoteChip
-                          key={`${index}-${quote.sourceMessageId ?? ''}`}
-                          text={quote.text}
-                          onRemove={() => removeQuote(chatThreadId, index)}
+                          key={quote.id}
+                          text={quote.data.text}
+                          onRemove={() => removeQuote(chatThreadId, quote.id)}
                         />
                       ))}
                     </div>

--- a/src/components/chat/message-bubbles.tsx
+++ b/src/components/chat/message-bubbles.tsx
@@ -5,6 +5,7 @@
 import { hasTransformer } from '@/files/transformers'
 import { useShowSideview } from '@/content-view/context'
 import { getAttachments } from '@/lib/attachments'
+import { getQuotes } from '@/lib/quotes'
 import type { ThunderboltUIMessage } from '@/types'
 import { buildDocumentSideviewId } from '@/types/citation'
 import type { UIMessage } from 'ai'
@@ -22,9 +23,22 @@ type MessageBubblesProps = {
 export const MessageBubbles = ({ message, onResendAttachment }: MessageBubblesProps) => {
   const showSideview = useShowSideview()
   const attachments = getAttachments(message as ThunderboltUIMessage)
+  const quotes = getQuotes(message as ThunderboltUIMessage)
 
   return (
     <>
+      {quotes.length > 0 && (
+        <div className="ml-auto mt-6 flex max-w-3/4 flex-col gap-1.5">
+          {quotes.map((quote, i) => (
+            <blockquote
+              key={i}
+              className="whitespace-pre-wrap rounded-md border border-l-2 border-l-primary/60 bg-muted/50 py-1.5 pl-3 pr-3 text-[length:var(--font-size-sm)] text-muted-foreground dark:bg-secondary/40"
+            >
+              {quote.text}
+            </blockquote>
+          ))}
+        </div>
+      )}
       {attachments.length > 0 && (
         <div className="ml-auto mt-6 flex max-w-3/4 flex-wrap justify-end gap-2">
           {attachments.map((attachment) => {

--- a/src/components/chat/quote-chip.tsx
+++ b/src/components/chat/quote-chip.tsx
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Quote, X } from 'lucide-react'
+
+type QuoteChipProps = {
+  /** The quoted passage. */
+  text: string
+  /** When set, shows a remove affordance (pending composer quote). */
+  onRemove?: () => void
+}
+
+/**
+ * A first-class quote-reply chip for the composer: a compact blockquote-styled
+ * pill showing the passage the user pulled in from a response (see the "Reply"
+ * button on assistant messages). The preview clamps to two lines; clicking it
+ * opens a scrollable popover with the full passage.
+ */
+export const QuoteChip = ({ text, onRemove }: QuoteChipProps) => (
+  <div className="group relative flex max-w-full items-start rounded-md border border-l-2 border-l-primary/60 bg-muted/50">
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title="View quote"
+          className="flex min-w-0 flex-1 cursor-pointer items-start gap-2 rounded-md py-1.5 pl-2.5 pr-7 text-left hover:bg-muted"
+        >
+          <Quote className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <span className="line-clamp-2 min-w-0 whitespace-pre-wrap text-[length:var(--font-size-xs)] text-muted-foreground">
+            {text}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent side="top" align="start" className="max-h-64 w-80 max-w-[90vw] overflow-y-auto p-3">
+        <blockquote className="whitespace-pre-wrap border-l-2 border-l-primary/60 pl-3 text-[length:var(--font-size-sm)] text-foreground">
+          {text}
+        </blockquote>
+      </PopoverContent>
+    </Popover>
+    {onRemove && (
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label="Remove quote"
+        className="absolute right-1 top-1 cursor-pointer rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <X className="size-3.5" />
+      </button>
+    )}
+  </div>
+)

--- a/src/components/chat/quote-reply-button.tsx
+++ b/src/components/chat/quote-reply-button.tsx
@@ -25,7 +25,7 @@ export const QuoteReplyButton = () => {
   const { selection, clear } = useQuoteSelection()
   const threadId = useCurrentChatSession().id
   const addQuote = usePendingQuotesStore((s) => s.addQuote)
-  const isMobile = useIsMobile()
+  const { isMobile } = useIsMobile()
 
   if (!selection) {
     return null
@@ -51,9 +51,11 @@ export const QuoteReplyButton = () => {
     <button
       type="button"
       style={style}
-      // Keep the text selection (and focus) intact: a plain mousedown would
-      // collapse it before onClick fires, hiding the button via selectionchange.
-      onMouseDown={(e) => e.preventDefault()}
+      // Keep the text selection (and focus) intact: pressing anywhere would
+      // otherwise collapse it before onClick fires, hiding the button via
+      // selectionchange. onPointerDown covers both mouse and touch — a plain
+      // mousedown handler misses touch, which collapses the selection first.
+      onPointerDown={(e) => e.preventDefault()}
       onClick={onReply}
       className="z-50 flex items-center gap-1.5 rounded-full border bg-popover px-3.5 py-2 text-[length:var(--font-size-sm)] font-medium text-popover-foreground shadow-md transition hover:bg-muted"
     >

--- a/src/components/chat/quote-reply-button.tsx
+++ b/src/components/chat/quote-reply-button.tsx
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useCurrentChatSession } from '@/chats/chat-store'
+import { usePendingQuotesStore } from '@/chats/pending-quotes-store'
+import { useIsMobile } from '@/hooks/use-mobile'
+import { Reply } from 'lucide-react'
+import { type CSSProperties } from 'react'
+import { createPortal } from 'react-dom'
+import { useQuoteSelection } from './use-quote-selection'
+
+/** Gap in px between the selection and the floating button. */
+const gap = 8
+/** Below this many px from the viewport top, place the button under the selection instead of above. */
+const flipThreshold = 44
+
+/**
+ * Renders a floating "Reply" button over a text selection inside an assistant
+ * response, and on click pulls the passage into the composer as a first-class
+ * quote (via the per-thread pending-quotes store). Mounted once in the message
+ * list. Portaled to the body so overflow/scroll containers don't clip it.
+ */
+export const QuoteReplyButton = () => {
+  const { selection, clear } = useQuoteSelection()
+  const threadId = useCurrentChatSession().id
+  const addQuote = usePendingQuotesStore((s) => s.addQuote)
+  const isMobile = useIsMobile()
+
+  if (!selection) {
+    return null
+  }
+
+  // On mobile, sit below the selection — closer to the thumbs and clear of iOS's
+  // own selection menu, which appears above. On desktop, prefer above unless the
+  // selection is near the viewport top.
+  const placeAbove = !isMobile && selection.rect.top > flipThreshold
+  const style: CSSProperties = {
+    position: 'fixed',
+    top: placeAbove ? selection.rect.top - gap : selection.rect.bottom + gap,
+    left: selection.rect.left + selection.rect.width / 2,
+    transform: `translate(-50%, ${placeAbove ? '-100%' : '0'})`,
+  }
+
+  const onReply = () => {
+    addQuote(threadId, { text: selection.text, sourceMessageId: selection.sourceMessageId })
+    clear()
+  }
+
+  return createPortal(
+    <button
+      type="button"
+      style={style}
+      // Keep the text selection (and focus) intact: a plain mousedown would
+      // collapse it before onClick fires, hiding the button via selectionchange.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onReply}
+      className="z-50 flex items-center gap-1.5 rounded-full border bg-popover px-3.5 py-2 text-[length:var(--font-size-sm)] font-medium text-popover-foreground shadow-md transition hover:bg-muted"
+    >
+      <Reply className="size-4" aria-hidden="true" />
+      Reply
+    </button>,
+    document.body,
+  )
+}

--- a/src/components/chat/use-quote-selection.ts
+++ b/src/components/chat/use-quote-selection.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useEffect, useState } from 'react'
+
+/** Marks an element whose text can be quoted; its value is the source message id. */
+export const quotableMessageIdAttr = 'data-quotable-message-id'
+
+export type QuoteSelection = {
+  /** The trimmed selected text. */
+  text: string
+  /** The message the passage was selected from (provenance). */
+  sourceMessageId: string
+  /** Viewport rect of the selection, for anchoring the floating button. */
+  rect: DOMRect
+}
+
+/** The quotable container the selection sits in, or null if it spans none/many. */
+const quotableContainerOf = (range: Range): Element | null => {
+  const node = range.commonAncestorContainer
+  const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement
+  // `.closest` on the common ancestor naturally rejects selections that span two
+  // messages: their shared ancestor sits above any single quotable container.
+  return el?.closest(`[${quotableMessageIdAttr}]`) ?? null
+}
+
+/**
+ * Tracks a text selection made inside an assistant response (an element marked
+ * with {@link quotableMessageIdAttr}) so a floating "Reply" button can anchor to
+ * it. Returns the current selection (text + provenance + rect) or null, plus a
+ * `clear` to dismiss it. DOM event listeners with cleanup — a legitimate effect.
+ */
+export const useQuoteSelection = (): { selection: QuoteSelection | null; clear: () => void } => {
+  const [selection, setSelection] = useState<QuoteSelection | null>(null)
+
+  const clear = useCallback(() => {
+    setSelection(null)
+    window.getSelection()?.removeAllRanges()
+  }, [])
+
+  useEffect(() => {
+    // A settled selection (pointer/key released) — show the button if it's a
+    // non-empty selection within a single quotable assistant message.
+    const evaluate = () => {
+      const sel = window.getSelection()
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+        return setSelection(null)
+      }
+      const text = sel.toString().trim()
+      const range = sel.getRangeAt(0)
+      const container = quotableContainerOf(range)
+      const sourceMessageId = container?.getAttribute(quotableMessageIdAttr)
+      if (!text || !sourceMessageId) {
+        return setSelection(null)
+      }
+      setSelection({ text, sourceMessageId, rect: range.getBoundingClientRect() })
+    }
+
+    // Hide as soon as the selection collapses (e.g. a click elsewhere). Live
+    // drags stay non-collapsed, so the button only appears on release.
+    const onSelectionChange = () => {
+      if (window.getSelection()?.isCollapsed) {
+        setSelection(null)
+      }
+    }
+
+    // The anchored rect goes stale on scroll/resize — simplest correct behavior
+    // is to dismiss and let the user re-select.
+    const hide = () => setSelection(null)
+
+    document.addEventListener('mouseup', evaluate)
+    document.addEventListener('keyup', evaluate)
+    document.addEventListener('touchend', evaluate)
+    document.addEventListener('selectionchange', onSelectionChange)
+    window.addEventListener('scroll', hide, true)
+    window.addEventListener('resize', hide)
+    return () => {
+      document.removeEventListener('mouseup', evaluate)
+      document.removeEventListener('keyup', evaluate)
+      document.removeEventListener('touchend', evaluate)
+      document.removeEventListener('selectionchange', onSelectionChange)
+      window.removeEventListener('scroll', hide, true)
+      window.removeEventListener('resize', hide)
+    }
+  }, [])
+
+  return { selection, clear }
+}

--- a/src/lib/quotes.test.ts
+++ b/src/lib/quotes.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { ThunderboltUIMessage } from '@/types'
+import { describe, expect, test } from 'bun:test'
+import { buildQuotePart, getQuotes, hydrateQuotesAsText, isQuotePart, quotePartType } from './quotes'
+
+const quote = { text: 'the mitochondria is the powerhouse of the cell', sourceMessageId: 'm0' }
+
+const messageWith = (...parts: unknown[]): ThunderboltUIMessage =>
+  ({ id: 'm1', role: 'user', parts }) as unknown as ThunderboltUIMessage
+
+describe('quotes', () => {
+  test('buildQuotePart wraps the passage in a data-quote part', () => {
+    expect(buildQuotePart(quote)).toEqual({ type: quotePartType, data: quote })
+  })
+
+  test('isQuotePart matches only quote parts', () => {
+    expect(isQuotePart({ type: quotePartType })).toBe(true)
+    expect(isQuotePart({ type: 'text' })).toBe(false)
+    expect(isQuotePart({ type: 'data-attachment' })).toBe(false)
+  })
+
+  test('getQuotes extracts passages in order, ignoring other parts', () => {
+    const message = messageWith(
+      { type: 'text', text: 'what about this?' },
+      buildQuotePart(quote),
+      buildQuotePart({ text: 'second' }),
+    )
+    expect(getQuotes(message).map((q) => q.text)).toEqual([quote.text, 'second'])
+  })
+
+  test('hydrateQuotesAsText replaces quote parts with a Markdown blockquote text part', () => {
+    const [message] = hydrateQuotesAsText([messageWith(buildQuotePart(quote), { type: 'text', text: 'follow-up' })])
+    expect(message.parts).toEqual([
+      { type: 'text', text: '> the mitochondria is the powerhouse of the cell' },
+      { type: 'text', text: 'follow-up' },
+    ] as ThunderboltUIMessage['parts'])
+  })
+
+  test('hydrateQuotesAsText prefixes every line of a multi-line quote', () => {
+    const [message] = hydrateQuotesAsText([messageWith(buildQuotePart({ text: 'line one\nline two' }))])
+    expect(message.parts).toEqual([{ type: 'text', text: '> line one\n> line two' }] as ThunderboltUIMessage['parts'])
+  })
+
+  test('hydrateQuotesAsText leaves messages without quotes untouched (same reference)', () => {
+    const messages = [messageWith({ type: 'text', text: 'plain' })]
+    expect(hydrateQuotesAsText(messages)[0]).toBe(messages[0])
+  })
+})

--- a/src/lib/quotes.test.ts
+++ b/src/lib/quotes.test.ts
@@ -4,7 +4,14 @@
 
 import type { ThunderboltUIMessage } from '@/types'
 import { describe, expect, test } from 'bun:test'
-import { buildQuotePart, getQuotes, hydrateQuotesAsText, isQuotePart, quotePartType } from './quotes'
+import {
+  buildQuotePart,
+  getQuotes,
+  hydrateQuotesAsText,
+  isQuotePart,
+  quotePartType,
+  renderMessageQuotesAsText,
+} from './quotes'
 
 const quote = { text: 'the mitochondria is the powerhouse of the cell', sourceMessageId: 'm0' }
 
@@ -47,5 +54,20 @@ describe('quotes', () => {
   test('hydrateQuotesAsText leaves messages without quotes untouched (same reference)', () => {
     const messages = [messageWith({ type: 'text', text: 'plain' })]
     expect(hydrateQuotesAsText(messages)[0]).toBe(messages[0])
+  })
+
+  test('renderMessageQuotesAsText joins quotes as blockquotes separated by blank lines', () => {
+    const message = messageWith(
+      buildQuotePart(quote),
+      { type: 'text', text: 'ignored reply text' },
+      buildQuotePart({ text: 'line one\nline two' }),
+    )
+    expect(renderMessageQuotesAsText(message)).toBe(
+      '> the mitochondria is the powerhouse of the cell\n\n> line one\n> line two',
+    )
+  })
+
+  test('renderMessageQuotesAsText returns empty string when the message has no quotes', () => {
+    expect(renderMessageQuotesAsText(messageWith({ type: 'text', text: 'plain' }))).toBe('')
   })
 })

--- a/src/lib/quotes.ts
+++ b/src/lib/quotes.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { QuoteData, ThunderboltUIMessage } from '@/types'
+
+/**
+ * The AI SDK `data-*` part type for a quoted passage the user is replying to.
+ * Like `data-attachment` it's UI-only — `convertToModelMessages` ignores data
+ * parts — so it persists/syncs cheaply and renders as a first-class chip in the
+ * composer and a blockquote in the sent bubble. {@link hydrateQuotesAsText}
+ * flattens it into a `> …` text part at send time so the model sees the context.
+ */
+export const quotePartType = 'data-quote' as const
+
+export type QuotePart = {
+  type: typeof quotePartType
+  id?: string
+  data: QuoteData
+}
+
+/** Build the quote part to include in an outgoing message. */
+export const buildQuotePart = (data: QuoteData): QuotePart => ({
+  type: quotePartType,
+  data,
+})
+
+/** Type guard for quote parts. */
+export const isQuotePart = (part: { type: string }): part is QuotePart => part.type === quotePartType
+
+/** Extract all quoted passages from a message, in order. */
+export const getQuotes = (message: ThunderboltUIMessage): QuoteData[] =>
+  message.parts.filter(isQuotePart).map((part) => part.data)
+
+/** Render a quoted passage as a Markdown blockquote (every line prefixed with `> `). */
+const quoteToBlockquote = (data: QuoteData): string =>
+  data.text
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n')
+
+/**
+ * Replace reference-only quote parts with a `text` part carrying the passage as
+ * a Markdown blockquote, so `convertToModelMessages` forwards it to the model.
+ * Mirrors `hydrateAttachmentsAsFileParts`: the persisted message keeps only the
+ * structured `data-quote` part; the blockquote is materialized in-flight.
+ *
+ * Applies to every turn (not just the latest) — quotes are small text, so unlike
+ * native attachment bytes there's no payload or replay concern in resending them.
+ */
+export const hydrateQuotesAsText = (messages: ThunderboltUIMessage[]): ThunderboltUIMessage[] =>
+  messages.map((message) => {
+    if (!message.parts.some(isQuotePart)) {
+      return message
+    }
+    return {
+      ...message,
+      parts: message.parts.map((part) =>
+        isQuotePart(part) ? { type: 'text' as const, text: quoteToBlockquote(part.data) } : part,
+      ),
+    }
+  })

--- a/src/lib/quotes.ts
+++ b/src/lib/quotes.ts
@@ -60,3 +60,13 @@ export const hydrateQuotesAsText = (messages: ThunderboltUIMessage[]): Thunderbo
       ),
     }
   })
+
+/**
+ * Flatten a message's quote parts into a single Markdown blockquote string,
+ * quotes separated by blank lines, or `''` when the message carries none.
+ * For transports that assemble a plain-text prompt (ACP) rather than passing
+ * structured parts through {@link hydrateQuotesAsText} — same flattening, so the
+ * model sees the quoted context regardless of which agent handles the turn.
+ */
+export const renderMessageQuotesAsText = (message: ThunderboltUIMessage): string =>
+  getQuotes(message).map(quoteToBlockquote).join('\n\n')

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,9 +57,26 @@ export type AttachmentData = {
   deliverAs?: 'text' | 'images'
 }
 
-/** Custom `data-*` parts on Thunderbolt messages (`data-attachment` → {@link AttachmentData}). */
+/**
+ * A passage the user quoted from an earlier message to reply to (see the quote-
+ * reply flow). Like {@link AttachmentData} it's a reference-only, UI-first part:
+ * it renders as a chip in the composer and a blockquote in the sent bubble, and
+ * is hydrated into a `> …` text part at send time so the model sees the context.
+ */
+export type QuoteData = {
+  /** The verbatim selected text. */
+  text: string
+  /** The message the passage was quoted from — provenance for a future "jump to source". */
+  sourceMessageId?: string
+}
+
+/**
+ * Custom `data-*` parts on Thunderbolt messages (`data-attachment` →
+ * {@link AttachmentData}, `data-quote` → {@link QuoteData}).
+ */
 export type ThunderboltUIDataTypes = {
   attachment: AttachmentData
+  quote: QuoteData
 }
 
 export type ThunderboltUIMessage = UIMessage<UIMessageMetadata, ThunderboltUIDataTypes, UITools>


### PR DESCRIPTION
## What

Select text in an assistant response → a floating **Reply** button appears → the passage lands in the composer as a **first-class quote chip** (not injected text, not a file attachment). On send it renders as a blockquote in the user bubble and reaches the model as a `> …` blockquote. Mirrors the file-attachment `data-*` part pattern (THU-625): a UI-only part that `convertToModelMessages` ignores, made model-visible by a hydration step in the transport.

Closes THU-651.

## How it's built

- **Foundation** — new `data-quote` part + `QuoteData` type (`types.ts`); `src/lib/quotes.ts` (`buildQuotePart`/`isQuotePart`/`getQuotes`/`hydrateQuotesAsText`) wired into `fetch.ts` next to attachment hydration.
- **Composer channel** — per-thread `pending-quotes` zustand store connects the Reply button (deep in the message list) to the composer without prop-drilling; both address the thread via `useCurrentChatSession().id`.
- **Selection UI** — `useQuoteSelection` detects a settled selection scoped to `data-quotable-message-id` (cross-message selections rejected); portaled floating Reply button, `preventDefault` on pointer-down so the selection survives the click. On mobile the button sits **below** the selection (thumb reach, clear of iOS's own menu).
- **Composer chips** — quote chips in the `headerSlot`; clicking one opens a scrollable popover with the full passage.
- **Bubble** — quotes render as blockquotes in the sent user bubble.

## Model delivery

`hydrateQuotesAsText` flattens each quote part into a `> …` Markdown blockquote text part at send time. Runs in the built-in AI SDK transport (`fetch.ts`); ACP agents don't see quotes yet — same per-transport situation attachments have, a follow-up if we want it there.

## Tests

Unit tests for `src/lib/quotes.ts` and the pending-quotes store. tsc + lint + the chat test suite (315) green. Selection/popover interactions are DOM-integration — verified manually on desktop + iOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive chat UX and message-part plumbing with unit tests; no auth or persistence schema changes beyond new optional `data-quote` parts on messages.
> 
> **Overview**
> **Quote-reply** lets users select text in an assistant response, tap a floating **Reply** button, and send that passage as first-class **`data-quote`** message parts (same pattern as `data-attachment`), not raw pasted text.
> 
> A new **`src/lib/quotes`** layer defines `QuoteData`, `buildQuotePart`, and send-time **`hydrateQuotesAsText`** in the AI SDK path (`fetch.ts`) plus **`renderMessageQuotesAsText`** when ACP builds plain-text prompts (`acp-adapter.ts`). The UI uses a per-thread **`pending-quotes`** Zustand store to link the message list and composer; **`QuoteChip`** in the composer header, blockquotes in sent user bubbles, and context-overflow token estimates include quoted text.
> 
> Selection is scoped via **`data-quotable-message-id`** on assistant messages; **`useQuoteSelection`** + a portaled **`QuoteReplyButton`** anchor to the selection (with mobile/desktop placement). Quote-only sends are allowed; failed sends restore pending quotes like attachments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a6066cbfa4e567bf94a3d97c97f4b98f6df841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->