### PR TITLE
feat(THU-652): support file attachments from the clipboard

### DIFF
--- a/src/components/chat/chat-prompt-input.test.tsx
+++ b/src/components/chat/chat-prompt-input.test.tsx
@@ -13,12 +13,26 @@ import {
 } from '@/test-utils/chat-store-mocks'
 import { createQueryTestWrapper } from '@/test-utils/react-query'
 import type { Model } from '@/types'
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { createElement, type ReactNode, type RefObject } from 'react'
 import { BrowserRouter } from 'react-router'
 import { useChatStore } from '@/chats/chat-store'
+import { getClock } from '@/testing-library'
 import { ChatPromptInput, type ChatPromptInputRef } from './chat-prompt-input'
+
+// The real blob store uses IndexedDB, which isn't available in the test env.
+// Back it with an in-memory Map so the attach path (put → chip render) works.
+const attachmentStore = new Map<string, unknown>()
+mock.module('@/lib/file-blob-storage', () => ({
+  putAttachment: async (file: { id: string }) => {
+    attachmentStore.set(file.id, file)
+  },
+  getAttachment: async (id: string) => attachmentStore.get(id) ?? null,
+  deleteAttachment: async (id: string) => {
+    attachmentStore.delete(id)
+  },
+}))
 
 const createMockUseContextTracking =
   (
@@ -281,6 +295,85 @@ describe('ChatPromptInput', () => {
 
       expect(screen.queryByRole('status')).toBeNull()
       expect(screen.queryByRole('alert')).toBeNull()
+    })
+  })
+
+  describe('clipboard paste', () => {
+    type ClipboardItemInit = { kind: string; type: string; getAsFile: () => File | null }
+
+    /** Dispatch a paste on the textarea with a stubbed clipboard, spying on preventDefault. */
+    const pasteItems = (textarea: HTMLTextAreaElement, items: ClipboardItemInit[]) => {
+      const pasteEvent = createEvent.paste(textarea, {
+        clipboardData: { items, files: items.map((i) => i.getAsFile()).filter(Boolean) },
+      })
+      const preventDefaultSpy = mock(() => {})
+      Object.defineProperty(pasteEvent, 'preventDefault', { value: preventDefaultSpy })
+      act(() => {
+        fireEvent(textarea, pasteEvent)
+      })
+      return preventDefaultSpy
+    }
+
+    /** Flush the async addFiles pipeline (IndexedDB write → setState) under fake timers. */
+    const flushAttachments = async () => {
+      await act(async () => {
+        await getClock().runAllAsync()
+      })
+    }
+
+    it('attaches a pasted image file and prevents the default text paste', async () => {
+      const { mockUseChat } = setupStore()
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      const textarea = screen.getByPlaceholderText('Ask me anything...') as HTMLTextAreaElement
+      const file = new File(['data'], 'shot.png', { type: 'image/png' })
+      const preventDefaultSpy = pasteItems(textarea, [{ kind: 'file', type: 'image/png', getAsFile: () => file }])
+      await flushAttachments()
+
+      expect(preventDefaultSpy).toHaveBeenCalled()
+      expect(screen.getByLabelText('Remove shot.png')).toBeInTheDocument()
+    })
+
+    it('synthesizes a filename for a nameless clipboard image', async () => {
+      const { mockUseChat } = setupStore()
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      const textarea = screen.getByPlaceholderText('Ask me anything...') as HTMLTextAreaElement
+      const file = new File(['data'], '', { type: 'image/png' })
+      pasteItems(textarea, [{ kind: 'file', type: 'image/png', getAsFile: () => file }])
+      await flushAttachments()
+
+      expect(screen.getByLabelText(/Remove pasted-image-.*\.png/)).toBeInTheDocument()
+    })
+
+    it('leaves a plain-text paste untouched (no attachment, no preventDefault)', () => {
+      const { mockUseChat } = setupStore()
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      const textarea = screen.getByPlaceholderText('Ask me anything...') as HTMLTextAreaElement
+      const preventDefaultSpy = pasteItems(textarea, [{ kind: 'string', type: 'text/plain', getAsFile: () => null }])
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unsupported pasted file type with an error banner', async () => {
+      const { mockUseChat } = setupStore()
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      const textarea = screen.getByPlaceholderText('Ask me anything...') as HTMLTextAreaElement
+      const file = new File(['<html>'], 'page.html', { type: 'text/html' })
+      pasteItems(textarea, [{ kind: 'file', type: 'text/html', getAsFile: () => file }])
+      await flushAttachments()
+
+      expect(screen.getByText(/isn't a supported file type/)).toBeInTheDocument()
     })
   })
 

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -26,7 +26,7 @@ import { useChat as useChat_default } from '@ai-sdk/react'
 import { useDraftInput } from '@/hooks/use-draft-input'
 import { AnimatePresence, m } from 'framer-motion'
 import { AlertCircle, Loader2, Paperclip, X } from 'lucide-react'
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { type ClipboardEvent, forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { useLocation as useLocation_default, useNavigate as useNavigate_default } from 'react-router'
 import { ChatSkillsBar } from './chat-skills-bar'
 import { ContextOverflowModal } from '../context-overflow-modal'
@@ -81,6 +81,17 @@ const attachmentAcceptAttr = [...acceptedAttachmentMimeTypes, ...acceptedAttachm
 const isAcceptedAttachment = (file: File): boolean =>
   acceptedAttachmentMimeTypes.has(file.type) ||
   acceptedAttachmentExtensions.some((ext) => file.name.toLowerCase().endsWith(ext))
+
+/** Clipboard files (e.g. a pasted screenshot) often arrive with an empty name.
+ *  Give them a stable, extension-bearing filename so the chip renders and the
+ *  extension-based accept check has something to work with. */
+const withClipboardFilename = (file: File, index: number): File => {
+  if (file.name) {
+    return file
+  }
+  const ext = file.type.split('/')[1] ?? 'png'
+  return new File([file], `pasted-image-${Date.now()}-${index}.${ext}`, { type: file.type })
+}
 
 /**
  * Extract a human-readable display string from a connection error.
@@ -399,6 +410,25 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
       [attachments.length],
     )
 
+    // Intercept clipboard paste (Cmd/Ctrl+V) so copied files and pasted images
+    // become attachments — the same path as drag-drop and the paperclip. Only
+    // preventDefault when the clipboard actually carries files, so a normal text
+    // paste falls through untouched.
+    const handlePaste = useCallback(
+      (e: ClipboardEvent<HTMLTextAreaElement>) => {
+        const files = Array.from(e.clipboardData?.items ?? [])
+          .filter((item) => item.kind === 'file')
+          .map((item) => item.getAsFile())
+          .filter((file): file is File => file != null)
+        if (files.length === 0) {
+          return
+        }
+        e.preventDefault()
+        void addFiles(files.map(withClipboardFilename))
+      },
+      [addFiles],
+    )
+
     const removeAttachment = useCallback((localFileId: string) => {
       setAttachments((prev) => prev.filter((a) => a.localFileId !== localFileId))
       deleteAttachment(localFileId).catch((error) => console.error('Failed to delete local attachment:', error))
@@ -666,6 +696,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             }
             onTextareaKeyDown={handleSlashKeyDown}
             onTextareaSelect={(e) => setCursorPos(e.currentTarget.selectionStart)}
+            onTextareaPaste={handlePaste}
           />
         </div>
         <ContextOverflowModal

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -10,6 +10,7 @@ import type { Model } from '@/types'
 import { ArrowUp, Square } from 'lucide-react'
 import {
   type ChangeEvent,
+  type ClipboardEvent,
   type FormEvent,
   forwardRef,
   type KeyboardEvent,
@@ -64,6 +65,8 @@ type PromptInputProps = {
   onTextareaSelect?: (e: SyntheticEvent<HTMLTextAreaElement>) => void
   /** Fires on scroll so callers can sync overlays / popups. */
   onTextareaScroll?: (e: UIEvent<HTMLTextAreaElement>) => void
+  /** Fires on paste so callers can intercept clipboard files (e.g. attachments). */
+  onTextareaPaste?: (e: ClipboardEvent<HTMLTextAreaElement>) => void
 }
 
 /**
@@ -97,6 +100,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
       onTextareaKeyDown,
       onTextareaSelect,
       onTextareaScroll,
+      onTextareaPaste,
     },
     ref,
   ) => {
@@ -180,6 +184,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
             onKeyDown={submitOnEnter || hasTextareaHooks ? handleKeyDown : undefined}
             onSelect={onTextareaSelect}
             onScroll={hasTextareaHooks ? handleScroll : undefined}
+            onPaste={onTextareaPaste}
             placeholder={placeholder}
             minHeight={42}
             maxHeight={240}


### PR DESCRIPTION
## Summary

Adds clipboard paste support for file attachments in the chat composer (THU-652). Copied files and pasted screenshots now become attachments via the same pipeline as drag-drop and the paperclip button.

## Changes

- **chat-prompt-input.tsx** — Intercept `paste` on the textarea. Only `preventDefault` when the clipboard actually carries files, so plain-text pastes fall through untouched. Nameless clipboard images (e.g. screenshots) get a synthesized `pasted-image-<ts>-<i>.<ext>` filename so the chip renders and the extension-based accept check has input.
- **prompt-input.tsx** — Thread an `onTextareaPaste` hook through the shared `PromptInput`.
- **chat-prompt-input.test.tsx** — Cover pasted image attach + `preventDefault`, filename synthesis, plain-text passthrough, and unsupported-type rejection banner.

## Test plan

- [x] `bun test` for the new clipboard paste cases
- [ ] Manual: paste a screenshot and a copied file into the composer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only composer behavior reusing existing attachment validation and storage; tests cover main paste paths.
> 
> **Overview**
> Users can paste **copied files and screenshots** into the chat composer; they follow the same attachment path as drag-drop and the paperclip.
> 
> **`ChatPromptInput`** listens for paste on the textarea, pulls `clipboardData` file items, and routes them through **`addFiles`**. It only calls **`preventDefault`** when the clipboard has files, so plain text paste is unchanged. **`withClipboardFilename`** assigns `pasted-image-<timestamp>-<i>.<ext>` when the browser leaves the file name empty (typical for screenshots).
> 
> **`PromptInput`** exposes **`onTextareaPaste`** and wires it to the textarea’s **`onPaste`**.
> 
> Tests mock **`file-blob-storage`** with an in-memory store and add clipboard cases: image attach + preventDefault, synthesized names, text passthrough, and unsupported-type error banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dcc38e15f49896ec33a3cc344aaa77583aa092a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->