### PR TITLE
docs(THU-653): update sync-rule workflow for self-hosted PowerSync

### DIFF
--- a/.claude/agents/powersync-sync-reviewer.md
+++ b/.claude/agents/powersync-sync-reviewer.md
@@ -32,8 +32,8 @@ Before reviewing, read the relevant architecture docs (don't rely on memory):
 - For every new `backend/drizzle/*.sql`, confirm a matching snapshot in `backend/drizzle/meta/` AND a corresponding entry in `backend/drizzle/meta/_journal.json`. A missing journal entry means the migration never runs. This is easy to miss when cherry-picking migration files across branches.
 
 **3. Sync-rule & schema parity**
-- The table/columns must agree across: backend Drizzle schema, frontend Drizzle schema (PR 2), `shared/powersync-tables.ts`, and the `config.yaml` sync rule. Flag any column present in one but missing in another.
-- Remind the reviewer (note) that the PowerSync Cloud **dashboard rules must be updated manually** after PR 1's migration — code alone is not enough.
+- The table/columns must agree across: backend Drizzle schema, frontend Drizzle schema (PR 2), `shared/powersync-tables.ts`, and **all three** sync-rule configs (`powersync-service/config/config.yaml`, `deploy/config/powersync-config.yaml`, `deploy/k8s/templates/configmaps.yaml`). Flag any column or table present in one but missing in another.
+- Remind the reviewer (note) that after PR 1 merges, the new `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` image must be rolled onto the Render `powersync` service before PR 2 merges — CI rebuilds the image automatically, but the Render service does not auto-deploy.
 
 **4. Encryption**
 - If the table carries sensitive data, verify encrypted-column configuration matches `docs/architecture/e2e-encryption.md`. Flag plaintext storage of data that should be E2E-encrypted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,8 @@ See [docs/architecture/e2e-encryption.md](docs/architecture/e2e-encryption.md) f
 
 **Deploying new synced tables (two-PR process):**
 
-1. **PR 1 (backend-only):** Backend schema, Drizzle migration, `shared/powersync-tables.ts`, and `config.yaml` sync rule. Merge → run migration → update PowerSync Cloud dashboard rules.
-2. **PR 2 (frontend + everything else):** Frontend schema, DAL, defaults, reconciliation, and any UI/logic. Merge only after PR 1's dashboard rules are live.
+1. **PR 1 (backend + sync rules):** Backend schema, Drizzle migration, `shared/powersync-tables.ts`, and all three sync-rule configs (`powersync-service/config/config.yaml`, `deploy/config/powersync-config.yaml`, and `deploy/k8s/templates/configmaps.yaml`). Merge → run migration → wait for `images-publish.yml` to publish the new `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` image → **roll the Render `powersync` service to the new tag** (dashboard → Manual Deploy → Deploy latest reference).
+2. **PR 2 (frontend + everything else):** Frontend schema, DAL, defaults, reconciliation, and any UI/logic. Merge only after PR 1's image is live on Render.
 
 Deploying frontend before the sync rules are updated causes silent sync failure — the table works locally but won't replicate across devices.
 See [docs/architecture/powersync-account-devices.md](docs/architecture/powersync-account-devices.md#pr-flow-for-adding-tables).

--- a/docs/architecture/multi-device-sync.md
+++ b/docs/architecture/multi-device-sync.md
@@ -68,7 +68,7 @@ Adding a table touches both clients and the backend plus the PowerSync sync rule
 
 1. **Backend + sync rules PR**
    - Add the table to `backend/src/db/powersync-schema.ts` with a Drizzle migration.
-   - Register in [`shared/powersync-tables.ts`](../../shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` + `powersyncTableToQueryKeys`).
+   - Register in [`shared/powersync-tables.ts`](../../shared/powersync-tables.ts) (`powersyncTableNames` + `powersyncTableToQueryKeys`).
    - Add the sync rule to all three configs: `powersync-service/config/config.yaml`, `deploy/config/powersync-config.yaml`, and `deploy/k8s/templates/configmaps.yaml`.
    - Merge and deploy this first. On merge, CI publishes a new `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` image; roll the Render `powersync` service to that new tag before PR 2 merges.
 

--- a/docs/architecture/multi-device-sync.md
+++ b/docs/architecture/multi-device-sync.md
@@ -68,9 +68,9 @@ Adding a table touches both clients and the backend plus the PowerSync sync rule
 
 1. **Backend + sync rules PR**
    - Add the table to `backend/src/db/powersync-schema.ts` with a Drizzle migration.
-   - Register in [`shared/powersync-tables.ts`](../shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` + `powersyncTableToQueryKeys`).
-   - Add the sync rule to `powersync-service/config/config.yaml`.
-   - Merge and deploy this first, then update the PowerSync Cloud dashboard rules for production.
+   - Register in [`shared/powersync-tables.ts`](../../shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` + `powersyncTableToQueryKeys`).
+   - Add the sync rule to all three configs: `powersync-service/config/config.yaml`, `deploy/config/powersync-config.yaml`, and `deploy/k8s/templates/configmaps.yaml`.
+   - Merge and deploy this first. On merge, CI publishes a new `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` image; roll the Render `powersync` service to that new tag before PR 2 merges.
 
 2. **Frontend + feature PR**
    - Add the table to `src/db/tables.ts` and `src/db/powersync/schema.ts`.

--- a/docs/architecture/powersync-account-devices.md
+++ b/docs/architecture/powersync-account-devices.md
@@ -10,7 +10,7 @@ This document consolidates documentation for:
 
 ## 1. PowerSync Overview
 
-PowerSync provides offline-first sync between the backend (PostgreSQL) and clients (SQLite). Data is scoped by `user_id` from the JWT. The backend issues PowerSync JWTs and can apply client uploads (PUT/PATCH/DELETE) to Postgres. Production uses PowerSync Cloud; local development uses the Docker stack in `powersync-service/`.
+PowerSync provides offline-first sync between the backend (PostgreSQL) and clients (SQLite). Data is scoped by `user_id` from the JWT. The backend issues PowerSync JWTs and can apply client uploads (PUT/PATCH/DELETE) to Postgres. Production runs the self-hosted PowerSync service on Render (image: `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync`); local development uses the Docker stack in `powersync-service/`. The frontend never hard-codes the PowerSync URL — the backend returns it in `/powersync/token`, so URL changes are transparent to clients.
 
 For the sync data transformation middleware and custom SharedWorker (E2E encryption pipeline), see [docs/powersync-sync-middleware.md](powersync-sync-middleware.md).
 
@@ -30,7 +30,7 @@ For the sync data transformation middleware and custom SharedWorker (E2E encrypt
 
 Defined in [shared/powersync-tables.ts](../shared/powersync-tables.ts):
 
-`settings`, `chat_threads`, `chat_messages`, `tasks`, `models`, `mcp_servers`, `prompts`, `triggers`, `modes`, `model_profiles`, `devices`.
+`settings`, `chat_threads`, `chat_messages`, `tasks`, `models`, `prompts`, `skills`, `triggers`, `modes`, `model_profiles`, `devices`, `agents`.
 
 ### Indexes and Foreign Keys
 
@@ -54,21 +54,25 @@ See [docs/composite-primary-keys-and-default-data.md](composite-primary-keys-and
 2. **Backend schema**: Add only a `user_id` index: `index('idx_[table]_user_id').on(table.userId)`. Do not add composite foreign keys or other indexes (see above).
 3. Register in [src/db/powersync/schema.ts](../src/db/powersync/schema.ts) (`drizzleSchema`).
 4. Add the table name and query keys in [shared/powersync-tables.ts](../shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` and `powersyncTableToQueryKeys`).
-5. Update [powersync-service/config/config.yaml](../powersync-service/config/config.yaml): add a line under `sync_rules.content` → `bucket_definitions.user_data.data` (e.g. `- SELECT * FROM my_table WHERE my_table.user_id = bucket.user_id`).
+5. Update **all three** sync-rule configs so local, preview, prod, and enterprise-k8s stay in parity:
+   - [powersync-service/config/config.yaml](../../powersync-service/config/config.yaml) — local docker-compose.
+   - [deploy/config/powersync-config.yaml](../../deploy/config/powersync-config.yaml) — baked into the `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` image; used by preview stacks (Pulumi) and prod on Render.
+   - [deploy/k8s/templates/configmaps.yaml](../../deploy/k8s/templates/configmaps.yaml) — Helm-rendered config for the enterprise k8s deploy path.
+   Add a line under `sync_rules.content` → the appropriate bucket in each: `bucket_definitions.user_essentials.data` for latency-sensitive tables (loaded first, priority 1), or `bucket_definitions.user_data.data` for the rest (priority 2). Example: `- SELECT * FROM powersync.my_table WHERE user_id = bucket.user_id`.
 6. Run migrations for frontend and backend as needed.
 
 ### PR Flow for Adding Tables
 
 Split the work into two PRs to avoid sync rule mismatches:
 
-1. **PR 1 – Backend schemas and migrations**
-   - Backend: table in `backend/src/db/powersync-schema.ts`, migration, `shared/powersync-tables.ts`, `config.yaml` sync rules.
-   - Merge this PR first.
-   - After deploy finishes, update sync rules in the PowerSync Cloud dashboard (production uses PowerSync Cloud; local uses `powersync-service` config).
+1. **PR 1 – Backend schemas, migrations, and sync rules**
+   - Backend: table in `backend/src/db/powersync-schema.ts`, migration, `shared/powersync-tables.ts`, and all three sync-rule configs (see step 5 above).
+   - Merge this PR first. On merge, `.github/workflows/images-publish.yml` rebuilds `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` with the updated sync rules baked in.
+   - **Roll the Render `powersync` service to the new image tag** before merging PR 2. Preview stacks pick up the new image on their next Pulumi apply.
 
 2. **PR 2 – Frontend and remaining changes**
    - Frontend: table in `src/db/tables.ts`, `src/db/powersync/schema.ts`, and any UI/feature code.
-   - Merge after PR 1 is deployed and PowerSync rules are updated.
+   - Merge after PR 1's image is live on Render.
 
 ---
 

--- a/docs/architecture/powersync-account-devices.md
+++ b/docs/architecture/powersync-account-devices.md
@@ -53,7 +53,7 @@ See [docs/composite-primary-keys-and-default-data.md](composite-primary-keys-and
 1. Create the table in both `src/db/tables.ts` and `backend/src/db/powersync-schema.ts` (include `user_id`).
 2. **Backend schema**: Add only a `user_id` index: `index('idx_[table]_user_id').on(table.userId)`. Do not add composite foreign keys or other indexes (see above).
 3. Register in [src/db/powersync/schema.ts](../src/db/powersync/schema.ts) (`drizzleSchema`).
-4. Add the table name and query keys in [shared/powersync-tables.ts](../shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` and `powersyncTableToQueryKeys`).
+4. Add the table name and query keys in [shared/powersync-tables.ts](../../shared/powersync-tables.ts) (`powersyncTableNames` and `powersyncTableToQueryKeys`).
 5. Update **all three** sync-rule configs so local, preview, prod, and enterprise-k8s stay in parity:
    - [powersync-service/config/config.yaml](../../powersync-service/config/config.yaml) — local docker-compose.
    - [deploy/config/powersync-config.yaml](../../deploy/config/powersync-config.yaml) — baked into the `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` image; used by preview stacks (Pulumi) and prod on Render.
@@ -84,7 +84,7 @@ See [powersync-service/README.md](../powersync-service/README.md) for full steps
 - PowerSync API: http://localhost:8080
 - Postgres: localhost:5433 (use this for the backend so PowerSync and app share one database)
 - Backend `.env`: set `DATABASE_DRIVER=postgres`, `DATABASE_URL=postgresql://postgres:postgres@localhost:5433/postgres`, and PowerSync vars (see below)
-- Sync rules in `powersync-service/config/config.yaml` must match backend tables; when you add/change tables, update that file and `VALID_TABLES` in `backend/src/api/powersync.ts` (which uses `POWERSYNC_TABLE_NAMES` from shared).
+- Sync rules in `powersync-service/config/config.yaml` must match backend tables; when you add/change tables, update that file. The backend's upload validator (`validTables` in `backend/src/dal/powersync.ts`) is derived from `powersyncTableNames` in `shared/powersync-tables.ts` automatically — no manual sync needed there.
 
 ### Backend PowerSync Env Vars (Local)
 

--- a/docs/architecture/powersync-sync-middleware.md
+++ b/docs/architecture/powersync-sync-middleware.md
@@ -35,7 +35,7 @@ Two distinct paths exist depending on the platform. Both end at the same point �
 
 ```mermaid
 flowchart TD
-    Server["PowerSync Cloud<br/>(encrypted data)"]
+    Server["PowerSync service<br/>(encrypted data)"]
 
     subgraph MainThread["Main Thread"]
         TPS["ThunderboltPowerSyncDatabase<br/>extends PowerSyncDatabase<br/><br/>generateBucketStorageAdapter()<br/>→ creates TransformableBucketStorage<br/>  (unused in SharedWorker path)"]
@@ -63,7 +63,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    Server["PowerSync Cloud<br/>(encrypted data)"]
+    Server["PowerSync service<br/>(encrypted data)"]
 
     subgraph MainThread["Main Thread"]
         TPS["ThunderboltPowerSyncDatabase<br/>extends PowerSyncDatabase<br/><br/>generateBucketStorageAdapter()<br/>→ creates TransformableBucketStorage<br/>  + registers encryptionMiddleware"]

--- a/docs/multi-device-sync.md
+++ b/docs/multi-device-sync.md
@@ -68,7 +68,7 @@ Adding a table touches both clients and the backend plus the PowerSync sync rule
 
 1. **Backend + sync rules PR**
    - Add the table to `backend/src/db/powersync-schema.ts` with a Drizzle migration.
-   - Register in [`shared/powersync-tables.ts`](../shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` + `powersyncTableToQueryKeys`).
+   - Register in [`shared/powersync-tables.ts`](../shared/powersync-tables.ts) (`powersyncTableNames` + `powersyncTableToQueryKeys`).
    - Add the sync rule to all three configs: `powersync-service/config/config.yaml`, `deploy/config/powersync-config.yaml`, and `deploy/k8s/templates/configmaps.yaml`.
    - Merge and deploy this first. On merge, CI publishes a new `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` image; roll the Render `powersync` service to that new tag before PR 2 merges.
 

--- a/docs/multi-device-sync.md
+++ b/docs/multi-device-sync.md
@@ -69,8 +69,8 @@ Adding a table touches both clients and the backend plus the PowerSync sync rule
 1. **Backend + sync rules PR**
    - Add the table to `backend/src/db/powersync-schema.ts` with a Drizzle migration.
    - Register in [`shared/powersync-tables.ts`](../shared/powersync-tables.ts) (`POWERSYNC_TABLE_NAMES` + `powersyncTableToQueryKeys`).
-   - Add the sync rule to `powersync-service/config/config.yaml`.
-   - Merge and deploy this first, then update the PowerSync Cloud dashboard rules for production.
+   - Add the sync rule to all three configs: `powersync-service/config/config.yaml`, `deploy/config/powersync-config.yaml`, and `deploy/k8s/templates/configmaps.yaml`.
+   - Merge and deploy this first. On merge, CI publishes a new `ghcr.io/thunderbird/thunderbolt/thunderbolt-powersync` image; roll the Render `powersync` service to that new tag before PR 2 merges.
 
 2. **Frontend + feature PR**
    - Add the table to `src/db/tables.ts` and `src/db/powersync/schema.ts`.

--- a/docs/self-hosting/configuration.md
+++ b/docs/self-hosting/configuration.md
@@ -58,7 +58,7 @@ User-level keys (e.g. OpenAI, OpenRouter) are configured in the app itself, not 
 | `POWERSYNC_JWT_KID`              | —        |                  | Key ID for PowerSync to pick among multiple secrets during rotation          |
 | `POWERSYNC_TOKEN_EXPIRY_SECONDS` | `3600`   |                  | PowerSync JWT lifetime                                                       |
 
-The JWT secret must match the `secret` in `powersync-service/config/config.yaml` (local dev) or in the PowerSync Cloud dashboard (production).
+The JWT secret must match the `k` value the PowerSync service loads at runtime. For self-hosted deploys, `deploy/config/powersync-config.yaml` reads it from the `PS_JWT_KEY_BASE64` env var (base64 of the raw secret); `POWERSYNC_JWT_KID` on the backend must match `PS_JWT_KID` set on the PowerSync service. For local dev, both values are baked into `powersync-service/config/config.yaml`.
 
 ## CORS
 

--- a/shared/powersync-tables.ts
+++ b/shared/powersync-tables.ts
@@ -6,7 +6,10 @@
  * Single source of truth for PowerSync-synced table names and React Query invalidation.
  * Used by backend (validTables), frontend (use-powersync-invalidation), and sync rules (config.yaml).
  * When adding a table: add here, then to src/db/tables.ts, backend/src/db/powersync-schema.ts,
- * src/db/powersync/schema.ts, and powersync-service/config/config.yaml.
+ * src/db/powersync/schema.ts, and ALL THREE sync-rule configs:
+ *   - powersync-service/config/config.yaml   (local docker-compose)
+ *   - deploy/config/powersync-config.yaml    (baked into the ghcr image; preview + Render prod)
+ *   - deploy/k8s/templates/configmaps.yaml   (Helm-rendered config for enterprise k8s)
  */
 
 export const powersyncTableNames = [


### PR DESCRIPTION
## Summary

Follow-up to PR 1068 (env-driven kid) now that prod PowerSync runs self-hosted on Render. Sweeps stale "PowerSync Cloud dashboard" references and updates the sync-rule workflow to reflect the new operational reality.

## Key changes

- **Two-PR flow for adding synced tables** (documented in `AGENTS.md`, `docs/architecture/powersync-account-devices.md`, `docs/architecture/multi-device-sync.md`, `docs/multi-device-sync.md`): now instructs devs to update **all three** sync-rule configs (`powersync-service/config/config.yaml`, `deploy/config/powersync-config.yaml`, `deploy/k8s/templates/configmaps.yaml`) and to **roll the Render `powersync` service** to the new image tag after CI republishes it, replacing the "update PowerSync Cloud dashboard" step.
- **Table list** in `docs/architecture/powersync-account-devices.md` corrected — drop `mcp_servers` (local-only, was never synced), add `skills` + `agents` (were missing).
- **`.claude/agents/powersync-sync-reviewer.md`** — reviewer bot now checks all three configs and reminds about the Render image roll instead of the Cloud dashboard update.
- **`shared/powersync-tables.ts`** header comment lists all three sync-rule configs (was: only local).
- **Sync-middleware diagrams** — `PowerSync Cloud` labels → `PowerSync service`.
- **`docs/self-hosting/configuration.md`** — JWT-secret must-match phrasing now describes env-driven `PS_JWT_KEY_BASE64` / `PS_JWT_KID`.

## Test plan

- Docs-only change. `make check` passes.
- No code affected; sync-rule reviewer bot changes take effect on next invocation.