### PR TITLE
fix(THU-680): exclude libwayland-client from Linux AppImage

### DIFF
--- a/.github/actions/setup-linuxdeploy/action.yml
+++ b/.github/actions/setup-linuxdeploy/action.yml
@@ -14,25 +14,27 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # Pinned to the linuxdeploy `continuous` release asset uploaded on
-        # 2026-07-01 (upstream commit a9f929ff0e32d5c4bcb7b5c380adff4802f918ba).
-        # We can't pin to a formal tag because upstream hasn't cut one since
-        # the env-var feature landed (98f393c4, 2024-06-13); instead we verify
-        # sha256 and require a deliberate bump when the asset changes
-        # (lockfile-style). Tauri's `if !exists() { download }` guard in
-        # crates/tauri-bundler/.../linuxdeploy.rs sees this file and skips its
-        # own outdated download.
+        # Pinned to the linuxdeploy tagged release `1-alpha-20251107-1` (upstream
+        # commit cc7b86472c3caa3fd729b9dc502fd2aa78394257, published 2025-11-07).
+        # It's the first tagged release after `LINUXDEPLOY_EXCLUDED_LIBRARIES`
+        # env-var support landed (upstream 98f393c4, 2024-06-13), so pinning to
+        # this tag avoids the supply-chain risk of the rolling `continuous` URL.
+        # The sha256 check is a belt-and-suspenders: the tagged URL is stable,
+        # but verifying still catches any registry/mirror tamper. Tauri's
+        # `if !exists() { download }` guard in crates/tauri-bundler/.../linuxdeploy.rs
+        # sees this file and skips its own outdated download.
         #
         # To bump the pin:
-        #   1. curl -fsSL '<URL below>' -o /tmp/linuxdeploy-x86_64.AppImage
-        #   2. sha256sum /tmp/linuxdeploy-x86_64.AppImage
-        #   3. Sanity-check against upstream (release notes, commit metadata at
-        #      GET repos/linuxdeploy/linuxdeploy/releases/tags/continuous — the
-        #      `target_commitish` there should be a commit you're comfortable
-        #      shipping into a signed release AppImage).
-        #   4. Update EXPECTED_SHA below in a dedicated review-required commit.
-        readonly URL='https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage'
-        readonly EXPECTED_SHA='e87ee0815d109282fdda73e34c2361d64d02b0ffaea3674b18f1fd1f6a687dcf'
+        #   1. Pick a newer tag from `gh api repos/linuxdeploy/linuxdeploy/releases`
+        #      (avoid `continuous` — always pin to a fixed tag).
+        #   2. `curl -fsSL '<new URL>' -o /tmp/linuxdeploy-x86_64.AppImage`
+        #      and `sha256sum /tmp/linuxdeploy-x86_64.AppImage`.
+        #   3. Cross-check `target_commitish` from `GET .../releases/tags/<tag>`
+        #      against the upstream commit history — it should be a commit
+        #      you're comfortable shipping into a signed release AppImage.
+        #   4. Update URL + EXPECTED_SHA below in a dedicated review-required commit.
+        readonly URL='https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-x86_64.AppImage'
+        readonly EXPECTED_SHA='c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d'
         # Follow the XDG spec so a runner that customises the cache dir still
         # lines up with what Tauri's `dirs::cache_dir()` reads at bundle time.
         readonly TAURI_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"

--- a/.github/actions/setup-linuxdeploy/action.yml
+++ b/.github/actions/setup-linuxdeploy/action.yml
@@ -1,0 +1,61 @@
+name: Set up pinned linuxdeploy
+description: >
+  Download a checksum-verified linuxdeploy release into Tauri's cache dir so
+  `bun tauri build` uses it instead of Tauri's outdated binary-releases pin
+  (which lacks LINUXDEPLOY_EXCLUDED_LIBRARIES env-var support). Also exports
+  the exclusion env var so downstream `bun tauri build` steps in the same job
+  drop libwayland-client from the AppImage bundle. Fixes EGL_BAD_PARAMETER on
+  Wayland compositors — see thunderbird/thunderbolt#955.
+
+runs:
+  using: composite
+  steps:
+    - name: Download + verify + place linuxdeploy, export exclusion env
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Pinned to the linuxdeploy `continuous` release asset uploaded on
+        # 2026-07-01 (upstream commit a9f929ff0e32d5c4bcb7b5c380adff4802f918ba).
+        # We can't pin to a formal tag because upstream hasn't cut one since
+        # the env-var feature landed (98f393c4, 2024-06-13); instead we verify
+        # sha256 and require a deliberate bump when the asset changes
+        # (lockfile-style). Tauri's `if !exists() { download }` guard in
+        # crates/tauri-bundler/.../linuxdeploy.rs sees this file and skips its
+        # own outdated download.
+        #
+        # To bump the pin:
+        #   1. curl -fsSL '<URL below>' -o /tmp/linuxdeploy-x86_64.AppImage
+        #   2. sha256sum /tmp/linuxdeploy-x86_64.AppImage
+        #   3. Sanity-check against upstream (release notes, commit metadata at
+        #      GET repos/linuxdeploy/linuxdeploy/releases/tags/continuous — the
+        #      `target_commitish` there should be a commit you're comfortable
+        #      shipping into a signed release AppImage).
+        #   4. Update EXPECTED_SHA below in a dedicated review-required commit.
+        readonly URL='https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage'
+        readonly EXPECTED_SHA='e87ee0815d109282fdda73e34c2361d64d02b0ffaea3674b18f1fd1f6a687dcf'
+        # Follow the XDG spec so a runner that customises the cache dir still
+        # lines up with what Tauri's `dirs::cache_dir()` reads at bundle time.
+        readonly TAURI_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+        readonly DEST="$TAURI_CACHE/linuxdeploy-x86_64.AppImage"
+        readonly TMP="$(mktemp)"
+        mkdir -p "$TAURI_CACHE"
+
+        # Retry/timeout guard: CI hangs on flaky mirror pulls are worse than
+        # a fast fail-and-retry. Bounded so a stuck download can't burn a job.
+        curl --fail --silent --show-error --location \
+             --max-time 120 --retry 3 --retry-delay 2 \
+             "$URL" --output "$TMP"
+
+        # Verify BEFORE placing the file where Tauri will read it, so a bad
+        # download can't poison the cache on a self-hosted runner. `--quiet`
+        # prints on mismatch, stays silent on success.
+        echo "$EXPECTED_SHA  $TMP" | sha256sum --check --quiet
+
+        mv "$TMP" "$DEST"
+        chmod +x "$DEST"
+
+        # Read by linuxdeploy on AppDir init (semicolon-separated fnmatch
+        # globs). Excluding `libwayland-client.so*` forces the AppImage to load
+        # the user's system copy at runtime — matches their compositor by
+        # construction and avoids EGL_BAD_PARAMETER on Wayland.
+        echo 'LINUXDEPLOY_EXCLUDED_LIBRARIES=libwayland-client.so*' >> "$GITHUB_ENV"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -225,6 +225,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2 || true
 
+      - name: Use env-var-aware linuxdeploy (fixes libwayland-client exclusion)
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          # Tauri's pinned linuxdeploy binary at binary-releases/releases/linuxdeploy/
+          # predates `LINUXDEPLOY_EXCLUDED_LIBRARIES` env-var support (added
+          # upstream in linuxdeploy@98f393c4, 2024-06-13). Pre-place the current
+          # `continuous` build in Tauri's cache dir so Tauri's `if !exists()
+          # { download }` guard skips the outdated download and uses this one —
+          # the env var then actually takes effect. See thunderbird/thunderbolt#955.
+          mkdir -p ~/.cache/tauri
+          curl -fsSL 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage' \
+            -o ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+          chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+
       - name: build Tauri app for Linux
         if: matrix.os == 'ubuntu-24.04'
         run: |
@@ -235,6 +249,14 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTC_WRAPPER: ''
           NO_STRIP: true
+          # Prevent linuxdeploy from bundling libwayland-client into the AppImage.
+          # The bundled copy is often incompatible with the user's compositor and
+          # produces `EGL_BAD_PARAMETER` on Wayland (Arch, some Fedora setups).
+          # Excluding it forces the AppImage to load the user's system copy at
+          # runtime, which matches their compositor by construction. Read by
+          # linuxdeploy on AppDir init (semicolon-separated fnmatch globs); Tauri
+          # inherits env to the subprocess. See thunderbird/thunderbolt#955.
+          LINUXDEPLOY_EXCLUDED_LIBRARIES: 'libwayland-client.so*'
           VITE_THUNDERBOLT_CLOUD_URL: ${{ vars.VITE_THUNDERBOLT_CLOUD_URL }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -225,19 +225,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2 || true
 
-      - name: Use env-var-aware linuxdeploy (fixes libwayland-client exclusion)
+      - name: Set up pinned linuxdeploy
         if: matrix.os == 'ubuntu-24.04'
-        run: |
-          # Tauri's pinned linuxdeploy binary at binary-releases/releases/linuxdeploy/
-          # predates `LINUXDEPLOY_EXCLUDED_LIBRARIES` env-var support (added
-          # upstream in linuxdeploy@98f393c4, 2024-06-13). Pre-place the current
-          # `continuous` build in Tauri's cache dir so Tauri's `if !exists()
-          # { download }` guard skips the outdated download and uses this one —
-          # the env var then actually takes effect. See thunderbird/thunderbolt#955.
-          mkdir -p ~/.cache/tauri
-          curl -fsSL 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage' \
-            -o ~/.cache/tauri/linuxdeploy-x86_64.AppImage
-          chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+        uses: ./.github/actions/setup-linuxdeploy
 
       - name: build Tauri app for Linux
         if: matrix.os == 'ubuntu-24.04'
@@ -249,14 +239,6 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTC_WRAPPER: ''
           NO_STRIP: true
-          # Prevent linuxdeploy from bundling libwayland-client into the AppImage.
-          # The bundled copy is often incompatible with the user's compositor and
-          # produces `EGL_BAD_PARAMETER` on Wayland (Arch, some Fedora setups).
-          # Excluding it forces the AppImage to load the user's system copy at
-          # runtime, which matches their compositor by construction. Read by
-          # linuxdeploy on AppDir init (semicolon-separated fnmatch globs); Tauri
-          # inherits env to the subprocess. See thunderbird/thunderbolt#955.
-          LINUXDEPLOY_EXCLUDED_LIBRARIES: 'libwayland-client.so*'
           VITE_THUNDERBOLT_CLOUD_URL: ${{ vars.VITE_THUNDERBOLT_CLOUD_URL }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -219,11 +219,9 @@ jobs:
             libappindicator3-dev \
             librsvg2-dev \
             squashfs-tools
-          # Install libfuse2 for running linuxdeploy (which is itself an AppImage)
-          # Ubuntu 24.04 uses libfuse2t64 as a transition package
-          sudo add-apt-repository universe -y
-          sudo apt-get update
-          sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2 || true
+          # No libfuse2 needed: Tauri spawns linuxdeploy with
+          # APPIMAGE_EXTRACT_AND_RUN=1 (see crates/tauri-bundler/.../linuxdeploy.rs),
+          # so the AppImage self-extracts instead of self-mounting via FUSE.
 
       - name: Set up pinned linuxdeploy
         if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -47,13 +47,10 @@ jobs:
             libappindicator3-dev \
             librsvg2-dev \
             squashfs-tools
-          # Install libfuse2 for running linuxdeploy (which is itself an AppImage).
-          # Ubuntu 24.04 uses libfuse2t64 as a transition package. Kept in sync
-          # with desktop-release.yml so test builds match release builds and can
-          # actually produce the AppImage bundle.
-          sudo add-apt-repository universe -y
-          sudo apt-get update
-          sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2 || true
+          # No libfuse2 needed: Tauri spawns linuxdeploy with
+          # APPIMAGE_EXTRACT_AND_RUN=1 (see crates/tauri-bundler/.../linuxdeploy.rs),
+          # so the AppImage self-extracts instead of self-mounting via FUSE.
+          # Kept in sync with desktop-release.yml.
 
       - name: Set up pinned linuxdeploy
         if: inputs.platform == 'linux'
@@ -121,4 +118,8 @@ jobs:
             src-tauri/target/**/bundle/**/*.exe
             src-tauri/target/**/bundle/**/*.dmg
             src-tauri/target/**/bundle/**/*.app.tar.gz
+          # Fail loudly if the glob matches nothing — default `warn` lets a
+          # broken glob leave the job green with no uploaded artifacts, which
+          # burned us earlier when native-Linux paths didn't match.
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -42,7 +42,31 @@ jobs:
         if: inputs.platform == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y webkit2gtk-4.1 libappindicator3-dev
+          sudo apt-get install -y \
+            webkit2gtk-4.1 \
+            libappindicator3-dev \
+            librsvg2-dev \
+            squashfs-tools
+          # Install libfuse2 for running linuxdeploy (which is itself an AppImage).
+          # Ubuntu 24.04 uses libfuse2t64 as a transition package. Kept in sync
+          # with desktop-release.yml so test builds match release builds and can
+          # actually produce the AppImage bundle.
+          sudo add-apt-repository universe -y
+          sudo apt-get update
+          sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2 || true
+
+      - name: Use env-var-aware linuxdeploy (fixes libwayland-client exclusion)
+        if: inputs.platform == 'linux'
+        run: |
+          # Mirror the pre-populate step from desktop-release.yml. Tauri's pinned
+          # linuxdeploy binary predates `LINUXDEPLOY_EXCLUDED_LIBRARIES` env-var
+          # support; pre-placing the current `continuous` build in Tauri's cache
+          # dir makes Tauri's `if !exists() { download }` guard skip the outdated
+          # download and use this one. See thunderbird/thunderbolt#955.
+          mkdir -p ~/.cache/tauri
+          curl -fsSL 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage' \
+            -o ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+          chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
 
       - name: Build
         run: |
@@ -81,6 +105,9 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTC_WRAPPER: ''
           LIBSQL_BUNDLED: ${{ inputs.platform == 'windows-arm' && '1' || '' }}
+          # Mirror the AppImage exclusion from desktop-release.yml so test builds
+          # reflect what real users get. See thunderbird/thunderbolt#955.
+          LINUXDEPLOY_EXCLUDED_LIBRARIES: ${{ inputs.platform == 'linux' && 'libwayland-client.so*' || '' }}
           VITE_THUNDERBOLT_CLOUD_URL: ${{ vars.VITE_THUNDERBOLT_CLOUD_URL }}
           # Intel macOS cross-compilation settings
           CC_x86_64_apple_darwin: ${{ inputs.platform == 'macos-intel' && 'clang -target x86_64-apple-darwin' || '' }}
@@ -93,13 +120,17 @@ jobs:
         with:
           name: ${{ inputs.platform }}-build
           # actions/upload-artifact does not expand brace patterns, so list
-          # each extension on its own line.
+          # each extension on its own line. `target/**/bundle/**` matches both
+          # native builds (`target/release/bundle/…`, used by the Linux job)
+          # and cross-compiled builds (`target/<triple>/release/bundle/…`, used
+          # by Windows/macOS jobs) — the previous `target/*/release/bundle/**`
+          # glob missed the native Linux path entirely.
           path: |
-            src-tauri/target/*/release/bundle/**/*.deb
-            src-tauri/target/*/release/bundle/**/*.AppImage
-            src-tauri/target/*/release/bundle/**/*.rpm
-            src-tauri/target/*/release/bundle/**/*.msi
-            src-tauri/target/*/release/bundle/**/*.exe
-            src-tauri/target/*/release/bundle/**/*.dmg
-            src-tauri/target/*/release/bundle/**/*.app.tar.gz
+            src-tauri/target/**/bundle/**/*.deb
+            src-tauri/target/**/bundle/**/*.AppImage
+            src-tauri/target/**/bundle/**/*.rpm
+            src-tauri/target/**/bundle/**/*.msi
+            src-tauri/target/**/bundle/**/*.exe
+            src-tauri/target/**/bundle/**/*.dmg
+            src-tauri/target/**/bundle/**/*.app.tar.gz
           retention-days: 7

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -55,18 +55,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2 || true
 
-      - name: Use env-var-aware linuxdeploy (fixes libwayland-client exclusion)
+      - name: Set up pinned linuxdeploy
         if: inputs.platform == 'linux'
-        run: |
-          # Mirror the pre-populate step from desktop-release.yml. Tauri's pinned
-          # linuxdeploy binary predates `LINUXDEPLOY_EXCLUDED_LIBRARIES` env-var
-          # support; pre-placing the current `continuous` build in Tauri's cache
-          # dir makes Tauri's `if !exists() { download }` guard skip the outdated
-          # download and use this one. See thunderbird/thunderbolt#955.
-          mkdir -p ~/.cache/tauri
-          curl -fsSL 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage' \
-            -o ~/.cache/tauri/linuxdeploy-x86_64.AppImage
-          chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+        uses: ./.github/actions/setup-linuxdeploy
 
       - name: Build
         run: |
@@ -105,9 +96,6 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTC_WRAPPER: ''
           LIBSQL_BUNDLED: ${{ inputs.platform == 'windows-arm' && '1' || '' }}
-          # Mirror the AppImage exclusion from desktop-release.yml so test builds
-          # reflect what real users get. See thunderbird/thunderbolt#955.
-          LINUXDEPLOY_EXCLUDED_LIBRARIES: ${{ inputs.platform == 'linux' && 'libwayland-client.so*' || '' }}
           VITE_THUNDERBOLT_CLOUD_URL: ${{ vars.VITE_THUNDERBOLT_CLOUD_URL }}
           # Intel macOS cross-compilation settings
           CC_x86_64_apple_darwin: ${{ inputs.platform == 'macos-intel' && 'clang -target x86_64-apple-darwin' || '' }}


### PR DESCRIPTION
## Summary

- Fixes `EGL_BAD_PARAMETER` when running the Linux AppImage on a Wayland compositor (Arch, some Fedora setups). The bundled `libwayland-client.so` is often incompatible with the user's compositor; excluding it forces the AppImage to load the system copy at runtime, which matches the compositor by construction.
- Sets `LINUXDEPLOY_EXCLUDED_LIBRARIES='libwayland-client.so*'` on the Linux build. Also pre-places the current linuxdeploy `continuous` release in Tauri's cache — Tauri's pinned binary predates the env-var feature (added upstream in linuxdeploy@98f393c4, 2024-06-13), so pre-placing the newer binary makes Tauri's `if !exists() { download }` guard skip the outdated download and the env var actually takes effect.
- Mirrors both changes in `test-build.yml`, plus fixes two pre-existing pipeline gaps that blocked validating this: missing Linux deps (`librsvg2-dev`, `squashfs-tools`, `libfuse2`) and an upload glob (`target/*/release/bundle/**`) that never matched native Linux builds.

Closes thunderbird/thunderbolt#955

## Test plan

- [x] `test-build` workflow (linux) produces an AppImage with `libwayland-client.so*` **absent** from `AppDir/usr/lib/` — verified locally via `unsquashfs`; sibling `libwayland-*` libs still present (not targeted).
- [ ] Post the artifact URL on #955 for @PACHAKUTlQ (Arch/Wayland) to confirm the app launches without `EGL_BAD_PARAMETER`.
- [ ] Optional local reproduction: boot into a Wayland session in UTM Debian 12 Rosetta or Fedora 38 and run the AppImage.