### PR TITLE
fix: show correct setup commands for binary-distributed catalog agents

### DIFF
--- a/src/components/settings/agents/agent-catalog-view.test.tsx
+++ b/src/components/settings/agents/agent-catalog-view.test.tsx
@@ -135,7 +135,7 @@ describe('AgentCatalogView', () => {
     expect(within(card).getByRole('button', { name: /set up/i })).toBeInTheDocument()
   })
 
-  it('opens the setup dialog with the run command when Set up is clicked', () => {
+  it('opens the setup dialog with the authored run command when Set up is clicked', () => {
     renderCatalog([entry({ id: 'goose', name: 'goose', distribution: { npx: { package: 'goose@1.2.3' } } })])
     const card = screen.getByTestId('agent-catalog-card-goose')
 
@@ -143,7 +143,7 @@ describe('AgentCatalogView', () => {
     fireEvent.click(within(card).getByRole('button', { name: /set up/i }))
 
     expect(screen.getByText(/run this command/i)).toBeInTheDocument()
-    expect(screen.getByText('npx -y goose@1.2.3')).toBeInTheDocument()
+    expect(screen.getByText('goose acp')).toBeInTheDocument()
   })
 
   it('keeps all cards visible for a whitespace-only query', () => {

--- a/src/components/settings/agents/agent-install-dialog.test.tsx
+++ b/src/components/settings/agents/agent-install-dialog.test.tsx
@@ -5,7 +5,7 @@
 import '@testing-library/jest-dom'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, mock } from 'bun:test'
-import type { AgentInstallMeta } from '@/defaults/agent-install-metadata'
+import { agentInstallMetadata, type AgentInstallMeta } from '@/defaults/agent-install-metadata'
 import type { RegistryEntry } from '@/types/registry'
 import { AgentInstallDialog } from './agent-install-dialog'
 
@@ -32,7 +32,7 @@ const entry = (overrides: Partial<RegistryEntry> = {}): RegistryEntry => ({
 })
 
 const renderDialog = (props: Partial<Parameters<typeof AgentInstallDialog>[0]> = {}) =>
-  render(<AgentInstallDialog entry={entry()} open={true} onOpenChange={() => {}} platform="macos" {...props} />)
+  render(<AgentInstallDialog entry={entry()} open={true} onOpenChange={() => {}} {...props} />)
 
 describe('AgentInstallDialog', () => {
   it('renders the derived run command', () => {
@@ -40,8 +40,10 @@ describe('AgentInstallDialog', () => {
     expect(screen.getByText('npx -y @google/gemini-cli@1.0.0 --acp')).toBeInTheDocument()
   })
 
-  it('resolves the binary command for the given platform', () => {
-    const binaryEntry = entry({
+  it('renders the authored amp-acp run command', () => {
+    const ampEntry = entry({
+      id: 'amp-acp',
+      name: 'Amp',
       distribution: {
         binary: {
           'darwin-aarch64': { cmd: './amp-acp' },
@@ -49,8 +51,34 @@ describe('AgentInstallDialog', () => {
         },
       },
     })
-    renderDialog({ entry: binaryEntry, platform: 'windows' })
-    expect(screen.getByText('amp-acp.exe')).toBeInTheDocument()
+    renderDialog({ entry: ampEntry, meta: agentInstallMetadata['amp-acp'] })
+    expect(screen.getByText('npx -y amp-acp')).toBeInTheDocument()
+  })
+
+  it('renders install and run sections when both commands are authored', () => {
+    const meta: AgentInstallMeta = {
+      installCommand: 'brew install example-agent',
+      runCommand: 'example-agent acp',
+    }
+    renderDialog({ meta })
+
+    expect(screen.getByText('Install')).toBeInTheDocument()
+    expect(screen.getByText('brew install example-agent')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /copy install command/i })).toBeInTheDocument()
+    expect(screen.getByText('Run this command')).toBeInTheDocument()
+    expect(screen.getByText('example-agent acp')).toBeInTheDocument()
+  })
+
+  it('renders no command row for a binary entry without authored metadata', () => {
+    const binaryEntry = entry({
+      distribution: { binary: { 'darwin-aarch64': { cmd: './future-agent' } } },
+    })
+    renderDialog({ entry: binaryEntry })
+
+    expect(screen.getByText('Set up Gemini CLI')).toBeInTheDocument()
+    expect(screen.queryByText('Run this command')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /copy run command/i })).not.toBeInTheDocument()
+    expect(screen.getByText(/check the agent's website/i)).toBeInTheDocument()
   })
 
   it('renders authored env vars and the setup guide link when meta is present', () => {

--- a/src/components/settings/agents/agent-install-dialog.tsx
+++ b/src/components/settings/agents/agent-install-dialog.tsx
@@ -14,27 +14,31 @@ import {
 } from '@/components/ui/responsive-modal'
 import type { AgentInstallMeta } from '@/defaults/agent-install-metadata'
 import { buildRunCommand } from '@/lib/agent-install-command'
-import { getPlatform } from '@/lib/platform'
 import type { RegistryEntry } from '@/types/registry'
 
 type AgentInstallDialogProps = {
   entry: RegistryEntry
-  /** Extra setup detail the registry doesn't carry (API-key env vars, docs). When
-   *  omitted, the dialog shows only the derived run command. */
+  /** Extra setup detail the registry doesn't carry, including authored commands,
+   *  API-key environment variables, and docs. */
   meta?: AgentInstallMeta
   open: boolean
   onOpenChange: (open: boolean) => void
-  /** Test/DI override for the runtime platform used to resolve a binary agent's
-   *  command. Production omits and reads the real platform. */
-  platform?: string
 }
+
+/** Titled copyable command, shared by the install and run steps. */
+const CommandSection = ({ title, command, copyLabel }: { title: string; command: string; copyLabel: string }) => (
+  <div className="grid grid-cols-1 gap-2">
+    <p className="text-[length:var(--font-size-sm)] font-medium">{title}</p>
+    <CopyCommandRow command={command} label={copyLabel} />
+  </div>
+)
 
 /** Setup instructions for a catalogue agent: the exact command to run it (with
  *  copy-to-clipboard), plus any authored API-key requirements and setup-doc link.
  *  These agents run on the user's own machine — this is the "how to run it" panel,
  *  not an in-app installer. */
-export const AgentInstallDialog = ({ entry, meta, open, onOpenChange, platform }: AgentInstallDialogProps) => {
-  const command = buildRunCommand(entry, platform ?? getPlatform())
+export const AgentInstallDialog = ({ entry, meta, open, onOpenChange }: AgentInstallDialogProps) => {
+  const command = meta?.runCommand ?? buildRunCommand(entry)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -46,11 +50,14 @@ export const AgentInstallDialog = ({ entry, meta, open, onOpenChange, platform }
           </ResponsiveModalDescription>
         </ResponsiveModalHeader>
         <div className="flex flex-col gap-4 pt-4 pb-2">
-          {command && (
-            <div className="grid grid-cols-1 gap-2">
-              <p className="text-[length:var(--font-size-sm)] font-medium">Run this command</p>
-              <CopyCommandRow command={command} label="Copy run command" />
-            </div>
+          {meta?.installCommand && (
+            <CommandSection title="Install" command={meta.installCommand} copyLabel="Copy install command" />
+          )}
+          {command && <CommandSection title="Run this command" command={command} copyLabel="Copy run command" />}
+          {!command && !meta?.installCommand && (
+            <p className="text-[length:var(--font-size-xs)] text-muted-foreground">
+              Check the agent's website for install instructions.
+            </p>
           )}
           {meta?.requiredEnv && meta.requiredEnv.length > 0 && (
             <div className="grid grid-cols-1 gap-2">

--- a/src/defaults/acp-registry-snapshot.json
+++ b/src/defaults/acp-registry-snapshot.json
@@ -55,7 +55,7 @@
     {
       "id": "auggie",
       "name": "Auggie CLI",
-      "version": "0.29.0",
+      "version": "0.32.0",
       "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
       "repository": "https://github.com/augmentcode/auggie",
       "website": "https://www.augmentcode.com/",
@@ -64,7 +64,7 @@
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/auggie.svg",
       "distribution": {
         "npx": {
-          "package": "@augmentcode/auggie@0.29.0",
+          "package": "@augmentcode/auggie@0.32.0",
           "args": ["--acp"],
           "env": {
             "AUGMENT_DISABLE_AUTO_UPDATE": "1"
@@ -91,14 +91,14 @@
     {
       "id": "claude-acp",
       "name": "Claude Agent",
-      "version": "0.44.0",
+      "version": "0.59.0",
       "description": "ACP wrapper for Anthropic's Claude",
       "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
       "authors": ["Anthropic", "Zed Industries", "JetBrains"],
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "@agentclientprotocol/claude-agent-acp@0.44.0"
+          "package": "@agentclientprotocol/claude-agent-acp@0.59.0"
         }
       },
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/claude-acp.svg"
@@ -106,7 +106,7 @@
     {
       "id": "cline",
       "name": "Cline",
-      "version": "3.0.24",
+      "version": "3.0.42",
       "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
       "repository": "https://github.com/cline/cline",
       "website": "https://cline.bot/cli",
@@ -115,7 +115,7 @@
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/cline.svg",
       "distribution": {
         "npx": {
-          "package": "cline@3.0.24",
+          "package": "cline@3.0.42",
           "args": ["--acp"]
         }
       }
@@ -123,14 +123,14 @@
     {
       "id": "codebuddy-code",
       "name": "Codebuddy Code",
-      "version": "2.106.4",
+      "version": "2.106.7",
       "description": "Tencent Cloud's official intelligent coding tool",
       "website": "https://www.codebuddy.cn/cli/",
       "authors": ["Tencent Cloud"],
       "license": "Proprietary",
       "distribution": {
         "npx": {
-          "package": "@tencent-ai/codebuddy-code@2.106.4",
+          "package": "@tencent-ai/codebuddy-code@2.106.7",
           "args": ["--acp"]
         }
       },
@@ -138,41 +138,15 @@
     },
     {
       "id": "codex-acp",
-      "name": "Codex CLI",
-      "version": "0.16.0",
+      "name": "Codex",
+      "version": "1.1.4",
       "description": "ACP adapter for OpenAI's coding assistant",
-      "repository": "https://github.com/zed-industries/codex-acp",
-      "authors": ["OpenAI", "Zed Industries"],
+      "repository": "https://github.com/agentclientprotocol/codex-acp",
+      "authors": ["OpenAI", "JetBrains s.r.o", "Zed Industries"],
       "license": "Apache-2.0",
       "distribution": {
-        "binary": {
-          "darwin-aarch64": {
-            "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.16.0/codex-acp-0.16.0-aarch64-apple-darwin.tar.gz",
-            "cmd": "./codex-acp"
-          },
-          "darwin-x86_64": {
-            "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.16.0/codex-acp-0.16.0-x86_64-apple-darwin.tar.gz",
-            "cmd": "./codex-acp"
-          },
-          "linux-aarch64": {
-            "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.16.0/codex-acp-0.16.0-aarch64-unknown-linux-gnu.tar.gz",
-            "cmd": "./codex-acp"
-          },
-          "linux-x86_64": {
-            "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.16.0/codex-acp-0.16.0-x86_64-unknown-linux-gnu.tar.gz",
-            "cmd": "./codex-acp"
-          },
-          "windows-aarch64": {
-            "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.16.0/codex-acp-0.16.0-aarch64-pc-windows-msvc.zip",
-            "cmd": "./codex-acp.exe"
-          },
-          "windows-x86_64": {
-            "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.16.0/codex-acp-0.16.0-x86_64-pc-windows-msvc.zip",
-            "cmd": "./codex-acp.exe"
-          }
-        },
         "npx": {
-          "package": "@zed-industries/codex-acp@0.16.0"
+          "package": "@agentclientprotocol/codex-acp@1.1.4"
         }
       },
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/codex-acp.svg"
@@ -295,7 +269,7 @@
     {
       "id": "cursor",
       "name": "Cursor",
-      "version": "2026.06.15",
+      "version": "2026.07.09",
       "description": "Cursor's coding agent",
       "website": "https://cursor.com/docs/cli/acp",
       "authors": ["Cursor"],
@@ -303,32 +277,32 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/darwin/arm64/agent-cli-package.tar.gz",
+            "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/darwin/arm64/agent-cli-package.tar.gz",
             "cmd": "./dist-package/cursor-agent",
             "args": ["acp"]
           },
           "darwin-x86_64": {
-            "archive": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/darwin/x64/agent-cli-package.tar.gz",
+            "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/darwin/x64/agent-cli-package.tar.gz",
             "cmd": "./dist-package/cursor-agent",
             "args": ["acp"]
           },
           "linux-aarch64": {
-            "archive": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/linux/arm64/agent-cli-package.tar.gz",
+            "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/linux/arm64/agent-cli-package.tar.gz",
             "cmd": "./dist-package/cursor-agent",
             "args": ["acp"]
           },
           "linux-x86_64": {
-            "archive": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/linux/x64/agent-cli-package.tar.gz",
+            "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/linux/x64/agent-cli-package.tar.gz",
             "cmd": "./dist-package/cursor-agent",
             "args": ["acp"]
           },
           "windows-aarch64": {
-            "archive": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/windows/arm64/agent-cli-package.zip",
+            "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/windows/arm64/agent-cli-package.zip",
             "cmd": "./dist-package\\cursor-agent.cmd",
             "args": ["acp"]
           },
           "windows-x86_64": {
-            "archive": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/windows/x64/agent-cli-package.zip",
+            "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/windows/x64/agent-cli-package.zip",
             "cmd": "./dist-package\\cursor-agent.cmd",
             "args": ["acp"]
           }
@@ -356,41 +330,42 @@
     {
       "id": "devin",
       "name": "Devin",
-      "version": "2026.5.26",
+      "version": "3000.1.27",
       "description": "Devin CLI coding agent by Cognition",
       "website": "https://docs.devin.ai/cli",
       "authors": ["Cognition"],
       "license": "proprietary",
+      "repository": "https://github.com/CognitionAI/devin-cli",
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-aarch64-apple-darwin.tar.gz",
+            "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-apple-darwin.tar.gz",
             "cmd": "./bin/devin",
             "args": ["acp"]
           },
           "darwin-x86_64": {
-            "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-x86_64-apple-darwin.tar.gz",
+            "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-apple-darwin.tar.gz",
             "cmd": "./bin/devin",
             "args": ["acp"]
           },
           "linux-aarch64": {
-            "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-aarch64-unknown-linux.tar.gz",
+            "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-unknown-linux.tar.gz",
             "cmd": "./bin/devin",
             "args": ["acp"]
           },
           "linux-x86_64": {
-            "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-x86_64-unknown-linux.tar.gz",
+            "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-unknown-linux.tar.gz",
             "cmd": "./bin/devin",
             "args": ["acp"]
           },
           "windows-aarch64": {
-            "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-aarch64-pc-windows.zip",
-            "cmd": ".\\bin\\devin.exe",
+            "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-pc-windows.zip",
+            "cmd": "./bin\\devin.exe",
             "args": ["acp"]
           },
           "windows-x86_64": {
-            "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-x86_64-pc-windows.zip",
-            "cmd": ".\\bin\\devin.exe",
+            "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-pc-windows.zip",
+            "cmd": "./bin\\devin.exe",
             "args": ["acp"]
           }
         }
@@ -400,14 +375,14 @@
     {
       "id": "dimcode",
       "name": "DimCode",
-      "version": "0.2.2",
+      "version": "0.2.31",
       "description": "A coding agent that puts leading models at your command.",
       "website": "https://dimcode.dev/docs/acp.html",
       "authors": ["ArcShips"],
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "dimcode@0.2.2",
+          "package": "dimcode@0.2.31",
           "args": ["acp"]
         }
       },
@@ -416,7 +391,7 @@
     {
       "id": "dirac",
       "name": "Dirac",
-      "version": "0.4.0",
+      "version": "0.4.17",
       "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
       "repository": "https://github.com/dirac-run/dirac",
       "website": "https://dirac.run",
@@ -425,7 +400,7 @@
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/dirac.svg",
       "distribution": {
         "npx": {
-          "package": "dirac-cli@0.4.0",
+          "package": "dirac-cli@0.4.17",
           "args": ["--acp"]
         }
       }
@@ -433,14 +408,14 @@
     {
       "id": "factory-droid",
       "name": "Factory Droid",
-      "version": "0.148.0",
+      "version": "0.173.0",
       "description": "Factory Droid - AI coding agent powered by Factory AI",
       "website": "https://factory.ai/product/cli",
       "authors": ["Factory AI"],
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "droid@0.148.0",
+          "package": "droid@0.173.0",
           "args": ["exec", "--output-format", "acp-daemon"],
           "env": {
             "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -453,7 +428,7 @@
     {
       "id": "fast-agent",
       "name": "fast-agent",
-      "version": "0.7.20",
+      "version": "0.9.10",
       "description": "Code and build agents with comprehensive multi-provider support",
       "repository": "https://github.com/evalstate/fast-agent",
       "website": "https://fast-agent.ai",
@@ -461,7 +436,7 @@
       "license": "Apache 2.0",
       "distribution": {
         "uvx": {
-          "package": "fast-agent-acp==0.7.20",
+          "package": "fast-agent-acp==0.9.10",
           "args": ["-x"]
         }
       },
@@ -470,7 +445,7 @@
     {
       "id": "gemini",
       "name": "Gemini CLI",
-      "version": "0.46.0",
+      "version": "0.51.0",
       "description": "Google's official CLI for Gemini",
       "repository": "https://github.com/google-gemini/gemini-cli",
       "website": "https://geminicli.com",
@@ -478,7 +453,7 @@
       "license": "Apache-2.0",
       "distribution": {
         "npx": {
-          "package": "@google/gemini-cli@0.46.0",
+          "package": "@google/gemini-cli@0.51.0",
           "args": ["--acp"]
         }
       },
@@ -487,7 +462,7 @@
     {
       "id": "github-copilot-cli",
       "name": "GitHub Copilot",
-      "version": "1.0.62",
+      "version": "1.0.71",
       "description": "GitHub's AI pair programmer",
       "repository": "https://github.com/github/copilot-cli",
       "website": "https://github.com/features/copilot/cli/",
@@ -495,7 +470,7 @@
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "@github/copilot@1.0.62",
+          "package": "@github/copilot@1.0.71",
           "args": ["--acp"]
         }
       },
@@ -519,7 +494,7 @@
     {
       "id": "goose",
       "name": "goose",
-      "version": "1.37.0",
+      "version": "1.43.0",
       "description": "A local, extensible, open source AI agent that automates engineering tasks",
       "repository": "https://github.com/block/goose",
       "website": "https://block.github.io/goose/",
@@ -528,29 +503,34 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/block/goose/releases/download/v1.37.0/goose-aarch64-apple-darwin.tar.bz2",
+            "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-aarch64-apple-darwin.tar.bz2",
             "cmd": "./goose",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "c24ffdd8a3863288592ab211758d41f0a779428f77e92fcaa73e9882899a4eec"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/block/goose/releases/download/v1.37.0/goose-x86_64-apple-darwin.tar.bz2",
+            "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-apple-darwin.tar.bz2",
             "cmd": "./goose",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "6d0fad77f52f8177a3c3f8f40b8af3260a4ec057c06cfd8dcaf3af1b39de1e78"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/block/goose/releases/download/v1.37.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+            "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
             "cmd": "./goose",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "5d2e93b7c740409ce09782d98b70db87eac2e1fcff527bdbaf44a98da8b3b597"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/block/goose/releases/download/v1.37.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+            "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
             "cmd": "./goose",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "b218b08c0a86c9f356623f51bb91fc14c4de6667bc9c15d6d922778beb20f1bf"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/block/goose/releases/download/v1.37.0/goose-x86_64-pc-windows-msvc.zip",
+            "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-pc-windows-msvc.zip",
             "cmd": "./goose-package\\goose.exe",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "e76ddbaa331f54f837e7697108f901f09d7e56b07e81c1b7fa41da9e58ba5a7a"
           }
         }
       },
@@ -559,23 +539,68 @@
     {
       "id": "grok-build",
       "name": "Grok Build",
-      "version": "0.2.39",
+      "version": "0.2.101",
       "description": "xAI's coding agent and CLI",
       "website": "https://x.ai/cli",
       "authors": ["xAI"],
       "license": "proprietary",
       "distribution": {
         "npx": {
-          "package": "@xai-official/grok@0.2.39",
+          "package": "@xai-official/grok@0.2.101",
           "args": ["agent", "stdio"]
         }
       },
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/grok-build.svg"
     },
     {
+      "id": "harn",
+      "name": "Harn",
+      "version": "0.10.21",
+      "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
+      "repository": "https://github.com/burin-labs/harn",
+      "website": "https://harnlang.com",
+      "authors": ["Burin Labs"],
+      "license": "Apache-2.0",
+      "distribution": {
+        "binary": {
+          "darwin-aarch64": {
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-aarch64-apple-darwin.tar.gz",
+            "cmd": "./harn",
+            "args": ["serve", "acp"],
+            "sha256": "9421bd8af7c007a21038bf3e0fb2964bb7c48f64f415e5442c74ae1c9622160b"
+          },
+          "darwin-x86_64": {
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-apple-darwin.tar.gz",
+            "cmd": "./harn",
+            "args": ["serve", "acp"],
+            "sha256": "2e9a9e24c73123cc42dbd1f8fb9b9d5e64d7e9ab57902ffa91ad8fc9f16f50d7"
+          },
+          "linux-aarch64": {
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-aarch64-unknown-linux-gnu.tar.gz",
+            "cmd": "./harn",
+            "args": ["serve", "acp"],
+            "sha256": "35980f869692b65b1b5c8061d2da552aa95b2eb2f1f95aae15d47bebf9edcf04"
+          },
+          "linux-x86_64": {
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-unknown-linux-gnu.tar.gz",
+            "cmd": "./harn",
+            "args": ["serve", "acp"],
+            "sha256": "9fe05464712de8b524273eb927fcfc89dfe97d3250d3a8a70df075288ed311f1"
+          },
+          "windows-x86_64": {
+            "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-pc-windows-msvc.zip",
+            "cmd": "harn.exe",
+            "args": ["serve", "acp"],
+            "sha256": "aa7680629825e096461cd2951fe36c38c1199e7a3a8b07235599b428e574e0c1"
+          }
+        }
+      },
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/harn.svg"
+    },
+    {
       "id": "junie",
       "name": "Junie",
-      "version": "1892.26.0",
+      "version": "2144.9.0",
       "description": "AI Coding Agent by JetBrains",
       "repository": "https://github.com/JetBrains/junie",
       "website": "https://junie.jetbrains.com",
@@ -584,27 +609,27 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-macos-aarch64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-macos-aarch64.zip",
             "cmd": "./Applications/junie.app/Contents/MacOS/junie",
             "args": ["--acp=true"]
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-macos-amd64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-macos-amd64.zip",
             "cmd": "./Applications/junie.app/Contents/MacOS/junie",
             "args": ["--acp=true"]
           },
           "linux-aarch64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-linux-aarch64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-linux-aarch64.zip",
             "cmd": "./junie-app/bin/junie",
             "args": ["--acp=true"]
           },
           "linux-x86_64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-linux-amd64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-linux-amd64.zip",
             "cmd": "./junie-app/bin/junie",
             "args": ["--acp=true"]
           },
           "windows-x86_64": {
-            "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-windows-amd64.zip",
+            "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-windows-amd64.zip",
             "cmd": "./junie/junie.exe",
             "args": ["--acp=true"]
           }
@@ -615,7 +640,7 @@
     {
       "id": "kilo",
       "name": "Kilo",
-      "version": "7.3.46",
+      "version": "7.4.11",
       "description": "The open source coding agent",
       "repository": "https://github.com/Kilo-Org/kilocode",
       "website": "https://kilo.ai/",
@@ -625,33 +650,38 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.3.46/kilo-darwin-arm64.zip",
+            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-darwin-arm64.zip",
             "cmd": "./kilo",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "14a030a354f3b51f0241662627702e7b06cddf3fcb6e0f1415279e9d3a3b8998"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.3.46/kilo-darwin-x64.zip",
+            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-darwin-x64.zip",
             "cmd": "./kilo",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "66e302e09b96fd9794012bdb608622b589e4810ba31eca35918d8acd1a32a438"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.3.46/kilo-linux-arm64.tar.gz",
+            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-linux-arm64.tar.gz",
             "cmd": "./kilo",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "48c5405eb05efb3558d120b521d1a2b097cd8e99d36d7caf015e7c467922793c"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.3.46/kilo-linux-x64.tar.gz",
+            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-linux-x64.tar.gz",
             "cmd": "./kilo",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "b060dd4e094b0f9966de03d8a0d0d5cc8e6bb23ab04f1d04b7e3951d13079770"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.3.46/kilo-windows-x64.zip",
+            "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-windows-x64.zip",
             "cmd": "./kilo.exe",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "1c04d25b1484526b1eb8abe44bbcfc179fb71b1efa88b0164cd5709ca8bb00e7"
           }
         },
         "npx": {
-          "package": "@kilocode/cli@7.3.46",
+          "package": "@kilocode/cli@7.4.11",
           "args": ["acp"]
         }
       }
@@ -659,7 +689,7 @@
     {
       "id": "kimi",
       "name": "Kimi CLI",
-      "version": "1.47.0",
+      "version": "1.49.0",
       "description": "Moonshot AI's coding assistant",
       "repository": "https://github.com/MoonshotAI/kimi-cli",
       "website": "https://moonshotai.github.io/kimi-cli/",
@@ -668,29 +698,34 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.47.0/kimi-1.47.0-aarch64-apple-darwin.tar.gz",
+            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-apple-darwin.tar.gz",
             "cmd": "./kimi",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "15018b20b203aee09658fdc64840c4846fc17c108d8dba1a19a95581d3ce2921"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.47.0/kimi-1.47.0-aarch64-unknown-linux-gnu.tar.gz",
+            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-unknown-linux-gnu.tar.gz",
             "cmd": "./kimi",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "5ac54cabce16ede27b9d2069b9b88edee25528646e7bb5befa9980a1ca71febb"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.47.0/kimi-1.47.0-x86_64-unknown-linux-gnu.tar.gz",
+            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-unknown-linux-gnu.tar.gz",
             "cmd": "./kimi",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "6ce0b83f583c45a64cc9f51ffe7e1a8e03ee79acda69945fcf8c23341b9d892f"
           },
           "windows-aarch64": {
-            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.47.0/kimi-1.47.0-aarch64-pc-windows-msvc.zip",
+            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-pc-windows-msvc.zip",
             "cmd": "./kimi.exe",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "3ac8f05c7bd18d902a324c6c03a71084cfbe785b9669bbd556c071ee1d8f2f26"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.47.0/kimi-1.47.0-x86_64-pc-windows-msvc.zip",
+            "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-pc-windows-msvc.zip",
             "cmd": "./kimi.exe",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "2acbbc7ca8c8ac4b03dab1d970f53a292bd226168151b423499feab9fc203ddd"
           }
         }
       },
@@ -715,7 +750,7 @@
     {
       "id": "mistral-vibe",
       "name": "Mistral Vibe",
-      "version": "2.15.0",
+      "version": "2.20.0",
       "description": "Mistral's open-source coding assistant",
       "repository": "https://github.com/mistralai/mistral-vibe",
       "website": "https://mistral.ai/products/vibe",
@@ -725,24 +760,29 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.15.0/vibe-acp-darwin-aarch64-2.15.0.zip",
-            "cmd": "./vibe-acp"
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-darwin-aarch64-2.20.0.zip",
+            "cmd": "./vibe-acp",
+            "sha256": "7dbce5483566389334fcff40772c194004925767d8c3a68791b7e12dd0417264"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.15.0/vibe-acp-darwin-x86_64-2.15.0.zip",
-            "cmd": "./vibe-acp"
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-darwin-x86_64-2.20.0.zip",
+            "cmd": "./vibe-acp",
+            "sha256": "f8d2aec921288c48ab9e19afbc9c23bd1449b7301570ca8b15a9c7845c767642"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.15.0/vibe-acp-linux-aarch64-2.15.0.zip",
-            "cmd": "./vibe-acp"
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-linux-aarch64-2.20.0.zip",
+            "cmd": "./vibe-acp",
+            "sha256": "8b3847ea1c3206cfbb739c6ab6918c1856799bcd064b1581ca450c83db13fe65"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.15.0/vibe-acp-linux-x86_64-2.15.0.zip",
-            "cmd": "./vibe-acp"
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-linux-x86_64-2.20.0.zip",
+            "cmd": "./vibe-acp",
+            "sha256": "9467392eba45fcc209faa2a9443f5a9eaab8d2f476586e2ffacca9f1101f0297"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.15.0/vibe-acp-windows-x86_64-2.15.0.zip",
-            "cmd": "./vibe-acp.exe"
+            "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-windows-x86_64-2.20.0.zip",
+            "cmd": "./vibe-acp.exe",
+            "sha256": "1772a7f3ff49ad9874318242d78e72459163fcb7f787f266f0fff3047d1b02c5"
           }
         }
       }
@@ -750,7 +790,7 @@
     {
       "id": "nova",
       "name": "Nova",
-      "version": "1.1.18",
+      "version": "1.1.27",
       "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
       "repository": "https://github.com/Compass-Agentic-Platform/nova",
       "website": "https://www.compassap.ai/portfolio/nova.html",
@@ -759,7 +799,7 @@
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/nova.svg",
       "distribution": {
         "npx": {
-          "package": "@compass-ai/nova@1.1.18",
+          "package": "@compass-ai/nova@1.1.27",
           "args": ["acp"]
         }
       }
@@ -767,7 +807,7 @@
     {
       "id": "opencode",
       "name": "OpenCode",
-      "version": "1.17.7",
+      "version": "1.18.3",
       "description": "The open source coding agent",
       "repository": "https://github.com/anomalyco/opencode",
       "website": "https://opencode.ai",
@@ -777,34 +817,40 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-darwin-arm64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-arm64.zip",
             "cmd": "./opencode",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "946f62b155638b911144b7bef520ee4a6442f696297907873463bca3524e40ef"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-darwin-x64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-x64.zip",
             "cmd": "./opencode",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "4ea147867ba19e4ec03559df557811f1674f40788aea4d10326dc563b7667c6d"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-linux-arm64.tar.gz",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-arm64.tar.gz",
             "cmd": "./opencode",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "da0a631174eba380b2a1d51f9d364fa3812da433e72743c72471d4b5da59c69d"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-linux-x64.tar.gz",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-x64.tar.gz",
             "cmd": "./opencode",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "60f27b2679f00a511b6539f97e02448afaf58d9c66e2448285ea0c517ca84583"
           },
           "windows-aarch64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-windows-arm64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-windows-arm64.zip",
             "cmd": "./opencode",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "a549fb2e9041db9438bcd9b77bfa0a4b2476caf2d550f37479aabfec1b079bfb"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-windows-x64.zip",
+            "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-windows-x64.zip",
             "cmd": "./opencode.exe",
-            "args": ["acp"]
+            "args": ["acp"],
+            "sha256": "68bc62930f6cb5755e0409aa9de0bb270a66ed2b8c9cf0c029e9f2287ed5486e"
           }
         }
       }
@@ -812,14 +858,14 @@
     {
       "id": "pi-acp",
       "name": "pi ACP",
-      "version": "0.0.28",
+      "version": "0.0.31",
       "description": "ACP adapter for pi coding agent",
       "repository": "https://github.com/svkozak/pi-acp",
       "authors": ["Sergii Kozak <svkozak@gmail.com>"],
       "license": "MIT",
       "distribution": {
         "npx": {
-          "package": "pi-acp@0.0.28"
+          "package": "pi-acp@0.0.31"
         }
       },
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/pi-acp.svg"
@@ -827,7 +873,7 @@
     {
       "id": "poolside",
       "name": "Poolside",
-      "version": "1.0.5",
+      "version": "1.0.11",
       "description": "Poolside's coding agent",
       "repository": "https://github.com/poolsideai/pool",
       "website": "https://poolside.ai",
@@ -836,32 +882,32 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://downloads.poolside.ai/pool/v1.0.5/pool-darwin-arm64.tar.gz",
+            "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-darwin-arm64.tar.gz",
             "cmd": "./pool-darwin-arm64",
             "args": ["acp"]
           },
           "darwin-x86_64": {
-            "archive": "https://downloads.poolside.ai/pool/v1.0.5/pool-darwin-amd64.tar.gz",
+            "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-darwin-amd64.tar.gz",
             "cmd": "./pool-darwin-amd64",
             "args": ["acp"]
           },
           "linux-aarch64": {
-            "archive": "https://downloads.poolside.ai/pool/v1.0.5/pool-linux-arm64.tar.gz",
+            "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-linux-arm64.tar.gz",
             "cmd": "./pool-linux-arm64",
             "args": ["acp"]
           },
           "linux-x86_64": {
-            "archive": "https://downloads.poolside.ai/pool/v1.0.5/pool-linux-amd64.tar.gz",
+            "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-linux-amd64.tar.gz",
             "cmd": "./pool-linux-amd64",
             "args": ["acp"]
           },
           "windows-aarch64": {
-            "archive": "https://downloads.poolside.ai/pool/v1.0.5/pool-windows-arm64.tar.gz",
+            "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-windows-arm64.tar.gz",
             "cmd": "./pool-windows-arm64.exe",
             "args": ["acp"]
           },
           "windows-x86_64": {
-            "archive": "https://downloads.poolside.ai/pool/v1.0.5/pool-windows-amd64.tar.gz",
+            "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-windows-amd64.tar.gz",
             "cmd": "./pool-windows-amd64.exe",
             "args": ["acp"]
           }
@@ -888,7 +934,7 @@
     {
       "id": "qwen-code",
       "name": "Qwen Code",
-      "version": "0.18.1",
+      "version": "0.19.11",
       "description": "Alibaba's Qwen coding assistant",
       "repository": "https://github.com/QwenLM/qwen-code",
       "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -896,7 +942,7 @@
       "license": "Apache-2.0",
       "distribution": {
         "npx": {
-          "package": "@qwen-code/qwen-code@0.18.1",
+          "package": "@qwen-code/qwen-code@0.19.11",
           "args": ["--acp", "--experimental-skills"]
         }
       },
@@ -905,7 +951,7 @@
     {
       "id": "sigit",
       "name": "siGit Code",
-      "version": "1.1.0",
+      "version": "1.4.1",
       "description": "Local-first coding agent. Runs entirely on your machine with optional on-device LLM inference via Onde.",
       "repository": "https://github.com/getsigit/sigit",
       "website": "https://github.com/getsigit/sigit",
@@ -914,32 +960,32 @@
       "distribution": {
         "binary": {
           "darwin-aarch64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.1.0/sigit-macos-arm64.tar.gz",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-macos-arm64.tar.gz",
             "cmd": "./sigit"
           },
           "darwin-x86_64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.1.0/sigit-macos-amd64.tar.gz",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-macos-amd64.tar.gz",
             "cmd": "./sigit"
           },
           "linux-aarch64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.1.0/sigit-linux-arm64",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-linux-arm64",
             "cmd": "./sigit-linux-arm64"
           },
           "linux-x86_64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.1.0/sigit-linux-amd64",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-linux-amd64",
             "cmd": "./sigit-linux-amd64"
           },
           "windows-aarch64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.1.0/sigit-win-arm64.exe",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-win-arm64.exe",
             "cmd": "./sigit-win-arm64.exe"
           },
           "windows-x86_64": {
-            "archive": "https://github.com/getsigit/sigit/releases/download/v1.1.0/sigit-win-amd64.exe",
+            "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-win-amd64.exe",
             "cmd": "./sigit-win-amd64.exe"
           }
         },
         "npx": {
-          "package": "@smbcloud/sigit@1.1.0"
+          "package": "@smbcloud/sigit@1.4.1"
         }
       },
       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/sigit.svg"

--- a/src/defaults/agent-install-metadata.test.ts
+++ b/src/defaults/agent-install-metadata.test.ts
@@ -31,4 +31,14 @@ describe('agentInstallMetadata', () => {
       }
     }
   })
+
+  it('gives every binary-only agent an authored run command', () => {
+    const binaryOnlyAgents = agentRegistrySnapshot.filter(
+      (entry) => entry.distribution.binary && !entry.distribution.npx && !entry.distribution.uvx,
+    )
+
+    for (const entry of binaryOnlyAgents) {
+      expect(agentInstallMetadata[entry.id]?.runCommand).toBeTruthy()
+    }
+  })
 })

--- a/src/defaults/agent-install-metadata.ts
+++ b/src/defaults/agent-install-metadata.ts
@@ -3,15 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * Setup detail the ACP registry doesn't carry: the API-key environment variables
- * an agent needs and where to read its setup docs. The run command itself is
- * always derived from the registry's `distribution` (see `buildRunCommand`), so
- * this map holds *only* the fields the registry lacks.
+ * Setup detail the ACP registry doesn't carry: packaged install commands,
+ * binary-agent run commands, API-key environment variables, and setup docs.
  *
- * Keyed by `RegistryEntry.id`. Only agents with an authored entry show the richer
- * setup panel; every other agent falls back to the copy-command-only view.
+ * Keyed by `RegistryEntry.id`. Agents without authored metadata fall back to a
+ * registry-derived npx/uvx run command when available.
  */
 export type AgentInstallMeta = {
+  /** One-time install command (macOS/Linux), shown above the run command. */
+  installCommand?: string
+  /** Overrides the registry-derived run command — an authored command always wins.
+   *  Required for `binary`-distributed agents, whose registry cmd is a
+   *  post-archive-extraction path (see buildRunCommand). */
+  runCommand?: string
   requiredEnv?: ReadonlyArray<{ name: string; description: string }>
   docsUrl?: string
   setupNote?: string
@@ -28,14 +32,112 @@ export const agentInstallMetadata: Readonly<Record<string, AgentInstallMeta>> = 
   },
   'codex-acp': {
     requiredEnv: [{ name: 'OPENAI_API_KEY', description: 'API key from the OpenAI Platform.' }],
-    docsUrl: 'https://github.com/zed-industries/codex-acp',
+    docsUrl: 'https://github.com/agentclientprotocol/codex-acp',
   },
   'grok-build': {
     requiredEnv: [{ name: 'XAI_API_KEY', description: 'API key from the xAI Console.' }],
     docsUrl: 'https://x.ai/cli',
   },
+  'amp-acp': {
+    // Authored rather than derived: the registry lists only binary archives for
+    // amp-acp, but the same project ships the `amp-acp` package on npm.
+    runCommand: 'npx -y amp-acp',
+    requiredEnv: [
+      {
+        name: 'AMP_API_KEY',
+        description: 'API key from ampcode.com settings, or run `amp login` with the Amp CLI installed.',
+      },
+    ],
+    docsUrl: 'https://github.com/tao12345666333/amp-acp',
+  },
+  cursor: {
+    installCommand: 'curl https://cursor.com/install -fsS | bash',
+    runCommand: 'agent acp',
+    setupNote: 'Sign in first with `agent login`.',
+    docsUrl: 'https://cursor.com/docs/cli/acp',
+  },
+  goose: {
+    installCommand: 'brew install block-goose-cli',
+    runCommand: 'goose acp',
+    setupNote: 'Configure your model provider first with `goose configure`.',
+    docsUrl: 'https://block.github.io/goose/',
+  },
+  opencode: {
+    installCommand: 'curl -fsSL https://opencode.ai/install | bash',
+    runCommand: 'opencode acp',
+    setupNote: 'Sign in with `opencode auth login`.',
+    docsUrl: 'https://opencode.ai/docs/acp/',
+  },
+  devin: {
+    installCommand: 'curl -fsSL https://cli.devin.ai/install.sh | bash',
+    runCommand: 'devin acp',
+    setupNote: 'Sign in with `devin auth login`.',
+    docsUrl: 'https://docs.devin.ai/cli',
+  },
+  kimi: {
+    installCommand: 'brew install kimi-cli',
+    runCommand: 'kimi acp',
+    setupNote: 'Run `kimi` once and send /login to authenticate before connecting.',
+    docsUrl: 'https://moonshotai.github.io/kimi-cli/',
+  },
   'mistral-vibe': {
+    installCommand: 'brew install mistral-vibe',
+    runCommand: 'vibe-acp',
     requiredEnv: [{ name: 'MISTRAL_API_KEY', description: 'API key from La Plateforme.' }],
     docsUrl: 'https://mistral.ai/products/vibe',
+  },
+  junie: {
+    installCommand: 'curl -fsSL https://junie.jetbrains.com/install.sh | bash',
+    runCommand: 'junie --acp=true',
+    requiredEnv: [
+      {
+        name: 'JUNIE_API_KEY',
+        description: 'Token from junie.jetbrains.com/cli; JetBrains account login also works.',
+      },
+    ],
+    docsUrl: 'https://junie.jetbrains.com/docs/junie-cli.html',
+  },
+  poolside: {
+    installCommand: 'curl -fsSL https://downloads.poolside.ai/pool/install.sh | sh',
+    runCommand: 'pool acp',
+    setupNote: 'Sign in with `pool login`, or set POOLSIDE_API_KEY.',
+    docsUrl: 'https://docs.poolside.ai/cli/pool',
+  },
+  stakpak: {
+    installCommand: 'brew tap stakpak/stakpak && brew install stakpak',
+    runCommand: 'stakpak acp',
+    requiredEnv: [{ name: 'STAKPAK_API_KEY', description: 'API key from stakpak.dev.' }],
+    docsUrl: 'https://github.com/stakpak/agent',
+  },
+  vtcode: {
+    installCommand: 'brew install vtcode',
+    // VT Code refuses to start its ACP server unless both gates are enabled.
+    runCommand: 'VT_ACP_ENABLED=1 VT_ACP_ZED_ENABLED=1 vtcode acp',
+    setupNote: 'Configure your provider first with `vtcode init`.',
+    docsUrl: 'https://github.com/vinhnx/VTCode/blob/main/docs/guides/zed-acp.md',
+  },
+  'crow-cli': {
+    // crow-cli requires Python >= 3.14; the flag makes uv provision it.
+    installCommand: 'uv tool install crow-cli --python 3.14',
+    runCommand: 'crow-cli acp',
+    setupNote: 'Run `crow-cli init` once to configure before connecting.',
+    docsUrl: 'https://github.com/crow-cli/crow-cli',
+  },
+  'cortex-code': {
+    installCommand: 'curl -LsS https://ai.snowflake.com/static/cc-scripts/install.sh | sh',
+    runCommand: 'cortex acp serve',
+    setupNote: 'Authenticate first with `cortex auth login` — ACP mode does not prompt for authentication.',
+    docsUrl: 'https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code-acp',
+  },
+  'corust-agent': {
+    runCommand: './corust-agent-acp',
+    setupNote:
+      'Download the release archive for your platform from GitHub Releases, extract it, and run the command from that directory.',
+    docsUrl: 'https://github.com/Corust-ai/corust-agent-release/releases',
+  },
+  harn: {
+    installCommand: 'curl -fsSL https://harnlang.com/install.sh | sh',
+    runCommand: 'harn serve acp',
+    docsUrl: 'https://github.com/burin-labs/harn',
   },
 }

--- a/src/lib/agent-install-command.test.ts
+++ b/src/lib/agent-install-command.test.ts
@@ -18,17 +18,17 @@ const entry = (distribution: RegistryEntry['distribution']): RegistryEntry => ({
 
 describe('buildRunCommand', () => {
   it('builds an npx one-liner with -y and args', () => {
-    expect(buildRunCommand(entry({ npx: { package: '@augmentcode/auggie@0.29.0', args: ['--acp'] } }), 'macos')).toBe(
+    expect(buildRunCommand(entry({ npx: { package: '@augmentcode/auggie@0.29.0', args: ['--acp'] } }))).toBe(
       'npx -y @augmentcode/auggie@0.29.0 --acp',
     )
   })
 
   it('builds an npx command with no args', () => {
-    expect(buildRunCommand(entry({ npx: { package: 'goose@1.2.3' } }), 'macos')).toBe('npx -y goose@1.2.3')
+    expect(buildRunCommand(entry({ npx: { package: 'goose@1.2.3' } }))).toBe('npx -y goose@1.2.3')
   })
 
   it('builds a uvx command (no -y)', () => {
-    expect(buildRunCommand(entry({ uvx: { package: 'fast-agent@2.0.0', args: ['acp'] } }), 'linux')).toBe(
+    expect(buildRunCommand(entry({ uvx: { package: 'fast-agent@2.0.0', args: ['acp'] } }))).toBe(
       'uvx fast-agent@2.0.0 acp',
     )
   })
@@ -39,36 +39,18 @@ describe('buildRunCommand', () => {
       uvx: { package: 'secondary@1' },
       binary: { 'darwin-aarch64': { cmd: './fallback', args: ['acp'] } },
     }
-    expect(buildRunCommand(entry(distribution), 'macos')).toBe('npx -y primary@1')
+    expect(buildRunCommand(entry(distribution))).toBe('npx -y primary@1')
   })
 
-  it('selects the platform-matching binary target', () => {
+  it('returns null for binary-only distributions', () => {
     const binary = {
       'darwin-aarch64': { cmd: './vtcode', args: ['acp'] },
       'windows-x86_64': { cmd: 'vtcode.exe', args: ['acp'] },
     }
-    expect(buildRunCommand(entry({ binary }), 'windows')).toBe('vtcode.exe acp')
-    expect(buildRunCommand(entry({ binary }), 'macos')).toBe('./vtcode acp')
-  })
-
-  it('falls back to the first binary target when the platform has no matching key', () => {
-    const binary = {
-      'darwin-aarch64': { cmd: './vtcode', args: ['acp'] },
-      'linux-x86_64': { cmd: './vtcode', args: ['acp'] },
-    }
-    // Web/mobile have no per-platform binary — surface a representative command.
-    expect(buildRunCommand(entry({ binary }), 'web')).toBe('./vtcode acp')
+    expect(buildRunCommand(entry({ binary }))).toBeNull()
   })
 
   it('returns null when the entry ships no distribution', () => {
-    expect(buildRunCommand(entry({}), 'macos')).toBeNull()
-  })
-
-  it('returns null when a binary target lacks a string cmd', () => {
-    expect(buildRunCommand(entry({ binary: { 'darwin-aarch64': { archive: 'x.tar.gz' } } }), 'macos')).toBeNull()
-  })
-
-  it('returns null when the binary map is empty', () => {
-    expect(buildRunCommand(entry({ binary: {} }), 'macos')).toBeNull()
+    expect(buildRunCommand(entry({}))).toBeNull()
   })
 })

--- a/src/lib/agent-install-command.ts
+++ b/src/lib/agent-install-command.ts
@@ -2,65 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { asStringArray, isRecord } from '@/lib/agent-registry-filter'
 import type { RegistryEntry } from '@/types/registry'
-
-/** Maps a runtime platform to the prefix the registry uses on its per-platform
- *  binary keys (e.g. macOS → "darwin", matching "darwin-aarch64"). Returns null on
- *  platforms the registry never targets (web/mobile), where no key can match. */
-const binaryKeyPrefix = (platform: string): string | null => {
-  switch (platform) {
-    case 'macos':
-      return 'darwin'
-    case 'windows':
-      return 'windows'
-    case 'linux':
-      return 'linux'
-    default:
-      return null
-  }
-}
-
-/** Picks the binary target for `platform`, preferring a key that matches the
- *  platform prefix and otherwise falling back to the first listed target so
- *  browsing on web/mobile still surfaces a representative command. */
-const selectBinaryTarget = (binary: Record<string, unknown>, platform: string): Record<string, unknown> | null => {
-  const keys = Object.keys(binary)
-  if (keys.length === 0) {
-    return null
-  }
-  const prefix = binaryKeyPrefix(platform)
-  const key = prefix ? (keys.find((k) => k.startsWith(prefix)) ?? keys[0]) : keys[0]
-  const target = binary[key]
-  return isRecord(target) ? target : null
-}
 
 /**
  * Builds the shell command that runs an ACP agent from its registry
- * distribution, or `null` when the entry ships no runnable distribution. Prefers
- * npx > uvx > binary, matching the card's distribution badge: `npx`/`uvx` agents
- * produce a self-contained one-liner, while a `binary` agent resolves to the
- * downloaded binary's invocation for `platform` (falling back to the first listed
- * target when the platform isn't one the registry builds for).
+ * distribution, or `null` when the entry has no npx/uvx distribution. Binary
+ * commands are excluded because registry commands are post-archive-extraction
+ * paths rather than standalone setup commands; those agents require authored
+ * metadata.
  *
  * @param entry - The registry entry to derive the command from.
- * @param platform - The runtime platform (`getPlatform()`), used only for binary
- *   target selection; ignored for npx/uvx.
  */
-export const buildRunCommand = (entry: RegistryEntry, platform: string): string | null => {
-  const { npx, uvx, binary } = entry.distribution
+export const buildRunCommand = (entry: RegistryEntry): string | null => {
+  const { npx, uvx } = entry.distribution
   if (npx) {
     return ['npx', '-y', npx.package, ...(npx.args ?? [])].join(' ')
   }
   if (uvx) {
     return ['uvx', uvx.package, ...(uvx.args ?? [])].join(' ')
-  }
-  if (binary) {
-    const target = selectBinaryTarget(binary, platform)
-    if (!target || typeof target.cmd !== 'string') {
-      return null
-    }
-    return [target.cmd, ...asStringArray(target.args)].join(' ')
   }
   return null
 }


### PR DESCRIPTION
## Problem

The \`/settings/agents\` catalog "Set up" dialog derives its command from the ACP registry \`distribution\`. For \`binary\`-distributed agents it rendered the registry's **post-archive-extraction** invocation (e.g. \`./amp-acp\` for Amp) — meant for clients that auto-download the archive (like Zed), meaningless as a standalone copy-paste command. All 15 binary-only agents were affected.

## What changed

- **\`buildRunCommand\` no longer derives commands from \`binary\` distributions** (returns \`null\`; npx/uvx derivation unchanged — those were already correct). The platform-selection machinery (\`binaryKeyPrefix\`, \`selectBinaryTarget\`, \`platform\` prop) is deleted.
- **\`AgentInstallMeta\` gains \`installCommand\`/\`runCommand\`**, authored for all 15 binary-only agents from each vendor's official docs (verified July 2026): brew/curl/uv installers + the exact ACP stdio invocation (e.g. Cursor's binary is now \`agent\`, VT Code needs both \`VT_ACP_*\` gates, Cortex needs \`cortex auth login\` first, harn runs \`harn serve acp\`). Amp gets \`npx -y amp-acp\` (package verified on npm).
- **Dialog renders a two-step panel** — "Install" + "Run this command" — and a graceful fallback line for any future binary agent that lands in the live registry before metadata is authored.
- **Registry snapshot refreshed** from the live CDN (adds \`harn\`, version bumps, upstream \`sha256\` fields, codex-acp's move to npx-only under \`agentclientprotocol/codex-acp\`) — separate commit.
- **New invariant test**: every binary-only agent in the snapshot must have an authored \`runCommand\`, so future snapshot refreshes fail loudly instead of regressing to \`./cmd\`.

Research notes: Poolside's brew tap is a broken placeholder (curl installer only); npm \`crow-cli\` is an unrelated 2016 package (uv only); Corust has no packaged install (its brew tap ships a different, non-ACP binary) so it keeps honest manual-download instructions.

## Verification

- \`bun run check\` green (type-check, eslint, prettier, license headers)
- \`bun test --cwd=src --rerun-each 5\`: 18175 pass, 0 fail; shared/scripts suites green
- Deep review (10 lanes + react-effect-reviewer): no blockers; findings folded in