### PR TITLE
ci(THU-681): pin + verify linuxdeploy via shared composite action

### DIFF
--- a/.github/actions/setup-linuxdeploy/action.yml
+++ b/.github/actions/setup-linuxdeploy/action.yml
@@ -1,0 +1,61 @@
+name: Set up pinned linuxdeploy
+description: >
+  Download a checksum-verified linuxdeploy release into Tauri's cache dir so
+  `bun tauri build` uses it instead of Tauri's outdated binary-releases pin
+  (which lacks LINUXDEPLOY_EXCLUDED_LIBRARIES env-var support). Also exports
+  the exclusion env var so downstream `bun tauri build` steps in the same job
+  drop libwayland-client from the AppImage bundle. Fixes EGL_BAD_PARAMETER on
+  Wayland compositors — see thunderbird/thunderbolt#955.
+
+runs:
+  using: composite
+  steps:
+    - name: Download + verify + place linuxdeploy, export exclusion env
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Pinned to the linuxdeploy `continuous` release asset uploaded on
+        # 2026-07-01 (upstream commit a9f929ff0e32d5c4bcb7b5c380adff4802f918ba).
+        # We can't pin to a formal tag because upstream hasn't cut one since
+        # the env-var feature landed (98f393c4, 2024-06-13); instead we verify
+        # sha256 and require a deliberate bump when the asset changes
+        # (lockfile-style). Tauri's `if !exists() { download }` guard in
+        # crates/tauri-bundler/.../linuxdeploy.rs sees this file and skips its
+        # own outdated download.
+        #
+        # To bump the pin:
+        #   1. curl -fsSL '<URL below>' -o /tmp/linuxdeploy-x86_64.AppImage
+        #   2. sha256sum /tmp/linuxdeploy-x86_64.AppImage
+        #   3. Sanity-check against upstream (release notes, commit metadata at
+        #      GET repos/linuxdeploy/linuxdeploy/releases/tags/continuous — the
+        #      `target_commitish` there should be a commit you're comfortable
+        #      shipping into a signed release AppImage).
+        #   4. Update EXPECTED_SHA below in a dedicated review-required commit.
+        readonly URL='https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage'
+        readonly EXPECTED_SHA='e87ee0815d109282fdda73e34c2361d64d02b0ffaea3674b18f1fd1f6a687dcf'
+        # Follow the XDG spec so a runner that customises the cache dir still
+        # lines up with what Tauri's `dirs::cache_dir()` reads at bundle time.
+        readonly TAURI_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+        readonly DEST="$TAURI_CACHE/linuxdeploy-x86_64.AppImage"
+        readonly TMP="$(mktemp)"
+        mkdir -p "$TAURI_CACHE"
+
+        # Retry/timeout guard: CI hangs on flaky mirror pulls are worse than
+        # a fast fail-and-retry. Bounded so a stuck download can't burn a job.
+        curl --fail --silent --show-error --location \
+             --max-time 120 --retry 3 --retry-delay 2 \
+             "$URL" --output "$TMP"
+
+        # Verify BEFORE placing the file where Tauri will read it, so a bad
+        # download can't poison the cache on a self-hosted runner. `--quiet`
+        # prints on mismatch, stays silent on success.
+        echo "$EXPECTED_SHA  $TMP" | sha256sum --check --quiet
+
+        mv "$TMP" "$DEST"
+        chmod +x "$DEST"
+
+        # Read by linuxdeploy on AppDir init (semicolon-separated fnmatch
+        # globs). Excluding `libwayland-client.so*` forces the AppImage to load
+        # the user's system copy at runtime — matches their compositor by
+        # construction and avoids EGL_BAD_PARAMETER on Wayland.
+        echo 'LINUXDEPLOY_EXCLUDED_LIBRARIES=libwayland-client.so*' >> "$GITHUB_ENV"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -225,19 +225,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2 || true
 
-      - name: Use env-var-aware linuxdeploy (fixes libwayland-client exclusion)
+      - name: Set up pinned linuxdeploy
         if: matrix.os == 'ubuntu-24.04'
-        run: |
-          # Tauri's pinned linuxdeploy binary at binary-releases/releases/linuxdeploy/
-          # predates `LINUXDEPLOY_EXCLUDED_LIBRARIES` env-var support (added
-          # upstream in linuxdeploy@98f393c4, 2024-06-13). Pre-place the current
-          # `continuous` build in Tauri's cache dir so Tauri's `if !exists()
-          # { download }` guard skips the outdated download and uses this one —
-          # the env var then actually takes effect. See thunderbird/thunderbolt#955.
-          mkdir -p ~/.cache/tauri
-          curl -fsSL 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage' \
-            -o ~/.cache/tauri/linuxdeploy-x86_64.AppImage
-          chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+        uses: ./.github/actions/setup-linuxdeploy
 
       - name: build Tauri app for Linux
         if: matrix.os == 'ubuntu-24.04'
@@ -249,14 +239,6 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTC_WRAPPER: ''
           NO_STRIP: true
-          # Prevent linuxdeploy from bundling libwayland-client into the AppImage.
-          # The bundled copy is often incompatible with the user's compositor and
-          # produces `EGL_BAD_PARAMETER` on Wayland (Arch, some Fedora setups).
-          # Excluding it forces the AppImage to load the user's system copy at
-          # runtime, which matches their compositor by construction. Read by
-          # linuxdeploy on AppDir init (semicolon-separated fnmatch globs); Tauri
-          # inherits env to the subprocess. See thunderbird/thunderbolt#955.
-          LINUXDEPLOY_EXCLUDED_LIBRARIES: 'libwayland-client.so*'
           VITE_THUNDERBOLT_CLOUD_URL: ${{ vars.VITE_THUNDERBOLT_CLOUD_URL }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -55,18 +55,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2 || true
 
-      - name: Use env-var-aware linuxdeploy (fixes libwayland-client exclusion)
+      - name: Set up pinned linuxdeploy
         if: inputs.platform == 'linux'
-        run: |
-          # Mirror the pre-populate step from desktop-release.yml. Tauri's pinned
-          # linuxdeploy binary predates `LINUXDEPLOY_EXCLUDED_LIBRARIES` env-var
-          # support; pre-placing the current `continuous` build in Tauri's cache
-          # dir makes Tauri's `if !exists() { download }` guard skip the outdated
-          # download and use this one. See thunderbird/thunderbolt#955.
-          mkdir -p ~/.cache/tauri
-          curl -fsSL 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage' \
-            -o ~/.cache/tauri/linuxdeploy-x86_64.AppImage
-          chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+        uses: ./.github/actions/setup-linuxdeploy
 
       - name: Build
         run: |
@@ -105,9 +96,6 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTC_WRAPPER: ''
           LIBSQL_BUNDLED: ${{ inputs.platform == 'windows-arm' && '1' || '' }}
-          # Mirror the AppImage exclusion from desktop-release.yml so test builds
-          # reflect what real users get. See thunderbird/thunderbolt#955.
-          LINUXDEPLOY_EXCLUDED_LIBRARIES: ${{ inputs.platform == 'linux' && 'libwayland-client.so*' || '' }}
           VITE_THUNDERBOLT_CLOUD_URL: ${{ vars.VITE_THUNDERBOLT_CLOUD_URL }}
           # Intel macOS cross-compilation settings
           CC_x86_64_apple_darwin: ${{ inputs.platform == 'macos-intel' && 'clang -target x86_64-apple-darwin' || '' }}


### PR DESCRIPTION
## Summary

- Follow-up to [PR #1076](https://github.com/thunderbird/thunderbolt/pull/1076) review — addresses two bot comments flagging (1) supply-chain risk from pulling linuxdeploy from the rolling `continuous` tag without a checksum, and (2) duplication of that setup between `desktop-release.yml` and `test-build.yml`.
- Extracts the linuxdeploy pre-populate step + `LINUXDEPLOY_EXCLUDED_LIBRARIES` env var into a shared composite action at `.github/actions/setup-linuxdeploy/action.yml`. Both workflows now call `uses: ./.github/actions/setup-linuxdeploy`.
- The action pins to a specific `continuous` asset (2026-07-01, upstream commit `a9f929ff`), retries on transient failures, downloads to a temp file, verifies sha256 **before** placing in Tauri's cache, and exports the exclusion env var via `$GITHUB_ENV` so downstream `bun tauri build` steps inherit it.

Closes THU-681. Stacked on [PR #1076](https://github.com/thunderbird/thunderbolt/pull/1076) — will auto-retarget to `main` once that lands.

## Test plan

- [ ] Re-run the `test-build` (linux) workflow off this branch; artifact should still have `libwayland-client.so*` absent from the AppImage (identical bytes-worth of behavior to #1076).
- [ ] Deliberate-mismatch check: temporarily change `EXPECTED_SHA` to a wrong value, confirm the workflow fails with `sha256sum: WARNING: 1 computed checksum did NOT match`.