### PR TITLE
feat(THU-637): skip first-sync + /config wait on refresh (extend defaults version-gate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,9 +109,16 @@ See [docs/architecture/powersync-account-devices.md](docs/architecture/powersync
 
 ## Reconciled defaults and version bumps
 
-Reconciled default tables (`shared/defaults/models.ts` today, more to follow) ship a monotonic `defaults<X>Version` constant next to the defaults array. Reconciliation uses it as the ordering signal so multi-device sync groups converge without ping-ponging (see THU-637): a device only overwrites an existing row when its defaults version is strictly newer than the highest ever applied on this account.
+Reconciled default tables ship a monotonic `defaults<X>Version` constant next to the defaults array. Reconciliation uses it as the ordering signal so multi-device sync groups converge without ping-ponging (see THU-637, extended to the other reconciled tables in THU-677): a device only overwrites an existing row when its defaults version is strictly newer than the highest ever applied on this account.
 
-**When you change any default in one of these files, bump the version constant.** A colocated snapshot test (e.g. `shared/defaults/models.test.ts`) fails on any content change without a matching version bump and tells you exactly what to update.
+Files that ship a version constant today:
+- `shared/defaults/models.ts` — `defaultModelsVersion`
+- `src/defaults/modes.ts` — `defaultModesVersion`
+- `src/defaults/tasks.ts` — `defaultTasksVersion`
+- `src/defaults/skills.ts` — `defaultSkillsVersion`
+- `src/defaults/settings.ts` — `defaultSettingsVersion`
+
+**When you change any default in one of these files, bump the version constant.** A colocated snapshot test (e.g. `shared/defaults/models.test.ts`, `src/defaults/modes.test.ts`) fails on any content change without a matching version bump and tells you exactly what to update.
 
 ## CORS and API headers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ Files that ship a version constant today:
 - `src/defaults/skills.ts` — `defaultSkillsVersion`
 - `src/defaults/settings.ts` — `defaultSettingsVersion`
 
+`src/defaults/model-profiles.ts` is also reconciled but does not carry its own version — profiles ride the models gate (`insertMissing: true`, `canOverwrite: modelsGate.canOverwrite`), so bumping `defaultModelsVersion` covers profile changes too.
+
 **When you change any default in one of these files, bump the version constant.** A colocated snapshot test (e.g. `shared/defaults/models.test.ts`, `src/defaults/modes.test.ts`) fails on any content change without a matching version bump and tells you exactly what to update.
 
 ## CORS and API headers

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -26,6 +26,7 @@ export {
   getSettings,
   getSettingsRecords,
   getThemeSetting,
+  hasReconciledDefaults,
   hasSetting,
   resetSettingToDefault,
   updateSettings,

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -26,7 +26,7 @@ export {
   getSettings,
   getSettingsRecords,
   getThemeSetting,
-  hasReconciledDefaults,
+  hasCurrentBundleVersions,
   hasSetting,
   resetSettingToDefault,
   updateSettings,

--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -26,7 +26,7 @@ export {
   getSettings,
   getSettingsRecords,
   getThemeSetting,
-  hasCurrentBundleVersions,
+  hasCurrentDefaultsVersions,
   hasSetting,
   resetSettingToDefault,
   updateSettings,

--- a/src/dal/settings.test.ts
+++ b/src/dal/settings.test.ts
@@ -15,7 +15,7 @@ import {
   getSettings,
   getSettingsRecords,
   getThemeSetting,
-  hasCurrentBundleVersions,
+  hasCurrentDefaultsVersions,
   hasSetting,
   resetSettingToDefault,
   updateSettings,
@@ -25,7 +25,7 @@ import { defaultModesVersion } from '../defaults/modes'
 import { defaultSettingsVersion } from '../defaults/settings'
 import { defaultSkillsVersion } from '../defaults/skills'
 import { defaultTasksVersion } from '../defaults/tasks'
-import { versionMarkerKeys } from '../lib/reconcile-defaults'
+import { versionMarkerKeys, type VersionMarkerKey } from '../lib/reconcile-defaults'
 import { hashValues } from '../lib/utils'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 
@@ -62,7 +62,7 @@ describe('Settings DAL', () => {
     })
   })
 
-  describe('hasCurrentBundleVersions', () => {
+  describe('hasCurrentDefaultsVersions', () => {
     // Every reconciled table's (marker-key, bundled-version) pair — driving
     // the parametric "any one marker behind flips the check to false" case.
     const markerCases = [
@@ -72,6 +72,12 @@ describe('Settings DAL', () => {
       { key: versionMarkerKeys.skills, version: defaultSkillsVersion },
       { key: versionMarkerKeys.settings, version: defaultSettingsVersion },
     ] as const
+
+    // Targets a caller would build for the "no OTA in play" case.
+    const bundledTargets = Object.fromEntries(markerCases.map((c) => [c.key, c.version])) as Record<
+      VersionMarkerKey,
+      number
+    >
 
     const seedAllMarkers = async (offset = 0) => {
       const db = getDb()
@@ -83,23 +89,23 @@ describe('Settings DAL', () => {
     it('returns false on a truly fresh DB with no markers', async () => {
       // `resetTestDatabase` (beforeEach) reapplies schema without reconciling,
       // so no `defaults_version.*` rows exist here.
-      const seen = await hasCurrentBundleVersions(getDb())
+      const seen = await hasCurrentDefaultsVersions(getDb(), bundledTargets)
       expect(seen).toBe(false)
     })
 
-    it('returns true when every marker meets its bundled version exactly', async () => {
+    it('returns true when every marker meets its target exactly', async () => {
       await seedAllMarkers(0)
-      const seen = await hasCurrentBundleVersions(getDb())
+      const seen = await hasCurrentDefaultsVersions(getDb(), bundledTargets)
       expect(seen).toBe(true)
     })
 
-    it('returns true when every marker exceeds its bundled version (peer ahead of this build)', async () => {
+    it('returns true when every marker exceeds its target (peer ahead of this build)', async () => {
       // Every stored version is one ahead of what this build ships — a peer
       // that shipped a newer bundle already reconciled and synced its marker.
       // Reconcile would no-op via `rawCanOverwrite=false`, so the fast path
       // is safe.
       await seedAllMarkers(1)
-      const seen = await hasCurrentBundleVersions(getDb())
+      const seen = await hasCurrentDefaultsVersions(getDb(), bundledTargets)
       expect(seen).toBe(true)
     })
 
@@ -107,18 +113,32 @@ describe('Settings DAL', () => {
     // one of the versions. Reconcile has work to do — the fast path must not
     // fire, otherwise the bump would be stranded (nothing re-runs reconcile
     // after the background sync settles). Parameterized across every marker
-    // so a typo dropping any one key from the return chain fails a test.
+    // so a typo dropping any one key from the target map fails a test.
     for (const { key, version } of markerCases) {
-      it(`returns false when ${key} is behind its bundled version`, async () => {
+      it(`returns false when ${key} is behind its target`, async () => {
         await seedAllMarkers(0)
         await getDb()
           .update(settingsTable)
           .set({ value: String(version - 1) })
           .where(eq(settingsTable.key, key))
-        const seen = await hasCurrentBundleVersions(getDb())
+        const seen = await hasCurrentDefaultsVersions(getDb(), bundledTargets)
         expect(seen).toBe(false)
       })
     }
+
+    it('returns false when the caller passes an OTA target above the stored marker (models)', async () => {
+      // Direct regression guard for the OTA-stranding bug: stored marker is
+      // at the bundled version, but the caller's picked target is one ahead
+      // (via `pickModelsDefaults(useConfigStore.getState().config.defaults?.models)`).
+      // Fast path must not fire so reconcile can apply the OTA payload.
+      await seedAllMarkers(0)
+      const otaTargets: Record<VersionMarkerKey, number> = {
+        ...bundledTargets,
+        [versionMarkerKeys.models]: defaultModelsVersion + 1,
+      }
+      const seen = await hasCurrentDefaultsVersions(getDb(), otaTargets)
+      expect(seen).toBe(false)
+    })
 
     it('returns false when a marker is missing entirely', async () => {
       // A device that reconciled everything but one marker never got written
@@ -128,7 +148,7 @@ describe('Settings DAL', () => {
         await createSetting(db, key, String(version))
       }
       // Last marker deliberately missing.
-      const seen = await hasCurrentBundleVersions(db)
+      const seen = await hasCurrentDefaultsVersions(db, bundledTargets)
       expect(seen).toBe(false)
     })
 
@@ -141,7 +161,7 @@ describe('Settings DAL', () => {
         .update(settingsTable)
         .set({ value: 'not-a-number' })
         .where(eq(settingsTable.key, versionMarkerKeys.tasks))
-      const seen = await hasCurrentBundleVersions(getDb())
+      const seen = await hasCurrentDefaultsVersions(getDb(), bundledTargets)
       expect(seen).toBe(false)
     })
 
@@ -151,7 +171,7 @@ describe('Settings DAL', () => {
       // that drops the null-guard fails loudly.
       await seedAllMarkers(0)
       await getDb().update(settingsTable).set({ value: '' }).where(eq(settingsTable.key, versionMarkerKeys.modes))
-      const seen = await hasCurrentBundleVersions(getDb())
+      const seen = await hasCurrentDefaultsVersions(getDb(), bundledTargets)
       expect(seen).toBe(false)
     })
 
@@ -160,14 +180,14 @@ describe('Settings DAL', () => {
       // === 'object'` fails the number check. Pin the null-branch behavior.
       await seedAllMarkers(0)
       await getDb().update(settingsTable).set({ value: null }).where(eq(settingsTable.key, versionMarkerKeys.settings))
-      const seen = await hasCurrentBundleVersions(getDb())
+      const seen = await hasCurrentDefaultsVersions(getDb(), bundledTargets)
       expect(seen).toBe(false)
     })
 
     it('ignores non-marker settings rows', async () => {
       // A user preference row is not a marker; it must not affect the check.
       await createSetting(getDb(), 'preferred_name', 'test-user')
-      const seen = await hasCurrentBundleVersions(getDb())
+      const seen = await hasCurrentDefaultsVersions(getDb(), bundledTargets)
       expect(seen).toBe(false)
     })
   })

--- a/src/dal/settings.test.ts
+++ b/src/dal/settings.test.ts
@@ -15,6 +15,7 @@ import {
   getSettings,
   getSettingsRecords,
   getThemeSetting,
+  hasReconciledDefaults,
   hasSetting,
   resetSettingToDefault,
   updateSettings,
@@ -52,6 +53,30 @@ describe('Settings DAL', () => {
       await createSetting(getDb(), 'null_key', null)
       const exists = await hasSetting(getDb(), 'null_key')
       expect(exists).toBe(true)
+    })
+  })
+
+  describe('hasReconciledDefaults', () => {
+    it('returns false on a truly fresh DB with no markers', async () => {
+      // `resetTestDatabase` (beforeEach) reapplies schema without reconciling,
+      // so no `defaults_version.*` rows exist here.
+      const seen = await hasReconciledDefaults(getDb())
+      expect(seen).toBe(false)
+    })
+
+    it('returns true after a `defaults_version.*` marker is written', async () => {
+      await createSetting(getDb(), 'defaults_version.models', '1')
+      const seen = await hasReconciledDefaults(getDb())
+      expect(seen).toBe(true)
+    })
+
+    it('ignores non-marker settings rows (LIKE pattern is prefix-scoped)', async () => {
+      // A settings row that isn't a marker (e.g. a user preference) must not
+      // flip the probe — otherwise the returning-boot fast path would fire
+      // before any reconcile ever ran.
+      await createSetting(getDb(), 'preferred_name', 'test-user')
+      const seen = await hasReconciledDefaults(getDb())
+      expect(seen).toBe(false)
     })
   })
 

--- a/src/dal/settings.test.ts
+++ b/src/dal/settings.test.ts
@@ -15,11 +15,17 @@ import {
   getSettings,
   getSettingsRecords,
   getThemeSetting,
-  hasReconciledDefaults,
+  hasCurrentBundleVersions,
   hasSetting,
   resetSettingToDefault,
   updateSettings,
 } from './settings'
+import { defaultModelsVersion } from '@shared/defaults/models'
+import { defaultModesVersion } from '../defaults/modes'
+import { defaultSettingsVersion } from '../defaults/settings'
+import { defaultSkillsVersion } from '../defaults/skills'
+import { defaultTasksVersion } from '../defaults/tasks'
+import { versionMarkerKeys } from '../lib/reconcile-defaults'
 import { hashValues } from '../lib/utils'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 
@@ -56,26 +62,112 @@ describe('Settings DAL', () => {
     })
   })
 
-  describe('hasReconciledDefaults', () => {
+  describe('hasCurrentBundleVersions', () => {
+    // Every reconciled table's (marker-key, bundled-version) pair — driving
+    // the parametric "any one marker behind flips the check to false" case.
+    const markerCases = [
+      { key: versionMarkerKeys.models, version: defaultModelsVersion },
+      { key: versionMarkerKeys.modes, version: defaultModesVersion },
+      { key: versionMarkerKeys.tasks, version: defaultTasksVersion },
+      { key: versionMarkerKeys.skills, version: defaultSkillsVersion },
+      { key: versionMarkerKeys.settings, version: defaultSettingsVersion },
+    ] as const
+
+    const seedAllMarkers = async (offset = 0) => {
+      const db = getDb()
+      for (const { key, version } of markerCases) {
+        await createSetting(db, key, String(version + offset))
+      }
+    }
+
     it('returns false on a truly fresh DB with no markers', async () => {
       // `resetTestDatabase` (beforeEach) reapplies schema without reconciling,
       // so no `defaults_version.*` rows exist here.
-      const seen = await hasReconciledDefaults(getDb())
+      const seen = await hasCurrentBundleVersions(getDb())
       expect(seen).toBe(false)
     })
 
-    it('returns true after a `defaults_version.*` marker is written', async () => {
-      await createSetting(getDb(), 'defaults_version.models', '1')
-      const seen = await hasReconciledDefaults(getDb())
+    it('returns true when every marker meets its bundled version exactly', async () => {
+      await seedAllMarkers(0)
+      const seen = await hasCurrentBundleVersions(getDb())
       expect(seen).toBe(true)
     })
 
-    it('ignores non-marker settings rows (LIKE pattern is prefix-scoped)', async () => {
-      // A settings row that isn't a marker (e.g. a user preference) must not
-      // flip the probe — otherwise the returning-boot fast path would fire
-      // before any reconcile ever ran.
+    it('returns true when every marker exceeds its bundled version (peer ahead of this build)', async () => {
+      // Every stored version is one ahead of what this build ships — a peer
+      // that shipped a newer bundle already reconciled and synced its marker.
+      // Reconcile would no-op via `rawCanOverwrite=false`, so the fast path
+      // is safe.
+      await seedAllMarkers(1)
+      const seen = await hasCurrentBundleVersions(getDb())
+      expect(seen).toBe(true)
+    })
+
+    // Regression guard: this is the state after a client upgrade that bumped
+    // one of the versions. Reconcile has work to do — the fast path must not
+    // fire, otherwise the bump would be stranded (nothing re-runs reconcile
+    // after the background sync settles). Parameterized across every marker
+    // so a typo dropping any one key from the return chain fails a test.
+    for (const { key, version } of markerCases) {
+      it(`returns false when ${key} is behind its bundled version`, async () => {
+        await seedAllMarkers(0)
+        await getDb()
+          .update(settingsTable)
+          .set({ value: String(version - 1) })
+          .where(eq(settingsTable.key, key))
+        const seen = await hasCurrentBundleVersions(getDb())
+        expect(seen).toBe(false)
+      })
+    }
+
+    it('returns false when a marker is missing entirely', async () => {
+      // A device that reconciled everything but one marker never got written
+      // (e.g. mid-rollout) — treat as "reconcile pending".
+      const db = getDb()
+      for (const { key, version } of markerCases.slice(0, -1)) {
+        await createSetting(db, key, String(version))
+      }
+      // Last marker deliberately missing.
+      const seen = await hasCurrentBundleVersions(db)
+      expect(seen).toBe(false)
+    })
+
+    it('returns false when a marker exists with a non-numeric value', async () => {
+      // Data corruption / older schema — must not open the fast path on a
+      // marker we can't compare. `Number('not-a-number') === NaN`, rejected
+      // by the `Number.isFinite` guard.
+      await seedAllMarkers(0)
+      await getDb()
+        .update(settingsTable)
+        .set({ value: 'not-a-number' })
+        .where(eq(settingsTable.key, versionMarkerKeys.tasks))
+      const seen = await hasCurrentBundleVersions(getDb())
+      expect(seen).toBe(false)
+    })
+
+    it('returns false when a marker exists with an empty-string value', async () => {
+      // `Number('') === 0` — would silently pass `>= bundled` if the DAL
+      // didn't null-guard the map builder. Pin this behavior so a refactor
+      // that drops the null-guard fails loudly.
+      await seedAllMarkers(0)
+      await getDb().update(settingsTable).set({ value: '' }).where(eq(settingsTable.key, versionMarkerKeys.modes))
+      const seen = await hasCurrentBundleVersions(getDb())
+      expect(seen).toBe(false)
+    })
+
+    it('returns false when a marker exists with a null value', async () => {
+      // `r.value == null` short-circuits the map to `null`, and `typeof null
+      // === 'object'` fails the number check. Pin the null-branch behavior.
+      await seedAllMarkers(0)
+      await getDb().update(settingsTable).set({ value: null }).where(eq(settingsTable.key, versionMarkerKeys.settings))
+      const seen = await hasCurrentBundleVersions(getDb())
+      expect(seen).toBe(false)
+    })
+
+    it('ignores non-marker settings rows', async () => {
+      // A user preference row is not a marker; it must not affect the check.
       await createSetting(getDb(), 'preferred_name', 'test-user')
-      const seen = await hasReconciledDefaults(getDb())
+      const seen = await hasCurrentBundleVersions(getDb())
       expect(seen).toBe(false)
     })
   })

--- a/src/dal/settings.ts
+++ b/src/dal/settings.ts
@@ -6,7 +6,12 @@ import { eq, inArray, sql } from 'drizzle-orm'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { isInsertConflictError } from '../lib/sqlite-errors'
 import { settingsTable } from '../db/tables'
-import { hashSetting } from '../defaults/settings'
+import { defaultModelsVersion } from '@shared/defaults/models'
+import { defaultModesVersion } from '../defaults/modes'
+import { defaultSettingsVersion, hashSetting } from '../defaults/settings'
+import { defaultSkillsVersion } from '../defaults/skills'
+import { defaultTasksVersion } from '../defaults/tasks'
+import { versionMarkerKeys } from '../lib/reconcile-defaults'
 import { serializeValue } from '../lib/serialization'
 import { camelCased, hashValues } from '../lib/utils'
 import type { DrizzleQueryWithPromise, Setting } from '@/types'
@@ -216,20 +221,39 @@ export const hasSetting = async (db: AnyDrizzleDatabase, key: string): Promise<b
 }
 
 /**
- * Whether any `defaults_version.*` marker exists in `settingsTable`. Presence
- * proves `reconcileDefaults` (see `src/lib/reconcile-defaults.ts`) has run to
- * completion on some prior boot on this device — or synced in from a peer
- * that did — because `advanceVersionMarker` is the only writer of that key
- * namespace and it fires only on a real mutation. Used by the init pipeline
- * (THU-677) to route boots to the returning-boot fast path.
+ * Whether every reconciled-defaults version marker exists AND is at or above
+ * the bundled version this build ships. Used by the init pipeline (THU-677)
+ * to gate the returning-boot fast path: the fast path skips
+ * `waitForInitialSync` and passes `initialSyncCompleted: false` to reconcile,
+ * which collapses the version gate to a no-op for populated tables. That is
+ * only safe when there's no reconcile work pending — i.e. we already applied
+ * the current build's bundle versions. Otherwise a client-upgrade bump would
+ * be stranded forever (reconcile isn't re-run when the background sync
+ * settles).
+ *
+ * A missing marker or one behind the bundle → returns false → init takes the
+ * fresh-await path, sync settles, reconcile runs with
+ * `initialSyncCompleted: true`, marker advances, next boot is fast again.
+ * A marker above the bundle (peer at a newer version) is safe to skip on —
+ * reconcile would no-op via `rawCanOverwrite=false` regardless.
  */
-export const hasReconciledDefaults = async (db: AnyDrizzleDatabase): Promise<boolean> => {
+export const hasCurrentBundleVersions = async (db: AnyDrizzleDatabase): Promise<boolean> => {
   const rows = await db
-    .select({ key: settingsTable.key })
+    .select({ key: settingsTable.key, value: settingsTable.value })
     .from(settingsTable)
     .where(sql`${settingsTable.key} LIKE 'defaults_version.%'`)
-    .limit(1)
-  return rows.length > 0
+  const stored = new Map(rows.map((r) => [r.key, r.value == null ? null : Number(r.value)]))
+  const isCurrent = (key: string, bundled: number): boolean => {
+    const v = stored.get(key)
+    return typeof v === 'number' && Number.isFinite(v) && v >= bundled
+  }
+  return (
+    isCurrent(versionMarkerKeys.models, defaultModelsVersion) &&
+    isCurrent(versionMarkerKeys.modes, defaultModesVersion) &&
+    isCurrent(versionMarkerKeys.tasks, defaultTasksVersion) &&
+    isCurrent(versionMarkerKeys.skills, defaultSkillsVersion) &&
+    isCurrent(versionMarkerKeys.settings, defaultSettingsVersion)
+  )
 }
 
 /**

--- a/src/dal/settings.ts
+++ b/src/dal/settings.ts
@@ -216,6 +216,23 @@ export const hasSetting = async (db: AnyDrizzleDatabase, key: string): Promise<b
 }
 
 /**
+ * Whether any `defaults_version.*` marker exists in `settingsTable`. Presence
+ * proves `reconcileDefaults` (see `src/lib/reconcile-defaults.ts`) has run to
+ * completion on some prior boot on this device — or synced in from a peer
+ * that did — because `advanceVersionMarker` is the only writer of that key
+ * namespace and it fires only on a real mutation. Used by the init pipeline
+ * (THU-677) to route boots to the returning-boot fast path.
+ */
+export const hasReconciledDefaults = async (db: AnyDrizzleDatabase): Promise<boolean> => {
+  const rows = await db
+    .select({ key: settingsTable.key })
+    .from(settingsTable)
+    .where(sql`${settingsTable.key} LIKE 'defaults_version.%'`)
+    .limit(1)
+  return rows.length > 0
+}
+
+/**
  * Create a setting only if it doesn't already exist
  * Does nothing if the setting already exists (preserves existing value)
  * Uses insert-then-catch-conflict to avoid TOCTOU race (PowerSync views don't support ON CONFLICT)

--- a/src/dal/settings.ts
+++ b/src/dal/settings.ts
@@ -6,12 +6,8 @@ import { eq, inArray, sql } from 'drizzle-orm'
 import type { AnyDrizzleDatabase } from '../db/database-interface'
 import { isInsertConflictError } from '../lib/sqlite-errors'
 import { settingsTable } from '../db/tables'
-import { defaultModelsVersion } from '@shared/defaults/models'
-import { defaultModesVersion } from '../defaults/modes'
-import { defaultSettingsVersion, hashSetting } from '../defaults/settings'
-import { defaultSkillsVersion } from '../defaults/skills'
-import { defaultTasksVersion } from '../defaults/tasks'
-import { versionMarkerKeys } from '../lib/reconcile-defaults'
+import { hashSetting } from '../defaults/settings'
+import type { VersionMarkerKey } from '../lib/reconcile-defaults'
 import { serializeValue } from '../lib/serialization'
 import { camelCased, hashValues } from '../lib/utils'
 import type { DrizzleQueryWithPromise, Setting } from '@/types'
@@ -221,39 +217,55 @@ export const hasSetting = async (db: AnyDrizzleDatabase, key: string): Promise<b
 }
 
 /**
- * Whether every reconciled-defaults version marker exists AND is at or above
- * the bundled version this build ships. Used by the init pipeline (THU-677)
- * to gate the returning-boot fast path: the fast path skips
- * `waitForInitialSync` and passes `initialSyncCompleted: false` to reconcile,
- * which collapses the version gate to a no-op for populated tables. That is
- * only safe when there's no reconcile work pending — i.e. we already applied
- * the current build's bundle versions. Otherwise a client-upgrade bump would
- * be stranded forever (reconcile isn't re-run when the background sync
- * settles).
+ * Whether every marker key in `targets` exists in `settingsTable` AND
+ * holds a stored version at or above the target the caller supplied.
+ * Used by the init pipeline (THU-677) to gate the returning-boot fast
+ * path: the fast path skips `waitForInitialSync` and passes
+ * `initialSyncCompleted: false` to reconcile, which collapses the
+ * version gate to a no-op for populated tables. That is only safe
+ * when there's no reconcile work pending — i.e. every marker already
+ * matches whatever reconcile would pick this boot.
  *
- * A missing marker or one behind the bundle → returns false → init takes the
- * fresh-await path, sync settles, reconcile runs with
- * `initialSyncCompleted: true`, marker advances, next boot is fast again.
- * A marker above the bundle (peer at a newer version) is safe to skip on —
- * reconcile would no-op via `rawCanOverwrite=false` regardless.
+ * Callers supply `targets` so the DAL doesn't have to know which
+ * versions are relevant to this boot: the hook passes bundled versions
+ * for modes/tasks/skills/settings and the picked models version from
+ * `pickModelsDefaults(useConfigStore.getState().config.defaults?.models)`
+ * — that's `max(bundle, OTA)`, which is exactly the version reconcile
+ * will compare against.
+ *
+ * Missing marker, one behind the target, or non-numeric → returns false
+ * → init takes the fresh-await path, sync settles, reconcile runs with
+ * `initialSyncCompleted: true`, and the marker advances (either
+ * because reconcile mutated rows OR because it verified content is
+ * already at target — see `reconcileDefaultsForTable`'s
+ * `everyBundleRowAtTarget` result). Next boot the check returns true
+ * and the fast path fires.
+ *
+ * Caveat: the models path additionally gates marker advance on
+ * `droppedOtaModelIds.length === 0`, so an OTA payload that ships new
+ * model ids this build's bundle can't fully render will not advance
+ * the models marker on this device even after a fresh-await pass —
+ * that's a deliberate carve-out (see the guard comment in
+ * `src/lib/reconcile-defaults.ts`) and means the fast path won't
+ * activate until a later client build ships matching profiles.
+ *
+ * A marker at or above its target (peer at a newer version) is safe
+ * to skip on — reconcile would no-op via `rawCanOverwrite=false`
+ * regardless.
  */
-export const hasCurrentBundleVersions = async (db: AnyDrizzleDatabase): Promise<boolean> => {
+export const hasCurrentDefaultsVersions = async (
+  db: AnyDrizzleDatabase,
+  targets: Record<VersionMarkerKey, number>,
+): Promise<boolean> => {
   const rows = await db
     .select({ key: settingsTable.key, value: settingsTable.value })
     .from(settingsTable)
     .where(sql`${settingsTable.key} LIKE 'defaults_version.%'`)
   const stored = new Map(rows.map((r) => [r.key, r.value == null ? null : Number(r.value)]))
-  const isCurrent = (key: string, bundled: number): boolean => {
+  return Object.entries(targets).every(([key, target]) => {
     const v = stored.get(key)
-    return typeof v === 'number' && Number.isFinite(v) && v >= bundled
-  }
-  return (
-    isCurrent(versionMarkerKeys.models, defaultModelsVersion) &&
-    isCurrent(versionMarkerKeys.modes, defaultModesVersion) &&
-    isCurrent(versionMarkerKeys.tasks, defaultTasksVersion) &&
-    isCurrent(versionMarkerKeys.skills, defaultSkillsVersion) &&
-    isCurrent(versionMarkerKeys.settings, defaultSettingsVersion)
-  )
+    return typeof v === 'number' && Number.isFinite(v) && v >= target
+  })
 }
 
 /**

--- a/src/defaults/modes.test.ts
+++ b/src/defaults/modes.test.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { defaultModes, defaultModesVersion, hashMode } from './modes'
+
+/**
+ * Snapshot pinning the shipped defaults to their declared version. When you
+ * change any default mode (add/remove/edit/reorder), this test fails.
+ *
+ * Fix it in this order:
+ *   1. Bump `defaultModesVersion` in `src/defaults/modes.ts`.
+ *   2. Update `expected` below to match the actual values from the failure.
+ *
+ * The version is the ordering signal reconcile uses to decide who owns the
+ * newest defaults across devices (THU-637 pattern extended to modes in
+ * THU-677). Changing defaults without bumping the version breaks that
+ * ordering silently.
+ */
+const computeSnapshotHash = () => defaultModes.map((mode, index) => `${index}:${mode.id}:${hashMode(mode)}`).join('|')
+
+const expected = {
+  version: 1,
+  hash: '0:mode-chat:-12w2hw|1:mode-search:-9p223q|2:mode-research:-8fvmwl',
+}
+
+describe('defaultModes version snapshot', () => {
+  test('version and content are in sync — read the file header if this fails', () => {
+    expect({
+      version: defaultModesVersion,
+      hash: computeSnapshotHash(),
+    }).toEqual(expected)
+  })
+})

--- a/src/defaults/modes.ts
+++ b/src/defaults/modes.ts
@@ -61,3 +61,15 @@ export const defaultModeResearch: Mode = {
  * Array of all default modes for iteration
  */
 export const defaultModes: ReadonlyArray<Mode> = [defaultModeChat, defaultModeSearch, defaultModeResearch] as const
+
+/**
+ * Monotonic version of the shipped mode defaults. Bump every time `defaultModes`
+ * changes in any way. Reconcile uses this as the ordering signal so multi-device
+ * sync groups converge without ping-ponging (THU-637 pattern extended to modes
+ * in THU-677): a device only overwrites existing rows when its picked defaults
+ * version is strictly newer than the highest ever applied on this account.
+ *
+ * The paired snapshot test in `modes.test.ts` fails on any change to this
+ * file's defaults without a matching version bump.
+ */
+export const defaultModesVersion = 1

--- a/src/defaults/modes.ts
+++ b/src/defaults/modes.ts
@@ -66,8 +66,8 @@ export const defaultModes: ReadonlyArray<Mode> = [defaultModeChat, defaultModeSe
  * Monotonic version of the shipped mode defaults. Bump every time `defaultModes`
  * changes in any way. Reconcile uses this as the ordering signal so multi-device
  * sync groups converge without ping-ponging (THU-637 pattern extended to modes
- * in THU-677): a device only overwrites existing rows when its picked defaults
- * version is strictly newer than the highest ever applied on this account.
+ * in THU-677): a device only overwrites existing rows when this bundled version
+ * is strictly newer than the highest ever applied on this account.
  *
  * The paired snapshot test in `modes.test.ts` fails on any change to this
  * file's defaults without a matching version bump.

--- a/src/defaults/settings.test.ts
+++ b/src/defaults/settings.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { defaultSettings, defaultSettingsVersion, hashSetting } from './settings'
+
+/**
+ * Snapshot pinning the shipped defaults to their declared version. When you
+ * change any default setting (add/remove/edit/reorder), this test fails.
+ *
+ * Fix it in this order:
+ *   1. Bump `defaultSettingsVersion` in `src/defaults/settings.ts`.
+ *   2. Update `expected` below to match the actual values from the failure.
+ *
+ * The version is the ordering signal reconcile uses to decide who owns the
+ * newest defaults across devices (THU-637 pattern extended to settings in
+ * THU-677). Changing defaults without bumping the version breaks that
+ * ordering silently.
+ */
+const computeSnapshotHash = () =>
+  defaultSettings.map((setting, index) => `${index}:${setting.key}:${hashSetting(setting)}`).join('|')
+
+const expected = {
+  version: 1,
+  hash: '0:data_collection:9xnigq|1:is_triggers_enabled:eonvmh|2:experimental_feature_tasks:-zg8zmz|3:preferred_name:-5w6dil|4:location_name:27rtqf|5:location_lat:-tpss8p|6:location_lng:-tpsiwv|7:distance_unit:-3esuvm|8:temperature_unit:-dmzg9f|9:date_format:52oyc|10:time_format:we6fw3|11:currency:avihzf|12:integrations_pro_is_enabled:bbnpv0|13:user_has_completed_onboarding:-hxwxxt|14:content_view_width:8pnzc5|15:integrations_do_not_ask_again:yv9tj5',
+}
+
+describe('defaultSettings version snapshot', () => {
+  test('version and content are in sync — read the file header if this fails', () => {
+    expect({
+      version: defaultSettingsVersion,
+      hash: computeSnapshotHash(),
+    }).toEqual(expected)
+  })
+})

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -175,3 +175,16 @@ export const defaultSettings: ReadonlyArray<Setting> = [
   defaultSettingContentViewWidth,
   defaultSettingIntegrationsDoNotAskAgain,
 ] as const
+
+/**
+ * Monotonic version of the shipped setting defaults. Bump every time
+ * `defaultSettings` changes in any way. Reconcile uses this as the ordering
+ * signal so multi-device sync groups converge without ping-ponging (THU-637
+ * pattern extended to settings in THU-677): a device only overwrites existing
+ * rows when its picked defaults version is strictly newer than the highest
+ * ever applied on this account.
+ *
+ * The paired snapshot test in `settings.test.ts` fails on any change to this
+ * file's defaults without a matching version bump.
+ */
+export const defaultSettingsVersion = 1

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -181,8 +181,8 @@ export const defaultSettings: ReadonlyArray<Setting> = [
  * `defaultSettings` changes in any way. Reconcile uses this as the ordering
  * signal so multi-device sync groups converge without ping-ponging (THU-637
  * pattern extended to settings in THU-677): a device only overwrites existing
- * rows when its picked defaults version is strictly newer than the highest
- * ever applied on this account.
+ * rows when this bundled version is strictly newer than the highest ever
+ * applied on this account.
  *
  * The paired snapshot test in `settings.test.ts` fails on any change to this
  * file's defaults without a matching version bump.

--- a/src/defaults/skills.test.ts
+++ b/src/defaults/skills.test.ts
@@ -2,9 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 
-import { defaultSkills } from './skills'
+import { defaultSkills, defaultSkillsVersion, hashSkill } from './skills'
+
+/**
+ * Snapshot pinning the shipped defaults to their declared version. When you
+ * change any default skill (add/remove/edit/reorder), this test fails.
+ *
+ * Fix it in this order:
+ *   1. Bump `defaultSkillsVersion` in `src/defaults/skills.ts`.
+ *   2. Update `expected` below to match the actual values from the failure.
+ *
+ * The version is the ordering signal reconcile uses to decide who owns the
+ * newest defaults across devices (THU-637 pattern extended to skills in
+ * THU-677). Changing defaults without bumping the version breaks that
+ * ordering silently.
+ */
+const computeSnapshotHash = () =>
+  defaultSkills.map((skill, index) => `${index}:${skill.id}:${hashSkill(skill)}`).join('|')
+
+const expectedSnapshot = {
+  version: 1,
+  hash: '0:01996330-0000-7000-8000-000000000001:wy8tfw|1:01996330-0000-7000-8000-000000000002:75efa',
+}
+
+describe('defaultSkills version snapshot', () => {
+  test('version and content are in sync — read the file header if this fails', () => {
+    expect({
+      version: defaultSkillsVersion,
+      hash: computeSnapshotHash(),
+    }).toEqual(expectedSnapshot)
+  })
+})
 
 describe('defaultSkills', () => {
   it('seeds every default with a pinnedOrder so new users start with pinned chips in chat', () => {

--- a/src/defaults/skills.ts
+++ b/src/defaults/skills.ts
@@ -93,8 +93,8 @@ export const defaultSkills: ReadonlyArray<Skill> = [defaultSkillDailyBrief, defa
  * `defaultSkills` changes in any way. Reconcile uses this as the ordering
  * signal so multi-device sync groups converge without ping-ponging (THU-637
  * pattern extended to skills in THU-677): a device only overwrites existing
- * rows when its picked defaults version is strictly newer than the highest
- * ever applied on this account.
+ * rows when this bundled version is strictly newer than the highest ever
+ * applied on this account.
  *
  * The paired snapshot test in `skills.test.ts` fails on any change to this
  * file's defaults without a matching version bump.

--- a/src/defaults/skills.ts
+++ b/src/defaults/skills.ts
@@ -87,3 +87,16 @@ export const defaultSkillImportantEmails: Skill = {
 }
 
 export const defaultSkills: ReadonlyArray<Skill> = [defaultSkillDailyBrief, defaultSkillImportantEmails] as const
+
+/**
+ * Monotonic version of the shipped skill defaults. Bump every time
+ * `defaultSkills` changes in any way. Reconcile uses this as the ordering
+ * signal so multi-device sync groups converge without ping-ponging (THU-637
+ * pattern extended to skills in THU-677): a device only overwrites existing
+ * rows when its picked defaults version is strictly newer than the highest
+ * ever applied on this account.
+ *
+ * The paired snapshot test in `skills.test.ts` fails on any change to this
+ * file's defaults without a matching version bump.
+ */
+export const defaultSkillsVersion = 1

--- a/src/defaults/tasks.test.ts
+++ b/src/defaults/tasks.test.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { defaultTasks, defaultTasksVersion, hashTask } from './tasks'
+
+/**
+ * Snapshot pinning the shipped defaults to their declared version. When you
+ * change any default task (add/remove/edit/reorder), this test fails.
+ *
+ * Fix it in this order:
+ *   1. Bump `defaultTasksVersion` in `src/defaults/tasks.ts`.
+ *   2. Update `expected` below to match the actual values from the failure.
+ *
+ * The version is the ordering signal reconcile uses to decide who owns the
+ * newest defaults across devices (THU-637 pattern extended to tasks in
+ * THU-677). Changing defaults without bumping the version breaks that
+ * ordering silently.
+ */
+const computeSnapshotHash = () => defaultTasks.map((task, index) => `${index}:${task.id}:${hashTask(task)}`).join('|')
+
+const expected = {
+  version: 1,
+  hash: '0:0198ecc5-cc2b-735b-b478-93f8db7202ce:ewc0es|1:0198ecc5-cc2b-735b-b478-96071aa92f62:-9v5tnk|2:0198ecc5-cc2b-735b-b478-99e9874d61ba:-akftt5',
+}
+
+describe('defaultTasks version snapshot', () => {
+  test('version and content are in sync — read the file header if this fails', () => {
+    expect({
+      version: defaultTasksVersion,
+      hash: computeSnapshotHash(),
+    }).toEqual(expected)
+  })
+})

--- a/src/defaults/tasks.ts
+++ b/src/defaults/tasks.ts
@@ -61,8 +61,8 @@ export const defaultTasks: ReadonlyArray<Task> = [
  * Monotonic version of the shipped task defaults. Bump every time `defaultTasks`
  * changes in any way. Reconcile uses this as the ordering signal so multi-device
  * sync groups converge without ping-ponging (THU-637 pattern extended to tasks
- * in THU-677): a device only overwrites existing rows when its picked defaults
- * version is strictly newer than the highest ever applied on this account.
+ * in THU-677): a device only overwrites existing rows when this bundled version
+ * is strictly newer than the highest ever applied on this account.
  *
  * The paired snapshot test in `tasks.test.ts` fails on any change to this
  * file's defaults without a matching version bump.

--- a/src/defaults/tasks.ts
+++ b/src/defaults/tasks.ts
@@ -56,3 +56,15 @@ export const defaultTasks: ReadonlyArray<Task> = [
   defaultTaskSetPreferences,
   defaultTaskExplorePro,
 ] as const
+
+/**
+ * Monotonic version of the shipped task defaults. Bump every time `defaultTasks`
+ * changes in any way. Reconcile uses this as the ordering signal so multi-device
+ * sync groups converge without ping-ponging (THU-637 pattern extended to tasks
+ * in THU-677): a device only overwrites existing rows when its picked defaults
+ * version is strictly newer than the highest ever applied on this account.
+ *
+ * The paired snapshot test in `tasks.test.ts` fails on any change to this
+ * file's defaults without a matching version bump.
+ */
+export const defaultTasksVersion = 1

--- a/src/hooks/use-app-initialization.test.tsx
+++ b/src/hooks/use-app-initialization.test.tsx
@@ -2,14 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { InitialSyncOutcome } from '@/db/database-interface'
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getInitTimingPayload, resetInitTiming } from '@/lib/init-timing'
 import { createMockHttpClient } from '@/test-utils/http-client'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { getClock } from '@/testing-library'
 import { act, renderHook } from '@testing-library/react'
-import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
-import { useAppInitialization } from './use-app-initialization'
+import { afterAll, beforeAll, describe, expect, it, mock, test } from 'bun:test'
+import { resolveInitialSyncStep, useAppInitialization } from './use-app-initialization'
 
 mock.module('@tauri-apps/api/core', () => ({
   isTauri: () => false,
@@ -170,5 +171,55 @@ describe('useAppInitialization', () => {
     // step6 is skipped when an httpClient is injected (as in this test).
     expect(payload).not.toHaveProperty('step6_create_http_client_ms')
     expect(payload.init_run).toBeGreaterThanOrEqual(1)
+  })
+})
+
+/**
+ * Direct unit tests for the returning-boot branch (THU-677). The hook itself
+ * is hard to observe here because `initial_sync_outcome` / `init_path` are
+ * only visible through the PostHog `trackEvent` payload, and mocking that
+ * shared module would violate the no-shared-mocks rule. Testing the
+ * extracted branch keeps the observable surface small and honest.
+ */
+describe('resolveInitialSyncStep', () => {
+  const makeGate = (outcome: InitialSyncOutcome) => ({
+    waitForInitialSync: async () => outcome,
+  })
+
+  test('awaits waitForInitialSync when canSkipSyncWait=false and passes the outcome through', async () => {
+    const { initialSyncOutcome, initialSyncCompleted } = await resolveInitialSyncStep(makeGate('synced'), false)
+    expect(initialSyncOutcome).toBe('synced')
+    expect(initialSyncCompleted).toBe(true)
+  })
+
+  test('flags initialSyncCompleted=true when outcome is disabled — sync-disabled devices still receive bundle updates', async () => {
+    const { initialSyncOutcome, initialSyncCompleted } = await resolveInitialSyncStep(makeGate('disabled'), false)
+    expect(initialSyncOutcome).toBe('disabled')
+    expect(initialSyncCompleted).toBe(true)
+  })
+
+  test('flags initialSyncCompleted=false when outcome is timed_out or failed', async () => {
+    for (const outcome of ['timed_out', 'failed'] as const) {
+      const result = await resolveInitialSyncStep(makeGate(outcome), false)
+      expect(result.initialSyncCompleted).toBe(false)
+      expect(result.initialSyncOutcome).toBe(outcome)
+    }
+  })
+
+  test('returns skipped_returning without awaiting waitForInitialSync when canSkipSyncWait=true', async () => {
+    // Never-resolving promise: if the branch awaits it, the test hangs. The
+    // outer resolveInitialSyncStep attaches a .catch handler so the leak is
+    // silent — no unhandled rejection to worry about.
+    let called = false
+    const gate = {
+      waitForInitialSync: () => {
+        called = true
+        return new Promise<InitialSyncOutcome>(() => {})
+      },
+    }
+    const { initialSyncOutcome, initialSyncCompleted } = await resolveInitialSyncStep(gate, true)
+    expect(called).toBe(true)
+    expect(initialSyncOutcome).toBe('skipped_returning')
+    expect(initialSyncCompleted).toBe(false)
   })
 })

--- a/src/hooks/use-app-initialization.test.tsx
+++ b/src/hooks/use-app-initialization.test.tsx
@@ -156,6 +156,7 @@ describe('useAppInitialization', () => {
       'step1_create_app_dir_ms',
       'step2_initialize_database_ms',
       'step2b_db_ready_ms',
+      'step2c_returning_boot_probe_ms',
       'step3_wait_for_initial_sync_ms',
       'step4_reconcile_defaults_ms',
       'step4b_run_data_migrations_ms',

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -5,7 +5,7 @@
 import { fetchConfig } from '@/api/config'
 import { useConfigStore } from '@/api/config-store'
 import type { HttpClient } from '@/contexts'
-import { getSettings, hasReconciledDefaults } from '@/dal'
+import { getSettings, hasCurrentBundleVersions } from '@/dal'
 import { getAuthToken } from '@/lib/auth-token'
 import { Database, getCurrentDatabase, setDatabase } from '@/db/database'
 import type { AnyDrizzleDatabase, InitialSyncOutcome } from '@/db/database-interface'
@@ -203,37 +203,39 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     await db.get(sql`select 1`)
   })
 
-  // Step 2c: Returning-boot detection via the `hasReconciledDefaults` DAL
-  // helper. Presence of any `defaults_version.*` marker proves a prior
-  // reconcile completed on this device (or synced in from a peer that did).
-  // Under the per-table version-gate (THU-637 + THU-677) that same reconcile
-  // is safe to re-run without first waiting for cloud sync — with
-  // `initialSyncCompleted=false` the gate collapses to a no-op for any table
-  // that already has rows. This shaves the 10s waitForInitialSync ceiling
-  // off every refresh, at the cost of bundled default updates taking one
-  // extra boot to apply (they land on the next boot where sync completes).
-  const hasReconciledBefore = await time('step2c_returning_boot_probe', () => hasReconciledDefaults(db))
+  // Step 2c: Returning-boot detection via `hasCurrentBundleVersions`. Every
+  // `defaults_version.*` marker must exist AND meet-or-exceed the version
+  // this build ships. This is stricter than a "marker exists" probe on
+  // purpose — a client upgrade that bumped any bundled version needs the
+  // fresh-await path to run so reconcile can apply it; nothing re-runs
+  // reconcile when the background `waitForInitialSync()` later resolves, so
+  // an outstanding bump on the fast path would be stranded forever.
+  //
+  // When every marker is current: skipping is safe because reconcile would
+  // no-op anyway (`rawCanOverwrite=false` for every table).
+  const bundleVersionsCurrent = await time('step2c_returning_boot_probe', () => hasCurrentBundleVersions(db))
 
   // Step 3: Wait for PowerSync initial sync — only on fresh boots when sync is
-  // enabled. Returning boots on sync-enabled devices kick off the sync
-  // fire-and-forget so the engine still warms up and background updates land
-  // as they arrive, then feed `initialSyncCompleted: false` to reconcile so
-  // the version-gate stays closed against unsynced cloud state.
+  // enabled AND we already applied the current bundle versions. Returning
+  // boots on sync-enabled, up-to-date devices kick off the sync fire-and-
+  // forget so the engine still warms up and background updates land as they
+  // arrive, then feed `initialSyncCompleted: false` to reconcile so the
+  // version-gate stays closed against unsynced cloud state.
   //
   // Sync-disabled devices ALWAYS take the fresh path: `waitForInitialSync`
   // returns `'disabled'` immediately (zero wait), which sets
-  // `initialSyncCompleted=true` and lets reconcile freely apply bundle updates
-  // — the only way a standalone device ever picks up new defaults from a
-  // client upgrade. Taking the returning-boot skip here would force
-  // `initialSyncCompleted=false` and freeze standalone users on their current
-  // defaults forever (nothing else ever advances the marker).
+  // `initialSyncCompleted=true` and lets reconcile freely apply bundle
+  // updates — the only way a standalone device ever picks up new defaults
+  // from a client upgrade. Taking the returning-boot skip here would force
+  // `initialSyncCompleted=false` and freeze standalone users on their
+  // current defaults forever.
   //
   // `waitForInitialSync` never rejects (best-effort with internal timeout);
   // the `.catch` guards against that policy weakening.
   //
   // The outcome ('synced' / 'timed_out' / 'failed' / 'disabled' /
   // 'skipped_returning') is reported in the app_init_timing event below.
-  const canSkipSyncWait = hasReconciledBefore && getLocalSetting('syncEnabled')
+  const canSkipSyncWait = bundleVersionsCurrent && getLocalSetting('syncEnabled')
   const { initialSyncOutcome, initialSyncCompleted } = await time('step3_wait_for_initial_sync', () =>
     resolveInitialSyncStep(database, canSkipSyncWait),
   )

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -5,11 +5,10 @@
 import { fetchConfig } from '@/api/config'
 import { useConfigStore } from '@/api/config-store'
 import type { HttpClient } from '@/contexts'
-import { getSettings } from '@/dal'
+import { getSettings, hasReconciledDefaults } from '@/dal'
 import { getAuthToken } from '@/lib/auth-token'
 import { Database, getCurrentDatabase, setDatabase } from '@/db/database'
 import type { AnyDrizzleDatabase, InitialSyncOutcome } from '@/db/database-interface'
-import { settingsTable } from '@/db/tables'
 import { getLocalSetting } from '@/stores/local-settings-store'
 import { createHandleError } from '@/lib/error-utils'
 import { createAppDir, resetAppDir } from '@/lib/fs'
@@ -174,23 +173,16 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     await db.get(sql`select 1`)
   })
 
-  // Step 2c: Returning-boot detection. Presence of any `defaults_version.*`
-  // row in settingsTable proves `reconcileDefaults` ran to completion on some
-  // prior boot on this device (or synced in from a peer that did). Under the
-  // per-table version-gate (THU-637 + THU-677) that same reconcile is safe
-  // to re-run without first waiting for cloud sync — with
+  // Step 2c: Returning-boot detection via the `hasReconciledDefaults` DAL
+  // helper. Presence of any `defaults_version.*` marker proves a prior
+  // reconcile completed on this device (or synced in from a peer that did).
+  // Under the per-table version-gate (THU-637 + THU-677) that same reconcile
+  // is safe to re-run without first waiting for cloud sync — with
   // `initialSyncCompleted=false` the gate collapses to a no-op for any table
   // that already has rows. This shaves the 10s waitForInitialSync ceiling
   // off every refresh, at the cost of bundled default updates taking one
   // extra boot to apply (they land on the next boot where sync completes).
-  const hasReconciledBefore = await time('step2c_returning_boot_probe', async () => {
-    const rows = await db
-      .select({ key: settingsTable.key })
-      .from(settingsTable)
-      .where(sql`${settingsTable.key} LIKE 'defaults_version.%'`)
-      .limit(1)
-    return rows.length > 0
-  })
+  const hasReconciledBefore = await time('step2c_returning_boot_probe', () => hasReconciledDefaults(db))
 
   // Step 3: Wait for PowerSync initial sync — only on fresh boots when sync is
   // enabled. Returning boots on sync-enabled devices kick off the sync

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -377,6 +377,7 @@ export const useAppInitialization = (httpClient?: HttpClient) => {
       // deferred storage open) must surface as an error screen rather than
       // leaving the app stuck on the loading spinner forever. Tracked like the
       // per-step failures so an unexpected throw stays observable.
+      console.error('Failed to initialize app:', error)
       const unknownError = createHandleError('UNKNOWN_ERROR', 'Failed to initialize app', error)
       trackError(unknownError, { initialization_step: 'uncaught' })
       setInitError(unknownError)

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -98,13 +98,23 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
   const totalStartedAt = performance.now()
   console.info('[init] start')
 
-  // Step 0: Fetch backend config and hydrate store (only on success).
-  // When fetch fails (offline/error), the store retains its persisted localStorage value.
-  // Not awaited here: nothing in this pipeline consumes the config (it is read
-  // reactively from the store later), so it overlaps with the steps below
-  // (including the storage probe) and is only awaited at the end to land its
-  // duration in app_init_timing.
-  const fetchConfigPromise = time('step0_fetch_config', () => fetchConfig(getLocalSetting('cloudUrl'), httpClient))
+  // Step 0: Fire-and-forget `/config` fetch. On success `fetchConfig` hydrates
+  // `useConfigStore` (persisted to localStorage), so subsequent boots read the
+  // last-known value synchronously — `pickModelsDefaults` below reads the
+  // cache directly and no downstream step awaits this fetch. Reconcile's
+  // version gate no-ops any OTA payload that isn't strictly newer than the
+  // stored marker, so a fresh OTA arriving mid-boot lands cleanly on the
+  // next boot without needing to gate this one.
+  //
+  // `.catch` consumes the promise so it can't float unhandled — `fetchConfig`
+  // swallows errors internally today, but this guards the invariant against
+  // future changes. `step0_fetch_config_ms` still appears in the timing
+  // payload whenever the fetch completes before `trackEvent` fires; on
+  // returning boots where init finishes quickly it may be absent, which is
+  // the acceptable trade for not blocking every refresh on the network.
+  time('step0_fetch_config', () => fetchConfig(getLocalSetting('cloudUrl'), httpClient)).catch((error) => {
+    console.warn('[init] /config fetch failed:', error)
+  })
 
   // Step 0.5: Storage pre-flight. IndexedDB is required by both the local
   // PowerSync VFS (web) and the E2EE key store (all platforms). iOS Lockdown
@@ -197,16 +207,9 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     }
   })
 
-  // Step 3.5: Settle the /config fetch so reconcile can prefer server-shipped
-  // defaults when they declare a higher version than the bundle. Awaited
-  // unconditionally: (a) `step0_fetch_config` must land in the timing payload
-  // for every boot, not just first launch; (b) leaving the promise floating
-  // past this point risks an unhandled rejection on any environment where
-  // fetchConfig's error handling weakens. `fetchConfig` is bounded by its
-  // internal timeout and swallows errors — the persisted cache remains in
-  // the store until a successful fetch replaces it, so `pickModelsDefaults`
-  // still reads the same value it would on the cache-hit fast path.
-  await fetchConfigPromise
+  // Read the persisted /config cache directly. The step-0 fetch runs in the
+  // background and hydrates the store on completion; whatever it eventually
+  // writes lands cleanly on the next boot via reconcile's version gate.
   const modelsDefaults = pickModelsDefaults(useConfigStore.getState().config.defaults?.models)
 
   // Step 4: Reconcile defaults

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -9,6 +9,7 @@ import { getSettings } from '@/dal'
 import { getAuthToken } from '@/lib/auth-token'
 import { Database, getCurrentDatabase, setDatabase } from '@/db/database'
 import type { AnyDrizzleDatabase } from '@/db/database-interface'
+import { settingsTable } from '@/db/tables'
 import { getLocalSetting } from '@/stores/local-settings-store'
 import { createHandleError } from '@/lib/error-utils'
 import { createAppDir, resetAppDir } from '@/lib/fs'
@@ -155,11 +156,46 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     await db.get(sql`select 1`)
   })
 
-  // Step 3: Wait for PowerSync initial sync before reconciling defaults.
-  // This ensures synced data from the cloud is available before we check for missing
-  // defaults. The implementation never rejects (best-effort with internal timeout);
-  // the outcome is reported in the app_init_timing event below.
-  const initialSyncOutcome = await time('step3_wait_for_initial_sync', () => database.waitForInitialSync())
+  // Step 2c: Returning-boot detection. Presence of any `defaults_version.*`
+  // row in settingsTable proves `reconcileDefaults` ran to completion on some
+  // prior boot on this device (or synced in from a peer that did). Under the
+  // per-table version-gate (THU-637 + THU-677) that same reconcile is safe
+  // to re-run without first waiting for cloud sync — with
+  // `initialSyncCompleted=false` the gate collapses to a no-op for any table
+  // that already has rows. This shaves the 10s waitForInitialSync ceiling
+  // off every refresh, at the cost of bundled default updates taking one
+  // extra boot to apply (they land on the next boot where sync completes).
+  const hasReconciledBefore = await time('step2c_returning_boot_probe', async () => {
+    const rows = await db
+      .select({ key: settingsTable.key })
+      .from(settingsTable)
+      .where(sql`${settingsTable.key} LIKE 'defaults_version.%'`)
+      .limit(1)
+    return rows.length > 0
+  })
+
+  // Step 3: Wait for PowerSync initial sync — only on fresh boots. Returning
+  // boots kick off the sync fire-and-forget so the engine still warms up and
+  // background updates land as they arrive, then feed `initialSyncCompleted:
+  // false` to reconcile so the version-gate stays closed against unsynced
+  // cloud state. The implementation never rejects (best-effort with internal
+  // timeout); the `.catch` guards against that policy weakening.
+  //
+  // The outcome ('synced' / 'timed_out' / 'failed' / 'disabled' /
+  // 'skipped_returning') is reported in the app_init_timing event below.
+  const { initialSyncOutcome, initialSyncCompleted } = await time('step3_wait_for_initial_sync', async () => {
+    if (hasReconciledBefore) {
+      database.waitForInitialSync().catch((error) => {
+        console.warn('[init] Background waitForInitialSync failed:', error)
+      })
+      return { initialSyncOutcome: 'skipped_returning' as const, initialSyncCompleted: false }
+    }
+    const outcome = await database.waitForInitialSync()
+    return {
+      initialSyncOutcome: outcome,
+      initialSyncCompleted: outcome === 'synced' || outcome === 'disabled',
+    }
+  })
 
   // Step 3.5: Settle the /config fetch so reconcile can prefer server-shipped
   // defaults when they declare a higher version than the bundle. Awaited
@@ -172,7 +208,6 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
   // still reads the same value it would on the cache-hit fast path.
   await fetchConfigPromise
   const modelsDefaults = pickModelsDefaults(useConfigStore.getState().config.defaults?.models)
-  const initialSyncCompleted = initialSyncOutcome === 'synced' || initialSyncOutcome === 'disabled'
 
   // Step 4: Reconcile defaults
   try {
@@ -241,6 +276,7 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     ...getInitTimingPayload(),
     init_total_ms: initTotalMs,
     initial_sync_outcome: initialSyncOutcome,
+    init_path: hasReconciledBefore ? ('returning' as const) : ('fresh' as const),
     sync_enabled: getLocalSetting('syncEnabled'),
     platform: getPlatform(),
   }

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -8,7 +8,7 @@ import type { HttpClient } from '@/contexts'
 import { getSettings } from '@/dal'
 import { getAuthToken } from '@/lib/auth-token'
 import { Database, getCurrentDatabase, setDatabase } from '@/db/database'
-import type { AnyDrizzleDatabase } from '@/db/database-interface'
+import type { AnyDrizzleDatabase, InitialSyncOutcome } from '@/db/database-interface'
 import { settingsTable } from '@/db/tables'
 import { getLocalSetting } from '@/stores/local-settings-store'
 import { createHandleError } from '@/lib/error-utils'
@@ -29,6 +29,14 @@ import type { Window } from '@tauri-apps/api/window'
 import type { PostHog } from 'posthog-js'
 import { sql } from 'drizzle-orm'
 import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * Wider outcome type reported in the `app_init_timing` PostHog event. Callers
+ * of `waitForInitialSync` see the primitive `InitialSyncOutcome`; the init
+ * orchestration additionally reports `'skipped_returning'` when the
+ * returning-boot fast path bypassed the wait (THU-677).
+ */
+type InitTimingSyncOutcome = InitialSyncOutcome | 'skipped_returning'
 
 const createAppDirectory = async (): Promise<string> => {
   return await createAppDir()
@@ -184,28 +192,43 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     return rows.length > 0
   })
 
-  // Step 3: Wait for PowerSync initial sync — only on fresh boots. Returning
-  // boots kick off the sync fire-and-forget so the engine still warms up and
-  // background updates land as they arrive, then feed `initialSyncCompleted:
-  // false` to reconcile so the version-gate stays closed against unsynced
-  // cloud state. The implementation never rejects (best-effort with internal
-  // timeout); the `.catch` guards against that policy weakening.
+  // Step 3: Wait for PowerSync initial sync — only on fresh boots when sync is
+  // enabled. Returning boots on sync-enabled devices kick off the sync
+  // fire-and-forget so the engine still warms up and background updates land
+  // as they arrive, then feed `initialSyncCompleted: false` to reconcile so
+  // the version-gate stays closed against unsynced cloud state.
+  //
+  // Sync-disabled devices ALWAYS take the fresh path: `waitForInitialSync`
+  // returns `'disabled'` immediately (zero wait), which sets
+  // `initialSyncCompleted=true` and lets reconcile freely apply bundle updates
+  // — the only way a standalone device ever picks up new defaults from a
+  // client upgrade. Taking the returning-boot skip here would force
+  // `initialSyncCompleted=false` and freeze standalone users on their current
+  // defaults forever (nothing else ever advances the marker).
+  //
+  // `waitForInitialSync` never rejects (best-effort with internal timeout);
+  // the `.catch` guards against that policy weakening.
   //
   // The outcome ('synced' / 'timed_out' / 'failed' / 'disabled' /
   // 'skipped_returning') is reported in the app_init_timing event below.
-  const { initialSyncOutcome, initialSyncCompleted } = await time('step3_wait_for_initial_sync', async () => {
-    if (hasReconciledBefore) {
-      database.waitForInitialSync().catch((error) => {
-        console.warn('[init] Background waitForInitialSync failed:', error)
-      })
-      return { initialSyncOutcome: 'skipped_returning' as const, initialSyncCompleted: false }
-    }
-    const outcome = await database.waitForInitialSync()
-    return {
-      initialSyncOutcome: outcome,
-      initialSyncCompleted: outcome === 'synced' || outcome === 'disabled',
-    }
-  })
+  const canSkipSyncWait = hasReconciledBefore && getLocalSetting('syncEnabled')
+  const step3Result: { initialSyncOutcome: InitTimingSyncOutcome; initialSyncCompleted: boolean } = await time(
+    'step3_wait_for_initial_sync',
+    async () => {
+      if (canSkipSyncWait) {
+        database.waitForInitialSync().catch((error) => {
+          console.warn('[init] Background waitForInitialSync failed:', error)
+        })
+        return { initialSyncOutcome: 'skipped_returning', initialSyncCompleted: false }
+      }
+      const outcome = await database.waitForInitialSync()
+      return {
+        initialSyncOutcome: outcome,
+        initialSyncCompleted: outcome === 'synced' || outcome === 'disabled',
+      }
+    },
+  )
+  const { initialSyncOutcome, initialSyncCompleted } = step3Result
 
   // Read the persisted /config cache directly. The step-0 fetch runs in the
   // background and hydrates the store on completion; whatever it eventually
@@ -279,7 +302,7 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     ...getInitTimingPayload(),
     init_total_ms: initTotalMs,
     initial_sync_outcome: initialSyncOutcome,
-    init_path: hasReconciledBefore ? ('returning' as const) : ('fresh' as const),
+    init_path: canSkipSyncWait ? ('returning' as const) : ('fresh' as const),
     sync_enabled: getLocalSetting('syncEnabled'),
     platform: getPlatform(),
   }

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -5,7 +5,7 @@
 import { fetchConfig } from '@/api/config'
 import { useConfigStore } from '@/api/config-store'
 import type { HttpClient } from '@/contexts'
-import { getSettings, hasCurrentBundleVersions } from '@/dal'
+import { getSettings, hasCurrentDefaultsVersions } from '@/dal'
 import { getAuthToken } from '@/lib/auth-token'
 import { Database, getCurrentDatabase, setDatabase } from '@/db/database'
 import type { AnyDrizzleDatabase, InitialSyncOutcome } from '@/db/database-interface'
@@ -19,7 +19,11 @@ import { pickModelsDefaults } from '@/lib/pick-defaults'
 import { getDatabasePath, getDatabaseType, getPlatform, isIndexedDbAvailable } from '@/lib/platform'
 import { initPosthog, trackError, trackEvent } from '@/lib/posthog'
 import { runDataMigrations } from '@/lib/data-migrations'
-import { reconcileDefaults } from '@/lib/reconcile-defaults'
+import { reconcileDefaults, versionMarkerKeys, type VersionMarkerKey } from '@/lib/reconcile-defaults'
+import { defaultModesVersion } from '@/defaults/modes'
+import { defaultSettingsVersion } from '@/defaults/settings'
+import { defaultSkillsVersion } from '@/defaults/skills'
+import { defaultTasksVersion } from '@/defaults/tasks'
 import { TrayManager } from '@/lib/tray'
 import type { InitData } from '@/types'
 import type { HandleError, HandleResult } from '@/types/handle-errors'
@@ -203,17 +207,38 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     await db.get(sql`select 1`)
   })
 
-  // Step 2c: Returning-boot detection via `hasCurrentBundleVersions`. Every
-  // `defaults_version.*` marker must exist AND meet-or-exceed the version
-  // this build ships. This is stricter than a "marker exists" probe on
-  // purpose — a client upgrade that bumped any bundled version needs the
-  // fresh-await path to run so reconcile can apply it; nothing re-runs
-  // reconcile when the background `waitForInitialSync()` later resolves, so
-  // an outstanding bump on the fast path would be stranded forever.
+  // Read the persisted `/config` cache once, up front. `pickModelsDefaults`
+  // returns whichever of (bundled models, OTA models) declares the higher
+  // version — reconcile uses this at step 4, and the returning-boot probe
+  // below needs the same value so a device sitting behind a cached OTA
+  // bump correctly takes the fresh-await path.
+  const modelsDefaults = pickModelsDefaults(useConfigStore.getState().config.defaults?.models)
+
+  // Step 2c: Returning-boot detection via `hasCurrentDefaultsVersions`.
+  // Every `defaults_version.*` marker must exist AND meet-or-exceed the
+  // version reconcile would pick this boot — that's the bundled version
+  // for modes/tasks/skills/settings and the OTA-or-bundle picked version
+  // for models. This is stricter than a "marker exists" probe on purpose:
+  // a client upgrade that bumped any bundled version OR a fresh OTA
+  // payload needs the fresh-await path so reconcile can apply it. Nothing
+  // re-runs reconcile when the background `waitForInitialSync()` later
+  // resolves, so an outstanding bump on the fast path would be stranded
+  // forever.
   //
-  // When every marker is current: skipping is safe because reconcile would
-  // no-op anyway (`rawCanOverwrite=false` for every table).
-  const bundleVersionsCurrent = await time('step2c_returning_boot_probe', () => hasCurrentBundleVersions(db))
+  // When every marker meets its target: skipping is safe. Reconcile still
+  // runs at step 4 and correctly advances the marker on the fresh-await
+  // path even for existing-user upgrades where rows already hash to target
+  // (see `everyBundleRowAtTarget` in `reconcileDefaultsForTable`).
+  const defaultsTargets: Record<VersionMarkerKey, number> = {
+    [versionMarkerKeys.models]: modelsDefaults.version,
+    [versionMarkerKeys.modes]: defaultModesVersion,
+    [versionMarkerKeys.tasks]: defaultTasksVersion,
+    [versionMarkerKeys.skills]: defaultSkillsVersion,
+    [versionMarkerKeys.settings]: defaultSettingsVersion,
+  }
+  const bundleVersionsCurrent = await time('step2c_returning_boot_probe', () =>
+    hasCurrentDefaultsVersions(db, defaultsTargets),
+  )
 
   // Step 3: Wait for PowerSync initial sync — only on fresh boots when sync is
   // enabled AND we already applied the current bundle versions. Returning
@@ -240,12 +265,8 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
     resolveInitialSyncStep(database, canSkipSyncWait),
   )
 
-  // Read the persisted /config cache directly. The step-0 fetch runs in the
-  // background and hydrates the store on completion; whatever it eventually
-  // writes lands cleanly on the next boot via reconcile's version gate.
-  const modelsDefaults = pickModelsDefaults(useConfigStore.getState().config.defaults?.models)
-
-  // Step 4: Reconcile defaults
+  // Step 4: Reconcile defaults (uses `modelsDefaults` picked above step 2c
+  // so both the returning-boot probe and reconcile see the same OTA payload).
   try {
     await time('step4_reconcile_defaults', () =>
       reconcileDefaults(db, { models: modelsDefaults, initialSyncCompleted }),

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -35,7 +35,37 @@ import { useCallback, useEffect, useState } from 'react'
  * orchestration additionally reports `'skipped_returning'` when the
  * returning-boot fast path bypassed the wait (THU-677).
  */
-type InitTimingSyncOutcome = InitialSyncOutcome | 'skipped_returning'
+export type InitTimingSyncOutcome = InitialSyncOutcome | 'skipped_returning'
+
+type SyncGate = { waitForInitialSync(): Promise<InitialSyncOutcome> }
+
+/**
+ * Resolves the step-3 sync-gate outcome. On the fast path (returning boot +
+ * sync enabled) it fires `waitForInitialSync` in the background and returns
+ * `'skipped_returning'` + `initialSyncCompleted: false` synchronously so
+ * reconcile's version-gate stays closed against unsynced cloud state; on
+ * every other path it awaits the outcome and derives `initialSyncCompleted`.
+ *
+ * Exported so the branch can be unit-tested directly — the containing hook
+ * body isn't easily observable, and the two branches diverge on both return
+ * value and side effect (does the caller await or not).
+ */
+export const resolveInitialSyncStep = async (
+  database: SyncGate,
+  canSkipSyncWait: boolean,
+): Promise<{ initialSyncOutcome: InitTimingSyncOutcome; initialSyncCompleted: boolean }> => {
+  if (canSkipSyncWait) {
+    database.waitForInitialSync().catch((error) => {
+      console.warn('[init] Background waitForInitialSync failed:', error)
+    })
+    return { initialSyncOutcome: 'skipped_returning', initialSyncCompleted: false }
+  }
+  const outcome = await database.waitForInitialSync()
+  return {
+    initialSyncOutcome: outcome,
+    initialSyncCompleted: outcome === 'synced' || outcome === 'disabled',
+  }
+}
 
 const createAppDirectory = async (): Promise<string> => {
   return await createAppDir()
@@ -204,23 +234,9 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
   // The outcome ('synced' / 'timed_out' / 'failed' / 'disabled' /
   // 'skipped_returning') is reported in the app_init_timing event below.
   const canSkipSyncWait = hasReconciledBefore && getLocalSetting('syncEnabled')
-  const step3Result: { initialSyncOutcome: InitTimingSyncOutcome; initialSyncCompleted: boolean } = await time(
-    'step3_wait_for_initial_sync',
-    async () => {
-      if (canSkipSyncWait) {
-        database.waitForInitialSync().catch((error) => {
-          console.warn('[init] Background waitForInitialSync failed:', error)
-        })
-        return { initialSyncOutcome: 'skipped_returning', initialSyncCompleted: false }
-      }
-      const outcome = await database.waitForInitialSync()
-      return {
-        initialSyncOutcome: outcome,
-        initialSyncCompleted: outcome === 'synced' || outcome === 'disabled',
-      }
-    },
+  const { initialSyncOutcome, initialSyncCompleted } = await time('step3_wait_for_initial_sync', () =>
+    resolveInitialSyncStep(database, canSkipSyncWait),
   )
-  const { initialSyncOutcome, initialSyncCompleted } = step3Result
 
   // Read the persisted /config cache directly. The step-0 fetch runs in the
   // background and hydrates the store on completion; whatever it eventually

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -7,6 +7,7 @@ import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/da
 import { getDb } from '@/db/database'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 import { eq } from 'drizzle-orm'
+import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
 import {
   modelProfilesTable,
   modelsTable,
@@ -1212,45 +1213,22 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
     return row?.value == null ? null : Number(row.value)
   }
 
-  // Widen each hashFn to accept the union of default row shapes so the
-  // parametric loop below can pass any table's row to any case's hash.
-  type AnyDefaultRow = (typeof defaultModes)[number] | (typeof defaultTasks)[number] | (typeof defaultSkills)[number]
-  const asAnyHash = (fn: (row: never) => string) => fn as (row: AnyDefaultRow) => string
-
-  const gateCases = [
-    {
-      table: 'modes',
-      versionKey: 'defaults_version.modes',
-      currentVersion: defaultModesVersion,
-      defaults: defaultModes,
-      hashFn: asAnyHash(hashMode as (row: never) => string),
-      dbTable: modesTable,
-      pk: modesTable.id,
-      editableField: 'label',
-    },
-    {
-      table: 'tasks',
-      versionKey: 'defaults_version.tasks',
-      currentVersion: defaultTasksVersion,
-      defaults: defaultTasks,
-      hashFn: asAnyHash(hashTask as (row: never) => string),
-      dbTable: tasksTable,
-      pk: tasksTable.id,
-      editableField: 'item',
-    },
-    {
-      table: 'skills',
-      versionKey: 'defaults_version.skills',
-      currentVersion: defaultSkillsVersion,
-      defaults: defaultSkills,
-      hashFn: asAnyHash(hashSkill as (row: never) => string),
-      dbTable: skillsTable,
-      pk: skillsTable.id,
-      editableField: 'description',
-    },
-  ] as const
-
-  for (const c of gateCases) {
+  /**
+   * Runs the four-scenario gate suite against one id-keyed reconciled table.
+   * `Row` is captured per call so `hashFn`, `defaults`, and `editableField`
+   * stay correlated — no cross-table casts needed. Settings has a distinct
+   * shape (key-keyed) and gets its own `describe` below.
+   */
+  const describeGateCase = <Row extends { id: string; defaultHash: string | null }>(c: {
+    table: string
+    versionKey: string
+    currentVersion: number
+    defaults: readonly Row[]
+    hashFn: (row: Row) => string
+    dbTable: SQLiteTableWithColumns<any>
+    pk: SQLiteTableWithColumns<any>['id']
+    editableField: keyof Row & string
+  }) => {
     describe(c.table, () => {
       test('fresh install seeds defaults and stamps the applied version', async () => {
         const db = getDb()
@@ -1270,16 +1248,16 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
         // delivering. Marker is absent (never arrived). Under the sync-
         // incomplete guard, this device must not seed, overwrite, or stamp.
         const [first, ...rest] = c.defaults
-        const newer = { ...first, [c.editableField]: 'from-newer-peer' }
-        await db.insert(c.dbTable).values({ ...newer, defaultHash: c.hashFn(newer) } as never)
+        const newer: Row = { ...first, [c.editableField]: 'from-newer-peer' }
+        await db.insert(c.dbTable).values({ ...newer, defaultHash: c.hashFn(newer) })
         for (const row of rest) {
-          await db.insert(c.dbTable).values({ ...row, defaultHash: c.hashFn(row) } as never)
+          await db.insert(c.dbTable).values({ ...row, defaultHash: c.hashFn(row) })
         }
 
         await reconcileDefaults(db, { initialSyncCompleted: false })
 
-        const preserved = await db.select().from(c.dbTable).where(eq(c.pk, first.id)).get()
-        expect((preserved as Record<string, unknown>)?.[c.editableField]).toBe('from-newer-peer')
+        const preserved = (await db.select().from(c.dbTable).where(eq(c.pk, first.id)).get()) as Row | undefined
+        expect(preserved?.[c.editableField] as string | undefined).toBe('from-newer-peer')
         expect(await readStoredVersion(c.versionKey)).toBeNull()
       })
 
@@ -1291,10 +1269,10 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
         // row so the pass has something to upgrade (otherwise mutated=false
         // and the marker deliberately does not advance).
         const target = c.defaults[0]
-        const staleRow = { ...target, [c.editableField]: 'stale' }
+        const staleRow: Row = { ...target, [c.editableField]: 'stale' }
         await db
           .update(c.dbTable)
-          .set({ [c.editableField]: 'stale', defaultHash: c.hashFn(staleRow) } as never)
+          .set({ [c.editableField]: 'stale', defaultHash: c.hashFn(staleRow) })
           .where(eq(c.pk, target.id))
         await db
           .update(settingsTable)
@@ -1303,10 +1281,8 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
 
         await reconcileDefaults(db)
 
-        const upgraded = await db.select().from(c.dbTable).where(eq(c.pk, target.id)).get()
-        expect((upgraded as Record<string, unknown>)?.[c.editableField]).toBe(
-          (target as Record<string, unknown>)[c.editableField],
-        )
+        const upgraded = (await db.select().from(c.dbTable).where(eq(c.pk, target.id)).get()) as Row | undefined
+        expect(upgraded?.[c.editableField]).toBe(target[c.editableField])
         expect(await readStoredVersion(c.versionKey)).toBe(c.currentVersion)
       })
 
@@ -1314,10 +1290,10 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
         const db = getDb()
 
         const target = c.defaults[0]
-        const newer = { ...target, [c.editableField]: 'from-newer-bundle' }
-        await db.insert(c.dbTable).values({ ...newer, defaultHash: c.hashFn(newer) } as never)
+        const newer: Row = { ...target, [c.editableField]: 'from-newer-bundle' }
+        await db.insert(c.dbTable).values({ ...newer, defaultHash: c.hashFn(newer) })
         for (const other of c.defaults.slice(1)) {
-          await db.insert(c.dbTable).values({ ...other, defaultHash: c.hashFn(other) } as never)
+          await db.insert(c.dbTable).values({ ...other, defaultHash: c.hashFn(other) })
         }
         await db.insert(settingsTable).values({
           key: c.versionKey,
@@ -1326,12 +1302,43 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
 
         await reconcileDefaults(db)
 
-        const preserved = await db.select().from(c.dbTable).where(eq(c.pk, target.id)).get()
-        expect((preserved as Record<string, unknown>)?.[c.editableField]).toBe('from-newer-bundle')
+        const preserved = (await db.select().from(c.dbTable).where(eq(c.pk, target.id)).get()) as Row | undefined
+        expect(preserved?.[c.editableField] as string | undefined).toBe('from-newer-bundle')
         expect(await readStoredVersion(c.versionKey)).toBe(c.currentVersion + 1)
       })
     })
   }
+
+  describeGateCase({
+    table: 'modes',
+    versionKey: 'defaults_version.modes',
+    currentVersion: defaultModesVersion,
+    defaults: defaultModes,
+    hashFn: hashMode,
+    dbTable: modesTable,
+    pk: modesTable.id,
+    editableField: 'label',
+  })
+  describeGateCase({
+    table: 'tasks',
+    versionKey: 'defaults_version.tasks',
+    currentVersion: defaultTasksVersion,
+    defaults: defaultTasks,
+    hashFn: hashTask,
+    dbTable: tasksTable,
+    pk: tasksTable.id,
+    editableField: 'item',
+  })
+  describeGateCase({
+    table: 'skills',
+    versionKey: 'defaults_version.skills',
+    currentVersion: defaultSkillsVersion,
+    defaults: defaultSkills,
+    hashFn: hashSkill,
+    dbTable: skillsTable,
+    pk: skillsTable.id,
+    editableField: 'description',
+  })
 
   // Settings gets its own describe because its key-field and default shape
   // differ from the id-keyed tables above.
@@ -1352,10 +1359,10 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
     test('sync-incomplete + populated table → no-op and no marker written', async () => {
       const db = getDb()
 
-      // Seed one non-default row so `hasAnySettingsRow` returns true without
-      // depending on any per-table marker writes. That row simulates state
-      // the cloud may have already synced (e.g., a user preference); the gate
-      // must refuse to seed the bundle defaults on top of it.
+      // Seed one settings row directly (bypassing reconcile) so
+      // `hasAnySettingsRow` returns true. That row simulates state the cloud
+      // may have already synced (e.g., a user preference); the gate must
+      // refuse to seed the bundle defaults on top of it.
       await db.insert(settingsTable).values({ key: 'preferred_name', value: 'cloud-user' })
 
       await reconcileDefaults(db, { initialSyncCompleted: false })
@@ -1363,6 +1370,34 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
       const seeded = await db.select().from(settingsTable).where(eq(settingsTable.key, key)).get()
       expect(seeded).toBeUndefined()
       expect(await readStoredVersion('defaults_version.settings')).toBeNull()
+    })
+
+    test('newer bundle upgrades in place and advances the stored version', async () => {
+      const db = getDb()
+      await reconcileDefaults(db)
+
+      // Rewind stored version and stale one row so the pass has something to
+      // upgrade (otherwise mutated=false and the marker deliberately does
+      // not advance). Target a default whose value is non-null and boolean-ish
+      // — `data_collection` — so overwriting doesn't collide with the null-
+      // preservation guard on user-set values.
+      const target = defaultSettings.find((s) => s.key === 'data_collection')
+      expect(target).toBeDefined()
+      const staleRow = { ...target!, value: 'stale' }
+      await db
+        .update(settingsTable)
+        .set({ value: 'stale', defaultHash: hashSetting(staleRow) })
+        .where(eq(settingsTable.key, target!.key))
+      await db
+        .update(settingsTable)
+        .set({ value: String(defaultSettingsVersion - 1) })
+        .where(eq(settingsTable.key, 'defaults_version.settings'))
+
+      await reconcileDefaults(db)
+
+      const upgraded = await db.select().from(settingsTable).where(eq(settingsTable.key, target!.key)).get()
+      expect(upgraded?.value).toBe(target!.value)
+      expect(await readStoredVersion('defaults_version.settings')).toBe(defaultSettingsVersion)
     })
 
     test('older bundle does not downgrade rows authored by a newer version', async () => {

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -7,11 +7,22 @@ import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/da
 import { getDb } from '@/db/database'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 import { eq } from 'drizzle-orm'
-import { modelProfilesTable, modelsTable, promptsTable, settingsTable } from '../db/tables'
+import {
+  modelProfilesTable,
+  modelsTable,
+  modesTable,
+  promptsTable,
+  settingsTable,
+  skillsTable,
+  tasksTable,
+} from '../db/tables'
 import { defaultAutomations, hashPrompt } from '../defaults/automations'
 import { defaultModelProfiles, hashModelProfile } from '../defaults/model-profiles'
 import { defaultModels, defaultModelsVersion, hashModel, type SharedModel } from '@shared/defaults/models'
-import { defaultSettings, hashSetting } from '../defaults/settings'
+import { defaultModes, defaultModesVersion, hashMode } from '../defaults/modes'
+import { defaultSettings, defaultSettingsVersion, hashSetting } from '../defaults/settings'
+import { defaultSkills, defaultSkillsVersion, hashSkill } from '../defaults/skills'
+import { defaultTasks, defaultTasksVersion, hashTask } from '../defaults/tasks'
 import type { ModelsDefaults } from './pick-defaults'
 import { cleanupRemovedDefaults, reconcileDefaults, reconcileDefaultsForTable } from './reconcile-defaults'
 import type { Model, ModelProfile, Prompt } from '@/types'
@@ -1184,5 +1195,211 @@ describe('reconcileDefaults version gate (THU-637)', () => {
     // version yet, so peers with the fuller bundle should still be able to
     // reach open canOverwrite on their next boot.
     expect(await readStoredModelsVersion()).not.toBe(defaultModelsVersion + 1)
+  })
+})
+
+/**
+ * THU-677 extends the THU-637 version-gate pattern from models to every
+ * other reconciled table (modes, tasks, skills, settings). The scenarios
+ * per table mirror the models coverage above but at reduced depth — the
+ * shared `reconcileDefaultsForTable` and `computeCanOverwrite` behaviour
+ * is already exercised by the models suite. Here we prove each table
+ * routes through the gate correctly.
+ */
+describe('reconcileDefaults per-table version gates (THU-677)', () => {
+  const readStoredVersion = async (key: string) => {
+    const row = await getDb().select().from(settingsTable).where(eq(settingsTable.key, key)).get()
+    return row?.value == null ? null : Number(row.value)
+  }
+
+  // Widen each hashFn to accept the union of default row shapes so the
+  // parametric loop below can pass any table's row to any case's hash.
+  type AnyDefaultRow = (typeof defaultModes)[number] | (typeof defaultTasks)[number] | (typeof defaultSkills)[number]
+  const asAnyHash = (fn: (row: never) => string) => fn as (row: AnyDefaultRow) => string
+
+  const gateCases = [
+    {
+      table: 'modes',
+      versionKey: 'defaults_version.modes',
+      currentVersion: defaultModesVersion,
+      defaults: defaultModes,
+      hashFn: asAnyHash(hashMode as (row: never) => string),
+      dbTable: modesTable,
+      pk: modesTable.id,
+      editableField: 'label',
+    },
+    {
+      table: 'tasks',
+      versionKey: 'defaults_version.tasks',
+      currentVersion: defaultTasksVersion,
+      defaults: defaultTasks,
+      hashFn: asAnyHash(hashTask as (row: never) => string),
+      dbTable: tasksTable,
+      pk: tasksTable.id,
+      editableField: 'item',
+    },
+    {
+      table: 'skills',
+      versionKey: 'defaults_version.skills',
+      currentVersion: defaultSkillsVersion,
+      defaults: defaultSkills,
+      hashFn: asAnyHash(hashSkill as (row: never) => string),
+      dbTable: skillsTable,
+      pk: skillsTable.id,
+      editableField: 'description',
+    },
+  ] as const
+
+  for (const c of gateCases) {
+    describe(c.table, () => {
+      test('fresh install seeds defaults and stamps the applied version', async () => {
+        const db = getDb()
+        await reconcileDefaults(db)
+
+        const rows = await db.select().from(c.dbTable)
+        for (const bundle of c.defaults) {
+          expect(rows.find((r) => r.id === bundle.id)).toBeDefined()
+        }
+        expect(await readStoredVersion(c.versionKey)).toBe(c.currentVersion)
+      })
+
+      test('sync-incomplete + populated table → no-op and no marker written', async () => {
+        const db = getDb()
+
+        // Populate the table with newer content the cloud may still be
+        // delivering. Marker is absent (never arrived). Under the sync-
+        // incomplete guard, this device must not seed, overwrite, or stamp.
+        const [first, ...rest] = c.defaults
+        const newer = { ...first, [c.editableField]: 'from-newer-peer' }
+        await db.insert(c.dbTable).values({ ...newer, defaultHash: c.hashFn(newer) } as never)
+        for (const row of rest) {
+          await db.insert(c.dbTable).values({ ...row, defaultHash: c.hashFn(row) } as never)
+        }
+
+        await reconcileDefaults(db, { initialSyncCompleted: false })
+
+        const preserved = await db.select().from(c.dbTable).where(eq(c.pk, first.id)).get()
+        expect((preserved as Record<string, unknown>)?.[c.editableField]).toBe('from-newer-peer')
+        expect(await readStoredVersion(c.versionKey)).toBeNull()
+      })
+
+      test('newer bundle upgrades in place and advances the stored version', async () => {
+        const db = getDb()
+        await reconcileDefaults(db)
+
+        // Rewind stored version to look like a prior release; also stale one
+        // row so the pass has something to upgrade (otherwise mutated=false
+        // and the marker deliberately does not advance).
+        const target = c.defaults[0]
+        const staleRow = { ...target, [c.editableField]: 'stale' }
+        await db
+          .update(c.dbTable)
+          .set({ [c.editableField]: 'stale', defaultHash: c.hashFn(staleRow) } as never)
+          .where(eq(c.pk, target.id))
+        await db
+          .update(settingsTable)
+          .set({ value: String(c.currentVersion - 1) })
+          .where(eq(settingsTable.key, c.versionKey))
+
+        await reconcileDefaults(db)
+
+        const upgraded = await db.select().from(c.dbTable).where(eq(c.pk, target.id)).get()
+        expect((upgraded as Record<string, unknown>)?.[c.editableField]).toBe(
+          (target as Record<string, unknown>)[c.editableField],
+        )
+        expect(await readStoredVersion(c.versionKey)).toBe(c.currentVersion)
+      })
+
+      test('older bundle does not downgrade rows authored by a newer version', async () => {
+        const db = getDb()
+
+        const target = c.defaults[0]
+        const newer = { ...target, [c.editableField]: 'from-newer-bundle' }
+        await db.insert(c.dbTable).values({ ...newer, defaultHash: c.hashFn(newer) } as never)
+        for (const other of c.defaults.slice(1)) {
+          await db.insert(c.dbTable).values({ ...other, defaultHash: c.hashFn(other) } as never)
+        }
+        await db.insert(settingsTable).values({
+          key: c.versionKey,
+          value: String(c.currentVersion + 1),
+        })
+
+        await reconcileDefaults(db)
+
+        const preserved = await db.select().from(c.dbTable).where(eq(c.pk, target.id)).get()
+        expect((preserved as Record<string, unknown>)?.[c.editableField]).toBe('from-newer-bundle')
+        expect(await readStoredVersion(c.versionKey)).toBe(c.currentVersion + 1)
+      })
+    })
+  }
+
+  // Settings gets its own describe because its key-field and default shape
+  // differ from the id-keyed tables above.
+  describe('settings', () => {
+    const key = defaultSettings[0].key
+
+    test('fresh install seeds defaults and stamps the applied version', async () => {
+      const db = getDb()
+      await reconcileDefaults(db)
+
+      for (const bundle of defaultSettings) {
+        const row = await db.select().from(settingsTable).where(eq(settingsTable.key, bundle.key)).get()
+        expect(row).toBeDefined()
+      }
+      expect(await readStoredVersion('defaults_version.settings')).toBe(defaultSettingsVersion)
+    })
+
+    test('sync-incomplete + populated table → no-op and no marker written', async () => {
+      const db = getDb()
+
+      // Seed one non-default row so `hasAnySettingsRow` returns true without
+      // depending on any per-table marker writes. That row simulates state
+      // the cloud may have already synced (e.g., a user preference); the gate
+      // must refuse to seed the bundle defaults on top of it.
+      await db.insert(settingsTable).values({ key: 'preferred_name', value: 'cloud-user' })
+
+      await reconcileDefaults(db, { initialSyncCompleted: false })
+
+      const seeded = await db.select().from(settingsTable).where(eq(settingsTable.key, key)).get()
+      expect(seeded).toBeUndefined()
+      expect(await readStoredVersion('defaults_version.settings')).toBeNull()
+    })
+
+    test('older bundle does not downgrade rows authored by a newer version', async () => {
+      const db = getDb()
+
+      const target = defaultSettings.find((s) => s.value !== null)
+      expect(target).toBeDefined()
+      const newer = { ...target!, value: 'from-newer-bundle' }
+      await db.insert(settingsTable).values({ ...newer, defaultHash: hashSetting(newer) })
+      await db.insert(settingsTable).values({
+        key: 'defaults_version.settings',
+        value: String(defaultSettingsVersion + 1),
+      })
+
+      await reconcileDefaults(db)
+
+      const preserved = await db.select().from(settingsTable).where(eq(settingsTable.key, target!.key)).get()
+      expect(preserved?.value).toBe('from-newer-bundle')
+      expect(await readStoredVersion('defaults_version.settings')).toBe(defaultSettingsVersion + 1)
+    })
+  })
+
+  test('per-table marker writes do not poison the settings hasAnyRow probe on fresh install', async () => {
+    // Regression guard for the intra-transaction ordering hazard: the models/
+    // modes/tasks/skills passes each land a marker row in `settingsTable` via
+    // `advanceVersionMarker`. If `hasAnySettingsRow` were read inline before
+    // the settings block instead of at the top of the transaction, those
+    // earlier marker writes would flip the probe to `true` on a fresh install
+    // and the settings gate would refuse to seed. Every default settings row
+    // and the settings marker must land on this pass.
+    const db = getDb()
+    await reconcileDefaults(db)
+
+    for (const bundle of defaultSettings) {
+      const row = await db.select().from(settingsTable).where(eq(settingsTable.key, bundle.key)).get()
+      expect(row).toBeDefined()
+    }
+    expect(await readStoredVersion('defaults_version.settings')).toBe(defaultSettingsVersion)
   })
 })

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -734,6 +734,66 @@ describe('reconcileDefaultsForTable', () => {
       expect(result.mutated).toBe(false)
       expect(result.everyBundleRowAtTarget).toBe(false)
     })
+
+    test('cleanup-shaped soft-delete + canResurrect=false → false', async () => {
+      // Sync-incomplete device: cleanup-shape row (`deletedAt` set,
+      // `defaultHash` still matches content) can't be safely resurrected
+      // because a peer's authoritative retirement may just be partially
+      // synced. Row stays deleted — content isn't at bundle target — flag
+      // must flip. Seed the other default rows unedited so the only branch
+      // exercised on this pass is the resurrect skip.
+      const db = getDb()
+      const [soft, ...rest] = defaultModels
+      await db.insert(modelsTable).values({
+        ...soft,
+        deletedAt: '2026-01-01T00:00:00.000Z',
+        defaultHash: hashModel(soft),
+      })
+      for (const other of rest) {
+        await db.insert(modelsTable).values({ ...other, defaultHash: hashModel(other) })
+      }
+      const result = await reconcileDefaultsForTable(db, modelsTable, defaultModels, hashModel, {
+        canOverwrite: true,
+        canResurrect: false,
+      })
+      expect(result.mutated).toBe(false)
+      expect(result.everyBundleRowAtTarget).toBe(false)
+    })
+
+    test('user-filled null-default setting counts as at-target (wouldOverwriteUserValue branch)', async () => {
+      // A user who filled in a null-default via `setValue(..., { recomputeHash:
+      // true })` (onboarding pattern for preferred_name / location_* /
+      // distance_unit / etc.) creates a row whose stored `defaultHash`
+      // matches its user value — passes the user-edit check — but trips
+      // `wouldOverwriteUserValue` because the bundle default is null and the
+      // row's value isn't. Target IS "user-owned" for those rows; keeping
+      // `everyBundleRowAtTarget=true` here lets the settings marker advance
+      // on the first THU-677 boot for existing users who ran onboarding
+      // instead of stranding them on the slow sync-wait path.
+      const db = getDb()
+      const target = defaultSettings.find((s) => s.key === 'preferred_name')
+      if (!target) {
+        throw new Error('fixture drift: `preferred_name` no longer in defaultSettings')
+      }
+      // User filled in the setting via recomputeHash — value populated, hash
+      // matches the user's current content.
+      const userFilled = { ...target, value: 'John' }
+      await db.insert(settingsTable).values({ ...userFilled, defaultHash: hashSetting(userFilled) })
+      // Also seed the other defaults untouched so the only "concerning" row
+      // in the pass is the user-filled one.
+      for (const other of defaultSettings.filter((s) => s.key !== target.key)) {
+        await db.insert(settingsTable).values({ ...other, defaultHash: hashSetting(other) })
+      }
+
+      const result = await reconcileDefaultsForTable(db, settingsTable, defaultSettings, hashSetting, {
+        keyField: 'key',
+      })
+
+      expect(result.mutated).toBe(false)
+      // The critical assertion — must not be flipped false by the
+      // wouldOverwriteUserValue branch.
+      expect(result.everyBundleRowAtTarget).toBe(true)
+    })
   })
 })
 
@@ -1556,6 +1616,53 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
       const preserved = await db.select().from(settingsTable).where(eq(settingsTable.key, target.key)).get()
       expect(preserved?.value).toBe('from-newer-bundle')
       expect(await readStoredVersion('defaults_version.settings')).toBe(defaultSettingsVersion + 1)
+    })
+
+    test('marker advances even when a user has filled in null-default settings (pre-THU-677 upgrade path)', async () => {
+      // On a pre-THU-677 device where the user filled in `preferred_name`
+      // (and similar null-default settings) via onboarding, the settings
+      // marker used to get stuck at absent — the `wouldOverwriteUserValue`
+      // branch flipped `everyBundleRowAtTarget` to false, so with
+      // `mutated=false` the marker never advanced. That kept
+      // `hasCurrentDefaultsVersions` returning false on every boot and the
+      // returning-boot fast path never activated.
+      //
+      // Now that the wouldOverwriteUserValue branch treats the row as
+      // at-target (user IS the intended target for null-default settings),
+      // the marker advances cleanly and the next boot takes the fast path.
+      const db = getDb()
+
+      // Seed the bundle defaults so the pre-THU-677 device has all rows.
+      await reconcileDefaults(db)
+
+      // Simulate the pre-THU-677 state: settings marker doesn't exist yet.
+      await db.delete(settingsTable).where(eq(settingsTable.key, 'defaults_version.settings'))
+
+      // User filled in `preferred_name` via onboarding (`setValue(..., {
+      // recomputeHash: true })` — the row's `defaultHash` matches its user
+      // value, so it passes the user-edit check, but the bundle default has
+      // `value: null`).
+      const target = defaultSettings.find((s) => s.key === 'preferred_name')
+      if (!target) {
+        throw new Error('fixture drift: `preferred_name` no longer in defaultSettings')
+      }
+      const userFilled = { ...target, value: 'John' }
+      await db
+        .update(settingsTable)
+        .set({ value: 'John', defaultHash: hashSetting(userFilled) })
+        .where(eq(settingsTable.key, target.key))
+
+      await reconcileDefaults(db)
+
+      // Marker advances despite `mutated=false` — the user-filled null-default
+      // row counts as at-target via the wouldOverwriteUserValue branch's
+      // updated semantics.
+      expect(await readStoredVersion('defaults_version.settings')).toBe(defaultSettingsVersion)
+
+      // The user's value must still be preserved (that's what
+      // wouldOverwriteUserValue exists for).
+      const preserved = await db.select().from(settingsTable).where(eq(settingsTable.key, target.key)).get()
+      expect(preserved?.value).toBe('John')
     })
   })
 

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -1033,6 +1033,54 @@ describe('reconcileDefaults version gate (THU-637)', () => {
     expect(await readStoredModelsVersion()).toBe(defaultModelsVersion)
   })
 
+  test('models marker advances when models mutated even if a user has edited a profile', async () => {
+    // A user tweaked a model profile (temperature, tools, addenda) — their
+    // profile row is hash-mismatched relative to the bundled profile default.
+    // A subsequent models bundle bump lands and the models pass mutates the
+    // row it targets. Guard must advance the marker on the strength of the
+    // models mutation alone; requiring BOTH passes to individually verify
+    // would strand the marker permanently for anyone who edited a profile.
+    const db = getDb()
+
+    await reconcileDefaults(db)
+
+    // Simulate a user-edited model profile: hash-mismatched relative to its
+    // stored `defaultHash` (as would happen after a `updateModelProfile` write
+    // that intentionally diverges from the bundle default).
+    const targetProfile = defaultModelProfiles[0]
+    await db
+      .update(modelProfilesTable)
+      .set({ temperature: 0.77 })
+      .where(eq(modelProfilesTable.modelId, targetProfile.modelId))
+
+    // Rewind stored version and stale one models row so the pass has real
+    // work to do (mutated=true), then re-run reconcile.
+    const targetModel = defaultModels[0]
+    const staleModel = { ...targetModel, name: 'stale' }
+    await db
+      .update(modelsTable)
+      .set({ name: 'stale', defaultHash: hashModel(staleModel) })
+      .where(eq(modelsTable.id, targetModel.id))
+    await db
+      .update(settingsTable)
+      .set({ value: String(defaultModelsVersion - 1) })
+      .where(eq(settingsTable.key, modelsVersionKey))
+
+    await reconcileDefaults(db)
+
+    // Marker advances because the models pass mutated, even though the
+    // profiles pass sees a user-edited row (not at target, not mutated).
+    expect(await readStoredModelsVersion()).toBe(defaultModelsVersion)
+
+    // User-edited profile stays user-edited (hash mismatch → skip).
+    const preservedProfile = await db
+      .select()
+      .from(modelProfilesTable)
+      .where(eq(modelProfilesTable.modelId, targetProfile.modelId))
+      .get()
+    expect(preservedProfile?.temperature).toBe(0.77)
+  })
+
   // Coverage guard for `runGatedPass` (modes/tasks/skills/settings) — the
   // models path has its own dedicated test above. Modes is a good stand-in
   // for the loop because it has multiple rows and its own hashFn/defaults.

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -7,7 +7,8 @@ import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/da
 import { getDb } from '@/db/database'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 import { eq } from 'drizzle-orm'
-import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
+import type { AnyColumn } from 'drizzle-orm'
+import type { AnySQLiteTable } from 'drizzle-orm/sqlite-core'
 import {
   modelProfilesTable,
   modelsTable,
@@ -1225,8 +1226,8 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
     currentVersion: number
     defaults: readonly Row[]
     hashFn: (row: Row) => string
-    dbTable: SQLiteTableWithColumns<any>
-    pk: SQLiteTableWithColumns<any>['id']
+    dbTable: AnySQLiteTable
+    pk: AnyColumn
     editableField: keyof Row & string
   }) => {
     describe(c.table, () => {
@@ -1382,12 +1383,14 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
       // — `data_collection` — so overwriting doesn't collide with the null-
       // preservation guard on user-set values.
       const target = defaultSettings.find((s) => s.key === 'data_collection')
-      expect(target).toBeDefined()
-      const staleRow = { ...target!, value: 'stale' }
+      if (!target) {
+        throw new Error('fixture drift: `data_collection` no longer in defaultSettings')
+      }
+      const staleRow = { ...target, value: 'stale' }
       await db
         .update(settingsTable)
         .set({ value: 'stale', defaultHash: hashSetting(staleRow) })
-        .where(eq(settingsTable.key, target!.key))
+        .where(eq(settingsTable.key, target.key))
       await db
         .update(settingsTable)
         .set({ value: String(defaultSettingsVersion - 1) })
@@ -1395,8 +1398,8 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
 
       await reconcileDefaults(db)
 
-      const upgraded = await db.select().from(settingsTable).where(eq(settingsTable.key, target!.key)).get()
-      expect(upgraded?.value).toBe(target!.value)
+      const upgraded = await db.select().from(settingsTable).where(eq(settingsTable.key, target.key)).get()
+      expect(upgraded?.value).toBe(target.value)
       expect(await readStoredVersion('defaults_version.settings')).toBe(defaultSettingsVersion)
     })
 
@@ -1404,8 +1407,10 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
       const db = getDb()
 
       const target = defaultSettings.find((s) => s.value !== null)
-      expect(target).toBeDefined()
-      const newer = { ...target!, value: 'from-newer-bundle' }
+      if (!target) {
+        throw new Error('fixture drift: defaultSettings has no non-null-value entry')
+      }
+      const newer = { ...target, value: 'from-newer-bundle' }
       await db.insert(settingsTable).values({ ...newer, defaultHash: hashSetting(newer) })
       await db.insert(settingsTable).values({
         key: 'defaults_version.settings',
@@ -1414,7 +1419,7 @@ describe('reconcileDefaults per-table version gates (THU-677)', () => {
 
       await reconcileDefaults(db)
 
-      const preserved = await db.select().from(settingsTable).where(eq(settingsTable.key, target!.key)).get()
+      const preserved = await db.select().from(settingsTable).where(eq(settingsTable.key, target.key)).get()
       expect(preserved?.value).toBe('from-newer-bundle')
       expect(await readStoredVersion('defaults_version.settings')).toBe(defaultSettingsVersion + 1)
     })

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -675,6 +675,66 @@ describe('reconcileDefaultsForTable', () => {
     const afterReconcile = await db.select().from(settingsTable).where(eq(settingsTable.key, 'optional_setting')).get()
     expect(afterReconcile?.value).toBeNull()
   })
+
+  // Direct return-shape assertions for the `everyBundleRowAtTarget` field.
+  // Integration-level tests (marker advance / no advance) cover the wiring
+  // downstream; these lock the per-branch flag semantics so a future
+  // refactor that flips a polarity fails loudly close to the source.
+  describe('everyBundleRowAtTarget', () => {
+    test('empty defaults returns vacuous true (no rows to disprove target)', async () => {
+      const result = await reconcileDefaultsForTable(getDb(), modelsTable, [], hashModel)
+      expect(result).toEqual({ mutated: false, everyBundleRowAtTarget: true })
+    })
+
+    test('fresh install seeds all rows → true (all rows now at target)', async () => {
+      const result = await reconcileDefaultsForTable(getDb(), modelsTable, defaultModels, hashModel)
+      expect(result.mutated).toBe(true)
+      expect(result.everyBundleRowAtTarget).toBe(true)
+    })
+
+    test('every row already at target with no writes → true', async () => {
+      const db = getDb()
+      // Seed then run again — second run finds every row already at target.
+      await reconcileDefaultsForTable(db, modelsTable, defaultModels, hashModel)
+      const result = await reconcileDefaultsForTable(db, modelsTable, defaultModels, hashModel)
+      expect(result.mutated).toBe(false)
+      expect(result.everyBundleRowAtTarget).toBe(true)
+    })
+
+    test('any user-edited row (hash mismatch) → false', async () => {
+      const db = getDb()
+      await reconcileDefaultsForTable(db, modelsTable, defaultModels, hashModel)
+      // Edit one row so its content-hash no longer matches its defaultHash.
+      await db.update(modelsTable).set({ name: 'user rename' }).where(eq(modelsTable.id, defaultModels[0].id))
+      const result = await reconcileDefaultsForTable(db, modelsTable, defaultModels, hashModel)
+      expect(result.mutated).toBe(false)
+      expect(result.everyBundleRowAtTarget).toBe(false)
+    })
+
+    test('missing row with insertMissing=false → false', async () => {
+      const result = await reconcileDefaultsForTable(getDb(), modelsTable, defaultModels, hashModel, {
+        canOverwrite: false,
+        // insertMissing defaults to canOverwrite → false. Rows are missing
+        // and we don't seed → not at target.
+      })
+      expect(result.mutated).toBe(false)
+      expect(result.everyBundleRowAtTarget).toBe(false)
+    })
+
+    test('canOverwrite=false on populated table → false (unverifiable)', async () => {
+      const db = getDb()
+      // Seed rows so `existing` rows are present, then re-run with
+      // canOverwrite=false. Even though rows are still at target, the flag
+      // stays false because the closed gate means we deliberately can't
+      // trust our view enough to advance the marker.
+      await reconcileDefaultsForTable(db, modelsTable, defaultModels, hashModel)
+      const result = await reconcileDefaultsForTable(db, modelsTable, defaultModels, hashModel, {
+        canOverwrite: false,
+      })
+      expect(result.mutated).toBe(false)
+      expect(result.everyBundleRowAtTarget).toBe(false)
+    })
+  })
 })
 
 /**
@@ -888,6 +948,80 @@ describe('reconcileDefaults version gate (THU-637)', () => {
     // Marker must stay at the rewound value — advancing it here would signal
     // to peers that this version was applied when in fact nothing was written.
     expect(await readStoredModelsVersion()).toBe(defaultModelsVersion - 1)
+  })
+
+  test('marker advances when reconcile is a no-op but every row is at target (existing-user upgrade)', async () => {
+    const db = getDb()
+
+    // Seed at the current bundle so every row has a matching defaultHash.
+    // This models the state of a pre-THU-677 device on its first boot after
+    // upgrading to this build: the four new markers (modes/tasks/skills/
+    // settings) don't exist yet, but the rows themselves were already
+    // seeded by earlier reconcile runs and their hashes match the bundle.
+    await reconcileDefaults(db)
+
+    // Wipe the marker to simulate the pre-THU-677 "no marker written yet"
+    // state. The gate stays open (`stored=null → rawCanOverwrite=true`)
+    // but reconcile finds every row already at target so `mutated=false`.
+    // With the `everyBundleRowAtTarget` result on, the marker still
+    // advances — otherwise this device would take the full sync-wait path
+    // on every boot forever.
+    await db.delete(settingsTable).where(eq(settingsTable.key, modelsVersionKey))
+
+    await reconcileDefaults(db)
+
+    expect(await readStoredModelsVersion()).toBe(defaultModelsVersion)
+  })
+
+  // Coverage guard for `runGatedPass` (modes/tasks/skills/settings) — the
+  // models path has its own dedicated test above. Modes is a good stand-in
+  // for the loop because it has multiple rows and its own hashFn/defaults.
+  const readStoredModesVersion = async () => {
+    const db = getDb()
+    const row = await db.select().from(settingsTable).where(eq(settingsTable.key, 'defaults_version.modes')).get()
+    return row?.value == null ? null : Number(row.value)
+  }
+
+  test('runGatedPass advances marker when every mode row is at target and mutated is false', async () => {
+    const db = getDb()
+
+    // Seed at the current bundle so every modes row hashes to target.
+    await reconcileDefaults(db)
+
+    // Wipe the modes marker to simulate the pre-THU-677 "no marker yet"
+    // state for the non-models tables. The gate opens, reconcile finds
+    // every row already at target (mutated=false), and the marker must
+    // still advance via the `everyBundleRowAtTarget` branch.
+    await db.delete(settingsTable).where(eq(settingsTable.key, 'defaults_version.modes'))
+
+    await reconcileDefaults(db)
+
+    expect(await readStoredModesVersion()).toBe(defaultModesVersion)
+  })
+
+  test('runGatedPass does not advance marker when every mode row is user-edited', async () => {
+    const db = getDb()
+    await reconcileDefaults(db)
+
+    // Every modes row user-edited (hash mismatch) and marker rewound so the
+    // version gate opens. Reconcile skips every row → `mutated=false` AND
+    // `everyBundleRowAtTarget=false` (hash-mismatch branch). Marker must
+    // stay at the rewound value — mirrors the existing models-path
+    // regression guard for the runGatedPass loop.
+    for (const mode of defaultModes) {
+      await db
+        .update(modesTable)
+        .set({ label: `user-edited ${mode.id}` })
+        .where(eq(modesTable.id, mode.id))
+    }
+    await db
+      .update(settingsTable)
+      .set({ value: String(defaultModesVersion - 1) })
+      .where(eq(settingsTable.key, 'defaults_version.modes'))
+
+    await reconcileDefaults(db)
+
+    expect(await readStoredModesVersion()).toBe(defaultModesVersion - 1)
   })
 
   test('sync-incomplete + populated table + stale stored version → skip mutations', async () => {

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -26,7 +26,7 @@ const bundledModelsDefaults: ModelsDefaults = { version: defaultModelsVersion, d
  * in AGENTS.md and the THU-637 rationale for the version-gate design; THU-677
  * extended the pattern from models-only to every reconciled table.
  *
- * Exported so read-side callers (`hasCurrentBundleVersions` in
+ * Exported so read-side callers (`hasCurrentDefaultsVersions` in
  * `src/dal/settings.ts`) share the exact same key strings — a rename here
  * shouldn't require touching two files.
  */
@@ -37,6 +37,14 @@ export const versionMarkerKeys = {
   skills: 'defaults_version.skills',
   settings: 'defaults_version.settings',
 } as const
+
+/**
+ * Union of the marker key strings — every valid entry in a `targets` map
+ * passed to `hasCurrentDefaultsVersions`. Tightens the caller/callee
+ * contract so a typo like `'defaults_version.mode'` is a compile error
+ * instead of a silent skip.
+ */
+export type VersionMarkerKey = (typeof versionMarkerKeys)[keyof typeof versionMarkerKeys]
 
 type StoredVersion = { exists: boolean; version: number | null }
 
@@ -157,12 +165,19 @@ export type ReconcileDefaultsForTableOptions = {
  * Result of a `reconcileDefaultsForTable` pass.
  *
  * @property mutated - True iff at least one row was inserted or updated (this
- *   includes the legacy null-defaultHash bootstrap). Callers use this to
- *   decide whether to advance an external version marker — advancing when
- *   nothing was actually written would falsely signal to peers that the
- *   picked version has been applied here.
+ *   includes the legacy null-defaultHash bootstrap).
+ * @property everyBundleRowAtTarget - True iff every id in `defaults` ended
+ *   the pass with a row whose stored `defaultHash` matches the effective
+ *   target hash (i.e. content genuinely matches this version). False if any
+ *   default row is missing without insert, user-edited (hash mismatch), or
+ *   was skipped under `!canOverwrite`. Combined with `mutated` this lets
+ *   callers decide when to advance an external version marker: advance when
+ *   either something was written OR every row is verifiably at target
+ *   (existing-users-upgrade case). Refuse when neither holds — the "all
+ *   rows user-edited" case must not signal `stored=version` to peers, or
+ *   fresh-install peers would receive the marker and stop seeding.
  */
-export type ReconcileDefaultsForTableResult = { mutated: boolean }
+export type ReconcileDefaultsForTableResult = { mutated: boolean; everyBundleRowAtTarget: boolean }
 
 /**
  * Generic function to reconcile defaults into a table
@@ -187,7 +202,8 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
   } = options
 
   if (defaults.length === 0) {
-    return { mutated: false }
+    // Vacuously "at target" — no bundle-known rows means nothing to verify.
+    return { mutated: false, everyBundleRowAtTarget: true }
   }
 
   const keyValues = defaults.map((defaultItem) => (defaultItem as any)[keyField])
@@ -195,6 +211,12 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
   const existingByKey = new Map(existingRows.map((row) => [row[keyField], row] as const))
 
   let mutated = false
+  // Starts optimistic — cleared to false as soon as any bundle-known id ends
+  // the pass in a state that doesn't match the effective target: a missing
+  // row we couldn't insert, a user-edited row (hash mismatch), a
+  // cleanup-shaped soft-delete we couldn't resurrect, or any skip under
+  // `!canOverwrite` where we can't verify or fix content.
+  let everyBundleRowAtTarget = true
 
   for (const defaultItem of defaults) {
     const keyValue = (defaultItem as any)[keyField]
@@ -206,6 +228,7 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
       // into `insertMissing: true` seed regardless because their row must
       // exist for correctness (e.g. profiles paired with models).
       if (!insertMissing) {
+        everyBundleRowAtTarget = false
         continue
       }
       await db.insert(table).values({
@@ -240,12 +263,17 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
       if (canResurrect) {
         await db.update(table).set({ deletedAt: null }).where(eq(table[keyField], keyValue))
         mutated = true
+      } else {
+        // Row is soft-deleted and we can't resurrect it right now — not at target.
+        everyBundleRowAtTarget = false
       }
       continue
     }
 
     // Any write against an existing row requires authority.
     if (!canOverwrite) {
+      // We couldn't compare or update. Conservatively treat as "unverified".
+      everyBundleRowAtTarget = false
       continue
     }
 
@@ -262,6 +290,7 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
 
     // If hashes don't match, user has modified (including soft-delete) - skip update
     if (currentHash !== existing.defaultHash) {
+      everyBundleRowAtTarget = false
       continue
     }
 
@@ -277,7 +306,8 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
 
     // Skip update if the effective default matches what's already stored
     // (prevents empty PATCH operations, and collapses OTA payloads that only
-    // touch frozen fields to a no-op).
+    // touch frozen fields to a no-op). Row content genuinely matches target —
+    // keep `everyBundleRowAtTarget` true for this row.
     if (existing.defaultHash === effectiveHash) {
       continue
     }
@@ -289,6 +319,9 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
     const wouldOverwriteUserValue = existing.value !== null && (effectiveDefault as any).value === null
 
     if (wouldOverwriteUserValue) {
+      // User set a value; we're not overwriting it. Content is user-managed,
+      // not at bundle target — same category as a hash-mismatch user edit.
+      everyBundleRowAtTarget = false
       continue
     }
 
@@ -303,7 +336,7 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
     mutated = true
   }
 
-  return { mutated }
+  return { mutated, everyBundleRowAtTarget }
 }
 
 /**
@@ -502,20 +535,31 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
       },
     )
 
-    // Advance the models version marker. Two conditions must hold together:
+    // Advance the models version marker. Three conditions:
     //   1. `canOverwrite` — writing the marker under a closed gate would let
     //      peers falsely believe the picked version was applied here and stop
     //      their own in-place upgrades even though we never wrote the content.
-    //   2. Something actually mutated. Advancing on a pure no-op (all rows
-    //      user-edited, or all already at target) has the same false-signal
-    //      hazard as (1) — we effectively promised to peers we're at version
-    //      N without having verified our content matches N.
-    // Extra `droppedOtaModelIds.length === 0` check for models: our apply is
-    // a strict subset of the picked version when we filter OTA models, and
-    // stamping the full version would lock later fuller-bundle clients
-    // (canOverwrite=false because stored>=picked) out of inserting the
-    // missing models.
-    if (modelsGate.canOverwrite && (modelsPass.mutated || profilesPass.mutated) && droppedOtaModelIds.length === 0) {
+    //   2. Either something mutated OR both passes verified every row is
+    //      already at target (`everyBundleRowAtTarget`). The "all rows
+    //      already at target" case is a legitimate verification — our
+    //      content genuinely matches version N even though nothing changed —
+    //      and existing-user upgrades depend on it (rows seeded pre-THU-677
+    //      already hash to the current bundle, so `mutated=false` alone
+    //      would strand the marker forever). The "all rows user-edited"
+    //      case still refuses because a hash mismatch means content doesn't
+    //      match version N — advancing would tell fresh-install peers to
+    //      stop seeding their own rows.
+    //   3. `droppedOtaModelIds.length === 0` — our apply is a strict subset
+    //      of the picked version when we filter OTA models, and stamping the
+    //      full version would lock later fuller-bundle clients out of
+    //      inserting the missing models.
+    const passVerified = (p: ReconcileDefaultsForTableResult): boolean => p.mutated || p.everyBundleRowAtTarget
+    if (
+      modelsGate.canOverwrite &&
+      passVerified(modelsPass) &&
+      passVerified(profilesPass) &&
+      droppedOtaModelIds.length === 0
+    ) {
       await advanceVersionMarker(tx, versionMarkerKeys.models, modelsSource.version, modelsGate.stored)
     }
 
@@ -548,7 +592,9 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
         canResurrect: initialSyncCompleted,
         ...(keyField ? { keyField } : {}),
       })
-      if (gate.canOverwrite && pass.mutated) {
+      // Advance when we wrote something OR verified every row is at target.
+      // See the models-path guard above for the full rationale.
+      if (gate.canOverwrite && passVerified(pass)) {
         await advanceVersionMarker(tx, versionKey, currentVersion, gate.stored)
       }
     }

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -25,12 +25,18 @@ const bundledModelsDefaults: ModelsDefaults = { version: defaultModelsVersion, d
  * account per reconciled table. See "Reconciled defaults and version bumps"
  * in AGENTS.md and the THU-637 rationale for the version-gate design; THU-677
  * extended the pattern from models-only to every reconciled table.
+ *
+ * Exported so read-side callers (`hasCurrentBundleVersions` in
+ * `src/dal/settings.ts`) share the exact same key strings — a rename here
+ * shouldn't require touching two files.
  */
-const modelsVersionKey = 'defaults_version.models'
-const modesVersionKey = 'defaults_version.modes'
-const tasksVersionKey = 'defaults_version.tasks'
-const skillsVersionKey = 'defaults_version.skills'
-const settingsVersionKey = 'defaults_version.settings'
+export const versionMarkerKeys = {
+  models: 'defaults_version.models',
+  modes: 'defaults_version.modes',
+  tasks: 'defaults_version.tasks',
+  skills: 'defaults_version.skills',
+  settings: 'defaults_version.settings',
+} as const
 
 type StoredVersion = { exists: boolean; version: number | null }
 
@@ -413,7 +419,7 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
     // near the bottom of this transaction (THU-677).
     const modelsGate = await computeCanOverwrite(
       tx,
-      modelsVersionKey,
+      versionMarkerKeys.models,
       modelsSource.version,
       hasAnyModelRow,
       initialSyncCompleted,
@@ -510,7 +516,7 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
     // (canOverwrite=false because stored>=picked) out of inserting the
     // missing models.
     if (modelsGate.canOverwrite && (modelsPass.mutated || profilesPass.mutated) && droppedOtaModelIds.length === 0) {
-      await advanceVersionMarker(tx, modelsVersionKey, modelsSource.version, modelsGate.stored)
+      await advanceVersionMarker(tx, versionMarkerKeys.models, modelsSource.version, modelsGate.stored)
     }
 
     // Modes / tasks / skills / settings share the same shape: gate on the
@@ -547,14 +553,21 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
       }
     }
 
-    await runGatedPass(modesTable, defaultModes, hashMode, modesVersionKey, defaultModesVersion, hasAnyModeRow)
-    await runGatedPass(tasksTable, defaultTasks, hashTask, tasksVersionKey, defaultTasksVersion, hasAnyTaskRow)
-    await runGatedPass(skillsTable, defaultSkills, hashSkill, skillsVersionKey, defaultSkillsVersion, hasAnySkillRow)
+    await runGatedPass(modesTable, defaultModes, hashMode, versionMarkerKeys.modes, defaultModesVersion, hasAnyModeRow)
+    await runGatedPass(tasksTable, defaultTasks, hashTask, versionMarkerKeys.tasks, defaultTasksVersion, hasAnyTaskRow)
+    await runGatedPass(
+      skillsTable,
+      defaultSkills,
+      hashSkill,
+      versionMarkerKeys.skills,
+      defaultSkillsVersion,
+      hasAnySkillRow,
+    )
     await runGatedPass(
       settingsTable,
       defaultSettings,
       hashSetting,
-      settingsVersionKey,
+      versionMarkerKeys.settings,
       defaultSettingsVersion,
       hasAnySettingsRow,
       'key',

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -167,15 +167,19 @@ export type ReconcileDefaultsForTableOptions = {
  * @property mutated - True iff at least one row was inserted or updated (this
  *   includes the legacy null-defaultHash bootstrap).
  * @property everyBundleRowAtTarget - True iff every id in `defaults` ended
- *   the pass with a row whose stored `defaultHash` matches the effective
- *   target hash (i.e. content genuinely matches this version). False if any
- *   default row is missing without insert, user-edited (hash mismatch), or
- *   was skipped under `!canOverwrite`. Combined with `mutated` this lets
- *   callers decide when to advance an external version marker: advance when
- *   either something was written OR every row is verifiably at target
- *   (existing-users-upgrade case). Refuse when neither holds — the "all
- *   rows user-edited" case must not signal `stored=version` to peers, or
- *   fresh-install peers would receive the marker and stop seeding.
+ *   the pass in a state we consider "at target": either its stored
+ *   `defaultHash` matches the effective target hash (content genuinely
+ *   matches this version), OR it hit the `wouldOverwriteUserValue` branch
+ *   (settings-only: user filled in a null-default the app expects them to
+ *   own — target IS "user-owned" for those rows). False if any default row
+ *   is missing without insert, user-edited (hash mismatch), soft-deleted
+ *   without resurrect, or was skipped under `!canOverwrite`. Combined with
+ *   `mutated` this lets callers decide when to advance an external version
+ *   marker: advance when either something was written OR every row is
+ *   verifiably at target (existing-users-upgrade case). Refuse when neither
+ *   holds — the "all rows user-edited" case must not signal `stored=version`
+ *   to peers, or fresh-install peers would receive the marker and stop
+ *   seeding.
  */
 export type ReconcileDefaultsForTableResult = { mutated: boolean; everyBundleRowAtTarget: boolean }
 
@@ -319,9 +323,14 @@ export const reconcileDefaultsForTable = async <T extends { defaultHash: string 
     const wouldOverwriteUserValue = existing.value !== null && (effectiveDefault as any).value === null
 
     if (wouldOverwriteUserValue) {
-      // User set a value; we're not overwriting it. Content is user-managed,
-      // not at bundle target — same category as a hash-mismatch user edit.
-      everyBundleRowAtTarget = false
+      // User filled in a null-default setting the app expects them to own
+      // (preferred_name, location_*, distance_unit, etc.). The row IS at its
+      // intended target — target IS "user-owned" for these null defaults, and
+      // the whole point of `wouldOverwriteUserValue` is to preserve that
+      // ownership. Keeping `everyBundleRowAtTarget=true` here lets the
+      // settings marker advance on the first THU-677 boot for existing users
+      // who ran onboarding, instead of stranding them on the slow sync-wait
+      // path until a `defaultSettingsVersion` bump fires a real mutation.
       continue
     }
 

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -548,27 +548,25 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
     //   1. `canOverwrite` — writing the marker under a closed gate would let
     //      peers falsely believe the picked version was applied here and stop
     //      their own in-place upgrades even though we never wrote the content.
-    //   2. Either something mutated OR both passes verified every row is
-    //      already at target (`everyBundleRowAtTarget`). The "all rows
-    //      already at target" case is a legitimate verification — our
-    //      content genuinely matches version N even though nothing changed —
-    //      and existing-user upgrades depend on it (rows seeded pre-THU-677
-    //      already hash to the current bundle, so `mutated=false` alone
-    //      would strand the marker forever). The "all rows user-edited"
-    //      case still refuses because a hash mismatch means content doesn't
-    //      match version N — advancing would tell fresh-install peers to
-    //      stop seeding their own rows.
+    //   2. Either pass mutated OR both passes have every row at target.
+    //      The mutation-OR clause covers the common case: a bundle bump
+    //      writes to models (or profiles), and the marker legitimately
+    //      advances even if the OTHER pass is a no-op — e.g. a user who
+    //      customized a model profile shouldn't strand the models marker
+    //      just because their profile is user-edited (hash mismatch). The
+    //      at-target-AND clause covers the existing-user upgrade case:
+    //      pre-THU-677 rows already hash to the current bundle, both
+    //      passes verify without writing, and the marker still needs to
+    //      advance. The "all rows user-edited" case still refuses because
+    //      neither pass mutated and neither is at target — advancing would
+    //      tell fresh-install peers to stop seeding their own rows.
     //   3. `droppedOtaModelIds.length === 0` — our apply is a strict subset
     //      of the picked version when we filter OTA models, and stamping the
     //      full version would lock later fuller-bundle clients out of
     //      inserting the missing models.
-    const passVerified = (p: ReconcileDefaultsForTableResult): boolean => p.mutated || p.everyBundleRowAtTarget
-    if (
-      modelsGate.canOverwrite &&
-      passVerified(modelsPass) &&
-      passVerified(profilesPass) &&
-      droppedOtaModelIds.length === 0
-    ) {
+    const eitherPassMutated = modelsPass.mutated || profilesPass.mutated
+    const bothPassesAtTarget = modelsPass.everyBundleRowAtTarget && profilesPass.everyBundleRowAtTarget
+    if (modelsGate.canOverwrite && (eitherPassMutated || bothPassesAtTarget) && droppedOtaModelIds.length === 0) {
       await advanceVersionMarker(tx, versionMarkerKeys.models, modelsSource.version, modelsGate.stored)
     }
 
@@ -602,8 +600,9 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
         ...(keyField ? { keyField } : {}),
       })
       // Advance when we wrote something OR verified every row is at target.
-      // See the models-path guard above for the full rationale.
-      if (gate.canOverwrite && passVerified(pass)) {
+      // See the models-path guard above for the full rationale — single-table
+      // case is simpler because there's no sibling pass to coordinate with.
+      if (gate.canOverwrite && (pass.mutated || pass.everyBundleRowAtTarget)) {
         await advanceVersionMarker(tx, versionKey, currentVersion, gate.stored)
       }
     }

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -10,22 +10,29 @@ import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
 import { v7 as uuidv7 } from 'uuid'
 import { modelProfilesTable, modelsTable, modesTable, settingsTable, skillsTable, tasksTable } from '../db/tables'
 import { defaultModelProfiles, hashModelProfile } from '../defaults/model-profiles'
-import { defaultModes, hashMode } from '../defaults/modes'
+import { defaultModes, defaultModesVersion, hashMode } from '../defaults/modes'
 import { defaultModels, defaultModelsVersion, hashModel, type SharedModel } from '@shared/defaults/models'
-import { defaultSettings, hashSetting } from '../defaults/settings'
-import { defaultSkills, hashSkill } from '../defaults/skills'
-import { defaultTasks, hashTask } from '../defaults/tasks'
+import { defaultSettings, defaultSettingsVersion, hashSetting } from '../defaults/settings'
+import { defaultSkills, defaultSkillsVersion, hashSkill } from '../defaults/skills'
+import { defaultTasks, defaultTasksVersion, hashTask } from '../defaults/tasks'
 import type { ModelsDefaults } from './pick-defaults'
 import { nowIso } from './utils'
 
 const bundledModelsDefaults: ModelsDefaults = { version: defaultModelsVersion, data: defaultModels }
 
 /**
- * Settings key holding the highest defaults version ever applied to this
- * account's models table. See "Reconciled defaults and version bumps" in
- * AGENTS.md and the THU-637 rationale for the version-gate design.
+ * Settings keys holding the highest defaults version ever applied to this
+ * account per reconciled table. See "Reconciled defaults and version bumps"
+ * in AGENTS.md and the THU-637 rationale for the version-gate design; THU-677
+ * extended the pattern from models-only to every reconciled table.
  */
 const modelsVersionKey = 'defaults_version.models'
+const modesVersionKey = 'defaults_version.modes'
+const tasksVersionKey = 'defaults_version.tasks'
+const skillsVersionKey = 'defaults_version.skills'
+const settingsVersionKey = 'defaults_version.settings'
+
+type StoredVersion = { exists: boolean; version: number | null }
 
 /**
  * Read a previously-recorded defaults version from `settingsTable`. Returns
@@ -34,10 +41,7 @@ const modelsVersionKey = 'defaults_version.models'
  * update on write-back. `version` is null when the row is absent OR its value
  * is not a finite number (treat as "safe to apply" for the gate comparison).
  */
-const readAppliedVersion = async (
-  db: AnyDrizzleDatabase,
-  key: string,
-): Promise<{ exists: boolean; version: number | null }> => {
+const readAppliedVersion = async (db: AnyDrizzleDatabase, key: string): Promise<StoredVersion> => {
   const rows = await db.select().from(settingsTable).where(eq(settingsTable.key, key))
   const row = rows[0]
   if (!row) {
@@ -48,6 +52,63 @@ const readAppliedVersion = async (
   }
   const parsed = Number(row.value)
   return { exists: true, version: Number.isFinite(parsed) ? parsed : null }
+}
+
+/**
+ * Compute the version-gate + sync-incomplete guard for one reconciled table
+ * and return the stored-marker snapshot alongside, so the caller can branch
+ * on `stored.exists` for INSERT vs UPDATE on write-back without a second read.
+ *
+ * The gate collapses two safety concerns into one boolean:
+ *   1. Version ordering — reject writes when our defaults source is not
+ *      strictly newer than what has already been applied on this account
+ *      (prevents older-bundle devices from downgrading newer synced rows).
+ *   2. Sync-incomplete pessimism — when the local table already has rows and
+ *      first-sync has not finished, we cannot trust that a missing marker
+ *      means "never applied": cloud may hold both the marker and newer rows
+ *      we haven't received yet. Fresh installs (0 rows) bypass this so the
+ *      app still seeds bundle defaults offline.
+ */
+const computeCanOverwrite = async (
+  tx: AnyDrizzleDatabase,
+  versionKey: string,
+  pickedVersion: number,
+  hasAnyRow: boolean,
+  initialSyncCompleted: boolean,
+): Promise<{ canOverwrite: boolean; stored: StoredVersion }> => {
+  const stored = await readAppliedVersion(tx, versionKey)
+  const rawCanOverwrite = pickedVersion > (stored.version ?? Number.NEGATIVE_INFINITY)
+  const canOverwrite = ((): boolean => {
+    if (!hasAnyRow) {
+      return rawCanOverwrite
+    }
+    if (!initialSyncCompleted) {
+      return false
+    }
+    return rawCanOverwrite
+  })()
+  return { canOverwrite, stored }
+}
+
+/**
+ * Upsert a defaults version marker. Branches on `stored.exists` (not on the
+ * parsed version) so a pre-existing row with a non-numeric value — data
+ * corruption or an older schema — still routes to UPDATE instead of hitting a
+ * primary-key conflict on INSERT. Inline SQL rather than `updateSettings`
+ * because PowerSync's drizzle driver forbids nested transactions.
+ */
+const advanceVersionMarker = async (
+  tx: AnyDrizzleDatabase,
+  versionKey: string,
+  version: number,
+  stored: StoredVersion,
+) => {
+  const versionValue = String(version)
+  if (!stored.exists) {
+    await tx.insert(settingsTable).values({ key: versionKey, value: versionValue })
+  } else {
+    await tx.update(settingsTable).set({ value: versionValue }).where(eq(settingsTable.key, versionKey))
+  }
 }
 
 /**
@@ -337,29 +398,59 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
   const initialSyncCompleted = overrides?.initialSyncCompleted ?? true
 
   await db.transaction(async (tx) => {
-    // Version gate for models: only overwrite rows when our defaults source
-    // is strictly newer than the highest version ever applied on this account.
-    // Prevents older-bundle devices from downgrading newer synced rows (THU-637).
-    const stored = await readAppliedVersion(tx, modelsVersionKey)
-    const rawCanOverwrite = modelsSource.version > (stored.version ?? Number.NEGATIVE_INFINITY)
-
-    // Additional guard for the sync-incomplete case. Two scenarios collapse
-    // into the same rule: (a) fresh second device where the version marker
-    // hasn't arrived yet, and (b) any device with a stale local marker whose
-    // row content may already be at a newer version in cloud. In both, cloud
-    // may hold state we haven't received, and rawCanOverwrite is computed
-    // against an untrusted view. Fresh installs (0 rows) still seed the
-    // bundle so the app isn't crippled offline.
+    // Snapshot every reconciled table's row existence up front. Doing this
+    // per-table just before each reconcile block would poison the settings
+    // hasAnyRow probe on fresh installs: earlier tables advance their version
+    // markers into settingsTable via `advanceVersionMarker`, so by the time
+    // the settings block ran, the "empty settings table" signal would be
+    // gone. Reading all five probes here — before any writes land in this
+    // transaction — keeps every table's gate on the same pre-reconcile view.
     const hasAnyModelRow = (await tx.select({ id: modelsTable.id }).from(modelsTable).limit(1)).length > 0
-    const canOverwriteModels = ((): boolean => {
-      if (!hasAnyModelRow) {
-        return rawCanOverwrite
-      }
-      if (!initialSyncCompleted) {
-        return false
-      }
-      return rawCanOverwrite
-    })()
+    const hasAnyModeRow = (await tx.select({ id: modesTable.id }).from(modesTable).limit(1)).length > 0
+    const hasAnyTaskRow = (await tx.select({ id: tasksTable.id }).from(tasksTable).limit(1)).length > 0
+    const hasAnySkillRow = (await tx.select({ id: skillsTable.id }).from(skillsTable).limit(1)).length > 0
+    const hasAnySettingsRow = (await tx.select({ key: settingsTable.key }).from(settingsTable).limit(1)).length > 0
+
+    // Version gates per table. Each returns the stored marker snapshot so the
+    // per-table write-back can INSERT vs UPDATE without a second read. See
+    // `computeCanOverwrite` for the full rationale — in short, prevents an
+    // older-bundle device from downgrading newer synced rows (THU-637), and
+    // extends the same protection to modes/tasks/skills/settings (THU-677).
+    const modelsGate = await computeCanOverwrite(
+      tx,
+      modelsVersionKey,
+      modelsSource.version,
+      hasAnyModelRow,
+      initialSyncCompleted,
+    )
+    const modesGate = await computeCanOverwrite(
+      tx,
+      modesVersionKey,
+      defaultModesVersion,
+      hasAnyModeRow,
+      initialSyncCompleted,
+    )
+    const tasksGate = await computeCanOverwrite(
+      tx,
+      tasksVersionKey,
+      defaultTasksVersion,
+      hasAnyTaskRow,
+      initialSyncCompleted,
+    )
+    const skillsGate = await computeCanOverwrite(
+      tx,
+      skillsVersionKey,
+      defaultSkillsVersion,
+      hasAnySkillRow,
+      initialSyncCompleted,
+    )
+    const settingsGate = await computeCanOverwrite(
+      tx,
+      settingsVersionKey,
+      defaultSettingsVersion,
+      hasAnySettingsRow,
+      initialSyncCompleted,
+    )
 
     // OTA can ship models whose id isn't in this bundle's `defaultModelProfiles`
     // — profiles are not part of the OTA channel, so we have no profile to
@@ -387,7 +478,7 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
     // `modelsSource.data` overlaps with `defaultModels` by at least one id.
     // A fully-disjoint payload would otherwise let cleanup soft-delete every
     // bundle-known row (none appear in the passed-in `currentModelIds`).
-    await cleanupRemovedDefaults(tx, canOverwriteModels, modelsSource.data, initialSyncCompleted)
+    await cleanupRemovedDefaults(tx, modelsGate.canOverwrite, modelsSource.data, initialSyncCompleted)
 
     // AI models. `canResurrect` uses initialSyncCompleted so an older-bundle
     // but fully-synced device can still un-delete a pre-THU-637 mistake, while
@@ -404,7 +495,7 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
     // OTA can still update name, description, contextWindow, tool flags, etc.
     // To change a frozen field, ship the new value under a fresh model id.
     const modelsPass = await reconcileDefaultsForTable(tx, modelsTable, modelsForReconcile, hashModel, {
-      canOverwrite: canOverwriteModels,
+      canOverwrite: modelsGate.canOverwrite,
       canResurrect: initialSyncCompleted,
       frozenFields: ['isConfidential', 'provider'],
     })
@@ -432,48 +523,67 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
       hashModelProfile,
       {
         keyField: 'modelId',
-        canOverwrite: canOverwriteModels,
+        canOverwrite: modelsGate.canOverwrite,
         insertMissing: true,
         canResurrect: initialSyncCompleted,
       },
     )
 
-    // Modes
-    await reconcileDefaultsForTable(tx, modesTable, defaultModes, hashMode)
+    // Advance the models version marker. Two conditions must hold together:
+    //   1. `canOverwrite` — writing the marker under a closed gate would let
+    //      peers falsely believe the picked version was applied here and stop
+    //      their own in-place upgrades even though we never wrote the content.
+    //   2. Something actually mutated. Advancing on a pure no-op (all rows
+    //      user-edited, or all already at target) has the same false-signal
+    //      hazard as (1) — we effectively promised to peers we're at version
+    //      N without having verified our content matches N.
+    // Extra `droppedOtaModelIds.length === 0` check for models: our apply is
+    // a strict subset of the picked version when we filter OTA models, and
+    // stamping the full version would lock later fuller-bundle clients
+    // (canOverwrite=false because stored>=picked) out of inserting the
+    // missing models.
+    if (modelsGate.canOverwrite && (modelsPass.mutated || profilesPass.mutated) && droppedOtaModelIds.length === 0) {
+      await advanceVersionMarker(tx, modelsVersionKey, modelsSource.version, modelsGate.stored)
+    }
 
-    // Tasks
-    await reconcileDefaultsForTable(tx, tasksTable, defaultTasks, hashTask)
+    // Modes / tasks / skills / settings share the same shape: gate on the
+    // per-table version + sync-incomplete guard, reconcile, advance marker
+    // only on a real mutation. `canResurrect` follows the models pattern —
+    // sync must have completed before we un-delete a soft-deleted row (no
+    // cleanup step targets these tables today, but the option is future-safe).
+    const modesPass = await reconcileDefaultsForTable(tx, modesTable, defaultModes, hashMode, {
+      canOverwrite: modesGate.canOverwrite,
+      canResurrect: initialSyncCompleted,
+    })
+    if (modesGate.canOverwrite && modesPass.mutated) {
+      await advanceVersionMarker(tx, modesVersionKey, defaultModesVersion, modesGate.stored)
+    }
+
+    const tasksPass = await reconcileDefaultsForTable(tx, tasksTable, defaultTasks, hashTask, {
+      canOverwrite: tasksGate.canOverwrite,
+      canResurrect: initialSyncCompleted,
+    })
+    if (tasksGate.canOverwrite && tasksPass.mutated) {
+      await advanceVersionMarker(tx, tasksVersionKey, defaultTasksVersion, tasksGate.stored)
+    }
 
     // Skills (the default skills supersede the legacy default automations,
     // which used to seed promptsTable here. See THU-547.)
-    await reconcileDefaultsForTable(tx, skillsTable, defaultSkills, hashSkill)
+    const skillsPass = await reconcileDefaultsForTable(tx, skillsTable, defaultSkills, hashSkill, {
+      canOverwrite: skillsGate.canOverwrite,
+      canResurrect: initialSyncCompleted,
+    })
+    if (skillsGate.canOverwrite && skillsPass.mutated) {
+      await advanceVersionMarker(tx, skillsVersionKey, defaultSkillsVersion, skillsGate.stored)
+    }
 
-    // Settings
-    await reconcileDefaultsForTable(tx, settingsTable, defaultSettings, hashSetting, { keyField: 'key' })
-
-    // Only advance the version marker when we actually applied a change to
-    // models or profiles this pass. Advancing on a pure no-op (all rows
-    // user-edited, or all already at target) would falsely signal to peers
-    // that the picked version has been applied here — peers with `stored`
-    // already at `pickedVersion` would then stop in-place upgrades even
-    // though the writer never verified the content.
-    //
-    // Also skip the marker when we filtered any OTA models: our apply is a
-    // strict subset of the picked version, and stamping the full version
-    // would lock later fuller-bundle clients (canOverwrite=false because
-    // stored>=picked) out of inserting the missing models.
-    if (canOverwriteModels && (modelsPass.mutated || profilesPass.mutated) && droppedOtaModelIds.length === 0) {
-      // Inline upsert: `updateSettings` wraps its writes in its own transaction
-      // and PowerSync's drizzle driver forbids nested transactions. Branch on
-      // row existence — not on parsed version — so a pre-existing row with a
-      // non-numeric value (data corruption, older schema) still routes to
-      // UPDATE instead of hitting a primary-key conflict on INSERT.
-      const versionValue = String(modelsSource.version)
-      if (!stored.exists) {
-        await tx.insert(settingsTable).values({ key: modelsVersionKey, value: versionValue })
-      } else {
-        await tx.update(settingsTable).set({ value: versionValue }).where(eq(settingsTable.key, modelsVersionKey))
-      }
+    const settingsPass = await reconcileDefaultsForTable(tx, settingsTable, defaultSettings, hashSetting, {
+      keyField: 'key',
+      canOverwrite: settingsGate.canOverwrite,
+      canResurrect: initialSyncCompleted,
+    })
+    if (settingsGate.canOverwrite && settingsPass.mutated) {
+      await advanceVersionMarker(tx, settingsVersionKey, defaultSettingsVersion, settingsGate.stored)
     }
 
     // Initialize anonymous ID for analytics (unique per user)

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -78,15 +78,9 @@ const computeCanOverwrite = async (
 ): Promise<{ canOverwrite: boolean; stored: StoredVersion }> => {
   const stored = await readAppliedVersion(tx, versionKey)
   const rawCanOverwrite = pickedVersion > (stored.version ?? Number.NEGATIVE_INFINITY)
-  const canOverwrite = ((): boolean => {
-    if (!hasAnyRow) {
-      return rawCanOverwrite
-    }
-    if (!initialSyncCompleted) {
-      return false
-    }
-    return rawCanOverwrite
-  })()
+  // Fresh install (0 rows) always seeds; a populated table needs sync to have
+  // settled before we trust the stored marker enough to write.
+  const canOverwrite = rawCanOverwrite && (!hasAnyRow || initialSyncCompleted)
   return { canOverwrite, stored }
 }
 
@@ -411,44 +405,17 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
     const hasAnySkillRow = (await tx.select({ id: skillsTable.id }).from(skillsTable).limit(1)).length > 0
     const hasAnySettingsRow = (await tx.select({ key: settingsTable.key }).from(settingsTable).limit(1)).length > 0
 
-    // Version gates per table. Each returns the stored marker snapshot so the
+    // Version gate for models. Returns the stored marker snapshot so the
     // per-table write-back can INSERT vs UPDATE without a second read. See
     // `computeCanOverwrite` for the full rationale — in short, prevents an
-    // older-bundle device from downgrading newer synced rows (THU-637), and
-    // extends the same protection to modes/tasks/skills/settings (THU-677).
+    // older-bundle device from downgrading newer synced rows (THU-637).
+    // Modes/tasks/skills/settings gate the same way, folded into the loop
+    // near the bottom of this transaction (THU-677).
     const modelsGate = await computeCanOverwrite(
       tx,
       modelsVersionKey,
       modelsSource.version,
       hasAnyModelRow,
-      initialSyncCompleted,
-    )
-    const modesGate = await computeCanOverwrite(
-      tx,
-      modesVersionKey,
-      defaultModesVersion,
-      hasAnyModeRow,
-      initialSyncCompleted,
-    )
-    const tasksGate = await computeCanOverwrite(
-      tx,
-      tasksVersionKey,
-      defaultTasksVersion,
-      hasAnyTaskRow,
-      initialSyncCompleted,
-    )
-    const skillsGate = await computeCanOverwrite(
-      tx,
-      skillsVersionKey,
-      defaultSkillsVersion,
-      hasAnySkillRow,
-      initialSyncCompleted,
-    )
-    const settingsGate = await computeCanOverwrite(
-      tx,
-      settingsVersionKey,
-      defaultSettingsVersion,
-      hasAnySettingsRow,
       initialSyncCompleted,
     )
 
@@ -549,42 +516,49 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
     // Modes / tasks / skills / settings share the same shape: gate on the
     // per-table version + sync-incomplete guard, reconcile, advance marker
     // only on a real mutation. `canResurrect` follows the models pattern —
-    // sync must have completed before we un-delete a soft-deleted row (no
-    // cleanup step targets these tables today, but the option is future-safe).
-    const modesPass = await reconcileDefaultsForTable(tx, modesTable, defaultModes, hashMode, {
-      canOverwrite: modesGate.canOverwrite,
-      canResurrect: initialSyncCompleted,
-    })
-    if (modesGate.canOverwrite && modesPass.mutated) {
-      await advanceVersionMarker(tx, modesVersionKey, defaultModesVersion, modesGate.stored)
+    // it requires a trustworthy view of cloud state, otherwise a peer's
+    // genuine retirement could be masquerading as a cleanup shape from our
+    // partial view. No `cleanupRemovedDefaults` call targets these tables
+    // today, but resurrect still runs if a peer soft-deleted a bundle-known
+    // row this device still ships as default. Skills note: they superseded
+    // the legacy default automations that used to seed promptsTable here.
+    // See THU-547.
+    //
+    // Each pass is wrapped in a generic helper so its `defaults`/`hashFn` T
+    // binding is captured per-call — a `for-of` over a heterogeneous config
+    // array would force TS to unify T across the union and fail to typecheck.
+    const runGatedPass = async <T extends { defaultHash: string | null }>(
+      table: SQLiteTableWithColumns<any>,
+      defaults: readonly T[],
+      hashFn: (item: T) => string,
+      versionKey: string,
+      currentVersion: number,
+      hasAnyRow: boolean,
+      keyField?: string,
+    ): Promise<void> => {
+      const gate = await computeCanOverwrite(tx, versionKey, currentVersion, hasAnyRow, initialSyncCompleted)
+      const pass = await reconcileDefaultsForTable(tx, table, defaults, hashFn, {
+        canOverwrite: gate.canOverwrite,
+        canResurrect: initialSyncCompleted,
+        ...(keyField ? { keyField } : {}),
+      })
+      if (gate.canOverwrite && pass.mutated) {
+        await advanceVersionMarker(tx, versionKey, currentVersion, gate.stored)
+      }
     }
 
-    const tasksPass = await reconcileDefaultsForTable(tx, tasksTable, defaultTasks, hashTask, {
-      canOverwrite: tasksGate.canOverwrite,
-      canResurrect: initialSyncCompleted,
-    })
-    if (tasksGate.canOverwrite && tasksPass.mutated) {
-      await advanceVersionMarker(tx, tasksVersionKey, defaultTasksVersion, tasksGate.stored)
-    }
-
-    // Skills (the default skills supersede the legacy default automations,
-    // which used to seed promptsTable here. See THU-547.)
-    const skillsPass = await reconcileDefaultsForTable(tx, skillsTable, defaultSkills, hashSkill, {
-      canOverwrite: skillsGate.canOverwrite,
-      canResurrect: initialSyncCompleted,
-    })
-    if (skillsGate.canOverwrite && skillsPass.mutated) {
-      await advanceVersionMarker(tx, skillsVersionKey, defaultSkillsVersion, skillsGate.stored)
-    }
-
-    const settingsPass = await reconcileDefaultsForTable(tx, settingsTable, defaultSettings, hashSetting, {
-      keyField: 'key',
-      canOverwrite: settingsGate.canOverwrite,
-      canResurrect: initialSyncCompleted,
-    })
-    if (settingsGate.canOverwrite && settingsPass.mutated) {
-      await advanceVersionMarker(tx, settingsVersionKey, defaultSettingsVersion, settingsGate.stored)
-    }
+    await runGatedPass(modesTable, defaultModes, hashMode, modesVersionKey, defaultModesVersion, hasAnyModeRow)
+    await runGatedPass(tasksTable, defaultTasks, hashTask, tasksVersionKey, defaultTasksVersion, hasAnyTaskRow)
+    await runGatedPass(skillsTable, defaultSkills, hashSkill, skillsVersionKey, defaultSkillsVersion, hasAnySkillRow)
+    await runGatedPass(
+      settingsTable,
+      defaultSettings,
+      hashSetting,
+      settingsVersionKey,
+      defaultSettingsVersion,
+      hasAnySettingsRow,
+      'key',
+    )
 
     // Initialize anonymous ID for analytics (unique per user)
     await createSetting(tx, 'anonymous_id', uuidv7())


### PR DESCRIPTION
Extends the THU-637 version-gate pattern from models to modes/tasks/skills/settings, so every reconciled table gates writes on a monotonic version + sync-incomplete guard. Once every table is gated, init can skip `waitForInitialSync` on refresh (sync-enabled devices with any `defaults_version.*` marker) and read `/config` from the persisted zustand store instead of blocking on the network.

Shaves up to ~15 s off every refresh (10 s sync wait + 5 s `/config` timeout) where the local DB already carries account state. Sync-disabled devices always take the fresh path so bundle updates still apply on client upgrade.

Related: THU-595 (investigation), THU-637 (models-only version-gate).
