### PR TITLE
tooling: add the thunder-perf-hunt performance/a11y/bug-hunt skill

### DIFF
--- a/.claude/skills/thunder-perf-hunt/LEARNINGS.md
+++ b/.claude/skills/thunder-perf-hunt/LEARNINGS.md
@@ -1,0 +1,61 @@
+# perf-hunt learnings log
+
+Append one dated entry per run (newest first). Each entry records what the
+REFLECT phase changed, what it proposed but did not apply, and why. See
+`references/self-improve.md` for the rules. "No improvements warranted" is a
+valid entry — the log should show the harness was reflected on, not that it
+always changed.
+
+Format:
+```
+## <YYYY-MM-DD> — run <runId> (<mode>, <browsers>)
+- Applied: <safe-auto change + evidence> | none
+- Proposed: <proposal + why deferred> | none
+- Notes: <cost, coverage, calibration observations>
+```
+
+---
+
+## 2026-07-06 — run 2026-07-07T02-55-44-854Z (sweep→chromium-only, chromium)
+- Applied (1 SAFE-AUTO, probe fix): `scripts/lib/collect.ts` noise-render probe now returns the tree to idle (Escape + wait for no `[data-state="open"]` + 400ms settle) BEFORE `RESET_RENDERS`. Evidence: the sweep raised 107 `unnecessary-render` findings on `chat-sidebar-nav` (top `Presence` 228x, `DialogPortal` 116x — the whole Radix/framer overlay tree), all `isReal=false`. An adversarial verifier proved the scenario's 4-button-click leaves a Radix Dialog OPEN, so the probe's own `Escape` closed it and recorded the exit-animation as "idle" renders; a repeat probe from true idle gave 0 commits, matching the `chat-landing`=0 control. Post-fix focus smoke run: components with ≥3 idle commits dropped 107 → 0. tsc clean.
+- Proposed (PROPOSE-ONLY, not applied):
+  - **`run.ts` should persist results incrementally (per browser), not only at the very end.** This run's full sweep was hard-killed (likely OOM) during Firefox's first scenario; because `report.json` is written once at the end (run.ts:102), all 7 completed Chromium scenarios were discarded and the sweep had to be re-run Chromium-only. Writing per-browser (or per-scenario) would make a late-browser crash non-fatal. Deferred: changes run.ts control flow / adds surface — wants human review.
+  - **Investigate Playwright Firefox stability/memory on this host.** Firefox died on `chat-landing` even though browsers run sequentially (Chromium closes before Firefox launches), so co-residency isn't the cause. Firefox coverage was NOT obtained this run. Deferred: needs investigation, not a one-line fix.
+- Notes: Web vitals all `good` (LCP 600–1224ms, CLS ~0); no long-task (all 74–80ms, sub-threshold) or console-error findings. Real confirmed cluster: 3 axe `button-name` violations (2 high, 1 medium) → fixed in app PR #1057. After the probe fix, this sweep's dominant "finding" category evaporates entirely — the harness got materially cheaper to triage (fewer moving parts, as intended).
+
+## 2026-07-06 — run 2 (expanded coverage: streaming + bundle + explore + firefox)
+- Applied (SAFE-AUTO): (1) added a `chat-streaming-sim` BASE_SCENARIO driving the dev Message Simulator (`/message-simulator`, DEV-only) — replays canned SSE through the real streamText pipeline + production renderer, so the message-render hot path is measured with NO API key. (2) `calibration.json` excludeSignatures: suppressed the explorer's keyless-send false positives (`Ehbp-Response-Nonce`, `503 (Service Unavailable)`) — test-env artifacts, not shippable bugs.
+- Validated the run-1 probe fix: re-ran the Chromium sweep with the idle-restore fix → `noiseRenders≥3` dropped 107 → 0 across all scenarios. Confirms the run-1 render storm was 100% the overlay-close artifact.
+- Coverage achieved this run: Chromium sweep (7) + Firefox sweep (8, incl. streaming) + streaming focus + bundle + explore (21 states/46 transitions). **Firefox worked** when run isolated (not co-resident with Chromium) — reinforces the run-1 PROPOSE-ONLY that a full both-browser sweep OOMs on a 16GB host; keep browsers in separate runs or persist per-browser.
+- Findings:
+  - CONFIRMED perf: composer typing re-render cascade (chat-landing) — ~4 render passes/keystroke cascade through the closed Radix overlay/tooltip/dialog tree (Presence 136/keystroke). Verified real (3/3, linear scaling, not StrictMode, not the animation artifact). DEFERRED the fix: memoizing the two pickers zeroed them but the metric barely moved (churn is dominated by tooltips/dialogs across the whole composer, not the pickers); the real fix is isolating composer input/cursorPos state from the toolbar chrome — a risky core-input refactor for sub-ms/no-jank gain (fails CLAUDE.md no-premature-optimization). Recommend a scoped follow-up.
+  - CONFIRMED bundle: entry chunk ~800KB gzip; mostly irreducible (react-dom + AI SDK chat engine + markdown + drizzle/router + static-chat), but two clean CLAUDE-compliant wins: lazy-load katex (~70KB, math-only) and defer posthog-js (~55KB, post-paint). Both are moderate refactors on hot/sensitive code (per-message markdown-math render; analytics/consent across 4 files + provider) → surfaced as reviewed recommendations, not autonomous end-of-session commits. Also a real-but-negligible (<3KB) tauri plugin-process leak into the web entry (one-file dynamic-import fix in use-desktop-update.ts).
+  - Streaming hot path: HEALTHY both browsers (vitals good, 0 long tasks ≥120ms, 0 console/page errors).
+  - Firefox: clean (all vitals good, no errors); LoAF/INP/longtask empty as expected (Chromium-only).
+  - Sub-threshold a11y (not raised as findings): landmark-*, meta-viewport, page-has-heading-one, heading-order present on most pages (moderate impact) — noted for a future a11y pass.
+- Proposed (PROPOSE-ONLY): add a realistic numeric entry-chunk budget to `analyze-bundle.ts` (~700KB) AFTER the katex/posthog wins land (400KB is unreachable given the static-chat floor). Consider surfacing high load-render commit counts during real interactions (typing), not just the idle noise probe — the typing cascade was invisible to the finding logic (idle-only).
+
+## 2026-07-07 — run 3 (dependency slimming + bundle fixes shipped)
+- Ran a dependency-slimming survey (user directive: "less deps is better; replace heavy deps with slim in-house code"). Honest headline: the codebase is ALREADY well-split — the scary big chunks (maplibre-gl 273KB, react-pdf 115KB, acorn 35KB) are all lazy and each needs a real engine → KEEP. framer-motion already uses the optimal LazyMotion+`m`+async-domMax split → KEEP. uuid (~1KB, v7 sortable IDs) / dayjs (~8KB) → KEEP.
+- Shipped bundle wins (entry chunk 788.5 KB → 633.9 KB gzip, ~−154KB / ~20%), each a separate single-concern PR off main:
+  - #1058 posthog-js lazy-loaded off the entry (dynamic import + in-house `usePostHogClient` context replacing posthog-js/react; `getPosthogClient()` for the alias) → −62KB. Behavior/consent/alias preserved; analytics tests pass; focus run 0 errors.
+  - #1059 markdown slimming: lazy-load KaTeX (~80KB) gated per-block by the existing math regexes + drop `marked` (a 2nd tokenizer) by porting block-splitting to remark/mdast offset-slicing → −92KB. All 18 tests pass (made async for the lazy load); headless-verified math still renders. Caught+fixed a latent regex-lastIndex currency-escaping bug. Follow-up flagged: `bun remove marked && bun add unified remark-parse`.
+  - #1060 tauri plugin-process/updater moved to dynamic import (desktop-only code out of web entry; kills an INEFFECTIVE_DYNAMIC_IMPORT warning). <3KB, correctness fix.
+- Implementation method: two parallel sub-agents on disjoint file sets (posthog / markdown) with mandatory build-delta + test + headless-render verification, reviewed before PR. Worked well; the markdown agent self-found a real bug during its own verification.
+- Deferred (documented): composer typing re-render cascade — investigated the 711-line composer; input/cursorPos state is woven through submit/token/slash/draft logic and fires on separate unbatchable DOM events; full fix = uncontrolled textarea or memoize all chrome leaves (large rewrite) for imperceptible gain → not an autonomous change.
+- PROPOSE-ONLY (harness): the streaming/markdown hot-path re-render magnitude is only visible via the cumulative load-render tally, not the idle noise probe — consider a "renders during a scripted interaction" finding type. Add a numeric entry-chunk budget (~650KB now that the wins landed) to analyze-bundle.ts to prevent backsliding.
+
+## 2026-07-07 — run 4 (round 2: confirm fixes + regression hunt on the fixed tree)
+- Re-ran the full hunt on the working tree with ALL round-3 fixes applied (a11y + posthog + markdown + tauri). Result: the app is in excellent shape and the fixes introduced NO regressions.
+  - Entry chunk holds at 633.9 KB gzip (from 788.5 baseline). Render storm stays 0. Every scenario both browsers: all Web Vitals good, 0 long tasks ≥120ms, 0 LoAF ≥200ms, 0 console errors, 0 page errors.
+  - Specifically checked the regression my own katex lazy-load could cause: measured CLS on a math message (crafted SSE through the simulator) = 0.094 (good), and it attributed to the dev simulator page's own textarea layout, NOT the katex FOUC — so lazy KaTeX introduced no meaningful layout shift.
+  - 0 shippable findings after calibration. The only raw findings were the dev-only /message-simulator a11y and the known keyless-send test-env artifacts.
+- Applied (2 SAFE-AUTO harness fixes, both verified: tsc clean + focus smoke + re-report shows suppression working):
+  - **explore.ts now applies calibration `excludeSignatures`** (reusing `applyExclusions`). GAP found this round: the round-3 keyless-send exclusions only filtered the perf report, so the explorer kept re-emitting the same 3 test-env artifacts. Now the crawl honors them too.
+  - Added an `a11y`/`chat-streaming-sim` exclusion: that scenario targets the dev-only simulator page (tree-shaken from prod) and exists to measure streaming perf, so its axe findings aren't shipped-user concerns.
+- Net: two clean rounds; harness signal is now tight (0 false positives surfacing). The harness + all its self-improvements are being committed to the repo this session (previously untracked).
+
+## 2026-07-06 — harness authored + validated (bootstrap)
+- Applied: n/a (initial build). Seeded empty `calibration.json`.
+- Proposed: none.
+- Notes: Validated on Chromium (vitals+attribution, 146 renders, long tasks, LoAF, network, a11y incl. a real critical `button-name`, heap delta). Known env limit: Playwright Firefox crashes on ubuntu26.04-arm64 → Firefox via the devtools MCP here. `app_init_timing` marks came back empty (init-timing.ts uses `performance.now()` snapshots, not `performance.mark`) — candidate PROPOSE-ONLY improvement if startup attribution is ever needed.

--- a/.claude/skills/thunder-perf-hunt/SKILL.md
+++ b/.claude/skills/thunder-perf-hunt/SKILL.md
@@ -69,7 +69,7 @@ Scripts live in `scripts/` under this skill dir; run them from the repo root wit
 ## Workflow (follow in order — copy this checklist)
 
 ### 1. SETUP
-- Ensure browsers installed (`bunx playwright install chromium firefox` if `~/.cache/ms-playwright` lacks them).
+- Ensure browsers installed (if `~/.cache/ms-playwright` lacks them, run `bun node_modules/playwright-core/cli.js install chromium firefox` — **not** `bunx playwright`; see Prerequisites for why).
 - Choose mode. On a branch/PR: `diff` using the changed files (`git diff --name-only main...HEAD`). On explicit "audit everything": `sweep`. For a single surface or a re-measure: `focus`.
 - Choose browsers: default both (`chromium,firefox`); Chromium-only for a quick pass.
 

--- a/.claude/skills/thunder-perf-hunt/SKILL.md
+++ b/.claude/skills/thunder-perf-hunt/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: thunder-perf-hunt
+description: >-
+  Drives headless Chromium AND Firefox against a locally-booted Thunderbolt to
+  hunt performance bottlenecks (Core Web Vitals, unnecessary React re-renders,
+  long tasks, layout thrash, memory leaks, bundle bloat), functional bugs, and
+  a11y violations — then adversarially verifies each finding and autonomously
+  opens one small PR per fix or tight cluster. Use when the user says
+  perf-hunt, performance audit, "find slow/janky UI", "why is it re-rendering",
+  "hunt for bugs in the browser", "profile the app", or asks to speed up /
+  fix perf regressions. Boots its own Docker-free stack (pglite + anonymous
+  auth); never touches production.
+---
+
+# Thunder Perf Hunt
+
+A two-layer harness. **Layer 1 (deterministic)** = Bun + Playwright probe scripts
+that boot the app and emit compact JSON — real, reproducible numbers, no LLM
+guessing. **Layer 2 (agentic, this document)** = a Scout → Triage → **adversarial
+Verify** → Fix → PR pipeline modeled on Anthropic's security-review harness
+(separate discovery from verification; verify by reproduction; a good harness
+makes iteration cheap). You read only the JSON, never raw traces.
+
+## Operating rules (low freedom — always)
+
+- **The deterministic layer owns the numbers; you own attribution, verification, and fixes.** Never eyeball a screenshot and declare a metric — run the probe and cite its output.
+- **Separate finding from dismissing.** The agent that fixes must not be the one that verified a finding is real. Verification is adversarial: default to *refuted* unless reproduced AND attributed to a source location. See `references/verification-rubric.md`.
+- **Warm before you measure.** Vite transpiles a route on first hit; a cold first navigation is not a real metric. Every scenario is warmed once before the measured pass (the probes handle this; never bypass it).
+- **Fixes are architectural, never band-aids** (CLAUDE.md core principle). Follow the repo's React/`useEffect` discipline and route code-splitting rules. Soft-delete only; never hard-delete.
+- **Every fix carries a before/after number** from re-running the exact focus probe. No number → not a fix.
+- **One concern per PR.** One branch + PR per fix or tightly-related cluster, kept small for easy review (the user's explicit goal).
+- **Prove-then-commit.** Run `thundercheck` (types/lint/format) green before any PR. Use `/thunderpush` for all git — never manual `git add/commit/push`.
+- **Do not fix exclusion-category noise** (StrictMode double-render, streaming re-renders, third-party/analytics long tasks, dev-only warnings). Auto-refute them — see the rubric.
+
+## Prerequisites (one-time)
+
+```bash
+# From repo root. Browsers are ~700MB; only needed once.
+# NOTE: run the Playwright CLI through `bun`, NOT `bunx playwright` — this repo is
+# bun-only (no `node`), and the playwright bin has a `#!/usr/bin/env node` shebang
+# that fails with "env: node: No such file or directory".
+bun node_modules/playwright-core/cli.js install chromium firefox
+
+# On a very new OS where Playwright has no prebuilt browser (e.g. the install errors
+# with "does not support chromium on ubuntuXX.YY-arch"), download the nearest
+# supported build via the platform override — it runs fine on the newer glibc:
+PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-arm64 bun node_modules/playwright-core/cli.js install chromium firefox
+
+# A 32+ char BETTER_AUTH_SECRET must be exported (backend/.env has one, or `make doctor` generates it).
+# An AI provider key (ANTHROPIC_API_KEY) is only needed for scenarios that send a chat message.
+```
+
+If Playwright browsers cannot be installed at all on the host, the **Firefox path still works** via the `firefox-devtools` MCP + system Firefox (Marionette) — see `references/gecko-profiler.md`. Chromium-only metrics (LoAF, CDP heap) are unavailable in that fallback.
+
+The harness boots its own stack on dedicated ports (frontend :1431, backend :8010, pglite, anonymous auto-session) — it will not collide with `make dev` (:1420/:8000) or the e2e suite. It reuses an already-serving stack if one is up.
+
+## Inputs & modes
+
+Pick the narrowest mode that answers the question:
+
+| Mode | Command | When |
+| --- | --- | --- |
+| `diff` (default on a branch) | `bun scripts/run.ts --mode diff --changed <files>` | Reviewing a PR/branch — probes only the scenarios that exercise changed files. Fast + cheap. |
+| `focus` | `bun scripts/run.ts --mode focus --focus chat-landing` | Deep-dive one surface, or re-measure after a fix (before/after). |
+| `sweep` | `bun scripts/run.ts --mode sweep` | Full audit across all scenarios × both browsers. |
+
+Scripts live in `scripts/` under this skill dir; run them from the repo root with the skill path, e.g. `bun .claude/skills/thunder-perf-hunt/scripts/run.ts ...`.
+
+## Workflow (follow in order — copy this checklist)
+
+### 1. SETUP
+- Ensure browsers installed (`bunx playwright install chromium firefox` if `~/.cache/ms-playwright` lacks them).
+- Choose mode. On a branch/PR: `diff` using the changed files (`git diff --name-only main...HEAD`). On explicit "audit everything": `sweep`. For a single surface or a re-measure: `focus`.
+- Choose browsers: default both (`chromium,firefox`); Chromium-only for a quick pass.
+
+### 2. SCOUT (recall pass — run the probes)
+Run the lenses the request needs (all of them for a full hunt):
+- **Perf + a11y + console/crash:** `bun scripts/run.ts --mode <mode> [flags]` → prints the `report.json` path. Then `bun scripts/report.ts <report.json>` → writes `findings.json` + `summary.md` (recall-biased candidates with thresholds already applied).
+- **Bug/exploration lens:** `bun scripts/explore.ts [--browsers chromium] [--steps 40]` → curiosity-driven state-graph crawl → `explore/explore-findings.json` (crashes, console errors, dead-ends) + per-state screenshots. See `references/state-exploration.md`.
+- **Bundle lens:** `bun scripts/analyze-bundle.ts` → `bundle-report.json` (entry-chunk + largest chunks vs size-limit budgets).
+- **Firefox-deep lens (only if a finding is Firefox-only or Firefox-specific jank is suspected):** drive the Gecko profiler over the `firefox-devtools` MCP — see `references/gecko-profiler.md`. LoAF/CDP source attribution is Chromium-only, so this is how Firefox jank gets attributed.
+
+Read `summary.md` + the findings JSONs — never the raw traces. That is the whole candidate set.
+
+### 3. TRIAGE
+- Merge duplicates (the report already merges the same issue across browsers). Cluster related findings that would share a fix (`clusterId`).
+- Drop exclusion-category noise per `references/verification-rubric.md`.
+- Rank by severity × confidence. Carry forward the top findings; note (don't silently drop) anything cut for volume.
+
+### 4. VERIFY (precision pass — adversarial, parallel sub-agents)
+For each surviving finding, dispatch a **separate verifier sub-agent** (see execution model). The verifier:
+- Re-runs the exact `focus` probe (or Gecko profile for Firefox) to **reproduce** the number.
+- **Attributes to a source location** (`file:line` or component) — reading the LoAF `sourceURL:charPosition`, the render component name, the a11y selector, the crash stack.
+- Tries to **refute** it (is it expected? third-party? cold-cache artifact? StrictMode?). Returns a structured `VerdictReport` (`reproduced`, `isReal`, `rationale`, `sourceAttribution`, `correctedSeverity`).
+- For ambiguous perf findings, use a **2-of-3 vote**.
+Only `confirmed` findings with a source attribution proceed.
+
+### 5. FIX (per confirmed cluster)
+For each cluster, in its own git branch:
+- Consult `references/fix-playbook.md` (+ `react-rerender-playbook.md` for renders) and implement the **architectural** fix, obeying CLAUDE.md React/`useEffect`/code-splitting rules.
+- Re-run `focus` on the affected scenario(s) in the affected browser(s): capture the **before** (from the original run) and **after** numbers. If the metric didn't move, the fix is wrong — iterate.
+- **Hard cap: 3–5 fix↔measure iterations**, then stop and escalate the finding as `deferred` with notes (per `references/harness-tuning.md`).
+- Run `thundercheck` until green.
+
+### 6. PR (autonomous — one per cluster)
+- Use `/thunderpush` to branch/commit/push, then open a PR (via `/thunderpush`'s PR flow or `gh pr create`). One PR per cluster.
+- PR body from `assets/pr-template.md`: what was wrong, the fix, a **BEFORE/AFTER metric table**, how it was verified (probe/scenario/browser), reviewer checklist.
+- Fully autonomous per project config — no pause. Keep each PR single-concern so review stays trivial.
+
+### 7. REPORT
+Emit a concise summary to the user: findings by severity, which were confirmed vs refuted (with the false-positive reasons — this is signal), the PRs opened with links, and the before/after table per fix. Link the run dir (`.perf-hunt/runs/<runId>/`).
+
+### 8. REFLECT (self-improve — bounded)
+Make the harness a little better using signals from THIS run — but only in ways that add signal, never complexity. Read `references/self-improve.md` and follow it exactly. In short:
+- Read the run signals (probe errors/empty outputs, scenario timeouts, verifier-confirmed false positives, crawler-discovered routes, attribution gaps, cost).
+- **Auto-apply at most 3 SAFE changes:** suppress a confirmed false positive (`calibration.json` `excludeSignatures`, with a reason), add a discovered route (`calibration.json` `extraScenarios`), fix a broken probe, or tune one threshold by one step (only with ≥2-run evidence).
+- **Propose-only** (log to `LEARNINGS.md`, do NOT apply): anything that adds a dependency, abstraction, file, probe type, or cost.
+- **Guardrails:** after any self-edit, `bunx tsc -p scripts/tsconfig.json` must pass AND one `focus` smoke run must succeed, or revert. Harness self-edits go in their OWN PR titled `perf-hunt: self-improve (<date>)`, never mixed with app-fix PRs. Always append a dated entry to `LEARNINGS.md` (even "no improvements warranted"). The harness should trend toward FEWER moving parts.
+
+## Execution model — lens + finding fan-out (for recall and precision)
+
+- **Scout fan-out:** run the lenses (perf, explore, bundle) concurrently — they're independent scripts. On a full sweep, you may also fan out scenarios across sub-agents, but prefer one `run.ts` invocation (it already loops browsers×scenarios in one warm stack — cheaper than N cold boots).
+- **Verify fan-out:** one verifier sub-agent per finding (or per 2–3 clustered findings), in parallel. Each gets ONLY: the one finding's JSON, the repro command, and the rubric. It returns a `VerdictReport` — structured, not prose. This is the precision gate; do not skip it to save time.
+- **Fix fan-out:** fixes that touch disjoint files may run in parallel sub-agents (use worktree isolation if they'd otherwise conflict). Fixes to the same file are serialized.
+
+Keep sub-agent context minimal (compact JSON in, structured verdict out) — this is what keeps the harness itself cheap. See `references/harness-tuning.md`.
+
+## Severity & confidence
+
+- **Severity:** `critical` (crash/data-loss/broken core flow), `high` (poor Web Vital on the critical chat surface, >300ms task, confirmed leak), `medium` (needs-improvement vital, noisy re-renders, large chunk), `low` (minor).
+- **Confidence:** `high` (deterministic + reproduced + attributed), `medium` (reproduced, attribution partial), `low` (single sample / heuristic). Full ladder + exclusion categories in `references/verification-rubric.md`.
+
+## Reference files (read on demand — progressive disclosure)
+
+- `references/metrics-and-thresholds.md` — every metric, its threshold, how it's captured, browser-support caveats. Read in SCOUT/TRIAGE.
+- `references/react-rerender-playbook.md` — how render counting works + the noise-render probe + re-render fix catalog. Read for `unnecessary-render` findings.
+- `references/fix-playbook.md` — architectural fixes per finding category. Read in FIX.
+- `references/verification-rubric.md` — the adversarial verify protocol, exclusion categories, severity/confidence ladder. Read in VERIFY (mandatory).
+- `references/state-exploration.md` — the curiosity-driven crawler + visual diffing. Read for the bug lens.
+- `references/a11y-checks.md` — axe rules + fixes. Read for `a11y` findings.
+- `references/gecko-profiler.md` — driving the Firefox Gecko profiler over the MCP. Read for Firefox-deep analysis.
+- `references/harness-tuning.md` — keeping the harness itself fast/cheap; diff mode, caps, cost knobs. Read when a run is slow/expensive.
+- `references/self-improve.md` — the REFLECT protocol: what may be auto-applied vs proposed, and the anti-complexity guardrails. Read in REFLECT (mandatory). Learnings accumulate in `calibration.json` (data) + `LEARNINGS.md` (log).
+- `references/finding-schema.md` — `Finding`/`VerdictReport` schema + run-artifact layout. The sub-agent contract.
+- `assets/finding-template.md`, `assets/pr-template.md` — fill-in templates.

--- a/.claude/skills/thunder-perf-hunt/assets/finding-template.md
+++ b/.claude/skills/thunder-perf-hunt/assets/finding-template.md
@@ -1,0 +1,67 @@
+<!--
+Fill-in template for ONE confirmed finding. Copy this file, replace every
+<placeholder>, delete guidance comments. Fields mirror the `Finding` type in
+../scripts/lib/types.ts — see ../references/finding-schema.md.
+Only fill this in AFTER a verifier sub-agent has confirmed the finding
+(status: confirmed) with a reproducible signal.
+-->
+
+# <one-line title — what's wrong and where>
+
+| field | value |
+| --- | --- |
+| id | `<slug, e.g. rerender-composer-chat-landing-chromium>` |
+| category | `<web-vital \| unnecessary-render \| long-task \| layout-thrash \| memory-leak \| bundle \| network \| console-error \| crash \| a11y>` |
+| severity | `<critical \| high \| medium \| low>` |
+| confidence | `<high \| medium \| low>` |
+| status | `confirmed` |
+| browsers | `<chromium \| firefox \| chromium, firefox>` |
+| scenario(s) | `<scenario name(s) from scripts/lib/scenarios.ts>` |
+| clusterId | `<clusterId if grouped into one PR, else —>` |
+
+## Evidence (with numbers)
+
+<The quantitative signal that triggered and confirmed this. Include the metric,
+value, unit, and threshold crossed. Examples:
+- "INP=412ms (poor) on chat-landing/chromium; budget 200ms."
+- "<ModelList> committed 11x during a no-op scroll, 84ms subtree render."
+- "LoAF 318ms, blocking 260ms, forced layout 47ms.">
+
+## Source attribution
+
+`<file:line function>`  or  `<CSS selector>`
+
+<If confirmed on Firefox via the Gecko profiler, note the hot self-time frame
+and the cross-check against the Chromium LoAF entry — see
+../references/gecko-profiler.md.>
+
+## Repro command
+
+```bash
+bun scripts/run.ts --mode focus --focus <scenario> --browsers <browser>
+```
+
+<For functional/explorer findings, give the click path instead, e.g.
+`/chats/new → click "Settings" → click "Devices" → click "Revoke"` — see
+../references/state-exploration.md.>
+
+## Root cause
+
+<Why it happens, in 1–3 sentences. Name the mechanism: unstable prop/context
+identity, missing memoization, synchronous layout read in a loop, oversized
+eager import, unbounded listener, etc.>
+
+## Proposed fix
+
+<The architectural fix — not a workaround. Reference the relevant house rule or
+playbook if one applies (e.g. useEffect discipline, route code-splitting).>
+
+## Before / after
+
+| metric | before | after | unit |
+| --- | --- | --- | --- |
+| <metric> | <before> | <after> | <ms \| KB \| commits \| MB \| count> |
+
+<Populate `after` only once the fix is verified by re-running the repro command.
+This row becomes the Finding.beforeAfter field and the PR's metric table — see
+../assets/pr-template.md.>

--- a/.claude/skills/thunder-perf-hunt/assets/pr-template.md
+++ b/.claude/skills/thunder-perf-hunt/assets/pr-template.md
@@ -1,0 +1,51 @@
+<!--
+PR body template for an autonomous perf-hunt fix PR.
+Keep every PR SMALL and SINGLE-CONCERN: one fix, or one tight cluster of
+findings that share a root cause (same clusterId). If two findings need
+different fixes, open two PRs. Small single-concern PRs are the explicit goal —
+they are fast to review and safe to revert.
+Copy this file, replace every <placeholder>, delete guidance comments.
+-->
+
+## What was wrong
+
+<1–3 sentences: the user-facing symptom + the finding(s) this PR closes. Link
+the finding id(s) from findings.json. Include severity and which browser(s).>
+
+- Finding: `<finding id>` (`<severity>`, `<category>`, `<browsers>`)
+- Scenario: `<scenario name>`
+- Source: `<file:line or selector>`
+
+## The fix
+
+<What changed and why it's the right architectural fix, not a workaround.
+Keep the diff focused — call out anything intentionally left out of scope.>
+
+## Before / after
+
+| metric | before | after | unit | Δ |
+| --- | --- | --- | --- | --- |
+| <metric> | <before> | <after> | <ms \| KB \| commits \| MB \| count> | <-X% / -Xms> |
+
+<One row per metric the fix moved. Numbers come from re-running the repro
+command below on this branch vs. the baseline.>
+
+## How it was verified
+
+- **Probe / scenario / browser:** `bun scripts/run.ts --mode focus --focus <scenario> --browsers <browser>`
+- **Verifier verdict:** `reproduced: false` on this branch (finding no longer
+  fires) — the `VerdictReport` rationale confirms the metric moved below
+  threshold.
+- <Firefox-only fixes: note the Gecko-profiler re-capture — see
+  ../references/gecko-profiler.md.>
+- <Functional fixes: note the explorer no longer reaches the failing state.>
+
+## Reviewer checklist
+
+- [ ] Single concern — one fix or one tight cluster (shared root cause).
+- [ ] Before/after numbers are real (re-run the repro command; not estimated).
+- [ ] No new console errors, crashes, or a11y regressions in the focus run.
+- [ ] Fix is architectural, not a workaround; follows house rules (no `any`,
+      `useEffect` discipline, soft-deletes, route code-splitting where relevant).
+- [ ] No unrelated files touched; diff stays reviewable.
+- [ ] Finding(s) marked `fixed` in findings.json with `beforeAfter` populated.

--- a/.claude/skills/thunder-perf-hunt/calibration.json
+++ b/.claude/skills/thunder-perf-hunt/calibration.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "Learned overlay for thunder-perf-hunt. Only false-positive exclusions and crawler-discovered scenarios live here (safe to auto-append). Everything else is a reviewed code change. See references/self-improve.md.",
+  "excludeSignatures": [
+    {
+      "category": "console-error",
+      "match": "Ehbp-Response-Nonce",
+      "reason": "Test-env artifact: the explorer clicks the real Send-message affordance, but the anonymous perf stack has no AI provider key, so the backend returns 503 and the client surfaces it as a 'Missing Ehbp-Response-Nonce header' protocol error. Not a shippable bug. (Use the /message-simulator scenario for the keyless streaming path.)"
+    },
+    {
+      "category": "console-error",
+      "match": "503 (Service Unavailable)",
+      "reason": "Test-env artifact: inference proxy returns 503 in the keyless perf stack when the explorer sends a real chat message. Not a shippable bug."
+    },
+    {
+      "category": "a11y",
+      "match": "chat-streaming-sim",
+      "reason": "The chat-streaming-sim scenario targets the dev-only /message-simulator page (tree-shaken from production builds), and exists to measure the streaming render hot path — its axe findings (e.g. an unlabeled dev Combobox) are not shipped-user concerns."
+    }
+  ],
+  "extraScenarios": []
+}

--- a/.claude/skills/thunder-perf-hunt/references/a11y-checks.md
+++ b/.claude/skills/thunder-perf-hunt/references/a11y-checks.md
@@ -1,0 +1,52 @@
+# Accessibility checks — axe-core probe
+
+`scripts/probes/a11y.ts` runs [axe-core](https://github.com/dequelabs/axe-core)
+against every scenario, in **both browsers**, and emits `a11y` findings.
+Accessibility defects are treated as first-class bugs, not warnings: broken
+labels, missing landmarks, and unreadable contrast are real user-facing
+failures.
+
+## How it runs
+
+- **Inline injection (COEP-safe).** The app ships
+  `Cross-Origin-Embedder-Policy: credentialless`, so axe cannot be pulled from a
+  CDN `<script src>`. The probe resolves the local `axe-core/axe.min.js`
+  devDependency (`require.resolve`, with an absolute fallback path) and injects
+  it with `page.addScriptTag({ path })`, then calls `window.axe.run()`.
+- **Per scenario.** It runs once per `(browser × scenario)` after the route
+  settles and the scenario's `interact` has run, so it sees the same post-load
+  DOM the perf probes measured.
+- **Fail-open.** Any failure at the injection boundary returns an empty list —
+  the harness never crashes on a page axe can't analyze.
+- **Compact output.** Each violation is reduced to `{ ruleId, impact, help,
+  selectors }` (`A11yViolation` in `scripts/lib/types.ts`), capped at 25 per
+  page.
+
+## What becomes a finding
+
+By default **only `critical` and `serious` impacts** are promoted to findings
+(see the filter in `scripts/report.ts`); `moderate` and `minor` are recorded in
+the report but not surfaced as candidates. Severity maps `critical → high`,
+`serious → medium`. Because the probe runs in both engines, the report merges a
+rule seen in both Chromium and Firefox into a single finding listing both
+browsers.
+
+## Common rule categories and the standard fix
+
+| axe rule(s) | What it means | Standard fix |
+| --- | --- | --- |
+| `color-contrast` | Text/background contrast below WCAG AA (4.5:1 body, 3:1 large). | Adjust the token/class to a compliant pair; use the theme's `--foreground`/`--muted-foreground` values, don't hand-pick a lighter gray. |
+| `aria-*` (e.g. `aria-required-attr`, `aria-valid-attr-value`, `aria-required-children`) | An ARIA role is present but its required attributes/children are missing or invalid. | Prefer a native element (`<button>`, `<nav>`) over a `role` + hand-rolled ARIA. If ARIA is required, supply every attribute the role mandates. |
+| `label` / `label-title-only` | A form control has no programmatic label. | Associate a `<label htmlFor>`, wrap the control in a `<label>`, or add `aria-label`/`aria-labelledby`. A `title` or placeholder alone does not count. |
+| `image-alt` | `<img>` (or `role="img"`) with no text alternative. | Add `alt` — descriptive for meaningful images, `alt=""` for decorative ones. For icon buttons, label the *button*, not the icon. |
+| `region` | Content sits outside any landmark region. | Wrap page content in landmarks (`<main>`, `<nav>`, `<header>`). Exactly one `<main>` per view. |
+| `button-name` / `link-name` | An interactive control has no accessible name. | Give icon-only buttons/links an `aria-label` or visually-hidden text. |
+| `document-title` / `html-has-lang` | Missing `<title>` or `lang` on `<html>`. | Set a route-appropriate document title and `lang="en"` on the root element. |
+
+## Cross-browser note
+
+Contrast and ARIA computations are engine-independent, so most `a11y` findings
+reproduce identically in Chromium and Firefox. When a finding appears in only
+one engine, treat it like any single-browser finding and verify it — see
+[gecko-profiler.md](gecko-profiler.md) for the Firefox-only investigation path
+and [finding-schema.md](finding-schema.md) for the finding contract.

--- a/.claude/skills/thunder-perf-hunt/references/finding-schema.md
+++ b/.claude/skills/thunder-perf-hunt/references/finding-schema.md
@@ -1,0 +1,83 @@
+# Finding schema and run artifacts — the sub-agent contract
+
+Every probe writes, and every sub-agent reads/writes, the compact structures
+defined in `scripts/lib/types.ts`. The agentic layer reasons **only** over these
+— never over raw traces. This doc is the canonical field reference and the
+on-disk layout.
+
+## `Finding` — a normalized, agent-facing issue
+
+| field | type | meaning |
+| --- | --- | --- |
+| `id` | `string` | Stable slug, derived from category + attribution + scenario/browser. |
+| `category` | `FindingCategory` | One of `web-vital`, `unnecessary-render`, `long-task`, `layout-thrash`, `memory-leak`, `bundle`, `network`, `console-error`, `crash`, `a11y`. |
+| `title` | `string` | One-line human summary. |
+| `severity` | `Severity` | `critical` \| `high` \| `medium` \| `low`. |
+| `confidence` | `Confidence` | `high` \| `medium` \| `low` — how sure the deterministic layer is *before* the agent verifies. |
+| `status` | `FindingStatus` | `candidate` → `confirmed` \| `refuted` → `fixed` \| `deferred`. |
+| `browsers` | `BrowserName[]` | `chromium` and/or `firefox` the issue was seen in. |
+| `scenarios` | `string[]` | Scenario name(s) it appeared in. |
+| `evidence` | `string` | Compact quantitative evidence — the metric that triggered it (include numbers + units). |
+| `sourceAttribution?` | `string` | `file:line` or a CSS selector the issue attributes to. |
+| `repro` | `string` | Exact deterministic steps: which probe + scenario + browser (usually a `bun scripts/run.ts --mode focus …` command). |
+| `beforeAfter?` | `{ metric, before, after, unit }` | Populated once a fix lands and the metric moves. |
+| `suggestedFix?` | `string` | Pointer to a playbook or a one-line remedy. |
+| `clusterId?` | `string` | Findings clustered for a single PR. |
+| `prUrl?` | `string` | Set when a fix PR is opened. |
+
+### Finding lifecycle
+
+`candidate` (emitted by a probe / `report.ts`) → verified by a sub-agent →
+`confirmed` (reproduced, with evidence) or `refuted` (couldn't reproduce, or
+expected/by-design) → after a fix lands and the metric moves, `fixed`; real but
+out-of-scope issues are `deferred`.
+
+## `VerdictReport` — what a verifier sub-agent returns
+
+A verifier re-runs the focused scenario and returns this (not prose), so the
+orchestrator can merge verdicts deterministically:
+
+| field | type | meaning |
+| --- | --- | --- |
+| `findingId` | `string` | The `Finding.id` under test. |
+| `reproduced` | `boolean` | Did the re-run reproduce the signal? |
+| `isReal` | `boolean` | Is it a genuine defect (vs. expected/by-design)? |
+| `rationale` | `string` | Why confirmed or refuted, citing the re-run evidence. |
+| `correctedSeverity?` | `Severity` | Override if the first-pass severity was wrong. |
+| `sourceAttribution?` | `string` | Refined `file:line`/selector found during verification. |
+
+## Run artifacts layout
+
+`run.ts` writes one directory per run under `.perf-hunt/runs/<runId>/`
+(`runId` defaults to an ISO timestamp with `:`/`.` replaced by `-`):
+
+```
+.perf-hunt/runs/<runId>/
+├── report.json        # the RunReport: runId, gitRef, mode, scenarios[], bundle?
+├── findings.json      # Finding[] derived by report.ts (deriveCandidates → merge)
+├── summary.md         # human-readable ranked summary (report.ts summarize())
+├── <scenario>.<browser>.png   # per-scenario screenshot (e.g. chat-landing.chromium.png)
+└── explore/           # explorer output: per-state screenshots + its findings
+```
+
+- **`report.json`** conforms to `RunReport` — the raw structured measurements
+  (`ScenarioReport[]`, optional `BundleReport`). Written by `run.ts`.
+- **`findings.json`** is `Finding[]` — the thresholded, cross-browser-merged
+  candidates. Written by `report.ts` (`deriveCandidates`). **This is the file
+  verifier sub-agents read and the fix agent updates** (setting `status`,
+  `beforeAfter`, `prUrl`).
+- **`summary.md`** is the ranked, emoji-tagged digest for humans.
+- **`*.png`** are evidence screenshots referenced by `ScenarioReport.screenshotPath`
+  and by findings.
+- **`explore/`** holds the crawler's per-state screenshots and functional-bug
+  findings (see [state-exploration.md](state-exploration.md)).
+
+Re-summarize an existing run without re-driving the browsers:
+
+```bash
+bun scripts/report.ts .perf-hunt/runs/<runId>/report.json
+```
+
+Keep this contract stable — the probes, the report aggregator, the verifier
+sub-agents, and the fix/PR templates ([../assets/finding-template.md](../assets/finding-template.md),
+[../assets/pr-template.md](../assets/pr-template.md)) all depend on it.

--- a/.claude/skills/thunder-perf-hunt/references/fix-playbook.md
+++ b/.claude/skills/thunder-perf-hunt/references/fix-playbook.md
@@ -1,0 +1,129 @@
+# Fix playbook
+
+A catalog keyed by `FindingCategory` (from `scripts/lib/types.ts`). For each: a root-cause checklist and the **architectural** fix that fits this codebase. Two rules override everything below, from `CLAUDE.md`:
+
+1. **Architectural fixes, not band-aids.** No shortcuts, hacky workarounds, or defensive `try/catch` around a symptom. Fix the cause at the right layer.
+2. **Every fix must include a before/after number** from re-running the probe (`beforeAfter` on the `Finding`). A fix with no moved metric is not a fix.
+
+Prefer optimistic code over defensive code; let errors surface. Follow the React and route-splitting rules verbatim.
+
+---
+
+## `web-vital` (LCP / INP / CLS / FCP / TTFB)
+
+**Root-cause checklist:**
+- LCP: is the largest element a late-loading image, a web font swap, or a component that mounts after data? Check the attributed selector.
+- CLS: which node shifts (attribution selector)? Missing width/height, late-injected banner, font swap reflow?
+- INP: which element (attribution)? Is the handler doing sync work on the main thread?
+- FCP/TTFB slow only on the dev server → likely measurement artifact, verify against a prod-like build.
+
+**Fixes:**
+- LCP image → set explicit dimensions, preload the hero, avoid gating it behind a data fetch; move it off a lazy chunk if it's on the landing path.
+- CLS → reserve space (aspect-ratio / fixed dimensions); avoid inserting content above existing content after paint.
+- INP → move the expensive handler work off the critical path (see `long-task` below); keep the handler to a state update and defer the rest.
+- Chat/landing must feel instant — keep `ChatLayout`/`ChatDetailPage` static in the entry bundle (`CLAUDE.md` route rules); don't regress them to lazy.
+
+---
+
+## `unnecessary-render`
+
+Fully covered in **`react-rerender-playbook.md`** — unstable props → `useMemo`/`useCallback`/hoist; context churn → split/memoize; derived state in effect → compute during render; cascades → `React.memo` on leaf or move state down; lists → stable keys + virtualization. Prove with `commits` before/after.
+
+---
+
+## `long-task` (LoAF ≥200ms / longtask ≥120ms)
+
+**Root-cause checklist:**
+- Read the LoAF `sourceURL:sourceCharPosition sourceFunctionName` — that's the offending function.
+- One big synchronous chunk, or many small ones coalesced into one frame?
+- Is it startup work that could run after first paint?
+
+**Fixes:**
+- **Break up the work** — chunk large loops, yield between batches.
+- **Defer non-critical work post-paint** — schedule with `requestIdleCallback` / a scheduler yield, or the app's existing post-paint deferral pattern (e.g. `loadMotionFeatures`-style lazy init after mount) instead of doing it during the init path.
+- **Move pure CPU work to a Web Worker** when it's genuinely heavy (parsing, crypto, diffing) and doesn't need the DOM.
+- Don't wrap in `setTimeout(0)` and call it done — that hides the work without reducing it. Confirm the LoAF is gone, not just relocated.
+
+---
+
+## `layout-thrash` (forced style/layout ≥30ms in a frame)
+
+**Root-cause checklist:**
+- Find the read-after-write loop: reading `offsetWidth`, `getBoundingClientRect`, `scrollHeight`, `getComputedStyle` in the same frame you mutate styles/DOM.
+- Often inside a loop over elements, or a resize/scroll handler.
+
+**Fixes:**
+- **Batch reads then writes** — read all layout values first, then apply all mutations (avoid interleaving).
+- Cache measurements; don't re-read layout inside a loop.
+- Use `ResizeObserver`/`IntersectionObserver` instead of polling layout in a handler.
+- For animation, prefer `transform`/`opacity` (compositor-only) over properties that force reflow.
+- Verify via the LoAF `forcedStyleAndLayoutDuration` dropping below `FORCED_LAYOUT_MS` (Chromium-only signal — see `metrics-and-thresholds.md`).
+
+---
+
+## `memory-leak` (heap Δ ≥3MB or detached nodes >0)
+
+**Root-cause checklist:**
+- An effect subscription/listener/timer with no cleanup.
+- A closure or module-level collection retaining unmounted component state.
+- Detached DOM nodes held by a ref, cache, or event handler.
+
+**Fixes:**
+- Return a cleanup from every `useEffect` that subscribes/listens/timers (this is a *legitimate* effect use per `CLAUDE.md`): `removeEventListener`, unsubscribe SDK/WebSocket, `clearInterval`.
+- Release references on unmount; don't cache DOM nodes across mount cycles.
+- Confidence starts `low` — the fix is proven only by repeating the mount/unmount cycle N times after a forced GC and showing the heap no longer grows monotonically and detached nodes return to 0.
+
+---
+
+## `bundle` (JS chunk ≥400KB)
+
+**Root-cause checklist:**
+- Is the heavy module in the **entry chunk**? Run `bun scripts/analyze-bundle.ts` and inspect `suspectEntryModules`.
+- Is it on the chat/landing critical path, or a secondary/settings route?
+
+**Fixes (follow `CLAUDE.md` route code-splitting rules exactly):**
+- **Route-level `React.lazy(() => import(...))`** for anything not on the chat/landing critical path — all settings/admin pages, secondary features (`TasksPage`, `AutomationsPage`), `WaitlistPage`, SSO flows. Pair with a content-area `<Suspense fallback>` around the relevant `<Outlet />` so nav stays mounted.
+- **Keep static** in the entry bundle: `ChatLayout`, `ChatDetailPage`, layouts (`SettingsLayout`, `WaitlistLayout`), and small auth/error pages — lazy-loading these creates a waterfall or costs more in per-chunk overhead than they save.
+- **Defer heavy non-route deps post-paint** (e.g. `loadMotionFeatures`) rather than importing them at module-eval time in the entry path.
+- Don't ship a big dep to shrink another — check if a lighter library or a subpath import removes the weight.
+
+---
+
+## `network`
+
+**Root-cause checklist:** render-blocking request on the critical chain? Oversized/uncompressed asset? Waterfall (request depends on a prior response)?
+
+**Fixes:** preload/parallelize critical requests; compress/resize assets; use the app's `HttpClient` (`src/lib/http.ts`), never bare `fetch`; avoid sequential fetch chains where a batch or parallel fetch works.
+
+---
+
+## `console-error`
+
+**Root-cause checklist:** is it our code or a third party? Dev-only warning or a real runtime error? (Dev-only warnings and third-party/analytics noise are **auto-refuted** — see `verification-rubric.md`.)
+
+**Fix:** address the actual error at its source. Do not silence with a `try/catch` that swallows it (`CLAUDE.md`: no error-swallowing). Handle errors architecturally at a boundary if appropriate.
+
+---
+
+## `crash` (uncaught page error)
+
+**Root-cause checklist:** read the stack in `pageErrors`; reproduce deterministically; confirm it's not Tauri-shell noise (the harness already filters known Tauri noise). Severity `critical` by default.
+
+**Fix:** fix the throwing code path. Add an error boundary only where the architecture calls for graceful degradation — not as a blanket suppressor.
+
+---
+
+## `a11y` (axe critical/serious)
+
+**Root-cause checklist:** read the `ruleId`, `impact`, and `selectors` from the `A11yViolation`.
+
+**Fixes, per rule family:**
+- `color-contrast` → adjust token/class to meet ratio (use the responsive Tailwind classes, not `var()` — `CLAUDE.md`).
+- `button-name` / `link-name` / `image-alt` → add accessible name (`aria-label`, text, `alt`).
+- `label` / `aria-*` → associate labels with controls; fix invalid ARIA.
+- `list` / `heading-order` / landmarks → correct semantic structure.
+- Fix the element at the attributed selector; re-run the scenario and confirm the violation is gone.
+
+---
+
+Once a fix lands and the metric moved, set the finding's `status` to `fixed` with `beforeAfter`. Cluster related findings under one `clusterId` for a single PR. Verification protocol and exclusions: `verification-rubric.md`.

--- a/.claude/skills/thunder-perf-hunt/references/gecko-profiler.md
+++ b/.claude/skills/thunder-perf-hunt/references/gecko-profiler.md
@@ -1,0 +1,108 @@
+# Firefox deep analysis — Gecko profiler over the firefox-devtools MCP
+
+The harness treats both browsers with equal depth. But the fine-grained
+attribution probes — Long Animation Frames (LoAF) and heap deltas — are built on
+Chromium/CDP APIs (`scripts/lib/collect.ts` only collects `heap` when
+`browserName === 'chromium'`, and LoAF via the `PerformanceObserver` LoAF entry
+type is Chromium-only). So when jank is **Firefox-specific**, Playwright's
+Firefox driver can *measure* it (vitals, long tasks, renders) but can't
+*attribute* it to a function.
+
+For that attribution, use the **Gecko profiler** through the connected
+`firefox-devtools` MCP server. This path drives real system Firefox (v153 beta,
+`/usr/local/bin/firefox`) over Marionette.
+
+**Use this path when:** a finding reproduces on Firefox but not Chromium, or for
+a Firefox-only regression, and you need to name the function responsible.
+
+## MCP server facts
+
+- Package `@mozilla/firefox-devtools-mcp`, launched with `--connectExisting`
+  (**Firefox must already be running** with Marionette) and `--enableScript`.
+- It attaches over Marionette on **port 2828** — that port must be free before
+  you launch Firefox.
+- Profiler tools: `mcp__firefox-devtools__profiler_start`,
+  `mcp__firefox-devtools__profiler_stop`,
+  `mcp__firefox-devtools__profiler_is_active`.
+- Driving tools: `mcp__firefox-devtools__navigate_page`,
+  `mcp__firefox-devtools__evaluate_script`,
+  `mcp__firefox-devtools__click_by_uid`,
+  `mcp__firefox-devtools__take_snapshot`,
+  `mcp__firefox-devtools__list_network_requests`,
+  `mcp__firefox-devtools__list_console_messages`,
+  `mcp__firefox-devtools__screenshot_page`.
+
+## Step-by-step
+
+### (a) Launch system Firefox with Marionette, headless
+
+Point it at the already-serving perf stack (`http://localhost:1431`). Use a
+throwaway profile dir so nothing leaks between runs, and confirm port 2828 is
+free first.
+
+```bash
+# fail fast if Marionette's port is taken
+lsof -i :2828 && echo "port 2828 busy — kill the stale Firefox first" && exit 1
+
+TMP_PROFILE="$(mktemp -d)"
+/usr/local/bin/firefox --marionette --headless -profile "$TMP_PROFILE" http://localhost:1431 &
+```
+
+Leave this running for the whole session; the MCP connects to it, it does not
+spawn it.
+
+### (b) Let the MCP attach
+
+The `firefox-devtools` server is already configured with `--connectExisting`,
+so it connects to the Firefox you just launched. Confirm the attach with a
+cheap call, e.g. `mcp__firefox-devtools__list_pages`.
+
+### (c) Navigate to the scenario URL
+
+```
+mcp__firefox-devtools__navigate_page  →  http://localhost:1431<scenario.path>
+```
+
+Use the same `path` the scenario uses (see `scripts/lib/scenarios.ts`), e.g.
+`/chats/new` for `chat-landing`.
+
+### (d) Profile the exact interaction
+
+1. `mcp__firefox-devtools__profiler_start` — use a preset suited to web/JS
+   work (a **Web/JavaScript** preset: JS stacks + markers, ~1ms sampling),
+   not the Media/Graphics preset.
+2. Reproduce the jank. Either replay the scenario's `interact` steps via
+   `mcp__firefox-devtools__evaluate_script`, or drive the concrete control with
+   `mcp__firefox-devtools__click_by_uid` (get the uid from
+   `mcp__firefox-devtools__take_snapshot` first). Keep the interaction short and
+   identical to the reproducing scenario.
+3. `mcp__firefox-devtools__profiler_stop` — returns the captured profile.
+
+Guard with `mcp__firefox-devtools__profiler_is_active` if you're unsure whether
+a prior capture is still running.
+
+### (e) Interpret the sampled stacks and attribute the jank
+
+- Find the **hottest stacks** during the interaction window — the leaf frames
+  that accumulate the most samples are where wall-clock went.
+- Read **markers** on the main thread: `Styles`, `Reflow`/`Layout`, `Paint`,
+  and long `Runnable`/`JS` markers pinpoint style recalculation and layout
+  (the Firefox equivalent of Chromium's `forcedStyleAndLayoutDuration`
+  layout-thrash signal).
+- Attribute the cost to a **function** via the leaf/self-time frame and its
+  source URL. That function + file is the `sourceAttribution` for the finding.
+- **Cross-check against Chromium LoAF.** Pull the same scenario's Chromium
+  `loaf[].scripts[]` entry from the sweep report (`sourceURL`,
+  `sourceFunctionName`, `sourceCharPosition`). If the Gecko hot frame names the
+  same function, it's a shared bug — fix once, verify in both. If Chromium is
+  clean and only Gecko is hot, it's a genuine Firefox-only regression; record it
+  with `browsers: ['firefox']` and note the engine difference in the rationale.
+
+## Output
+
+Distill the profile down to a `Finding` (see [finding-schema.md](finding-schema.md)):
+category `long-task` or `layout-thrash`, `browsers: ['firefox']`, `evidence`
+with the ms and hot-frame self-time, and `sourceAttribution` = `file:line
+function`. **Do not** attach the raw profile — the agentic layer reads only the
+compact finding, consistent with the rest of the harness
+([harness-tuning.md](harness-tuning.md)).

--- a/.claude/skills/thunder-perf-hunt/references/harness-tuning.md
+++ b/.claude/skills/thunder-perf-hunt/references/harness-tuning.md
@@ -1,0 +1,92 @@
+# Harness tuning — making the skill itself cheap
+
+> **Research finding: harness quality dominates agent effectiveness.** A good
+> harness makes iteration cheap — the agent spends its budget reasoning about
+> *findings*, not wrangling tools or re-reading traces. Every knob below exists
+> to keep the harness's own wall-clock and token cost low without losing recall.
+
+This doc is about the cost of *running the skill*, not the cost of the app under
+test. Tune these before reaching for more scenarios or more browsers.
+
+## (a) Do less work per run
+
+**Diff-aware selection (`--mode diff`).** On a branch or in CI, default to diff
+mode. `scenariosForChangedFiles` (`scripts/lib/scenarios.ts`) maps changed
+files → only the scenarios that exercise them via coverage `tags`, falling back
+to the full sweep only when the blast radius is unknown. A one-file change to
+`src/models/*` runs the `models` scenario, not all seven.
+
+```bash
+bun scripts/run.ts --mode diff --changed "$(git diff --name-only main... | paste -sd,)"
+```
+
+**Warm-stack reuse.** `bootStack` (`scripts/lib/boot.ts`) checks whether the
+backend health endpoint and frontend are already serving on `:8010`/`:1431`; if
+so it reuses them and its `teardown` is a no-op. Keep a stack warm across a
+verify-fix loop instead of paying the ~cold-boot cost (backend + Vite) every
+iteration.
+
+## (b) Deterministic layer keeps context small
+
+The scripts are the *deterministic layer*: they boot, drive, measure, threshold,
+and write compact JSON. **The agent reads only `findings.json` / `summary.md`
+— never raw traces, never probe stdout beyond the one printed report path**
+(`run.ts` prints exactly the report path to stdout by design). Every probe
+reduces its raw signal (LoAF scripts, axe violations, heap deltas, sampled
+stacks) to the compact structures in `scripts/lib/types.ts` before the agent
+sees anything. This is the single biggest token lever — protect it. If you find
+yourself piping a trace into the model, add a threshold to `report.ts` instead.
+
+## (c) Sub-agent orchestration
+
+- **Parallelize verification.** Fan candidate findings out to verifier
+  sub-agents (one per finding or per cluster) that each re-run the focused
+  scenario and return a **structured `VerdictReport`, not prose** (see
+  [finding-schema.md](finding-schema.md)). Structured returns keep the parent's
+  context flat and let it merge verdicts deterministically.
+- **Isolate the heavy tools.** A sub-agent that drives the Gecko profiler
+  ([gecko-profiler.md](gecko-profiler.md)) or the explorer
+  ([state-exploration.md](state-exploration.md)) keeps that tool's chatter out
+  of the orchestrator's context; only the verdict returns.
+
+## (d) Hard caps (non-negotiable)
+
+| Cap | Limit | Why |
+| --- | --- | --- |
+| Verify-fix loop | **3–5 iterations**, then escalate to a human | Prevents infinite "fix → still fails → fix" spins. |
+| Scenarios per run | the 7 in `SCENARIOS` (fewer in diff mode) | Bounds the sweep. |
+| Explored states | **~60** (`--steps` to raise) | Bounds the crawl. |
+| Findings promoted per category | capped in `report.ts` (e.g. long tasks `.slice(0,3)`, a11y `.slice(0,8)`, network `.slice(0,3)`) | Stops one noisy page from flooding triage. |
+
+If a fix hasn't landed the metric after the loop cap, stop and hand the finding
+back with its evidence — don't keep burning iterations.
+
+## (e) Cost knobs
+
+Turn these down for a quick run, up for a thorough nightly:
+
+- **Browsers** — `--browsers chromium` halves the sweep. Reserve
+  `chromium,firefox` for the full sweep or when a finding needs cross-engine
+  confirmation.
+- **Mode** — `focus` (one named scenario) < `diff` (changed-file scenarios) <
+  `sweep` (all). Use `--mode focus --focus <name>` when re-checking a single
+  fix.
+- **Skip the expensive probes for quick runs** — skip the heap delta
+  (Chromium-only re-navigation, the slowest probe) and skip the explorer crawl.
+  Reserve both for full sweeps.
+
+## (f) Measure the harness itself
+
+Treat the harness like any system under test. After each run, record:
+
+- **Wall-clock** — total and per-phase (boot vs. drive vs. verify).
+- **Tokens** — orchestrator + sub-agents.
+- **Findings count** and **false-positive rate** — refuted / total from the
+  `VerdictReport`s.
+
+Then tune the `report.ts` thresholds (`LONG_TASK_MS`, `LOAF_MS`,
+`FORCED_LAYOUT_MS`, `HEAP_LEAK_BYTES`, `NOISE_RENDER_MIN_COMMITS`,
+`BIG_JS_BYTES`): a high false-positive rate means a threshold is too loose
+(raise it); missed regressions mean it's too tight (lower it). The thresholds
+are deliberately recall-biased — the Verify phase pays for precision, so keep
+tightening only until false positives, not real bugs, drop out.

--- a/.claude/skills/thunder-perf-hunt/references/metrics-and-thresholds.md
+++ b/.claude/skills/thunder-perf-hunt/references/metrics-and-thresholds.md
@@ -1,0 +1,79 @@
+# Metrics & thresholds
+
+Every number the harness can raise a finding on, what it means, how it is captured, and where source attribution comes from. Thresholds are defined once in `scripts/report.ts` (constants at the top) and `scripts/lib/inject.ts` (`rate()` in `READ_SNAPSHOT`). Do not hardcode different numbers elsewhere — read them from there.
+
+All metrics are captured with **native `PerformanceObserver`s installed inline via `page.addInitScript`** (`INIT_SCRIPT` in `scripts/lib/inject.ts`). The script runs at document start, before any app code, and each observer uses `buffered: true` so entries that fire during first paint are not missed. No cross-origin script is loaded — the app ships `COEP: credentialless`, which would block a CDN `<script>`, so everything is inlined into `window.__PERF_HUNT__`.
+
+## Core Web Vitals
+
+`READ_SNAPSHOT` rates each vital `good` / `needs-improvement` / `poor` against these cutoffs. `report.ts` skips anything rated `good`; `needs-improvement` → severity `medium`, `poor` → severity `high`. Confidence is `high` (deterministic measurement).
+
+| Metric | good ≤ | needs-improvement ≤ | poor > | Unit | Observer `type` |
+| --- | --- | --- | --- | --- | --- |
+| LCP — Largest Contentful Paint | 2500 | 4000 | 4000 | ms | `largest-contentful-paint` |
+| INP — Interaction to Next Paint | 200 | 500 | 500 | ms | `event` (proxy, see caveat) |
+| CLS — Cumulative Layout Shift | 0.1 | 0.25 | 0.25 | unitless | `layout-shift` |
+| FCP — First Contentful Paint | 1800 | 3000 | 3000 | ms | `paint` |
+| TTFB — Time To First Byte | 800 | 1800 | 1800 | ms | `navigation` |
+
+What each means and how attribution works:
+
+- **LCP** — time until the largest above-the-fold element paints. Captured as `entry.startTime`; attribution is the element's CSS selector via `cssPath(entry.element)`, falling back to `entry.url` for image LCP. Fix targets the attributed element (oversized image, late-mounting hero, blocking font).
+- **INP** — worst interaction latency. The harness observes `event` entries with `interactionId` and `durationThreshold: 40`, keeping the max `duration`; attribution is `cssPath(entry.target)` — the element the user interacted with. This is an approximation of the real web-vitals INP algorithm (which buckets by interaction), good enough for finding the slow interaction, not for reporting a field-accurate score.
+- **CLS** — summed layout-shift `value` excluding `hadRecentInput` shifts; attribution is the CSS selector of the first shifting node's source. Fix targets reserved space / dimensions for that node.
+- **FCP** — first text/image paint (`first-contentful-paint` paint entry). No element attribution.
+- **TTFB** — `navigation.responseStart`. For this app served from a local dev server, TTFB is mostly meaningless; treat a `poor` TTFB on `localhost` as noise unless reproduced against a production-like build.
+
+## Long tasks — `duration ≥ 120ms` (`LONG_TASK_MS`)
+
+Captured via the `longtask` observer. Each sample records `duration`, `startTime`, and an `attribution` container name (e.g. `"self"`, `"same-origin"`) from `entry.attribution[0].name`. `report.ts` raises the **top 3** long tasks per scenario; `duration ≥ 300ms` → `high`, else `medium`; confidence `medium` (longtask attribution is coarse — it does not name a function). Cross-reference LoAF for a precise source location on the same frame.
+
+## Long Animation Frames (LoAF) — `duration ≥ 200ms` (`LOAF_MS`)
+
+Captured via the `long-animation-frame` observer. Richer than `longtask`: each LoAF exposes `duration`, `blockingDuration`, and a `scripts[]` array with **per-script source attribution**:
+
+- `sourceURL`, `sourceFunctionName`, `sourceCharPosition` — the exact file, function, and character offset of the script that ran. `report.ts` picks the longest-running script and emits `sourceURL:sourceCharPosition sourceFunctionName` as `sourceAttribution`. This is the single best signal for pinning a long task to code.
+- `invoker` — what triggered the script (event listener, timer, etc.).
+
+A LoAF ≥ 200ms → category `long-task`; `duration ≥ 400ms` → `high`, else `medium`; confidence `high`.
+
+## Layout thrash — `forcedStyleAndLayoutDuration ≥ 30ms` (`FORCED_LAYOUT_MS`)
+
+Derived from the same LoAF entries: `INIT_SCRIPT` sums each script's `forcedStyleAndLayoutDuration` per frame. When that sum ≥ 30ms, the finding is re-categorized `layout-thrash` (not `long-task`) — this is the fingerprint of a forced synchronous reflow (read layout → write style → read layout in a loop). Note a LoAF can trip the thrash threshold even when its total `duration` is under 200ms. Fix per `fix-playbook.md` (batch reads/writes; avoid reading `offsetWidth`/`getBoundingClientRect` mid-write).
+
+## Memory leak — `deltaBytes ≥ 3MB` (`HEAP_LEAK_BYTES`) **or** `detachedNodesDelta > 0`
+
+`HeapDelta` samples compare heap `before`/`after` a repeated interaction boundary (mount/unmount cycles, opening/closing a panel). Either a ≥3MB retained delta or **any** detached DOM nodes raises a finding: severity `high`, confidence **`low`** — heap deltas are noisy, so this always needs verification (force GC, repeat the cycle N times, confirm monotonic growth). Detached-node counts come from CDP and are **Chromium-only**.
+
+## Large JS chunk — `transferSizeBytes ≥ 400KB` (`BIG_JS_BYTES`)
+
+From the network capture: any response with `resourceType === 'script'` and transfer size ≥ 400KB raises a `bundle` finding (top 3 per scenario), severity `medium`, confidence `high`. `renderBlocking` is recorded so you can tell an entry-chunk bloat problem from a lazy chunk. Fix per the route code-splitting rules in `fix-playbook.md`. For entry-vs-lazy attribution, run `bun scripts/analyze-bundle.ts` (produces the `BundleReport`).
+
+## App-owned startup marks
+
+The harness also captures the app's own `performance` marks from `src/lib/init-timing.ts` into `initTiming[]` (`InitTimingMark`: `name`, `startTime`). The useful ones:
+
+- **`markAppMounted`** — first render of the root `App` component (offset from navigation start).
+- **`app_chat_ready`** — first usable chat render (one-shot per session).
+
+Use these to attribute a slow LCP/FCP to a specific startup phase — e.g. if `app_chat_ready` lands well after LCP, the paint is a skeleton and the real "ready" cost is later.
+
+## Browser support caveats — read before trusting an empty array
+
+The observers above are not uniformly supported. **An empty array is not the same as "no problem" — on Firefox it usually means "not measurable here."**
+
+| Signal | Chromium | Firefox (Gecko) |
+| --- | --- | --- |
+| LCP, CLS, FCP, TTFB | ✅ | ⚠️ partial / may be absent |
+| **LoAF** (`long-animation-frame`) | ✅ | ❌ **not supported — `loaf` is always empty** |
+| **INP proxy** (`event` timing) | ✅ | ❌ **not supported — `inp` never populates** |
+| `longtask` | ✅ | ❌ generally absent |
+| Detached nodes / heap via CDP | ✅ | ❌ |
+
+Consequences:
+
+- **LoAF and the INP `event` proxy are Chromium-only.** On Firefox those arrays are empty; do **not** conclude "no long tasks on Firefox." Instead drive the same scenario under the **Gecko profiler** (`mcp__firefox-devtools__profiler_start` / `profiler_stop`) and read the captured samples — see `gecko-profiler.md`.
+- Layout-thrash detection depends on LoAF, so it is **Chromium-only** too. A layout-thrash finding that only reproduces in Chromium is still real (same code runs in both) — verify it in Chromium, not by demanding a Firefox repro.
+- A finding present in Chromium but "absent" in Firefox where the metric is unsupported is **not** a cross-browser discrepancy. `report.ts` merges the same issue across browsers by source attribution; don't down-rank a Chromium finding just because Firefox couldn't measure it.
+
+See `react-rerender-playbook.md` for the render counter, `fix-playbook.md` for what to do per category, and `verification-rubric.md` for the precision gate that decides which candidates become confirmed.

--- a/.claude/skills/thunder-perf-hunt/references/react-rerender-playbook.md
+++ b/.claude/skills/thunder-perf-hunt/references/react-rerender-playbook.md
@@ -1,0 +1,69 @@
+# React re-render playbook
+
+How the harness counts renders, how to read the numbers without being misled, and how to fix an unnecessary-render finding in a way that fits this codebase's rules (`CLAUDE.md`). Every fix here ends the same way: **re-run the focus scenario and show `commits` dropped.**
+
+## How the render counter works
+
+`INIT_SCRIPT` (in `scripts/lib/inject.ts`) plants a **minimal `__REACT_DEVTOOLS_GLOBAL_HOOK__` shim before React loads**. React detects the hook and calls `onCommitFiberRoot` after every commit. The shim walks the committed fiber tree from `root.current`:
+
+- For each fiber with a numeric `actualDuration > 0` (i.e. it did render work this commit), it reads the component name (`displayName` / `name`, unwrapping `memo`/`forwardRef` via `type.render`). Host elements (`div`, `span`) are skipped.
+- It tallies per component into `RenderStat`: `commits` (count), `totalDuration` (summed `actualDuration`), `maxDuration`.
+
+Results are exposed via `READ_SNAPSHOT` sorted by `commits` desc. `store.commits` is the total commit count across the whole app.
+
+### Load-bearing caveat: `actualDuration` is subtree-inclusive
+
+**A parent fiber's `actualDuration` includes the time of every child it re-rendered.** So a high `totalDuration` on a top-level component (e.g. `<App>`, a layout, a provider) often just means "a lot rendered underneath it," not "this component is expensive." Do **not** rank findings by duration.
+
+**Use `commits` as the primary signal** — "how often does this component re-render." A leaf that commits 12 times during a no-op is a real problem; a root that commits twice with a large `totalDuration` is usually fine. Duration is a secondary tiebreaker for two components with similar commit counts.
+
+## The noise-render probe
+
+This is the harness's cheap unnecessary-render detector, feeding `noiseRenders` in each `ScenarioReport`.
+
+1. Warm the route (Vite compiles on first hit — an unwarmed route pollutes the measurement).
+2. `RESET_RENDERS` — zero all counters (`__resetRenders()`).
+3. Perform an interaction **unrelated to any component's data**: a mouse move over empty chrome, an `Escape` keypress, or a `wheel` scroll on a non-scrolling region. Nothing about app state should legitimately change.
+4. Read the snapshot. Any component that committed **≥ 3 times** (`NOISE_RENDER_MIN_COMMITS`) during that no-op is a strong unnecessary-render candidate.
+
+`report.ts` raises those as `unnecessary-render` findings: `commits ≥ 8` → `high`, else `medium`; confidence `medium` (a real interaction could legitimately touch some components — hence the verification gate). The idea: if a no-op interaction causes a component to re-render 3+ times, something is subscribing it to churn it has no business reacting to.
+
+## The precise oracle: react-scan
+
+The noise probe finds suspects cheaply; **react-scan confirms and pinpoints them.** Run it as a complementary check:
+
+```bash
+bunx react-scan@latest <url>
+```
+
+It instruments renders and reports exactly which components re-rendered, why (which prop/state/context changed), and how often — the "why" the noise probe can't give you. Use it to attribute a candidate to a specific unstable prop or context before writing a fix.
+
+## Fix catalog (each mapped to a `CLAUDE.md` rule)
+
+Pick the fix by **cause**, not by symptom. Confirm the cause with react-scan first.
+
+| Cause | Fix | Rule |
+| --- | --- | --- |
+| **Unstable object / array / function prop** — a new `{}`, `[]`, or inline `() => …` created every parent render | Wrap in `useMemo` / `useCallback`, or hoist the constant out of the component entirely | Prefer stable references; avoid re-creating on every render |
+| **Context value churns** — provider passes a fresh object each render, re-rendering every consumer | Memoize the value (`useMemo`), or split one context into stable + volatile halves so consumers subscribe only to what they use | Abstract state into hooks; don't over-subscribe |
+| **Derived state recomputed in a `useEffect`** that setStates → extra commit | Compute during render (`const x = derive(props)` or `useMemo`) — delete the effect | useEffect discipline: never derive state in an effect |
+| **Prop synced into state via effect** | Use the prop directly, or a ref to detect changes during render | useEffect discipline: never sync props into state |
+| **Parent re-render cascades into stable leaves** | `React.memo` the leaf (with stable props — see row 1), or move the churning state down so it doesn't sit above the leaves | useReducer / state-down; keep state at the lowest useful level |
+| **List re-renders whole list on any change** | Stable `key`s (never array index for reorderable lists) + virtualization for long lists; memoize row components | One component per file; keep renders cheap |
+| **Reset-on-prop via effect** | Use a `key` prop to remount, or a `useState` lazy initializer | useEffect discipline: reset via `key` |
+
+### Anti-patterns to avoid in the fix
+
+- Do **not** wrap everything in `useMemo`/`useCallback` reflexively — memoization has a cost and obscures intent. Memoize only the reference that react-scan proved is churning. (`CLAUDE.md`: tasteful simplicity, no premature optimization.)
+- Do **not** add a `useEffect` to "fix" a render loop — that usually adds a commit. The render-time / event-handler / `key` alternatives above are the architectural fix.
+- Do **not** suppress the symptom with `React.memo` on a component whose props are still unstable — memo with unstable props re-renders anyway. Fix the prop first.
+
+## Proving the fix
+
+A render finding is only `fixed` when the number moved. After the change:
+
+1. Re-run the exact focus scenario: `bun scripts/run.ts --mode focus --focus <scenario> --browsers <browser>`.
+2. Read `noiseRenders` (and/or re-run react-scan) for the target component.
+3. Record `beforeAfter` on the `Finding`: `{ metric: 'commits', before, after, unit: 'commits' }`. The component should now commit below `NOISE_RENDER_MIN_COMMITS` during the no-op.
+
+If commits didn't drop, the cause was misdiagnosed — go back to react-scan. See `verification-rubric.md` for what the separate verifier requires, and note the exclusions there: **re-renders during active AI streaming and StrictMode double-renders in dev are expected and auto-refuted** — don't chase them.

--- a/.claude/skills/thunder-perf-hunt/references/self-improve.md
+++ b/.claude/skills/thunder-perf-hunt/references/self-improve.md
@@ -1,0 +1,60 @@
+# Self-improvement (the REFLECT phase)
+
+After every run, the harness spends a little effort making itself measurably better — but **only in ways that add signal, never complexity**. Harness quality dominates agent effectiveness, so a cheap, well-calibrated harness compounds; a bloated one rots. This doc is the contract for that.
+
+> Guiding rule: **prefer deleting or tuning over adding.** If an "improvement" needs a new dependency, a new abstraction, or a new file, it is a *proposal*, not an auto-change.
+
+## When it runs
+
+REFLECT is step 8 of the workflow — after REPORT, using signals from the run just completed and the log in `../LEARNINGS.md`.
+
+## Signals to read (evidence, not vibes)
+
+| Signal | Where it shows up | What it usually means |
+| --- | --- | --- |
+| Probe errored / returned empty when it shouldn't | probe stderr, empty arrays in `report.json` | a harness bug (bad selector, wrong wait, gated metric) |
+| Scenario failed to load / timed out | `pageErrors`, missing metrics for a scenario | stale selector or a route that moved |
+| Verifier refuted a finding as a false positive | `VerdictReport.isReal=false` with a repeatable reason | a threshold or exclusion needs tuning |
+| Crawler reached a route not in the manifest | `explore/state-graph.json` vs `scenarios.ts` | a coverage gap |
+| Finding had no source attribution | `sourceAttribution` empty on a confirmed finding | attribution logic gap |
+| Run slow / expensive | wall-clock, token count | a cost knob to pull (see harness-tuning.md) |
+
+## What may be applied automatically (SAFE-AUTO)
+
+Cap: **at most 3 auto-applied changes per run.** Each must cite the run evidence.
+
+1. **Suppress a confirmed false positive** — append an `excludeSignatures` entry to `../calibration.json` (with a `reason`). Only after a verifier confirmed it's benign/expected.
+2. **Add a discovered route** — append an `extraScenarios` entry to `../calibration.json` (name/path/description/tags). It gets a default load+settle probe.
+3. **Fix a broken probe** — a targeted code fix when a probe errored or returned empty due to a bug (e.g. a selector/wait/flag). This is a normal bug fix, not a feature.
+4. **Tune one numeric threshold** in `report.ts` by at most one sensible step — only when the SAME false-positive or miss pattern appears in **≥2 runs** (check `../LEARNINGS.md`).
+
+## What must only be proposed (PROPOSE-ONLY — log, do not apply)
+
+- Any new probe type, dependency, abstraction, or net-new file.
+- Threshold changes beyond one step, or without ≥2-run evidence.
+- Anything that increases run cost or scenario count materially.
+- New scenario *interactions* that need real code (JSON can't hold functions) — propose a `BASE_SCENARIOS` edit for human review.
+
+Write proposals to `../LEARNINGS.md` under "Proposed". If the same proposal recurs across two runs, escalate it to the user instead of letting it accumulate.
+
+## Guardrails (non-negotiable)
+
+- **Green-or-revert:** after any self-edit, `bunx tsc -p scripts/tsconfig.json` must pass AND one `focus` smoke run must succeed. If not, revert the edit.
+- **Separate PR:** harness self-improvements go in their own branch/PR titled `perf-hunt: self-improve (<date>)`. Never mix them with app-fix PRs.
+- **Always log:** append a dated entry to `../LEARNINGS.md` every run — what changed, what was proposed, and why — even if nothing changed ("no improvements warranted" is a valid entry).
+- **Complexity budget:** the harness should trend toward *fewer* moving parts. If a run's proposals only add surface area, apply none and note it.
+
+## calibration.json schema
+
+```jsonc
+{
+  "excludeSignatures": [
+    { "category": "console-error", "match": "ResizeObserver loop limit", "reason": "benign browser warning, not our code" }
+  ],
+  "extraScenarios": [
+    { "name": "skills", "path": "/skills", "description": "Skills admin page (crawler-discovered)", "tags": ["settings", "lazy"] }
+  ]
+}
+```
+
+`match` is a case-insensitive substring tested against each finding's title + evidence + source. `category` is optional (omit to match any). Both arrays are read at run time by `report.ts` and `scenarios.ts`; a missing/invalid file falls back to built-in defaults.

--- a/.claude/skills/thunder-perf-hunt/references/state-exploration.md
+++ b/.claude/skills/thunder-perf-hunt/references/state-exploration.md
@@ -1,0 +1,89 @@
+# State exploration — curiosity-driven crawler
+
+`scripts/explore.ts` is the harness's functional bug-finder. Where the scenario
+sweep (`scripts/run.ts`) drives a fixed list of routes to measure performance,
+the explorer *wanders* the app to find things that are simply broken: uncaught
+errors, console errors, crashes, dead-ends, and unexpected navigations to
+`/not-found`.
+
+It runs against the same Docker-free anonymous stack as the sweep (frontend
+`:1431`, backend `:8010` — see `scripts/lib/env.ts`) and reuses a warm stack if
+one is already serving.
+
+## Live state graph, not random clicking
+
+Monkey-testing fires random inputs at random coordinates. The explorer instead
+builds a **live state graph** and picks its next move from what it can actually
+see:
+
+- **State key** = current URL + a signature of the visible interactive elements
+  (roles + accessible names of buttons, links, inputs, tabs, menu items). Two
+  screens that expose the same affordances collapse to the same node, so the
+  crawler doesn't re-explore cosmetically-different-but-equivalent states.
+- **Edges** = actions taken (click this button, fill this field, open this menu)
+  and the state they led to.
+- **Frontier** = the set of interactive elements in the current state that the
+  crawler has *not* yet exercised. Each step it picks an unvisited action,
+  performs it, snapshots the resulting state, and adds a new node/edge.
+
+Because every action is informed by observed state, the crawl is *directed*:
+it prefers unexplored affordances, backtracks out of dead-ends, and stops
+revisiting equivalent screens. This finds real reachable bugs far faster than
+random input, and every bug comes with the exact path that produced it.
+
+## What counts as a functional bug
+
+Each step evaluates the resulting state and emits a `Finding` (see
+[finding-schema.md](finding-schema.md)) when it observes any of:
+
+- **Uncaught page error** — `pageerror` fired (Tauri noise filtered as in
+  `scripts/lib/collect.ts`). Category `crash`, severity `critical`.
+- **Console error** — an `error`-level console message. Category
+  `console-error`.
+- **Crash / blank state** — the page has no visible `main`/`[role=main]` content
+  after the action settles, or the render tree threw.
+- **Dead-end** — an interactive element that leads nowhere (no state change, no
+  navigation, no network) where a transition was expected.
+- **Unexpected `/not-found`** — navigation landed on the not-found route from an
+  in-app affordance (a broken link/route).
+
+## Every finding carries a full repro
+
+A functional finding is only useful if a human or a verifier sub-agent can
+reproduce it. Each one records:
+
+- **Click path** — the ordered list of actions from the entry route to the
+  failing state (e.g. `/chats/new → click "Settings" → click "Devices" → click
+  "Revoke"`). This is the `repro` field.
+- **Evidence** — the error message, console text, or the "expected a transition,
+  got none" note, with numbers where relevant.
+- **Screenshot** — the per-state PNG captured at the moment of failure, written
+  under the run's `explore/` directory.
+
+## Visual diffing of per-state screenshots
+
+The explorer screenshots every distinct state. On a `--mode diff` run it
+compares each state's screenshot against the baseline (previous run or main)
+for the same state key. A pixel/region delta above threshold becomes a
+`Finding` even when the DOM assertions all pass — this catches UI regressions
+that are invisible to structural checks: clipped layouts, z-index/overlap
+regressions, missing icons, color/contrast shifts, off-screen content. Pair
+this with the axe pass (see [a11y-checks.md](a11y-checks.md)) for structural vs.
+visual coverage.
+
+## Cost bounds
+
+The crawl is capped at **~60 distinct states** by default so cost stays
+bounded — the state-collapsing key is what makes this cap meaningful (60
+*unique* screens, not 60 clicks). When the cap is hit the crawler stops and
+reports coverage.
+
+- Raise the budget with `--steps <n>` for a deeper crawl.
+- Scope the crawl with `--focus <route>` to explore a subtree.
+- Prefer running the explorer only on `--mode sweep` / nightly, not on every
+  quick diff run — see [harness-tuning.md](harness-tuning.md) for when to skip
+  it.
+
+The explorer, like every probe, writes only compact `Finding` JSON — never raw
+traces — so the agentic layer reads a small artifact. See
+[finding-schema.md](finding-schema.md) for the on-disk layout.

--- a/.claude/skills/thunder-perf-hunt/references/verification-rubric.md
+++ b/.claude/skills/thunder-perf-hunt/references/verification-rubric.md
@@ -1,0 +1,73 @@
+# Verification rubric
+
+The precision gate. `report.ts` thresholds are **recall-biased** — they deliberately over-emit candidates. This phase is what makes the harness trustworthy. It is modeled on Anthropic's security-review harness, where a separate adversarial verification pass cut false positives from ~33% to ~7%. The same discipline applies here.
+
+Output of this phase: a `VerdictReport` per candidate finding (shape below), flipping each `Finding.status` from `candidate` to `confirmed`, `refuted`, or `deferred`.
+
+## Hard rules
+
+1. **The verifier MUST be a separate agent from the finder.** Whoever produced or triaged the candidate does not also judge it. Combining find + dismiss causes self-censoring (the finder rationalizes its own noise, or defends its own weak signal). Spawn a fresh verifier agent per finding or per cluster.
+2. **Reproduce before believing.** The verifier must **re-run the exact probe/scenario/browser** from the finding's `repro` string and observe the metric again. A finding that cannot be reproduced on a warm route is `refuted`. No reproduction, no confirmation — never confirm from the candidate text alone.
+3. **Default to `refuted`.** Confirm only when the verifier can BOTH (a) reproduce the signal AND (b) attribute it to a specific source location (`file:line`, LoAF `sourceURL:sourceCharPosition`, or a CSS selector). Reproduced-but-unattributed → stays a candidate or is `deferred`, not `confirmed`.
+4. **2-of-3 vote for ambiguous perf findings.** For low-confidence or noisy categories (memory-leak, and any medium-confidence render/long-task finding), run the probe **three times** and require the signal in **at least two** runs. Perf metrics are noisy; a one-off spike is not a finding.
+
+## Auto-refuted exclusion categories (false positives by construction)
+
+These reproduce as signals but are **not** bugs in our code. The verifier marks them `refuted` (or `deferred` if real-but-out-of-scope) without further work:
+
+| Exclusion | Why it's not a finding |
+| --- | --- |
+| **StrictMode double-render in dev** | React intentionally double-invokes render/effects in dev StrictMode. Extra commits from this are expected — not an unnecessary-render bug. |
+| **Re-renders during active AI streaming** | Streaming a chat response legitimately commits many times as tokens arrive. High commit counts *during streaming* are expected; only judge renders during genuinely idle/no-op interactions (the noise probe). |
+| **Third-party / analytics long tasks** | Long tasks / LoAF attributed to PostHog and other third-party scripts are not our code to fix. Refute (or `deferred` with a note) — do not open a PR against vendor code. |
+| **Dev-only console warnings** | Warnings that only appear in the dev build (Vite HMR, React dev warnings that aren't real errors) are not shipped. `console-error` findings must be real runtime errors. |
+| **Cold dev-server first-compile metrics** | Vite transpiles a route on first hit, so the first navigation is artificially slow (long tasks, bad FCP/LCP, big "network" for uncached transforms). **Always warm the route once before measuring.** A metric seen only on the cold first hit is `refuted`. |
+| **`localhost` TTFB** | TTFB against the local dev server is meaningless; refute unless reproduced against a prod-like build. |
+
+If a candidate falls into one of these, cite the exclusion in the `rationale` and move on.
+
+## Severity ladder
+
+Set/correct severity based on **user-visible impact**, not raw magnitude. Use `correctedSeverity` when the deterministic pass over- or under-rated it.
+
+| Severity | Meaning | Example |
+| --- | --- | --- |
+| `critical` | Breaks the app or blocks core use | Uncaught error crashing chat; unusable interaction |
+| `high` | Clearly degrades UX on a common path | LCP `poor` on landing; LoAF ≥400ms during send; component commits ≥8x on a no-op; confirmed multi-MB leak |
+| `medium` | Noticeable but tolerable / off-path | INP `needs-improvement`; 3–7x noise renders; 400KB lazy chunk; serious a11y on a secondary page |
+| `low` | Minor / edge | Vital just over `good`; single small extra render |
+
+## Confidence ladder
+
+| Confidence | Meaning | Example |
+| --- | --- | --- |
+| `high` | Deterministic, attributed, reproduced every run | Web vital rating; LoAF with a clear `sourceURL`; axe violation with selector |
+| `medium` | Reproduces but attribution is coarse or interaction-dependent | `longtask` (container-only attribution); noise-render candidate before react-scan confirms the cause |
+| `low` | Noisy signal, needs the 2-of-3 vote | Heap delta; anything that varies run to run |
+
+Do not confirm a `low`-confidence finding without either raising it to `medium`+ via reproduction/attribution or clearing the 2-of-3 vote.
+
+## The `VerdictReport` the verifier returns
+
+Exactly this shape (from `scripts/lib/types.ts`):
+
+```ts
+type VerdictReport = {
+  findingId: string
+  reproduced: boolean          // did re-running the probe show the signal again?
+  isReal: boolean              // true → confirm; false → refute (incl. exclusions)
+  rationale: string            // cite the re-run evidence or the exclusion
+  correctedSeverity?: Severity // when the candidate was mis-rated
+  sourceAttribution?: string   // the file:line / selector the verifier pinned it to
+}
+```
+
+Mapping to `Finding.status`:
+
+- `reproduced && isReal` + attribution → `confirmed` (proceed to `fix-playbook.md`).
+- `!reproduced` OR matches an exclusion → `refuted`.
+- Real and reproduced but **out of scope** for autonomous fixing (vendor code, needs product decision, large refactor) → `deferred`, with the reason in `rationale`.
+
+`rationale` must cite the re-run — the metric value seen, the run count for a voted finding, and the source location — or the specific exclusion. "Looks plausible" is not a rationale.
+
+See `metrics-and-thresholds.md` for what each signal means and its browser-support caveats (empty Firefox arrays are not refutations — use the Gecko profiler), `react-rerender-playbook.md` for confirming render causes with react-scan, and `fix-playbook.md` for the fix once a finding is `confirmed`.

--- a/.claude/skills/thunder-perf-hunt/scripts/analyze-bundle.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/analyze-bundle.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env bun
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Production-bundle analyzer. Builds the app (or reuses an existing build),
+ * gzip-sizes every emitted JS chunk, and attributes the FCP-blocking weight to
+ * the entry chunk vs on-demand route chunks. Output conforms to the
+ * `BundleReport` type and is compared against the repo's `size-limit` budgets
+ * in package.json.
+ *
+ * Only the report path is printed to stdout; the build log, the human summary,
+ * and any budget overages go to stderr — mirroring scripts/run.ts.
+ *
+ * Usage:
+ *   bun scripts/analyze-bundle.ts            # always rebuilds
+ *   bun scripts/analyze-bundle.ts --reuse    # reuse dist/ if present
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { mkdirSync } from 'node:fs'
+import { REPO_ROOT } from './lib/env'
+import type { BundleReport } from './lib/types'
+
+const BUILD_SCRIPT = 'build' // package.json → "build": "vite build"
+const ASSETS_DIR = 'dist/assets' // vite emits entry-[hash].js + route chunks here
+
+const flag = (name: string): boolean => process.argv.includes(`--${name}`)
+
+/** A size-limit budget entry from package.json ("path" glob + optional "limit"). */
+type SizeLimitEntry = { name?: string; path: string | string[]; gzip?: boolean; limit?: string }
+
+const readSizeLimits = (): SizeLimitEntry[] => {
+  const pkg = JSON.parse(readFileSync(`${REPO_ROOT}/package.json`, 'utf8')) as { 'size-limit'?: SizeLimitEntry[] }
+  return pkg['size-limit'] ?? []
+}
+
+const runBuild = (): void => {
+  console.error(`perf-hunt/bundle: running \`bun run ${BUILD_SCRIPT}\` (this can take a few minutes)…`)
+  const proc = Bun.spawnSync(['bun', 'run', BUILD_SCRIPT], { cwd: REPO_ROOT, stdout: 'inherit', stderr: 'inherit' })
+  if (proc.exitCode !== 0) {
+    console.error(`perf-hunt/bundle: build failed (exit ${proc.exitCode}). See output above.`)
+    process.exit(1)
+  }
+}
+
+const gzipBytesOf = (absPath: string): number => Bun.gzipSync(readFileSync(absPath)).byteLength
+
+type Chunk = { file: string; gzipBytes: number }
+
+/** Gzip-size every .js chunk in the assets dir. `file` is repo-relative. */
+const measureChunks = (assetsAbs: string): Chunk[] =>
+  readdirSync(assetsAbs)
+    .filter((f) => f.endsWith('.js'))
+    .map((f) => ({ file: `${ASSETS_DIR}/${f}`, gzipBytes: gzipBytesOf(`${assetsAbs}/${f}`) }))
+
+const humanBytes = (n: number): string => `${(n / 1024).toFixed(1)} KB`
+
+/** Parse a size-limit "limit" (e.g. "180 KB", "1 MB") into bytes; 0 if absent/unparseable. */
+const parseLimit = (limit?: string): number => {
+  if (!limit) return 0
+  const match = limit.trim().match(/^([\d.]+)\s*(k|m)?b$/i)
+  if (!match) return 0
+  const value = Number(match[1])
+  const unit = (match[2] ?? '').toLowerCase()
+  const factor = unit === 'm' ? 1024 * 1024 : unit === 'k' ? 1024 : 1
+  return value * factor
+}
+
+const main = () => {
+  const assetsAbs = `${REPO_ROOT}/${ASSETS_DIR}`
+  const canReuse = flag('reuse') && existsSync(assetsAbs)
+  if (canReuse) console.error(`perf-hunt/bundle: --reuse set and ${ASSETS_DIR} exists — skipping rebuild`)
+  else runBuild()
+
+  if (!existsSync(assetsAbs)) {
+    console.error(`perf-hunt/bundle: assets dir not found at ${assetsAbs} after build`)
+    process.exit(1)
+  }
+
+  const chunks = measureChunks(assetsAbs)
+  if (chunks.length === 0) {
+    console.error(`perf-hunt/bundle: no .js chunks found in ${assetsAbs}`)
+    process.exit(1)
+  }
+
+  const entryChunks = chunks.filter((c) => /entry-[^/]+\.js$/.test(c.file))
+  const entryChunkGzipBytes = entryChunks.reduce((sum, c) => sum + c.gzipBytes, 0)
+  const totalJsGzipBytes = chunks.reduce((sum, c) => sum + c.gzipBytes, 0)
+  const largestChunks = [...chunks].sort((a, b) => b.gzipBytes - a.gzipBytes).slice(0, 10)
+
+  // A cheap manifest exists only if we can trivially read it; we don't attempt
+  // per-module attribution here, so suspectEntryModules stays empty by design.
+  const suspectEntryModules: string[] = []
+
+  const report: BundleReport = { entryChunkGzipBytes, totalJsGzipBytes, largestChunks, suspectEntryModules }
+
+  const reportPath = `${REPO_ROOT}/.perf-hunt/bundle-report.json`
+  mkdirSync(`${REPO_ROOT}/.perf-hunt`, { recursive: true })
+  writeFileSync(reportPath, JSON.stringify(report, null, 2))
+
+  // Human summary + budget check → stderr (stdout stays reserved for the path).
+  console.error(`perf-hunt/bundle: entry=${humanBytes(entryChunkGzipBytes)} total=${humanBytes(totalJsGzipBytes)} (${chunks.length} chunks, gzip)`)
+  const limits = readSizeLimits()
+  for (const entry of limits) {
+    const patterns = (Array.isArray(entry.path) ? entry.path : [entry.path]).map((p) => new Bun.Glob(p))
+    const matched = chunks.filter((c) => patterns.some((g) => g.match(c.file)))
+    const gzipSum = matched.reduce((sum, c) => sum + c.gzipBytes, 0)
+    const budget = parseLimit(entry.limit)
+    const budgetLabel = budget > 0 ? humanBytes(budget) : 'no numeric budget'
+    const status = budget > 0 && gzipSum > budget ? 'EXCEEDS' : 'ok'
+    console.error(`perf-hunt/bundle: budget "${entry.name ?? entry.path}" = ${humanBytes(gzipSum)} / ${budgetLabel} → ${status}`)
+  }
+
+  // The ONLY thing the agent parses from stdout: the path to the report JSON.
+  console.log(reportPath)
+}
+
+main()

--- a/.claude/skills/thunder-perf-hunt/scripts/explore.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/explore.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env bun
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Curiosity-driven state-graph crawler for functional bug hunting. This is NOT
+ * random monkey-testing: it models the app as a graph of "states" (a URL path
+ * plus the set of visible interactive-element labels), remembers where it has
+ * been, and deliberately steers toward UNVISITED actions. Along the way it
+ * listens for uncaught errors, console errors, dead-end navigations, and blank
+ * crashes, emitting each as a compact Finding the agentic layer can triage.
+ *
+ * The only thing printed to stdout is the path to the findings JSON — every
+ * other log goes to stderr, mirroring scripts/run.ts.
+ *
+ * Usage:
+ *   bun scripts/explore.ts --browsers chromium --steps 40
+ *   bun scripts/explore.ts --browsers chromium,firefox --steps 60 --run-id manual
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import type { Browser, Locator, Page } from 'playwright'
+import { REPO_ROOT } from './lib/env'
+import { bootStack } from './lib/boot'
+import { launchBrowser } from './lib/collect'
+import { INIT_SCRIPT } from './lib/inject'
+import { applyExclusions, loadCalibration } from './lib/calibration'
+import type { BrowserName, Confidence, Finding, FindingCategory, Severity } from './lib/types'
+
+const ROOT_PATH = '/chats/new'
+const MAX_STATES = 60
+const MAX_ACTIONS_PER_STATE = 25
+const SETTLE_TIMEOUT = 2_000
+const NAV_TIMEOUT = 30_000
+const TAURI_NOISE = ['__TAURI__', 'tauri', '__TAURI_INTERNALS__', 'convertFileSrc']
+
+const flag = (name: string, fallback = ''): string => {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const isTauriNoise = (text: string): boolean => TAURI_NOISE.some((n) => text.includes(n))
+
+/** Stable, order-independent hash of the visible action labels for a state. */
+const signature = (path: string, labels: string[]): string => {
+  const digest = Bun.hash([...labels].sort().join('\n')).toString(16)
+  return `${path}#${digest}`
+}
+
+type Action = { label: string; locator: Locator }
+type GraphNode = { id: string; signature: string; path: string; labelCount: number; browser: BrowserName }
+type GraphEdge = { from: string; to: string; action: string; browser: BrowserName }
+
+/** Path portion of a URL, so states compare on route rather than host/port. */
+const pathOf = (page: Page): string => {
+  try {
+    return new URL(page.url()).pathname
+  } catch {
+    return page.url()
+  }
+}
+
+/** Read a short, human-meaningful label for one interactive element. */
+const labelFor = async (locator: Locator): Promise<string> => {
+  const aria = (await locator.getAttribute('aria-label').catch(() => null))?.trim()
+  if (aria) return aria
+  const text = (await locator.innerText().catch(() => '')).trim().replace(/\s+/g, ' ')
+  if (text) return text.slice(0, 60)
+  const href = (await locator.getAttribute('href').catch(() => null))?.trim()
+  if (href) return `link:${href.slice(0, 60)}`
+  return 'unlabeled'
+}
+
+/** Enumerate visible, clickable actions in the current state (capped). */
+const enumerateActions = async (page: Page): Promise<Action[]> => {
+  const raw = [
+    ...(await page.getByRole('button').all().catch(() => [])),
+    ...(await page.locator('a[href]').all().catch(() => [])),
+    ...(await page.locator('[role="menuitem"]').all().catch(() => [])),
+  ]
+  const actions: Action[] = []
+  const seen = new Set<string>()
+  for (const locator of raw) {
+    if (actions.length >= MAX_ACTIONS_PER_STATE) break
+    if (!(await locator.isVisible().catch(() => false))) continue
+    if (!(await locator.isEnabled().catch(() => false))) continue
+    const label = await labelFor(locator)
+    if (seen.has(label)) continue
+    seen.add(label)
+    actions.push({ label, locator })
+  }
+  return actions
+}
+
+/** After a transition, is the app still showing its shell (vs a blank crash)? */
+const appAlive = (page: Page): Promise<boolean> =>
+  page
+    .locator('main, textarea, [role="main"]')
+    .first()
+    .isVisible({ timeout: 1_000 })
+    .catch(() => false)
+
+const settle = async (page: Page): Promise<void> => {
+  await page.waitForLoadState('networkidle', { timeout: SETTLE_TIMEOUT }).catch(() => {})
+  await page.waitForTimeout(250)
+}
+
+const gotoRoot = async (page: Page, baseUrl: string): Promise<void> => {
+  await page.goto(baseUrl + ROOT_PATH, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT }).catch(() => {})
+  await appAlive(page)
+  await page.waitForTimeout(300)
+}
+
+type ErrorLog = { pageErrors: string[]; consoleErrors: string[] }
+
+/** Crawl one browser, mutating the shared graph + findings accumulators. */
+const crawlBrowser = async (
+  browser: Browser,
+  browserName: BrowserName,
+  baseUrl: string,
+  maxSteps: number,
+  runDir: string,
+  nodes: Map<string, GraphNode>,
+  edges: GraphEdge[],
+  findings: Finding[],
+  seenFindingKeys: Set<string>,
+): Promise<void> => {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } })
+  const page = await context.newPage()
+  await page.addInitScript({ content: INIT_SCRIPT })
+
+  const errors: ErrorLog = { pageErrors: [], consoleErrors: [] }
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return
+    const text = msg.text()
+    if (isTauriNoise(text)) return
+    errors.consoleErrors.push(text.slice(0, 500))
+  })
+  page.on('pageerror', (err) => {
+    if (isTauriNoise(err.message)) return
+    errors.pageErrors.push(err.message.slice(0, 500))
+  })
+
+  const triedByState = new Map<string, Set<string>>()
+  let screenshotIndex = nodes.size
+  let currentPath: string[] = []
+
+  const addFinding = (
+    category: FindingCategory,
+    severity: Severity,
+    confidence: Confidence,
+    title: string,
+    evidence: string,
+    repro: string,
+  ): void => {
+    const key = `${category}:${title}:${evidence.slice(0, 120)}`
+    if (seenFindingKeys.has(key)) return
+    seenFindingKeys.add(key)
+    findings.push({
+      id: `explore-${findings.length + 1}`,
+      category,
+      title,
+      severity,
+      confidence,
+      status: 'candidate',
+      browsers: [browserName],
+      scenarios: ['explore'],
+      evidence,
+      repro,
+    })
+  }
+
+  const recordNode = async (sig: string, path: string, labels: string[]): Promise<void> => {
+    if (nodes.has(sig)) return
+    const node: GraphNode = { id: sig, signature: sig, path, labelCount: labels.length, browser: browserName }
+    nodes.set(sig, node)
+    const shot = `${runDir}/state-${screenshotIndex++}.${browserName}.png`
+    await page.screenshot({ path: shot }).catch(() => {})
+  }
+
+  await gotoRoot(page, baseUrl)
+
+  for (let step = 0; step < maxSteps && nodes.size < MAX_STATES; step++) {
+    const path = pathOf(page)
+    const actions = await enumerateActions(page)
+    const labels = actions.map((a) => a.label)
+    const sig = signature(path, labels)
+    await recordNode(sig, path, labels)
+
+    const tried = triedByState.get(sig) ?? new Set<string>()
+    triedByState.set(sig, tried)
+    const next = actions.find((a) => !tried.has(a.label))
+
+    if (!next) {
+      // Fully explored (or empty) state: rewind to root and keep hunting.
+      await gotoRoot(page, baseUrl)
+      currentPath = []
+      continue
+    }
+    tried.add(next.label)
+
+    const errBefore = errors.pageErrors.length
+    const consoleBefore = errors.consoleErrors.length
+    const clicked = await next.locator.click({ timeout: 3_000 }).then(() => true).catch(() => false)
+    if (!clicked) continue
+    await settle(page)
+
+    currentPath.push(next.label)
+    const repro = `Root(${ROOT_PATH}) -> ${currentPath.join(' -> ')}`
+
+    const afterPath = pathOf(page)
+    const afterActions = await enumerateActions(page)
+    const afterSig = signature(afterPath, afterActions.map((a) => a.label))
+    edges.push({ from: sig, to: afterSig, action: next.label, browser: browserName })
+
+    const newPageErrors = errors.pageErrors.slice(errBefore)
+    const newConsoleErrors = errors.consoleErrors.slice(consoleBefore)
+
+    for (const err of newPageErrors) {
+      addFinding('crash', 'critical', 'high', `Uncaught error after "${next.label}"`, `${err} | state=${afterSig}`, repro)
+    }
+    for (const err of newConsoleErrors) {
+      addFinding('console-error', 'medium', 'medium', `Console error after "${next.label}"`, `${err} | state=${afterSig}`, repro)
+    }
+    if (afterPath.includes('/not-found')) {
+      addFinding('crash', 'high', 'high', `Dead-end navigation to /not-found via "${next.label}"`, `navigated to ${afterPath} | state=${afterSig}`, repro)
+    }
+    if (!(await appAlive(page))) {
+      addFinding('crash', 'critical', 'high', `App shell disappeared after "${next.label}"`, `no main/textarea after transition | state=${afterSig}`, repro)
+      await gotoRoot(page, baseUrl)
+      currentPath = []
+    }
+  }
+
+  await context.close().catch(() => {})
+}
+
+const main = async () => {
+  const browsers = (flag('browsers', 'chromium').split(',').filter(Boolean) as BrowserName[])
+  const maxSteps = Number(flag('steps', '40')) || 40
+
+  const runId = flag('run-id', new Date().toISOString().replace(/[:.]/g, '-'))
+  const runDir = flag('out', `${REPO_ROOT}/.perf-hunt/runs/${runId}/explore`)
+  mkdirSync(runDir, { recursive: true })
+
+  console.error(`perf-hunt/explore: booting stack for run ${runId} (${browsers.join('+')}, ${maxSteps} steps)`)
+  const stack = await bootStack(REPO_ROOT)
+
+  const nodes = new Map<string, GraphNode>()
+  const edges: GraphEdge[] = []
+  const findings: Finding[] = []
+  const seenFindingKeys = new Set<string>()
+
+  try {
+    for (const browserName of browsers) {
+      console.error(`perf-hunt/explore: [${browserName}] crawling`)
+      const browser = await launchBrowser(browserName)
+      try {
+        await crawlBrowser(browser, browserName, stack.baseUrl, maxSteps, runDir, nodes, edges, findings, seenFindingKeys)
+      } finally {
+        await browser.close().catch(() => {})
+      }
+    }
+  } finally {
+    await stack.teardown()
+  }
+
+  // Apply the same learned exclusions the perf report uses, so calibrated false
+  // positives (e.g. keyless-stack send errors) don't recur in the crawl output.
+  const cal = loadCalibration()
+  const kept = applyExclusions(findings, cal)
+  if (kept.length < findings.length) {
+    console.error(`perf-hunt/explore: suppressed ${findings.length - kept.length} finding(s) via ${cal.excludeSignatures.length} learned exclusion(s)`)
+  }
+
+  const findingsPath = `${runDir}/explore-findings.json`
+  writeFileSync(findingsPath, JSON.stringify(kept, null, 2))
+  writeFileSync(`${runDir}/state-graph.json`, JSON.stringify({ nodes: [...nodes.values()], edges }, null, 2))
+
+  console.error(`perf-hunt/explore: ${nodes.size} states, ${edges.length} transitions, ${kept.length} findings`)
+  // The ONLY thing the agent parses from stdout: the path to the findings JSON.
+  console.log(findingsPath)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/.claude/skills/thunder-perf-hunt/scripts/explore.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/explore.ts
@@ -114,18 +114,25 @@ const gotoRoot = async (page: Page, baseUrl: string): Promise<void> => {
 
 type ErrorLog = { pageErrors: string[]; consoleErrors: string[] }
 
-/** Crawl one browser, mutating the shared graph + findings accumulators. */
+/**
+ * Crawl one browser and return its own state graph. The graph (`nodes`/`edges`
+ * and the `MAX_STATES` budget) is per-browser so a later browser gets a full
+ * crawl instead of short-circuiting on states an earlier browser already filled
+ * — `signature()` is browser-independent, so a shared graph would starve it.
+ * `findings`/`seenFindingKeys` stay shared so a bug seen in both browsers is
+ * reported once.
+ */
 const crawlBrowser = async (
   browser: Browser,
   browserName: BrowserName,
   baseUrl: string,
   maxSteps: number,
   runDir: string,
-  nodes: Map<string, GraphNode>,
-  edges: GraphEdge[],
   findings: Finding[],
   seenFindingKeys: Set<string>,
-): Promise<void> => {
+): Promise<{ nodes: Map<string, GraphNode>; edges: GraphEdge[] }> => {
+  const nodes = new Map<string, GraphNode>()
+  const edges: GraphEdge[] = []
   const context = await browser.newContext({ viewport: { width: 1280, height: 800 } })
   const page = await context.newPage()
   await page.addInitScript({ content: INIT_SCRIPT })
@@ -143,7 +150,7 @@ const crawlBrowser = async (
   })
 
   const triedByState = new Map<string, Set<string>>()
-  let screenshotIndex = nodes.size
+  let screenshotIndex = 0
   let currentPath: string[] = []
 
   const addFinding = (
@@ -234,6 +241,7 @@ const crawlBrowser = async (
   }
 
   await context.close().catch(() => {})
+  return { nodes, edges }
 }
 
 const main = async () => {
@@ -247,8 +255,8 @@ const main = async () => {
   console.error(`perf-hunt/explore: booting stack for run ${runId} (${browsers.join('+')}, ${maxSteps} steps)`)
   const stack = await bootStack(REPO_ROOT)
 
-  const nodes = new Map<string, GraphNode>()
-  const edges: GraphEdge[] = []
+  const allNodes: GraphNode[] = []
+  const allEdges: GraphEdge[] = []
   const findings: Finding[] = []
   const seenFindingKeys = new Set<string>()
 
@@ -257,7 +265,9 @@ const main = async () => {
       console.error(`perf-hunt/explore: [${browserName}] crawling`)
       const browser = await launchBrowser(browserName)
       try {
-        await crawlBrowser(browser, browserName, stack.baseUrl, maxSteps, runDir, nodes, edges, findings, seenFindingKeys)
+        const graph = await crawlBrowser(browser, browserName, stack.baseUrl, maxSteps, runDir, findings, seenFindingKeys)
+        allNodes.push(...graph.nodes.values())
+        allEdges.push(...graph.edges)
       } finally {
         await browser.close().catch(() => {})
       }
@@ -276,9 +286,9 @@ const main = async () => {
 
   const findingsPath = `${runDir}/explore-findings.json`
   writeFileSync(findingsPath, JSON.stringify(kept, null, 2))
-  writeFileSync(`${runDir}/state-graph.json`, JSON.stringify({ nodes: [...nodes.values()], edges }, null, 2))
+  writeFileSync(`${runDir}/state-graph.json`, JSON.stringify({ nodes: allNodes, edges: allEdges }, null, 2))
 
-  console.error(`perf-hunt/explore: ${nodes.size} states, ${edges.length} transitions, ${kept.length} findings`)
+  console.error(`perf-hunt/explore: ${allNodes.length} states, ${allEdges.length} transitions, ${kept.length} findings`)
   // The ONLY thing the agent parses from stdout: the path to the findings JSON.
   console.log(findingsPath)
 }

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/boot.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/boot.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { PERF_BACKEND_PORT, PERF_BACKEND_URL, PERF_BASE_URL, PERF_FRONTEND_PORT, backendEnv, frontendEnv, resolveSecret } from './env'
+
+/**
+ * Boots the Docker-free perf stack: a pglite backend and a Vite frontend on
+ * dedicated ports, both configured for the anonymous auto-session. Returns a
+ * teardown that kills both. Idempotent-ish: if the ports are already serving
+ * (a warm stack from a previous run), we reuse them instead of respawning.
+ */
+export type BootedStack = { baseUrl: string; teardown: () => Promise<void> }
+
+const waitForUrl = async (url: string, timeoutMs: number): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url)
+      if (res.ok || res.status === 401 || res.status === 404) return true
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  return false
+}
+
+const isServing = async (url: string): Promise<boolean> => {
+  try {
+    const res = await fetch(url)
+    return res.ok || res.status === 401 || res.status === 404
+  } catch {
+    return false
+  }
+}
+
+export const bootStack = async (repoRoot: string): Promise<BootedStack> => {
+  const backendHealth = `${PERF_BACKEND_URL}/v1/health`
+  const already = (await isServing(backendHealth)) && (await isServing(PERF_BASE_URL))
+  if (already) {
+    return { baseUrl: PERF_BASE_URL, teardown: async () => {} }
+  }
+
+  const secret = resolveSecret()
+  const backend = Bun.spawn(['bun', 'src/index.ts'], {
+    cwd: `${repoRoot}/backend`,
+    env: { ...process.env, ...backendEnv(secret) },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const backendOk = await waitForUrl(backendHealth, 120_000)
+  if (!backendOk) {
+    backend.kill()
+    throw new Error(`perf-hunt: backend did not become healthy on :${PERF_BACKEND_PORT}`)
+  }
+
+  const frontend = Bun.spawn(['bun', 'run', 'dev', '--', '--port', String(PERF_FRONTEND_PORT), '--strictPort'], {
+    cwd: repoRoot,
+    env: { ...process.env, ...frontendEnv() },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const frontendOk = await waitForUrl(PERF_BASE_URL, 120_000)
+  if (!frontendOk) {
+    frontend.kill()
+    backend.kill()
+    throw new Error(`perf-hunt: frontend did not become ready on :${PERF_FRONTEND_PORT}`)
+  }
+
+  return {
+    baseUrl: PERF_BASE_URL,
+    teardown: async () => {
+      frontend.kill()
+      backend.kill()
+    },
+  }
+}

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/boot.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/boot.ts
@@ -46,8 +46,10 @@ export const bootStack = async (repoRoot: string): Promise<BootedStack> => {
   const backend = Bun.spawn(['bun', 'src/index.ts'], {
     cwd: `${repoRoot}/backend`,
     env: { ...process.env, ...backendEnv(secret) },
-    stdout: 'pipe',
-    stderr: 'pipe',
+    // Readiness is polled via waitForUrl, and nothing consumes these streams —
+    // 'pipe' would let the ~64KB OS buffer fill and hang the chatty dev server.
+    stdout: 'ignore',
+    stderr: 'ignore',
   })
   const backendOk = await waitForUrl(backendHealth, 120_000)
   if (!backendOk) {
@@ -58,8 +60,10 @@ export const bootStack = async (repoRoot: string): Promise<BootedStack> => {
   const frontend = Bun.spawn(['bun', 'run', 'dev', '--', '--port', String(PERF_FRONTEND_PORT), '--strictPort'], {
     cwd: repoRoot,
     env: { ...process.env, ...frontendEnv() },
-    stdout: 'pipe',
-    stderr: 'pipe',
+    // Readiness is polled via waitForUrl, and nothing consumes these streams —
+    // 'pipe' would let the ~64KB OS buffer fill and hang the chatty dev server.
+    stdout: 'ignore',
+    stderr: 'ignore',
   })
   const frontendOk = await waitForUrl(PERF_BASE_URL, 120_000)
   if (!frontendOk) {

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/calibration.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/calibration.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * The harness's learned overlay — the mechanism that makes it self-improving
+ * without self-complicating. It carries only two kinds of learning that are
+ * safe to accumulate as data (see references/self-improve.md):
+ *   - excludeSignatures: confirmed false positives to suppress, each WITH a reason.
+ *   - extraScenarios: routes discovered by the crawler that deserve a probe.
+ * Everything else (new probes, thresholds, logic) is a reviewed code change,
+ * never a magic config value. If the file is missing/invalid, defaults apply.
+ */
+
+import { readFileSync } from 'node:fs'
+import type { Finding, FindingCategory } from './types'
+
+export type ExcludeSignature = {
+  /** Optional: restrict the match to one category. */
+  category?: FindingCategory
+  /** Case-insensitive substring matched against the finding's title+evidence+source. */
+  match: string
+  /** Why this is a known false positive — required, so learnings stay auditable. */
+  reason: string
+}
+
+export type CalibrationScenario = {
+  name: string
+  path: string
+  description: string
+  tags: string[]
+}
+
+export type Calibration = {
+  excludeSignatures: ExcludeSignature[]
+  extraScenarios: CalibrationScenario[]
+}
+
+const CALIBRATION_URL = new URL('../../calibration.json', import.meta.url)
+
+export const loadCalibration = (): Calibration => {
+  try {
+    const parsed = JSON.parse(readFileSync(CALIBRATION_URL, 'utf8')) as Partial<Calibration>
+    return {
+      excludeSignatures: parsed.excludeSignatures ?? [],
+      extraScenarios: parsed.extraScenarios ?? [],
+    }
+  } catch {
+    return { excludeSignatures: [], extraScenarios: [] }
+  }
+}
+
+/** Drop candidates matching a learned false-positive signature. */
+export const applyExclusions = (findings: Finding[], cal: Calibration): Finding[] =>
+  findings.filter(
+    (f) =>
+      !cal.excludeSignatures.some(
+        (s) =>
+          (!s.category || s.category === f.category) &&
+          `${f.title} ${f.evidence} ${f.sourceAttribution ?? ''}`.toLowerCase().includes(s.match.toLowerCase()),
+      ),
+  )

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/collect.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/collect.ts
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { chromium, firefox, type Browser, type Page } from 'playwright'
+import { INIT_SCRIPT, READ_SNAPSHOT, RESET_RENDERS } from './inject'
+import type {
+  BrowserName,
+  ConsoleSample,
+  HeapDelta,
+  InitTimingMark,
+  LoafSample,
+  LongTaskSample,
+  NetworkSample,
+  RenderStat,
+  ScenarioReport,
+  WebVitalSample,
+} from './types'
+import type { ScenarioDef } from './scenarios'
+import { collectA11y } from '../probes/a11y'
+import { collectHeapDelta } from '../probes/heap'
+
+const NAV_TIMEOUT = 45_000
+const TAURI_NOISE = ['__TAURI__', 'tauri', '__TAURI_INTERNALS__', 'convertFileSrc']
+
+type SnapshotShape = {
+  vitals: WebVitalSample[]
+  loaf: LoafSample[]
+  longTasks: LongTaskSample[]
+  renders: RenderStat[]
+  commits: number
+}
+
+export const launchBrowser = (name: BrowserName): Promise<Browser> =>
+  (name === 'firefox' ? firefox : chromium).launch({ headless: true })
+
+/** Keep the biggest, unique requests — enough to spot bloat without flooding the report. */
+const dedupeNetwork = (samples: NetworkSample[]): NetworkSample[] => {
+  const seen = new Set<string>()
+  const unique = samples.filter((s) => {
+    const key = `${s.method} ${s.url}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+  return unique.sort((a, b) => b.transferSizeBytes - a.transferSizeBytes).slice(0, 60)
+}
+
+const readSnapshot = (page: Page): Promise<SnapshotShape> =>
+  page.evaluate(READ_SNAPSHOT).then((v) => v as SnapshotShape)
+
+/** Drive one scenario in one browser and return its structured report. */
+export const collectScenario = async (
+  browser: Browser,
+  browserName: BrowserName,
+  baseUrl: string,
+  scenario: ScenarioDef,
+  runDir: string,
+): Promise<ScenarioReport> => {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } })
+  const page = await context.newPage()
+  await page.addInitScript({ content: INIT_SCRIPT })
+
+  const consoleSamples: ConsoleSample[] = []
+  const pageErrors: string[] = []
+  const network: NetworkSample[] = []
+
+  page.on('console', (msg) => {
+    const level = msg.type()
+    if (level !== 'error' && level !== 'warning') return
+    const text = msg.text()
+    if (TAURI_NOISE.some((n) => text.includes(n))) return
+    consoleSamples.push({ level, text: text.slice(0, 500), location: msg.location()?.url })
+  })
+  page.on('pageerror', (err) => {
+    if (TAURI_NOISE.some((n) => err.message.includes(n))) return
+    pageErrors.push(err.message.slice(0, 500))
+  })
+  page.on('response', (res) => {
+    const req = res.request()
+    const headers = res.headers()
+    const size = Number(headers['content-length'] ?? 0)
+    network.push({
+      url: res.url().slice(0, 300),
+      method: req.method(),
+      status: res.status(),
+      resourceType: req.resourceType(),
+      transferSizeBytes: Number.isFinite(size) ? size : 0,
+      durationMs: Math.max(0, req.timing().responseEnd),
+      renderBlocking: req.resourceType() === 'script' || req.resourceType() === 'stylesheet',
+    })
+  })
+
+  const startedAt = new Date().toISOString()
+  const url = baseUrl + scenario.path
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT }).catch(() => {})
+  await page
+    .locator('textarea, main, [role="main"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: NAV_TIMEOUT })
+    .catch(() => {})
+  await page.waitForTimeout(500)
+
+  if (scenario.interact) await scenario.interact(page).catch(() => {})
+  await page.waitForTimeout(400)
+
+  // Read the cumulative snapshot (load + interaction) BEFORE resetting — the
+  // reset below would otherwise wipe the render tallies we want here.
+  const snapshot = await readSnapshot(page).catch(() => null)
+
+  // Return to a truly idle tree BEFORE measuring noise renders. A scenario's
+  // interaction may leave a Radix overlay (dialog/popover/menu) open; the probe's
+  // own Escape below would then CLOSE it, recording a legitimate exit-animation
+  // (framer-motion/Radix `Presence` re-rendering per frame across the whole
+  // portal tree) as "idle" re-renders — a false-positive storm. Dismiss any open
+  // overlay and let exit animations settle so the counters zero from idle.
+  await page.keyboard.press('Escape').catch(() => {})
+  await page.waitForFunction(() => !document.querySelector('[data-state="open"]'), { timeout: 1_000 }).catch(() => {})
+  await page.waitForTimeout(400)
+
+  // Noise-render probe: zero the counters, perform an interaction unrelated to
+  // any specific component, and see which components re-render anyway. Anything
+  // that commits here is a strong unnecessary-render candidate.
+  await page.evaluate(RESET_RENDERS).catch(() => {})
+  await page.mouse.move(640, 400).catch(() => {})
+  await page.keyboard.press('Escape').catch(() => {})
+  await page.mouse.wheel(0, 300).catch(() => {})
+  await page.waitForTimeout(300)
+  const noise = await readSnapshot(page).catch(() => null)
+
+  const initTiming = await page
+    .evaluate(
+      `(() => performance.getEntriesByType('mark').map((m) => ({ name: m.name, startTime: Math.round(m.startTime) })))()`,
+    )
+    .then((v) => v as InitTimingMark[])
+    .catch(() => [] as InitTimingMark[])
+
+  const a11y = await collectA11y(page).catch(() => [])
+
+  const heap: HeapDelta[] = []
+  if (browserName === 'chromium') {
+    const delta = await collectHeapDelta(page, `${scenario.name}-renav`, async () => {
+      await page.goto(baseUrl + '/chats/new', { waitUntil: 'domcontentloaded' }).catch(() => {})
+      await page.goto(url, { waitUntil: 'domcontentloaded' }).catch(() => {})
+    }).catch(() => null)
+    if (delta) heap.push(delta)
+  }
+
+  const screenshotPath = `${runDir}/${scenario.name}.${browserName}.png`
+  await page.screenshot({ path: screenshotPath }).catch(() => {})
+
+  await context.close().catch(() => {})
+
+  const snap: SnapshotShape = snapshot ?? { vitals: [], loaf: [], longTasks: [], renders: [], commits: 0 }
+  return {
+    scenario: scenario.name,
+    browser: browserName,
+    url,
+    startedAt,
+    vitals: snap.vitals,
+    loaf: snap.loaf,
+    longTasks: snap.longTasks,
+    renders: snap.renders,
+    noiseRenders: noise?.renders ?? [],
+    network: dedupeNetwork(network),
+    console: consoleSamples,
+    heap,
+    a11y,
+    initTiming,
+    pageErrors,
+    screenshotPath,
+  }
+}

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/env.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/env.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Boot configuration for a perf-hunt run. We bind to dedicated ports (off the
+ * `make dev` band of 1420/8000 and off the e2e band of 1421-1422/8002-8003) so a
+ * perf run never collides with a dev server or the e2e suite. Auth uses the
+ * anonymous auto-session path (no Docker, no mock IdP, no magic-link scraping):
+ * the AuthGate silently creates a session and lands on /chats/new.
+ */
+
+export const PERF_FRONTEND_PORT = 1431
+export const PERF_BACKEND_PORT = 8010
+
+export const PERF_BASE_URL = `http://localhost:${PERF_FRONTEND_PORT}`
+export const PERF_BACKEND_URL = `http://localhost:${PERF_BACKEND_PORT}`
+
+/**
+ * Backend env for an anonymous, Docker-free stack. BETTER_AUTH_SECRET must be
+ * at least 32 chars; a stable dev secret is fine because pglite data is
+ * throwaway. An AI provider key is read from the caller's environment if set
+ * (chat streaming scenarios need it); perf runs that never send a message work
+ * without one.
+ */
+export const backendEnv = (secret: string): Record<string, string> => ({
+  PORT: String(PERF_BACKEND_PORT),
+  AUTH_MODE: 'consumer',
+  AUTH_ALLOW_ANONYMOUS: 'true',
+  DATABASE_DRIVER: 'pglite',
+  DATABASE_URL: '.pglite/perf-hunt',
+  BETTER_AUTH_SECRET: secret,
+  BETTER_AUTH_URL: PERF_BACKEND_URL,
+  APP_URL: PERF_BASE_URL,
+  CORS_ORIGINS: PERF_BASE_URL,
+  TRUSTED_ORIGINS: PERF_BASE_URL,
+  RATE_LIMIT_ENABLED: 'false',
+})
+
+/** Frontend (Vite) env for the anonymous auto-session, onboarding skipped. */
+export const frontendEnv = (): Record<string, string> => ({
+  VITE_AUTH_ENABLE_ANONYMOUS: 'true',
+  VITE_BYPASS_WAITLIST: 'true',
+  VITE_SKIP_ONBOARDING: 'true',
+  VITE_THUNDERBOLT_CLOUD_URL: `${PERF_BACKEND_URL}/v1`,
+})
+
+/** A 32+ char secret: caller's BETTER_AUTH_SECRET or a stable throwaway. */
+export const resolveSecret = (): string =>
+  process.env.BETTER_AUTH_SECRET ?? 'perf-hunt-throwaway-secret-at-least-32-characters'
+
+export const REPO_ROOT = new URL('../../../../../', import.meta.url).pathname

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/inject.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/inject.ts
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Browser-context instrumentation injected via `page.addInitScript`. These run
+ * BEFORE the app's own scripts so we can (a) install PerformanceObservers with
+ * `buffered: true` to catch metrics that fire during first paint, and (b) plant
+ * a minimal React DevTools global hook so React reports every commit to us —
+ * both without touching app source or loading any cross-origin script (the app
+ * ships COEP: credentialless, which would block a CDN <script>).
+ *
+ * Exported as source strings because they execute in the page realm, not Node;
+ * this keeps our typed Node code free of `any`-typed browser-global access.
+ */
+
+/** Installed at document start in every page/frame. Populates window.__PERF_HUNT__. */
+export const INIT_SCRIPT = /* js */ `
+(() => {
+  if (window.__PERF_HUNT__) return;
+  const store = {
+    lcp: null, cls: 0, clsTarget: null, inp: 0, inpTarget: null,
+    fcp: null, ttfb: null, longTasks: [], loaf: [],
+    renders: {}, commits: 0,
+  };
+  window.__PERF_HUNT__ = store;
+
+  const cssPath = (el) => {
+    if (!el || el.nodeType !== 1) return undefined;
+    const parts = [];
+    let node = el;
+    for (let depth = 0; node && node.nodeType === 1 && depth < 4; depth++) {
+      let sel = node.tagName.toLowerCase();
+      if (node.id) { sel += '#' + node.id; parts.unshift(sel); break; }
+      const cls = (node.className && node.className.baseVal !== undefined)
+        ? node.className.baseVal : node.className;
+      if (cls && typeof cls === 'string') {
+        const c = cls.trim().split(/\\s+/).slice(0, 2).join('.');
+        if (c) sel += '.' + c;
+      }
+      parts.unshift(sel);
+      node = node.parentElement;
+    }
+    return parts.join(' > ');
+  };
+
+  const observe = (type, cb, extra) => {
+    try { new PerformanceObserver((l) => cb(l.getEntries())).observe({ type, buffered: true, ...(extra || {}) }); } catch (e) {}
+  };
+
+  observe('largest-contentful-paint', (es) => {
+    for (const e of es) store.lcp = { value: e.startTime, target: cssPath(e.element), url: e.url || undefined };
+  });
+  observe('layout-shift', (es) => {
+    for (const e of es) {
+      if (e.hadRecentInput) continue;
+      store.cls += e.value;
+      const src = e.sources && e.sources[0] && e.sources[0].node;
+      if (src) store.clsTarget = cssPath(src);
+    }
+  });
+  observe('paint', (es) => {
+    for (const e of es) if (e.name === 'first-contentful-paint') store.fcp = e.startTime;
+  });
+  observe('navigation', (es) => { for (const e of es) store.ttfb = e.responseStart; });
+  observe('event', (es) => {
+    for (const e of es) if (e.interactionId && e.duration > store.inp) {
+      store.inp = e.duration; store.inpTarget = cssPath(e.target);
+    }
+  }, { durationThreshold: 40 });
+  observe('longtask', (es) => {
+    for (const e of es) store.longTasks.push({
+      duration: e.duration, startTime: e.startTime,
+      attribution: (e.attribution && e.attribution[0] && e.attribution[0].name) || 'unknown',
+    });
+  });
+  observe('long-animation-frame', (es) => {
+    for (const e of es) {
+      let forced = 0;
+      for (const s of (e.scripts || [])) forced += s.forcedStyleAndLayoutDuration || 0;
+      store.loaf.push({
+        duration: e.duration, blockingDuration: e.blockingDuration || 0,
+        forcedStyleAndLayoutDuration: forced,
+        scripts: (e.scripts || []).map((s) => ({
+          sourceURL: s.sourceURL || '', sourceFunctionName: s.sourceFunctionName || '',
+          sourceCharPosition: s.sourceCharPosition ?? -1, duration: s.duration || 0,
+          invoker: s.invoker || '',
+        })),
+      });
+    }
+  });
+
+  // ---- React commit accounting via a minimal DevTools global hook ----
+  // A fiber that performed render work this commit has a numeric actualDuration.
+  // We tally per-component commit counts and (subtree-inclusive) durations; the
+  // commit count is the load-bearing "how often does this re-render" signal.
+  const compName = (fiber) => {
+    const t = fiber && fiber.type;
+    if (!t) return null;
+    if (typeof t === 'string') return null; // host element (div/span) — skip
+    return t.displayName || t.name || (t.render && (t.render.displayName || t.render.name)) || null;
+  };
+  // A component "rendered" this commit iff React set the PerformedWork flag
+  // (bit 0b1) on its fiber — i.e. its render function actually ran. This is
+  // stable across React 18/19 and, unlike actualDuration, is populated in the
+  // ordinary dev build (actualDuration only exists in the profiling build).
+  const PERFORMED_WORK = 0b1;
+  const walk = (fiber) => {
+    if (!fiber) return;
+    const flags = fiber.flags ?? fiber.effectTag ?? 0;
+    if ((flags & PERFORMED_WORK) === PERFORMED_WORK) {
+      const name = compName(fiber);
+      if (name) {
+        const dur = typeof fiber.actualDuration === 'number' ? fiber.actualDuration : 0;
+        const r = store.renders[name] || (store.renders[name] = { component: name, commits: 0, totalDuration: 0, maxDuration: 0 });
+        r.commits += 1; r.totalDuration += dur; if (dur > r.maxDuration) r.maxDuration = dur;
+      }
+    }
+    walk(fiber.child); walk(fiber.sibling);
+  };
+  if (!window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+    let uid = 0;
+    window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      renderers: new Map(), supportsFiber: true,
+      inject(r) { const id = ++uid; this.renderers.set(id, r); return id; },
+      onScheduleFiberRoot() {}, onCommitFiberUnmount() {}, onPostCommitFiberRoot() {}, checkDCE() {},
+      onCommitFiberRoot(_id, root) {
+        store.commits += 1;
+        try { walk((root && root.current) || root); } catch (e) {}
+      },
+    };
+  }
+
+  store.__resetRenders = () => { store.renders = {}; store.commits = 0; };
+})();
+`
+
+/**
+ * Evaluated on demand to read a serializable snapshot with computed ratings.
+ * Returns a shape compatible with the vitals/loaf/longTask/render types.
+ */
+export const READ_SNAPSHOT = /* js */ `
+(() => {
+  const s = window.__PERF_HUNT__ || {};
+  const rate = (name, v) => {
+    if (v == null) return 'good';
+    const t = { LCP: [2500, 4000], INP: [200, 500], CLS: [0.1, 0.25], FCP: [1800, 3000], TTFB: [800, 1800] }[name];
+    if (!t) return 'good';
+    return v <= t[0] ? 'good' : v <= t[1] ? 'needs-improvement' : 'poor';
+  };
+  const vitals = [];
+  if (s.lcp) vitals.push({ name: 'LCP', value: Math.round(s.lcp.value), rating: rate('LCP', s.lcp.value), attribution: s.lcp.target || s.lcp.url });
+  if (s.inp) vitals.push({ name: 'INP', value: Math.round(s.inp), rating: rate('INP', s.inp), attribution: s.inpTarget });
+  vitals.push({ name: 'CLS', value: Math.round(s.cls * 1000) / 1000, rating: rate('CLS', s.cls), attribution: s.clsTarget || undefined });
+  if (s.fcp != null) vitals.push({ name: 'FCP', value: Math.round(s.fcp), rating: rate('FCP', s.fcp) });
+  if (s.ttfb != null) vitals.push({ name: 'TTFB', value: Math.round(s.ttfb), rating: rate('TTFB', s.ttfb) });
+  const renders = Object.values(s.renders || {})
+    .map((r) => ({ ...r, totalDuration: Math.round(r.totalDuration * 100) / 100, maxDuration: Math.round(r.maxDuration * 100) / 100 }))
+    .sort((a, b) => b.commits - a.commits);
+  return {
+    vitals,
+    loaf: (s.loaf || []).filter((f) => f.duration >= 50),
+    longTasks: s.longTasks || [],
+    renders,
+    commits: s.commits || 0,
+  };
+})();
+`
+
+/** Zeroes render counters so the next interaction can be measured in isolation. */
+export const RESET_RENDERS = `window.__PERF_HUNT__ && window.__PERF_HUNT__.__resetRenders && window.__PERF_HUNT__.__resetRenders();`

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/scenarios.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/scenarios.ts
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { Page } from '@playwright/test'
+import { loadCalibration } from './calibration'
+
+/**
+ * A deterministic scenario the harness drives in every browser. `interact`
+ * exercises the surface after load (navigation, typing, opening panels) so we
+ * capture INP, long tasks, and re-renders — not just cold load. Keep each
+ * interaction short, idempotent, and free of network sends unless the scenario
+ * explicitly targets streaming (which needs an AI key).
+ */
+export type ScenarioDef = {
+  name: string
+  path: string
+  description: string
+  /** Coverage tags for diff-aware selection (map changed files → scenarios). */
+  tags: string[]
+  /** Interaction run after the route settles; optional for pure load scenarios. */
+  interact?: (page: Page) => Promise<void>
+}
+
+const settle = (page: Page) => page.waitForLoadState('networkidle').catch(() => {})
+
+/**
+ * The canonical sweep. `chat-landing` is first and is the critical surface —
+ * it must stay in the entry bundle and feel instant (see AGENTS.md route
+ * splitting). Settings/admin routes are lazy chunks; we load them to catch
+ * chunk-load waterfalls and per-page render storms.
+ */
+const BASE_SCENARIOS: ScenarioDef[] = [
+  {
+    name: 'chat-landing',
+    path: '/chats/new',
+    description: 'Cold load of the landing chat surface — the primary perf target.',
+    tags: ['chat', 'entry', 'critical'],
+    interact: async (page) => {
+      const input = page.locator('textarea').first()
+      await input.click({ timeout: 15_000 }).catch(() => {})
+      // Typing exercises INP + reveals re-render storms on the composer without
+      // sending a message (no AI key required).
+      await input.pressSequentially('performance probe typing test', { delay: 25 }).catch(() => {})
+      await input.fill('').catch(() => {})
+    },
+  },
+  {
+    name: 'chat-sidebar-nav',
+    path: '/chats/new',
+    description: 'Open/close the sidebar and navigate chat history — layout + render cost.',
+    tags: ['chat', 'sidebar', 'navigation'],
+    interact: async (page) => {
+      const toggles = page.getByRole('button')
+      const count = await toggles.count().catch(() => 0)
+      for (let i = 0; i < Math.min(count, 4); i++) {
+        await toggles.nth(i).click({ timeout: 3_000, trial: false }).catch(() => {})
+        await page.waitForTimeout(150)
+      }
+    },
+  },
+  {
+    name: 'chat-streaming-sim',
+    path: '/message-simulator',
+    description:
+      'Simulated streaming assistant response via the dev Message Simulator (no API key) — replays a canned SSE log through the real streamText pipeline + production message renderer. Exercises the message-render hot path: streamed markdown, reasoning, and a tool-call block, plus per-chunk streaming re-renders.',
+    tags: ['chat', 'streaming', 'message', 'render'],
+    interact: async (page) => {
+      // Open the SSE-log picker and choose the tool-call fixture (the heaviest
+      // render path: streamed markdown + a tool-call block). The Combobox trigger
+      // exposes role="combobox"; options render as cmdk items.
+      const picker = page.getByRole('combobox').first()
+      await picker.click({ timeout: 10_000 }).catch(() => {})
+      const option = page.getByRole('option', { name: 'Tool call' }).first()
+      await option
+        .click({ timeout: 5_000 })
+        .catch(() => page.getByText('Tool call', { exact: true }).first().click({ timeout: 5_000 }).catch(() => {}))
+      // Run the simulation — it auto-streams through the real pipeline with a fake
+      // fetch. The button reads "Stop" while streaming, reverts to "Run" when done.
+      await page.getByRole('button', { name: /^Run$/ }).click({ timeout: 10_000 }).catch(() => {})
+      await page
+        .getByRole('button', { name: /^Stop$/ })
+        .waitFor({ state: 'visible', timeout: 10_000 })
+        .catch(() => {})
+      await page
+        .getByRole('button', { name: /^Stop$/ })
+        .waitFor({ state: 'detached', timeout: 30_000 })
+        .catch(() => {})
+      // Let final markdown/syntax-highlighting settle.
+      await page.waitForTimeout(500)
+    },
+  },
+  {
+    name: 'settings-preferences',
+    path: '/settings/preferences',
+    description: 'Lazy settings route — chunk-load waterfall + form render cost.',
+    tags: ['settings', 'lazy'],
+    interact: settle,
+  },
+  {
+    name: 'models',
+    path: '/models',
+    description: 'Models list — often a large list; watch virtualization + render count.',
+    tags: ['settings', 'models', 'list', 'lazy'],
+    interact: settle,
+  },
+  {
+    name: 'mcp-servers',
+    path: '/mcp-servers',
+    description: 'MCP servers admin page (lazy).',
+    tags: ['settings', 'mcp', 'lazy'],
+    interact: settle,
+  },
+  {
+    name: 'integrations',
+    path: '/integrations',
+    description: 'Integrations page (lazy).',
+    tags: ['settings', 'integrations', 'lazy'],
+    interact: settle,
+  },
+  {
+    name: 'devices',
+    path: '/devices',
+    description: 'Devices page (lazy) — PowerSync/device list rendering.',
+    tags: ['settings', 'devices', 'powersync', 'lazy'],
+    interact: settle,
+  },
+]
+
+/**
+ * The active scenario set = built-in scenarios + any the crawler discovered and
+ * the REFLECT phase promoted into calibration.json. Learned scenarios get a
+ * plain "load + settle" interaction (no bespoke steps encodable in JSON).
+ */
+export const SCENARIOS: ScenarioDef[] = [
+  ...BASE_SCENARIOS,
+  ...loadCalibration().extraScenarios.map(
+    (s): ScenarioDef => ({ ...s, interact: settle }),
+  ),
+]
+
+/**
+ * Maps a changed source path to the scenarios that exercise it, for diff mode.
+ * Falls back to the full sweep when nothing matches (unknown blast radius).
+ */
+export const scenariosForChangedFiles = (files: string[]): ScenarioDef[] => {
+  const matched = new Set<ScenarioDef>()
+  for (const f of files) {
+    const p = f.toLowerCase()
+    for (const s of SCENARIOS) {
+      if (s.tags.some((t) => p.includes(t)) || p.includes(s.name)) matched.add(s)
+    }
+    if (p.includes('chat') || p.includes('layout') || p.includes('app.tsx')) {
+      matched.add(SCENARIOS[0])
+    }
+  }
+  return matched.size > 0 ? [...matched] : SCENARIOS
+}

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/types.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/types.ts
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared contracts for the thunder-perf-hunt harness. Every probe writes data
+ * that conforms to these types, and the agentic layer reasons only over these
+ * compact structures — never raw traces. Keep this file dependency-free so it
+ * can be imported by any probe script and by the report aggregator.
+ */
+
+export type BrowserName = 'chromium' | 'firefox'
+
+/** Categories a finding can belong to. Drives triage routing and fix playbooks. */
+export type FindingCategory =
+  | 'web-vital'
+  | 'unnecessary-render'
+  | 'long-task'
+  | 'layout-thrash'
+  | 'memory-leak'
+  | 'bundle'
+  | 'network'
+  | 'console-error'
+  | 'crash'
+  | 'a11y'
+
+export type Severity = 'critical' | 'high' | 'medium' | 'low'
+
+/** How sure the deterministic layer is before the agent verifies. */
+export type Confidence = 'high' | 'medium' | 'low'
+
+/** Lifecycle of a finding as it moves through the agentic pipeline. */
+export type FindingStatus =
+  | 'candidate' // emitted by a probe, not yet verified
+  | 'confirmed' // survived adversarial verification with reproduction
+  | 'refuted' // verifier could not reproduce, or it is expected/by-design
+  | 'fixed' // a fix landed and the metric moved
+  | 'deferred' // real but out of scope for autonomous fixing
+
+/** A single Core Web Vital sample with source attribution when available. */
+export type WebVitalSample = {
+  name: 'LCP' | 'INP' | 'CLS' | 'FCP' | 'TTFB'
+  value: number
+  rating: 'good' | 'needs-improvement' | 'poor'
+  /** CSS selector or resource URL the metric attributes to, when derivable. */
+  attribution?: string
+}
+
+/** One Long Animation Frame (LoAF) with per-script source attribution. */
+export type LoafSample = {
+  duration: number
+  blockingDuration: number
+  /** ms spent in forced style/layout — a layout-thrash signal. */
+  forcedStyleAndLayoutDuration: number
+  scripts: Array<{
+    sourceURL: string
+    sourceFunctionName: string
+    sourceCharPosition: number
+    duration: number
+    invoker: string
+  }>
+}
+
+export type LongTaskSample = {
+  duration: number
+  startTime: number
+  /** Attribution container name from the longtask entry, when present. */
+  attribution: string
+}
+
+/** Per-component render accounting captured via the React commit hook. */
+export type RenderStat = {
+  component: string
+  commits: number
+  /** Summed actualDuration across commits (ms). */
+  totalDuration: number
+  maxDuration: number
+}
+
+export type NetworkSample = {
+  url: string
+  method: string
+  status: number
+  resourceType: string
+  transferSizeBytes: number
+  durationMs: number
+  /** true when it blocked first paint / is on the critical request chain. */
+  renderBlocking: boolean
+}
+
+export type ConsoleSample = {
+  level: 'error' | 'warning'
+  text: string
+  /** First stack location, when the browser provides one. */
+  location?: string
+}
+
+/** Heap comparison across a before/after boundary for leak detection. */
+export type HeapDelta = {
+  label: string
+  beforeBytes: number
+  afterBytes: number
+  deltaBytes: number
+  /** Detached DOM node count delta, when measurable via CDP. */
+  detachedNodesDelta?: number
+}
+
+export type A11yViolation = {
+  ruleId: string
+  impact: 'critical' | 'serious' | 'moderate' | 'minor'
+  help: string
+  selectors: string[]
+}
+
+/** App-owned startup marks read from performance.mark (init-timing.ts). */
+export type InitTimingMark = {
+  name: string
+  startTime: number
+}
+
+/** One probe run over a single (browser × scenario) pair. */
+export type ScenarioReport = {
+  scenario: string
+  browser: BrowserName
+  url: string
+  startedAt: string
+  vitals: WebVitalSample[]
+  loaf: LoafSample[]
+  longTasks: LongTaskSample[]
+  renders: RenderStat[]
+  /** Renders captured during a controlled unrelated interaction (noise probe). */
+  noiseRenders: RenderStat[]
+  network: NetworkSample[]
+  console: ConsoleSample[]
+  heap: HeapDelta[]
+  a11y: A11yViolation[]
+  initTiming: InitTimingMark[]
+  /** Uncaught page errors (crash signal), Tauri noise filtered out. */
+  pageErrors: string[]
+  screenshotPath?: string
+}
+
+/** Bundle/chunk analysis (cross-browser, run once per build). */
+export type BundleReport = {
+  entryChunkGzipBytes: number
+  totalJsGzipBytes: number
+  largestChunks: Array<{ file: string; gzipBytes: number }>
+  /** Modules unexpectedly pulled into the entry chunk. */
+  suspectEntryModules: string[]
+}
+
+/** Root artifact for one full harness run, written to the run directory. */
+export type RunReport = {
+  runId: string
+  startedAt: string
+  finishedAt?: string
+  gitRef: string
+  mode: 'sweep' | 'diff' | 'focus'
+  scenarios: ScenarioReport[]
+  bundle?: BundleReport
+}
+
+/** A normalized, agent-facing issue derived from one or more probe samples. */
+export type Finding = {
+  id: string
+  category: FindingCategory
+  title: string
+  severity: Severity
+  confidence: Confidence
+  status: FindingStatus
+  browsers: BrowserName[]
+  scenarios: string[]
+  /** Compact quantitative evidence (the metric that triggered this). */
+  evidence: string
+  /** Source location the issue attributes to: "file:line" or a selector. */
+  sourceAttribution?: string
+  /** Exact deterministic steps to reproduce (which probe + scenario + browser). */
+  repro: string
+  /** Before/after numbers once a fix is applied. */
+  beforeAfter?: { metric: string; before: number; after: number; unit: string }
+  suggestedFix?: string
+  /** Findings clustered with this one for a single PR. */
+  clusterId?: string
+  prUrl?: string
+}
+
+/** JSON Schema-friendly shape a verifier sub-agent must return. */
+export type VerdictReport = {
+  findingId: string
+  reproduced: boolean
+  isReal: boolean
+  /** Why it was confirmed or refuted, citing the re-run evidence. */
+  rationale: string
+  correctedSeverity?: Severity
+  sourceAttribution?: string
+}

--- a/.claude/skills/thunder-perf-hunt/scripts/lib/types.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/lib/types.ts
@@ -101,8 +101,12 @@ export type HeapDelta = {
   beforeBytes: number
   afterBytes: number
   deltaBytes: number
-  /** Detached DOM node count delta, when measurable via CDP. */
-  detachedNodesDelta?: number
+  /**
+   * Total live DOM node count delta (after − before), when measurable via CDP.
+   * Informational only — a positive value doesn't imply leaked/detached nodes,
+   * since live node counts fluctuate naturally across a navigate cycle.
+   */
+  domNodesDelta?: number
 }
 
 export type A11yViolation = {

--- a/.claude/skills/thunder-perf-hunt/scripts/probes/a11y.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/probes/a11y.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { Page } from 'playwright'
+import type { A11yViolation } from '../lib/types'
+
+const AXE_FALLBACK_PATH = '/home/chris/thunderbolt/node_modules/axe-core/axe.min.js'
+const MAX_VIOLATIONS = 25
+
+/** Shape of the subset of axe.run() output we read. Keeps `any` out of the probe. */
+type AxeResult = {
+  violations: Array<{
+    id: string
+    impact: A11yViolation['impact'] | null
+    help: string
+    nodes: Array<{ target: string[] }>
+  }>
+}
+
+/**
+ * Resolve the on-disk path to axe's minified bundle. The app ships
+ * `Cross-Origin-Embedder-Policy: credentialless`, so axe cannot be loaded from a
+ * CDN <script src> — we inject the local devDependency inline instead.
+ */
+const resolveAxePath = (): string => {
+  try {
+    return require.resolve('axe-core/axe.min.js')
+  } catch {
+    return AXE_FALLBACK_PATH
+  }
+}
+
+/**
+ * Inject axe-core into the page and run it, returning a compact list of
+ * violations. Any failure at the axe-injection boundary yields an empty list so
+ * the harness never crashes on a page axe can't analyze.
+ */
+export const collectA11y = async (page: Page): Promise<A11yViolation[]> => {
+  try {
+    await page.addScriptTag({ path: resolveAxePath() })
+  } catch {
+    return []
+  }
+
+  const result = (await page.evaluate(
+    `(async () => await window.axe.run())()`,
+  )) as AxeResult
+
+  return result.violations.slice(0, MAX_VIOLATIONS).map((violation) => ({
+    ruleId: violation.id,
+    impact: violation.impact ?? 'minor',
+    help: violation.help,
+    selectors: violation.nodes.flatMap((node) => node.target),
+  }))
+}

--- a/.claude/skills/thunder-perf-hunt/scripts/probes/a11y.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/probes/a11y.ts
@@ -5,7 +5,6 @@
 import type { Page } from 'playwright'
 import type { A11yViolation } from '../lib/types'
 
-const AXE_FALLBACK_PATH = '/home/chris/thunderbolt/node_modules/axe-core/axe.min.js'
 const MAX_VIOLATIONS = 25
 
 /** Shape of the subset of axe.run() output we read. Keeps `any` out of the probe. */
@@ -21,15 +20,10 @@ type AxeResult = {
 /**
  * Resolve the on-disk path to axe's minified bundle. The app ships
  * `Cross-Origin-Embedder-Policy: credentialless`, so axe cannot be loaded from a
- * CDN <script src> — we inject the local devDependency inline instead.
+ * CDN <script src> — we inject the local devDependency inline instead. Resolved
+ * from this module, so it works on any machine where axe-core is installed.
  */
-const resolveAxePath = (): string => {
-  try {
-    return require.resolve('axe-core/axe.min.js')
-  } catch {
-    return AXE_FALLBACK_PATH
-  }
-}
+const resolveAxePath = (): string => require.resolve('axe-core/axe.min.js')
 
 /**
  * Inject axe-core into the page and run it, returning a compact list of

--- a/.claude/skills/thunder-perf-hunt/scripts/probes/heap.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/probes/heap.ts
@@ -57,7 +57,7 @@ export const collectHeapDelta = async (
       beforeBytes: before.bytes,
       afterBytes: after.bytes,
       deltaBytes: after.bytes - before.bytes,
-      detachedNodesDelta: after.nodes - before.nodes,
+      domNodesDelta: after.nodes - before.nodes,
     }
   } catch {
     return null

--- a/.claude/skills/thunder-perf-hunt/scripts/probes/heap.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/probes/heap.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { CDPSession, Page } from 'playwright'
+import type { HeapDelta } from '../lib/types'
+
+/**
+ * Force a garbage collection, then read the used JS heap size (bytes) and the
+ * current DOM node count. Falls back to `performance.memory` for the heap when
+ * `Runtime.getHeapUsage` is unavailable.
+ */
+const measure = async (session: CDPSession, page: Page): Promise<{ bytes: number; nodes: number }> => {
+  await session.send('HeapProfiler.collectGarbage')
+
+  const usage = await session
+    .send('Runtime.getHeapUsage')
+    .then((r) => (r as { usedSize: number }).usedSize)
+    .catch(() => 0)
+  const bytes =
+    usage > 0
+      ? usage
+      : ((await page.evaluate(
+          `(() => performance.memory?.usedJSHeapSize ?? 0)()`,
+        )) as number)
+
+  const counters = (await session.send('Memory.getDOMCounters')) as { nodes: number }
+  return { bytes, nodes: counters.nodes }
+}
+
+/**
+ * Measure the JS heap and DOM-node delta across an action that stress-tests
+ * cleanup (typically navigate away and back). Chromium only — returns null on
+ * any CDP error (e.g. Firefox, where CDP sessions are unavailable).
+ */
+export const collectHeapDelta = async (
+  page: Page,
+  label: string,
+  action: () => Promise<void>,
+): Promise<HeapDelta | null> => {
+  const session = await page
+    .context()
+    .newCDPSession(page)
+    .catch(() => null)
+  if (!session) return null
+
+  try {
+    await session.send('HeapProfiler.enable')
+    const before = await measure(session, page)
+
+    await action()
+
+    const after = await measure(session, page)
+
+    return {
+      label,
+      beforeBytes: before.bytes,
+      afterBytes: after.bytes,
+      deltaBytes: after.bytes - before.bytes,
+      detachedNodesDelta: after.nodes - before.nodes,
+    }
+  } catch {
+    return null
+  } finally {
+    await session.detach().catch(() => {})
+  }
+}

--- a/.claude/skills/thunder-perf-hunt/scripts/report.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/report.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env bun
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Turns a RunReport into ranked candidate Findings by applying fixed
+ * thresholds, then renders a compact markdown summary. Thresholds are
+ * intentionally conservative (favor recall); the adversarial Verify phase in
+ * SKILL.md is responsible for precision. Run standalone to re-summarize:
+ *   bun scripts/report.ts .perf-hunt/runs/<id>/report.json
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import type { Finding, RunReport, ScenarioReport, Severity } from './lib/types'
+import { applyExclusions, loadCalibration } from './lib/calibration'
+
+const NOISE_RENDER_MIN_COMMITS = 3
+const LONG_TASK_MS = 120
+const LOAF_MS = 200
+const FORCED_LAYOUT_MS = 30
+const HEAP_LEAK_BYTES = 3_000_000
+const BIG_ASSET_BYTES = 1_000_000
+
+const sev = (rating: string): Severity =>
+  rating === 'poor' ? 'high' : rating === 'needs-improvement' ? 'medium' : 'low'
+
+const slug = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 60)
+
+/** Deterministic first-pass candidates. Recall-biased; verify downstream. */
+export const deriveCandidates = (report: RunReport): Finding[] => {
+  const out: Finding[] = []
+  const push = (f: Omit<Finding, 'status'>) => out.push({ ...f, status: 'candidate' })
+
+  for (const r of report.scenarios) {
+    const where = `${r.scenario}/${r.browser}`
+
+    for (const v of r.vitals) {
+      if (v.rating === 'good') continue
+      push({
+        id: slug(`vital-${v.name}-${where}`),
+        category: 'web-vital',
+        title: `${v.name} ${v.rating} on ${r.scenario} (${r.browser})`,
+        severity: sev(v.rating),
+        confidence: 'high',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: `${v.name}=${v.value}${v.name === 'CLS' ? '' : 'ms'} (${v.rating})`,
+        sourceAttribution: v.attribution,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser}`,
+      })
+    }
+
+    for (const rnd of r.noiseRenders) {
+      if (rnd.commits < NOISE_RENDER_MIN_COMMITS) continue
+      push({
+        id: slug(`rerender-${rnd.component}-${where}`),
+        category: 'unnecessary-render',
+        title: `<${rnd.component}> re-renders ${rnd.commits}x during unrelated interaction (${r.scenario}/${r.browser})`,
+        severity: rnd.commits >= 8 ? 'high' : 'medium',
+        confidence: 'medium',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: `${rnd.commits} commits, ${rnd.totalDuration}ms subtree render during a no-op interaction`,
+        sourceAttribution: rnd.component,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser} (inspect noiseRenders)`,
+        suggestedFix: 'Check for unstable props/context or missing memoization; see references/react-rerender-playbook.md',
+      })
+    }
+
+    for (const f of r.loaf) {
+      if (f.duration < LOAF_MS && f.forcedStyleAndLayoutDuration < FORCED_LAYOUT_MS) continue
+      const worst = [...f.scripts].sort((a, b) => b.duration - a.duration)[0]
+      const thrash = f.forcedStyleAndLayoutDuration >= FORCED_LAYOUT_MS
+      push({
+        id: slug(`${thrash ? 'thrash' : 'loaf'}-${worst?.sourceFunctionName || 'anon'}-${where}`),
+        category: thrash ? 'layout-thrash' : 'long-task',
+        title: `${thrash ? 'Layout thrash' : 'Long animation frame'} ${Math.round(f.duration)}ms on ${r.scenario} (${r.browser})`,
+        severity: f.duration >= 400 ? 'high' : 'medium',
+        confidence: 'high',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: `LoAF ${Math.round(f.duration)}ms, blocking ${Math.round(f.blockingDuration)}ms, forced layout ${Math.round(f.forcedStyleAndLayoutDuration)}ms`,
+        sourceAttribution: worst ? `${worst.sourceURL}:${worst.sourceCharPosition} ${worst.sourceFunctionName}` : undefined,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser}`,
+      })
+    }
+
+    for (const lt of r.longTasks.filter((t) => t.duration >= LONG_TASK_MS).slice(0, 3)) {
+      push({
+        id: slug(`longtask-${lt.attribution}-${where}-${Math.round(lt.startTime)}`),
+        category: 'long-task',
+        title: `Long task ${Math.round(lt.duration)}ms on ${r.scenario} (${r.browser})`,
+        severity: lt.duration >= 300 ? 'high' : 'medium',
+        confidence: 'medium',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: `${Math.round(lt.duration)}ms task, attribution=${lt.attribution}`,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser}`,
+      })
+    }
+
+    for (const h of r.heap) {
+      if (h.deltaBytes < HEAP_LEAK_BYTES && !(h.detachedNodesDelta && h.detachedNodesDelta > 0)) continue
+      push({
+        id: slug(`leak-${h.label}-${where}`),
+        category: 'memory-leak',
+        title: `Possible memory leak: +${(h.deltaBytes / 1e6).toFixed(1)}MB after ${h.label} (${r.browser})`,
+        severity: 'high',
+        confidence: 'low',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: `heap ${(h.beforeBytes / 1e6).toFixed(1)}→${(h.afterBytes / 1e6).toFixed(1)}MB, detached nodes Δ=${h.detachedNodesDelta ?? 'n/a'}`,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers chromium (heap delta)`,
+      })
+    }
+
+    for (const err of r.pageErrors.slice(0, 5)) {
+      push({
+        id: slug(`crash-${err}-${where}`),
+        category: 'crash',
+        title: `Uncaught error on ${r.scenario} (${r.browser})`,
+        severity: 'critical',
+        confidence: 'high',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: err,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser}`,
+      })
+    }
+
+    for (const c of r.console.filter((c) => c.level === 'error').slice(0, 5)) {
+      push({
+        id: slug(`console-${c.text}-${where}`),
+        category: 'console-error',
+        title: `Console error on ${r.scenario} (${r.browser})`,
+        severity: 'medium',
+        confidence: 'medium',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: c.text,
+        sourceAttribution: c.location,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser}`,
+      })
+    }
+
+    for (const a of r.a11y.filter((v) => v.impact === 'critical' || v.impact === 'serious').slice(0, 8)) {
+      push({
+        id: slug(`a11y-${a.ruleId}-${where}`),
+        category: 'a11y',
+        title: `a11y: ${a.ruleId} (${a.impact}) on ${r.scenario}`,
+        severity: a.impact === 'critical' ? 'high' : 'medium',
+        confidence: 'high',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: `${a.help} — ${a.selectors.slice(0, 3).join(', ')}`,
+        sourceAttribution: a.selectors[0],
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser}`,
+      })
+    }
+
+    // NOTE: script transfer sizes over the DEV server are Vite pre-bundles
+    // (node_modules/.vite/deps/*), not production chunks — so bundle findings
+    // come exclusively from analyze-bundle.ts (which builds prod), never from
+    // dev network sizes. Here we only flag network issues that ARE real in dev:
+    // server errors and oversized non-script assets (images/fonts/media).
+    for (const n of r.network.filter((n) => n.status >= 500 || n.status === 0).slice(0, 5)) {
+      push({
+        id: slug(`neterr-${n.url}-${where}`),
+        category: 'network',
+        title: `Failed request (${n.status || 'no response'}) on ${r.scenario} (${r.browser})`,
+        severity: 'high',
+        confidence: 'high',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: `${n.method} ${n.url} → ${n.status || 'network error'}`,
+        sourceAttribution: n.url,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser}`,
+      })
+    }
+    const bigAsset = r.network.filter(
+      (n) => n.resourceType !== 'script' && n.resourceType !== 'document' && n.transferSizeBytes >= BIG_ASSET_BYTES,
+    )
+    for (const n of bigAsset.slice(0, 3)) {
+      push({
+        id: slug(`asset-${n.url}-${where}`),
+        category: 'network',
+        title: `Large ${n.resourceType} asset ${(n.transferSizeBytes / 1024).toFixed(0)}KB on ${r.scenario}`,
+        severity: 'medium',
+        confidence: 'high',
+        browsers: [r.browser],
+        scenarios: [r.scenario],
+        evidence: `${n.url} = ${(n.transferSizeBytes / 1024).toFixed(0)}KB (${n.resourceType})`,
+        sourceAttribution: n.url,
+        repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers ${r.browser}`,
+      })
+    }
+  }
+
+  const merged = mergeAcrossBrowsers(out)
+  const cal = loadCalibration()
+  const kept = applyExclusions(merged, cal)
+  if (kept.length < merged.length) {
+    console.error(`perf-hunt: suppressed ${merged.length - kept.length} finding(s) via ${cal.excludeSignatures.length} learned exclusion(s)`)
+  }
+  return kept
+}
+
+/** Collapse the same issue seen in both browsers into one finding. */
+const mergeAcrossBrowsers = (findings: Finding[]): Finding[] => {
+  const byKey = new Map<string, Finding>()
+  for (const f of findings) {
+    const key = `${f.category}::${f.sourceAttribution ?? f.title.replace(/\(.*?\)/g, '')}`
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, f)
+      continue
+    }
+    existing.browsers = [...new Set([...existing.browsers, ...f.browsers])]
+    existing.scenarios = [...new Set([...existing.scenarios, ...f.scenarios])]
+  }
+  const order: Record<Severity, number> = { critical: 0, high: 1, medium: 2, low: 3 }
+  return [...byKey.values()].sort((a, b) => order[a.severity] - order[b.severity])
+}
+
+const perfLine = (r: ScenarioReport): string => {
+  const v = (n: string) => r.vitals.find((x) => x.name === n)
+  const lcp = v('LCP')
+  const inp = v('INP')
+  const cls = v('CLS')
+  const noisy = r.noiseRenders.filter((x) => x.commits >= NOISE_RENDER_MIN_COMMITS).length
+  return `| ${r.scenario} | ${r.browser} | ${lcp ? lcp.value + 'ms' : '—'} | ${inp ? inp.value + 'ms' : '—'} | ${cls ? cls.value : '—'} | ${r.longTasks.length} | ${noisy} | ${r.console.filter((c) => c.level === 'error').length} | ${r.a11y.length} |`
+}
+
+export const summarize = (report: RunReport, findings: Finding[]): string => {
+  const bySev = (s: Severity) => findings.filter((f) => f.severity === s).length
+  const lines = [
+    `# perf-hunt report — ${report.runId}`,
+    ``,
+    `Mode: **${report.mode}** · git \`${report.gitRef}\` · ${report.scenarios.length} scenario runs`,
+    `Findings: **${findings.length}** — 🔴 ${bySev('critical')} critical · 🟠 ${bySev('high')} high · 🟡 ${bySev('medium')} medium · ⚪ ${bySev('low')} low`,
+    ``,
+    `## Per-scenario metrics`,
+    ``,
+    `| scenario | browser | LCP | INP | CLS | long tasks | noisy renders | console errs | a11y |`,
+    `| --- | --- | --- | --- | --- | --- | --- | --- | --- |`,
+    ...report.scenarios.map(perfLine),
+    ``,
+    `## Candidate findings (recall-biased — verify before fixing)`,
+    ``,
+    ...findings.map(
+      (f, i) =>
+        `${i + 1}. **[${f.severity}/${f.category}]** ${f.title}\n   - evidence: ${f.evidence}\n   - source: ${f.sourceAttribution ?? '(needs attribution)'}\n   - repro: \`${f.repro}\``,
+    ),
+  ]
+  return lines.join('\n')
+}
+
+if (import.meta.main) {
+  const path = process.argv[2]
+  if (!path) throw new Error('usage: bun scripts/report.ts <report.json>')
+  const report = JSON.parse(readFileSync(path, 'utf8')) as RunReport
+  const findings = deriveCandidates(report)
+  const dir = path.replace(/\/report\.json$/, '')
+  writeFileSync(`${dir}/findings.json`, JSON.stringify(findings, null, 2))
+  writeFileSync(`${dir}/summary.md`, summarize(report, findings))
+  console.log(`${dir}/summary.md`)
+}

--- a/.claude/skills/thunder-perf-hunt/scripts/report.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/report.ts
@@ -101,7 +101,9 @@ export const deriveCandidates = (report: RunReport): Finding[] => {
     }
 
     for (const h of r.heap) {
-      if (h.deltaBytes < HEAP_LEAK_BYTES && !(h.detachedNodesDelta && h.detachedNodesDelta > 0)) continue
+      // The byte delta is the real leak signal; the DOM-node delta is only
+      // context (live node counts fluctuate, so >0 alone over-reports).
+      if (h.deltaBytes < HEAP_LEAK_BYTES) continue
       push({
         id: slug(`leak-${h.label}-${where}`),
         category: 'memory-leak',
@@ -110,7 +112,7 @@ export const deriveCandidates = (report: RunReport): Finding[] => {
         confidence: 'low',
         browsers: [r.browser],
         scenarios: [r.scenario],
-        evidence: `heap ${(h.beforeBytes / 1e6).toFixed(1)}→${(h.afterBytes / 1e6).toFixed(1)}MB, detached nodes Δ=${h.detachedNodesDelta ?? 'n/a'}`,
+        evidence: `heap ${(h.beforeBytes / 1e6).toFixed(1)}→${(h.afterBytes / 1e6).toFixed(1)}MB, DOM nodes Δ=${h.domNodesDelta ?? 'n/a'}`,
         repro: `bun scripts/run.ts --mode focus --focus ${r.scenario} --browsers chromium (heap delta)`,
       })
     }

--- a/.claude/skills/thunder-perf-hunt/scripts/report.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/report.ts
@@ -208,11 +208,17 @@ export const deriveCandidates = (report: RunReport): Finding[] => {
   return kept
 }
 
-/** Collapse the same issue seen in both browsers into one finding. */
+/** Collapse the same issue+scenario seen in both browsers into one finding. */
 const mergeAcrossBrowsers = (findings: Finding[]): Finding[] => {
+  const order: Record<Severity, number> = { critical: 0, high: 1, medium: 2, low: 3 }
   const byKey = new Map<string, Finding>()
   for (const f of findings) {
-    const key = `${f.category}::${f.sourceAttribution ?? f.title.replace(/\(.*?\)/g, '')}`
+    // Fold the scenario into the key so the same attribution on different pages
+    // (a component that re-renders on two routes, an axe selector flagged on
+    // both) stays distinct — only genuine cross-browser duplicates of one issue
+    // on one scenario merge.
+    const attribution = f.sourceAttribution ?? f.title.replace(/\(.*?\)/g, '')
+    const key = `${f.category}::${f.scenarios.join(',')}::${attribution}`
     const existing = byKey.get(key)
     if (!existing) {
       byKey.set(key, f)
@@ -220,8 +226,9 @@ const mergeAcrossBrowsers = (findings: Finding[]): Finding[] => {
     }
     existing.browsers = [...new Set([...existing.browsers, ...f.browsers])]
     existing.scenarios = [...new Set([...existing.scenarios, ...f.scenarios])]
+    // Keep the more severe reading rather than letting the first-seen browser win.
+    if (order[f.severity] < order[existing.severity]) existing.severity = f.severity
   }
-  const order: Record<Severity, number> = { critical: 0, high: 1, medium: 2, low: 3 }
   return [...byKey.values()].sort((a, b) => order[a.severity] - order[b.severity])
 }
 

--- a/.claude/skills/thunder-perf-hunt/scripts/run.ts
+++ b/.claude/skills/thunder-perf-hunt/scripts/run.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Deterministic entry point for the harness. Boots the stack, drives every
+ * requested (browser × scenario), and writes a single RunReport JSON plus
+ * screenshots to a run directory. The agentic layer (SKILL.md) reads only the
+ * JSON — never this script's stdout beyond the printed report path.
+ *
+ * Usage:
+ *   bun scripts/run.ts --mode sweep --browsers chromium,firefox
+ *   bun scripts/run.ts --mode diff --changed src/chat/foo.tsx,src/models/bar.tsx
+ *   bun scripts/run.ts --mode focus --focus chat-landing --browsers chromium
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { REPO_ROOT } from './lib/env'
+import { bootStack } from './lib/boot'
+import { collectScenario, launchBrowser } from './lib/collect'
+import { SCENARIOS, scenariosForChangedFiles, type ScenarioDef } from './lib/scenarios'
+import type { BrowserName, RunReport, ScenarioReport } from './lib/types'
+
+const flag = (name: string, fallback = ''): string => {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const gitRef = (): string => {
+  try {
+    return new TextDecoder().decode(Bun.spawnSync(['git', 'rev-parse', '--short', 'HEAD'], { cwd: REPO_ROOT }).stdout).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const selectScenarios = (mode: string): ScenarioDef[] => {
+  if (mode === 'diff') return scenariosForChangedFiles(flag('changed').split(',').filter(Boolean))
+  if (mode === 'focus') {
+    const names = flag('focus').split(',').filter(Boolean)
+    return SCENARIOS.filter((s) => names.includes(s.name))
+  }
+  return SCENARIOS
+}
+
+const main = async () => {
+  const mode = (flag('mode', 'sweep') as RunReport['mode']) || 'sweep'
+  const browsers = (flag('browsers', 'chromium,firefox').split(',').filter(Boolean) as BrowserName[])
+  const scenarios = selectScenarios(mode)
+  if (scenarios.length === 0) throw new Error(`perf-hunt: no scenarios matched (mode=${mode})`)
+
+  const runId = flag('run-id', new Date().toISOString().replace(/[:.]/g, '-'))
+  const runDir = flag('out', `${REPO_ROOT}/.perf-hunt/runs/${runId}`)
+  mkdirSync(runDir, { recursive: true })
+
+  console.error(`perf-hunt: booting stack for run ${runId} (${mode}, ${browsers.join('+')}, ${scenarios.length} scenarios)`)
+  const stack = await bootStack(REPO_ROOT)
+
+  const reports: ScenarioReport[] = []
+  const browserErrors: string[] = []
+  try {
+    for (const browserName of browsers) {
+      // Isolate per-browser failures: a browser that can't launch on this host
+      // (e.g. Playwright Firefox on a bleeding-edge OS) must not discard the
+      // results already gathered from the browsers that did work.
+      let browser
+      try {
+        browser = await launchBrowser(browserName)
+      } catch (err) {
+        const msg = `[${browserName}] launch failed: ${err instanceof Error ? err.message.split('\n')[0] : String(err)}`
+        console.error(`perf-hunt: ${msg}`)
+        browserErrors.push(msg)
+        continue
+      }
+      try {
+        for (const scenario of scenarios) {
+          console.error(`perf-hunt: [${browserName}] ${scenario.name}`)
+          reports.push(await collectScenario(browser, browserName, stack.baseUrl, scenario, runDir))
+        }
+      } finally {
+        await browser.close().catch(() => {})
+      }
+    }
+  } finally {
+    await stack.teardown()
+  }
+
+  if (reports.length === 0) {
+    throw new Error(`perf-hunt: no scenarios collected. ${browserErrors.join('; ') || 'unknown error'}`)
+  }
+
+  const report: RunReport = {
+    runId,
+    startedAt: reports[0]?.startedAt ?? new Date().toISOString(),
+    finishedAt: new Date().toISOString(),
+    gitRef: gitRef(),
+    mode,
+    scenarios: reports,
+  }
+  const reportPath = `${runDir}/report.json`
+  writeFileSync(reportPath, JSON.stringify(report, null, 2))
+  // The ONLY thing the agent parses from stdout: the path to the JSON report.
+  console.log(reportPath)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/.claude/skills/thunder-perf-hunt/scripts/tsconfig.json
+++ b/.claude/skills/thunder-perf-hunt/scripts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noUncheckedIndexedAccess": false
+  },
+  "include": ["**/*.ts"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ mise.toml
 !.claude/skills/
 !.claude/skills/thunder-deep-review/
 !.claude/skills/thunder-deep-review/**
+!.claude/skills/thunder-perf-hunt/
+!.claude/skills/thunder-perf-hunt/**
 .zed/**
 .zedscratches/**
 .mcp.json
@@ -80,3 +82,7 @@ Pulumi.*.yaml
 
 # Astro
 .astro/
+
+# thunder-perf-hunt run artifacts (reports, screenshots) + throwaway pglite data
+.perf-hunt/
+.pglite/

--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/browser": "^4.1.4",
         "@vitest/coverage-v8": "^4.1.4",
+        "axe-core": "^4.12.1",
         "bun-types": "^1.2.20",
         "dotenv": "^17.2.1",
         "drizzle-kit": "^0.31.4",
@@ -1036,7 +1037,7 @@
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
-    "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -2381,6 +2382,8 @@
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@storybook/addon-a11y/axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/browser": "^4.1.4",
     "@vitest/coverage-v8": "^4.1.4",
+    "axe-core": "^4.12.1",
     "bun-types": "^1.2.20",
     "dotenv": "^17.2.1",
     "drizzle-kit": "^0.31.4",


### PR DESCRIPTION
## What
Adds the **thunder-perf-hunt** skill — a two-layer harness for hunting performance, functional-bug, and a11y issues in the web app.

- **Layer 1 (deterministic):** Bun + Playwright probes that boot a Docker-free stack (pglite + anonymous auth) on dedicated ports (`:1431`/`:8010`) and drive headless **Chromium + Firefox**, emitting compact JSON — `run.ts` (perf/a11y/console sweep), `report.ts` (thresholded findings), `explore.ts` (curiosity-driven state-graph crawler), `analyze-bundle.ts`, plus `lib/` and `probes/`.
- **Layer 2 (agentic):** `SKILL.md` + `references/` — the Scout → Triage → **adversarial Verify** → Fix → PR workflow (separate discovery from verification; reproduce + attribute before believing), with per-lens playbooks (metrics/thresholds, re-render, fix, a11y, gecko-profiler, verification rubric, self-improve).
- **Learned overlay:** `calibration.json` (false-positive exclusions + discovered scenarios) and `LEARNINGS.md` (the self-improvement log).

## Why it's safe / self-contained
- Binds to dedicated ports off the `make dev` (1420/8000) and e2e bands, so it never collides with a dev server or the e2e suite; reuses an already-serving stack if present.
- Never touches production — pglite + anonymous auto-session; the only new runtime dep is `axe-core` (devDependency, for the a11y probe).
- `.gitignore` ignores the `.perf-hunt/` run artifacts and `.pglite/` throwaway data, so runs never dirty the tree.

## What this session produced with it
Four fix PRs (#1057 a11y; #1058/#1059/#1060 bundle — **entry chunk 788.5 → 633.9 KB gzip, ~−20%**), each adversarially verified. This PR also folds in the harness self-improvements from those runs (idle-restore render-probe fix that eliminated 107 false positives, a streaming scenario via the dev Message Simulator, `explore.ts` honoring calibration exclusions, and documented false-positive suppressions).

## How to run
See `SKILL.md`. Quick start: `bun .claude/skills/thunder-perf-hunt/scripts/run.ts --mode sweep --browsers chromium,firefox` (browsers install once via `bun node_modules/playwright-core/cli.js install chromium firefox`).

## Reviewer notes
- 32 files, no `src/` app changes (those are in #1057–#1060).
- Scripts are typechecked via `scripts/tsconfig.json` (`bun x tsc -p .claude/skills/thunder-perf-hunt/scripts/tsconfig.json`).
