### PR TITLE
build(cli): name release binaries thunderbolt-cli-<target>

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -5,7 +5,7 @@ run-name: CLI release for v${{ inputs.version }}
 # SHA256SUMS manifest, to the shared `v{version}` GitHub Release. The desktop
 # app derives download URLs from its own version:
 #
-#   https://github.com/thunderbird/thunderbolt/releases/download/v{APP_VERSION}/thunderbolt-{target}
+#   https://github.com/thunderbird/thunderbolt/releases/download/v{APP_VERSION}/thunderbolt-cli-{target}
 #   https://github.com/thunderbird/thunderbolt/releases/download/v{APP_VERSION}/SHA256SUMS
 #
 # where {target} is one of: darwin-arm64 | linux-x64 | linux-arm64.
@@ -128,8 +128,8 @@ jobs:
       - name: Upload CLI binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: thunderbolt-${{ matrix.target }}
-          path: cli/dist/thunderbolt-${{ matrix.target }}
+          name: thunderbolt-cli-${{ matrix.target }}
+          path: cli/dist/thunderbolt-cli-${{ matrix.target }}
           if-no-files-found: error
           retention-days: 1
 
@@ -144,7 +144,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
-          pattern: thunderbolt-*
+          pattern: thunderbolt-cli-*
           merge-multiple: true
 
       - name: Generate SHA256SUMS and upload all assets to the release
@@ -154,5 +154,5 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           cd dist
-          sha256sum thunderbolt-* > SHA256SUMS
-          gh release upload "v${VERSION}" thunderbolt-* SHA256SUMS --clobber --repo "$REPO"
+          sha256sum thunderbolt-cli-* > SHA256SUMS
+          gh release upload "v${VERSION}" thunderbolt-cli-* SHA256SUMS --clobber --repo "$REPO"

--- a/cli/README.md
+++ b/cli/README.md
@@ -47,14 +47,14 @@ see below) and verify the checksum before running:
 TARGET=darwin-arm64
 BASE=https://github.com/thunderbird/thunderbolt/releases/latest/download
 
-curl -fsSLO "$BASE/thunderbolt-$TARGET"
+curl -fsSLO "$BASE/thunderbolt-cli-$TARGET"
 curl -fsSLO "$BASE/SHA256SUMS"
-grep " thunderbolt-$TARGET\$" SHA256SUMS | shasum -a 256 -c -
+grep " thunderbolt-cli-$TARGET\$" SHA256SUMS | shasum -a 256 -c -
 
-chmod +x "thunderbolt-$TARGET"
+chmod +x "thunderbolt-cli-$TARGET"
 # macOS only: clear the download quarantine so Gatekeeper allows the unsigned binary
-xattr -d com.apple.quarantine "thunderbolt-$TARGET" 2>/dev/null || true
-mv "thunderbolt-$TARGET" ~/.local/bin/thunderbolt
+xattr -d com.apple.quarantine "thunderbolt-cli-$TARGET" 2>/dev/null || true
+mv "thunderbolt-cli-$TARGET" ~/.local/bin/thunderbolt
 ```
 
 > **What the checksum covers.** `SHA256SUMS` and the binary come from the same

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,9 +15,9 @@
     "test": "bun test ./src --timeout 5000 --randomize",
     "test:5x": "bun test ./src --timeout 5000 --randomize --rerun-each 5",
     "build": "bun build --compile --minify --sourcemap src/index.ts --outfile dist/thunderbolt",
-    "build:darwin-arm64": "bun build --compile --minify --target=bun-darwin-arm64 src/index.ts --outfile dist/thunderbolt-darwin-arm64",
-    "build:linux-x64": "bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile dist/thunderbolt-linux-x64",
-    "build:linux-arm64": "bun build --compile --minify --target=bun-linux-arm64 src/index.ts --outfile dist/thunderbolt-linux-arm64",
+    "build:darwin-arm64": "bun build --compile --minify --target=bun-darwin-arm64 src/index.ts --outfile dist/thunderbolt-cli-darwin-arm64",
+    "build:linux-x64": "bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile dist/thunderbolt-cli-linux-x64",
+    "build:linux-arm64": "bun build --compile --minify --target=bun-linux-arm64 src/index.ts --outfile dist/thunderbolt-cli-linux-arm64",
     "build:all": "bun run build:darwin-arm64 && bun run build:linux-x64 && bun run build:linux-arm64"
   },
   "dependencies": {

--- a/install.sh
+++ b/install.sh
@@ -152,7 +152,7 @@ else
   version=$(resolve_latest_version)
 fi
 
-binary_name="thunderbolt-${target}"
+binary_name="thunderbolt-cli-${target}"
 binary_file="${temp_dir}/${binary_name}"
 checksums_file="${temp_dir}/SHA256SUMS"
 download_url="${releases_url}/${version}"

--- a/src-tauri/src/cli_installer.rs
+++ b/src-tauri/src/cli_installer.rs
@@ -8,7 +8,7 @@
 //! scheme the CLI release pipeline defines (`.github/workflows/cli-release.yml`):
 //!
 //! ```text
-//! https://github.com/thunderbird/thunderbolt/releases/download/v{version}/thunderbolt-{target}
+//! https://github.com/thunderbird/thunderbolt/releases/download/v{version}/thunderbolt-cli-{target}
 //! https://github.com/thunderbird/thunderbolt/releases/download/v{version}/SHA256SUMS
 //! ```
 //!
@@ -86,11 +86,11 @@ fn resolve_target(os: &str, arch: &str) -> Option<&'static str> {
 
 /// The release asset filename for a target (matches the `SHA256SUMS` entries).
 fn asset_name(target: &str) -> String {
-    format!("thunderbolt-{target}")
+    format!("thunderbolt-cli-{target}")
 }
 
 fn binary_url(version: &str, target: &str) -> String {
-    format!("{RELEASE_BASE}/v{version}/thunderbolt-{target}")
+    format!("{RELEASE_BASE}/v{version}/thunderbolt-cli-{target}")
 }
 
 fn checksums_url(version: &str) -> String {
@@ -288,7 +288,7 @@ mod tests {
     fn urls_follow_the_release_scheme() {
         assert_eq!(
             binary_url("0.1.105", "darwin-arm64"),
-            "https://github.com/thunderbird/thunderbolt/releases/download/v0.1.105/thunderbolt-darwin-arm64"
+            "https://github.com/thunderbird/thunderbolt/releases/download/v0.1.105/thunderbolt-cli-darwin-arm64"
         );
         assert_eq!(
             checksums_url("0.1.105"),
@@ -298,18 +298,18 @@ mod tests {
 
     #[test]
     fn asset_name_matches_the_binary_filename() {
-        assert_eq!(asset_name("linux-x64"), "thunderbolt-linux-x64");
+        assert_eq!(asset_name("linux-x64"), "thunderbolt-cli-linux-x64");
     }
 
     #[test]
     fn expected_sha_parses_text_mode_manifest() {
         let manifest = "\
-aaaa1111  thunderbolt-darwin-arm64
-bbbb2222  thunderbolt-linux-x64
-cccc3333  thunderbolt-linux-arm64
+aaaa1111  thunderbolt-cli-darwin-arm64
+bbbb2222  thunderbolt-cli-linux-x64
+cccc3333  thunderbolt-cli-linux-arm64
 ";
         assert_eq!(
-            expected_sha_for(manifest, "thunderbolt-linux-x64"),
+            expected_sha_for(manifest, "thunderbolt-cli-linux-x64"),
             Some("bbbb2222".to_string())
         );
     }
@@ -317,19 +317,22 @@ cccc3333  thunderbolt-linux-arm64
     #[test]
     fn expected_sha_parses_binary_mode_and_lowercases() {
         // sha256sum binary mode uses ` *filename`; digests are compared lowercase.
-        let manifest = "ABCD1234 *thunderbolt-darwin-arm64\n";
+        let manifest = "ABCD1234 *thunderbolt-cli-darwin-arm64\n";
         assert_eq!(
-            expected_sha_for(manifest, "thunderbolt-darwin-arm64"),
+            expected_sha_for(manifest, "thunderbolt-cli-darwin-arm64"),
             Some("abcd1234".to_string())
         );
     }
 
     #[test]
     fn expected_sha_returns_none_for_absent_or_partial_names() {
-        let manifest = "aaaa1111  thunderbolt-linux-x64-old\n";
+        let manifest = "aaaa1111  thunderbolt-cli-linux-x64-old\n";
         // Must match the asset exactly, not as a prefix of another entry.
-        assert_eq!(expected_sha_for(manifest, "thunderbolt-linux-x64"), None);
-        assert_eq!(expected_sha_for("", "thunderbolt-linux-x64"), None);
+        assert_eq!(
+            expected_sha_for(manifest, "thunderbolt-cli-linux-x64"),
+            None
+        );
+        assert_eq!(expected_sha_for("", "thunderbolt-cli-linux-x64"), None);
     }
 
     #[test]


### PR DESCRIPTION
Renames the standalone CLI's GitHub Release **assets** from `thunderbolt-<target>` to `thunderbolt-cli-<target>` (e.g. `thunderbolt-cli-darwin-arm64`), to disambiguate them from the desktop app, which is named "Thunderbolt". The installed on-disk executable **stays `thunderbolt`** — only the downloadable asset filenames change.

Changed (asset name only):
- `cli/package.json` — the three release `build:<target>` outfiles.
- `.github/workflows/cli-release.yml` — artifact name/path, download pattern, `SHA256SUMS` generation, and `gh release upload`.
- `src-tauri/src/cli_installer.rs` — `asset_name`/`binary_url` and the test fixtures/manifests.
- `install.sh` — `binary_name`.
- `cli/README.md` — the manual prebuilt-binary section.

Kept as `thunderbolt` (installed executable): `~/.local/bin/thunderbolt` install paths, `dir.join("thunderbolt")`, the from-source `cli/install.sh`, and all `thunderbolt …` usage examples.

No backward-compat fallback (coordinated cutover). **This must be followed by a fresh release** so `thunderbolt-cli-<target>` assets exist; the current `v0.1.107` keeps its old `thunderbolt-<target>` assets untouched (existing desktop installs pinned to it keep working). Whole-tree re-grep confirmed no other asset reference; `cargo test cli_installer` passes with the renamed fixtures.