### PR TITLE
fix(THU-676): request advertised scopes in MCP OAuth flow

### DIFF
--- a/src/lib/mcp-auth/web-oauth-flow.test.ts
+++ b/src/lib/mcp-auth/web-oauth-flow.test.ts
@@ -17,7 +17,7 @@ import {
   type WebOAuthDeps,
 } from './web-oauth-flow'
 import type { LoopbackCallbackParams } from './mcp-oauth-loopback'
-import { getMcpOAuthState, setMcpOAuthState } from './mcp-oauth-state'
+import { clearMcpOAuthState, getMcpOAuthState, setMcpOAuthState } from './mcp-oauth-state'
 
 const serverId = 'srv-1'
 const serverUrl = 'https://mcp.example.com'
@@ -55,6 +55,14 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await teardownTestDatabase()
+})
+
+// Bun runs test files in one worker, so a fresh pending handshake left in
+// localStorage would leak into the next file and make isMcpOAuthCallback claim
+// callbacks that aren't ours (e.g. the deep-link routing test). Clear it after
+// every test so nothing escapes this file.
+afterEach(() => {
+  clearMcpOAuthState()
 })
 
 describe('isOAuthServer', () => {

--- a/src/lib/mcp-auth/web-oauth-flow.test.ts
+++ b/src/lib/mcp-auth/web-oauth-flow.test.ts
@@ -207,6 +207,60 @@ describe('startMcpOAuthFlow', () => {
     expect(redirectedTo).toBe(`${authServerUrl}/authorize?x=1`)
   })
 
+  it('requests the resource-advertised scopes_supported on registration and authorization', async () => {
+    const db = getDb()
+    let registeredScope: string | undefined
+    let authorizedScope: string | undefined
+
+    await startMcpOAuthFlow(
+      { db, serverId, serverUrl, fetchFn: noFetch, origin, isBackendConnected: () => false },
+      {
+        // A scope-gated resource (like Metabase) advertises the scopes its tools require.
+        discoverOAuthProtectedResourceMetadata: async () =>
+          ({
+            resource: serverUrl,
+            authorization_servers: [authServerUrl],
+            scopes_supported: ['agent:query', 'agent:search'],
+          }) as never,
+        discoverAuthorizationServerMetadata: async () => metadata(),
+        registerClient: async (_url, opts) => {
+          registeredScope = opts.scope
+          return { client_id: 'dcr-client', redirect_uris: [`${origin}/oauth/callback`] } as OAuthClientInformationFull
+        },
+        startAuthorization: async (_url, opts) => {
+          authorizedScope = opts.scope
+          return { authorizationUrl: new URL(`${authServerUrl}/authorize?x=1`), codeVerifier: 'verifier-1' }
+        },
+      },
+    )
+
+    // The advertised scopes are requested space-delimited on both the DCR registration
+    // and the authorization request — without this a scope-gated server issues a token
+    // authorized for nothing and tools/list comes back empty.
+    expect(registeredScope).toBe('agent:query agent:search')
+    expect(authorizedScope).toBe('agent:query agent:search')
+  })
+
+  it('omits scope when the resource advertises no scopes_supported (non-gated server)', async () => {
+    const db = getDb()
+    let authorizedScope: string | undefined = 'unset'
+
+    await startMcpOAuthFlow(
+      { db, serverId, serverUrl, fetchFn: noFetch, origin, isBackendConnected: () => false },
+      {
+        ...happyDiscovery(metadata()),
+        registerClient: async () =>
+          ({ client_id: 'dcr-client', redirect_uris: [`${origin}/oauth/callback`] }) as OAuthClientInformationFull,
+        startAuthorization: async (_url, opts) => {
+          authorizedScope = opts.scope
+          return { authorizationUrl: new URL(`${authServerUrl}/authorize?x=1`), codeVerifier: 'verifier-1' }
+        },
+      },
+    )
+
+    expect(authorizedScope).toBeUndefined()
+  })
+
   it('rejects an AS that does not advertise PKCE S256', async () => {
     const db = getDb()
     await expect(

--- a/src/lib/mcp-auth/web-oauth-flow.ts
+++ b/src/lib/mcp-auth/web-oauth-flow.ts
@@ -114,7 +114,7 @@ const discoverServer = async (
   serverUrl: string,
   fetchFn: FetchLike,
   deps: WebOAuthDeps,
-): Promise<{ authorizationServerUrl: string; metadata: AuthorizationServerMetadata }> => {
+): Promise<{ authorizationServerUrl: string; metadata: AuthorizationServerMetadata; scope?: string }> => {
   const discover = deps.discoverOAuthProtectedResourceMetadata ?? discoverOAuthProtectedResourceMetadata
   const discoverAs = deps.discoverAuthorizationServerMetadata ?? discoverAuthorizationServerMetadata
 
@@ -135,7 +135,14 @@ const discoverServer = async (
     throw new Error('Authorization server does not support PKCE S256.')
   }
 
-  return { authorizationServerUrl, metadata }
+  // RFC 9728: request the scopes the resource advertises (space-delimited). A
+  // scope-gated server issues a token authorized for nothing without this — e.g.
+  // Metabase gates every MCP tool behind an `agent:*` scope, so an unscoped token
+  // makes `tools/list` return empty. `undefined` when none are advertised, which
+  // omits the `scope` parameter and preserves behavior for non-gated servers.
+  const scope = prm.scopes_supported?.join(' ') || undefined
+
+  return { authorizationServerUrl, metadata, scope }
 }
 
 /**
@@ -223,7 +230,7 @@ const prepareAuthorization = async (
   const register = deps.registerClient ?? registerClient
   const start = deps.startAuthorization ?? startAuthorization
 
-  const { authorizationServerUrl, metadata } = await discoverServer(serverUrl, fetchFn, deps)
+  const { authorizationServerUrl, metadata, scope } = await discoverServer(serverUrl, fetchFn, deps)
 
   const provider = createMcpOAuthClientProvider({ serverId, db, origin, redirectUri, isBackendConnected })
 
@@ -243,6 +250,7 @@ const prepareAuthorization = async (
         const full = await register(authorizationServerUrl, {
           metadata,
           clientMetadata: provider.clientMetadata,
+          scope,
           fetchFn,
         })
         await provider.saveClientInformation(full)
@@ -273,6 +281,7 @@ const prepareAuthorization = async (
     metadata,
     clientInformation,
     redirectUrl: provider.redirectUrl,
+    scope,
     state: stateNonce,
     resource,
   })


### PR DESCRIPTION
## Problem

Thunderbolt's MCP OAuth flow never requested any OAuth scopes — it didn't read `scopes_supported` from the server's protected-resource metadata, didn't set `scope` on DCR registration, and didn't pass `scope` to `startAuthorization`. Every `scope` reference in the auth code only *stored* the token's returned scope; nothing ever *requested* one.

For MCP servers that don't scope-gate, a scope-less token still has full access, so this was invisible. But for servers that gate each tool behind a granular OAuth scope, the issued token is authorized for nothing → `tools/list` returns `[]` even though the connection, auth, and `capabilities.tools` are all fine.

### Repro (hosted Metabase MCP)

- OAuth completes; token is attached on `initialize` (verified on the wire).
- `initialize` → 200 with `capabilities.tools: { listChanged: true }`.
- `tools/list` → `{"tools":[]}`; the session id decodes to `{"v":1,"ui":false}` (unprivileged).
- Metabase's protected-resource metadata advertises 13 required `agent:*` scopes; our token carried none of them.

## Fix

`src/lib/mcp-auth/web-oauth-flow.ts`:
- `discoverServer` now reads `scopes_supported` from the protected-resource metadata and returns it space-delimited.
- `prepareAuthorization` passes that `scope` to **both** `registerClient` (DCR) and `startAuthorization`.
- When a server advertises no scopes, `scope` is `undefined` and the request is unchanged — no regression for non-gated servers.

Per the MCP auth spec (RFC 8707 / 9728) the client SHOULD request scopes from `scopes_supported`, so this is a correctness fix that unblocks any scope-gated OAuth MCP server, not just Metabase.

## Testing

- Added 2 unit tests: scope-gated server requests the advertised scopes on registration + authorization; non-gated server omits `scope`.
- `bun test src/lib/mcp-auth/web-oauth-flow.test.ts` → 35/35 pass.
- `bun run type-check` → clean.

Note: this requests all advertised scopes (incl. write/execute for Metabase). A read-only variant is a possible follow-up.

Linear: THU-676