### PR TITLE
refactor(THU-653): make PowerSync JWT kid env-driven

### DIFF
--- a/deploy/config/powersync-config.yaml
+++ b/deploy/config/powersync-config.yaml
@@ -30,7 +30,6 @@ sync_rules:
         data:
           - SELECT * FROM powersync.chat_messages WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
-          - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.skills WHERE user_id = bucket.user_id
           - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id
@@ -42,15 +41,14 @@ client_auth:
   jwks:
     keys:
       - kty: oct
-        # Base64 of POWERSYNC_JWT_SECRET. Sourced from PS_JWT_KEY_BASE64 at runtime so
-        # the value can rotate per environment without rebuilding the image. The PS_
-        # prefix is mandatory — PowerSync's YAML loader rejects !env substitutions for
-        # variables that don't start with it (security guardrail).
-        # Local default: base64("enterprise-thunderbolt-powersync-jwt-default-secret").
-        # Preview stacks (Pulumi) inject base64 of the per-stack random JWT secret.
+        # Both k (secret) and kid (label) are env-driven so the same image can serve
+        # multiple environments without a rebuild. Must match the values the backend
+        # signs with: k = base64(POWERSYNC_JWT_SECRET), kid = POWERSYNC_JWT_KID.
+        # The PS_ prefix is mandatory — PowerSync's YAML loader rejects !env
+        # substitutions for variables that don't start with it (security guardrail).
         # Backend validates the underlying secret is >=32 chars when decoded.
         k: !env PS_JWT_KEY_BASE64
         alg: HS256
-        kid: enterprise-powersync
+        kid: !env PS_JWT_KID
   telemetry:
     disable_telemetry_sharing: true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -93,6 +93,8 @@ services:
       # Default value below = base64("enterprise-thunderbolt-powersync-jwt-default-secret"),
       # which matches the default backend POWERSYNC_JWT_SECRET.
       PS_JWT_KEY_BASE64: ZW50ZXJwcmlzZS10aHVuZGVyYm9sdC1wb3dlcnN5bmMtand0LWRlZmF1bHQtc2VjcmV0
+      # Label paired with the JWT secret. Must match the backend's POWERSYNC_JWT_KID.
+      PS_JWT_KID: enterprise-powersync
     volumes:
       - ./config/powersync-config.yaml:/config/config.yaml
     ports:

--- a/deploy/k8s/templates/configmaps.yaml
+++ b/deploy/k8s/templates/configmaps.yaml
@@ -38,7 +38,6 @@ data:
             data:
               - SELECT * FROM powersync.chat_messages WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.tasks WHERE user_id = bucket.user_id
-              - SELECT * FROM powersync.mcp_servers WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.prompts WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.skills WHERE user_id = bucket.user_id
               - SELECT * FROM powersync.triggers WHERE user_id = bucket.user_id

--- a/deploy/pulumi/src/services.ts
+++ b/deploy/pulumi/src/services.ts
@@ -271,6 +271,9 @@ export const createServices = (args: ServiceArgs) => {
           // The PS_ prefix is mandatory: PowerSync's YAML loader rejects !env vars
           // that don't start with it.
           { name: 'PS_JWT_KEY_BASE64', value: args.secrets.powersyncJwtSecret.apply((s) => Buffer.from(s).toString('base64')) },
+          // Label paired with PS_JWT_KEY_BASE64. Must match the backend's
+          // POWERSYNC_JWT_KID so PowerSync can find the right key when validating.
+          { name: 'PS_JWT_KID', value: 'enterprise-powersync' },
         ],
         portMappings: [{ containerPort: 8080 }],
         logConfiguration: logConfig('powersync'),

--- a/deploy/pulumi/src/shared.ts
+++ b/deploy/pulumi/src/shared.ts
@@ -492,6 +492,9 @@ export const createSharedStack = (args: SharedStackArgs): SharedStackOutputs => 
             name: 'POWERSYNC_JWT_KEY_BASE64',
             value: args.powersyncJwtSecret.apply((s) => Buffer.from(s).toString('base64')),
           },
+          // Label paired with the JWT secret. Must match the backend's
+          // POWERSYNC_JWT_KID so PowerSync can find the right key when validating.
+          { name: 'PS_JWT_KID', value: 'enterprise-powersync' },
         ],
         portMappings: [{ containerPort: 8080 }],
         logConfiguration: logConfig('powersync'),


### PR DESCRIPTION
## Summary

Makes the JWT `kid` in `deploy/config/powersync-config.yaml` env-driven (`!env PS_JWT_KID`) so the same PowerSync image can validate JWTs signed with any backend's existing `POWERSYNC_JWT_KID` value. Unblocks the operational migration of production PowerSync from PowerSync Cloud to a self-hosted service on Render — the two Render resources (`powersync` Web Service + `powersync-storage` Postgres) will be provisioned manually via the Render dashboard, no repo changes needed.

Also removes an orphan `mcp_servers` sync rule from `deploy/config/powersync-config.yaml` and `deploy/k8s/templates/configmaps.yaml` — it was never in `shared/powersync-tables.ts` or the backend schema.

## Behavior preservation

- Preview + enterprise Pulumi stacks continue to work: `services.ts` and `shared.ts` now inject `PS_JWT_KID: enterprise-powersync` (the value the yaml previously hardcoded).
- The enterprise `docker-compose.yml` does the same for the local self-host stack.
- The k8s Helm chart is unaffected — its config already uses a Helm-templated `kid` (`{{ .Values.powersync.jwt.kid }}`).

## Test plan

- Local enterprise `docker compose up postgres powersync` — clean boot, sync rules load, replication starts, JWT validation works end-to-end (401 on unauth/malformed, valid HS256 JWT with matching kid reaches the post-auth Fastify layer).
- Locally-built `deploy/docker/powersync.Dockerfile` image tested identically.