### PR TITLE
fix(THU-695): clear stale ACP session id when switching agents

### DIFF
--- a/src/acp/acp-adapter.test.ts
+++ b/src/acp/acp-adapter.test.ts
@@ -525,6 +525,22 @@ describe('connectAcpAdapter — capability-aware continuity (resume / load / new
     })
   }
 
+  it('starts a new session without trying resume or load when no stored session id exists', async () => {
+    const { transport } = buildFakeTransport()
+    const { FakeConnection, calls, releasePrompts } = buildFakeConnection({ resume: true, loadSession: true })
+
+    const adapter = await connectAcpAdapter(remoteAgent, baseCtx(), {
+      openTransport: async () => transport,
+      ClientSideConnection: FakeConnection as never,
+    })
+
+    await drive(adapter, promptInit('hi'), threadCtx('t-new'), releasePrompts)
+
+    expect(calls.resumeSession).toHaveLength(0)
+    expect(calls.loadSession).toHaveLength(0)
+    expect(calls.newSession).toHaveLength(1)
+  })
+
   it('tier 1: resume-capable agent with a stored id resumes it — no newSession, no re-persist, no replay', async () => {
     const { transport } = buildFakeTransport()
     const { FakeConnection, calls, releasePrompts } = buildFakeConnection({ resume: true })

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -64,6 +64,7 @@ import { isTauri } from './lib/platform'
 import { getPowerSyncInstance } from './db/powersync/sync-state'
 import { refreshSystemAgents } from '@/db/seeding/seed-agents'
 import { useLocalSettingsStore } from '@/stores/local-settings-store'
+import { useChatStore } from '@/chats/chat-store'
 import { type ComponentProps, Suspense, lazy, useEffect, useState } from 'react'
 import { markAppMounted } from '@/lib/init-timing'
 import { LazyMotion } from 'framer-motion'
@@ -119,7 +120,15 @@ const useBootstrapSystemAgents = () => {
     if (!isRealUser || !cloudUrl) {
       return
     }
-    void refreshSystemAgents(db, cloudUrl, httpClient)
+    void (async () => {
+      const result = await refreshSystemAgents(db, cloudUrl, httpClient)
+      if (!result.refreshed) {
+        return
+      }
+      for (const agent of result.wireIdentityChangedAgents) {
+        useChatStore.getState().applyAgentWireIdentityChange(agent)
+      }
+    })()
   }, [isRealUser, cloudUrl, db, httpClient])
 }
 

--- a/src/chats/chat-store.test.ts
+++ b/src/chats/chat-store.test.ts
@@ -3,11 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getSettings } from '@/dal'
-import { createChatThread, getChatThread } from '@/dal/chat-threads'
+import { getChatThread } from '@/dal/chat-threads'
 import { setupTestDatabase, teardownTestDatabase, resetTestDatabase } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
+import { chatThreadsTable } from '@/db/tables'
 import { builtInAgent } from '@/defaults/agents'
-import type { Mode } from '@/types'
+import type { Agent } from '@/types/acp'
+import type { ChatThread, Mode } from '@/types'
 import {
   createMockAutomationRun,
   createMockChatInstanceWithValidation,
@@ -343,6 +345,24 @@ describe('chat-store', () => {
       userId: 'u1',
     }
 
+    /** Seeds a persisted thread and matching hydrated chat session. */
+    const seedThreadSession = async (id: string, agent: Agent, acpSessionId: string): Promise<ChatThread> => {
+      const model = createMockModel()
+      const chatThread = createMockChatThread({ id, agentId: agent.id, acpSessionId })
+      await getDb().insert(chatThreadsTable).values({ id, title: 'x', agentId: agent.id, acpSessionId })
+      hydrateStore({
+        chatInstance: createMockChatInstanceWithValidation(),
+        chatThread,
+        id,
+        mcpClients: [],
+        models: [model],
+        selectedModel: model,
+        triggerData: null,
+      })
+      useChatStore.getState().updateSession(id, { selectedAgent: agent })
+      return chatThread
+    }
+
     it('updates the in-memory session selectedAgent', async () => {
       const model = createMockModel()
       hydrateStore({
@@ -361,30 +381,26 @@ describe('chat-store', () => {
       expect(session?.selectedAgent.id).toBe(customAgent.id)
     })
 
-    it('persists agentId on the chat_threads row when a thread exists', async () => {
-      const model = createMockModel()
-      const chatThread = createMockChatThread({ id: 'thread-persist' })
-
-      await createChatThread(
-        getDb(),
-        { id: chatThread.id, title: 'x', contextSize: null, triggeredBy: null, wasTriggeredByAutomation: 0 },
-        model,
-      )
-
-      hydrateStore({
-        chatInstance: createMockChatInstanceWithValidation(),
-        chatThread,
-        id: chatThread.id,
-        mcpClients: [],
-        models: [model],
-        selectedModel: model,
-        triggerData: null,
-      })
+    it('switches the thread agent and clears its ACP session in memory and storage', async () => {
+      const chatThread = await seedThreadSession('thread-persist', builtInAgent, 'session-from-previous-agent')
 
       await useChatStore.getState().setSelectedAgent(chatThread.id, customAgent)
 
+      const session = getCurrentSession()
       const stored = await getChatThread(getDb(), chatThread.id)
+      expect(session?.chatThread?.agentId).toBe(customAgent.id)
+      expect(session?.chatThread?.acpSessionId).toBeNull()
       expect(stored?.agentId).toBe(customAgent.id)
+      expect(stored?.acpSessionId).toBeNull()
+    })
+
+    it('preserves the ACP session when selecting the current agent', async () => {
+      const chatThread = await seedThreadSession('thread-same-agent', customAgent, 'current-session')
+
+      await useChatStore.getState().setSelectedAgent(chatThread.id, customAgent)
+
+      expect(getCurrentSession()?.chatThread?.acpSessionId).toBe('current-session')
+      expect((await getChatThread(getDb(), chatThread.id))?.acpSessionId).toBe('current-session')
     })
 
     it('updates in-memory state and skips the DB write when no chat thread exists yet', async () => {

--- a/src/chats/chat-store.test.ts
+++ b/src/chats/chat-store.test.ts
@@ -403,6 +403,15 @@ describe('chat-store', () => {
       expect((await getChatThread(getDb(), chatThread.id))?.acpSessionId).toBe('current-session')
     })
 
+    it('refreshes active agent wire identity and clears matching in-memory ACP sessions', async () => {
+      await seedThreadSession('thread-wire-edit', customAgent, 'stale-session')
+
+      useChatStore.getState().applyAgentWireIdentityChange({ ...customAgent, url: 'wss://new.example.test/ws' })
+
+      expect(getCurrentSession()?.selectedAgent.url).toBe('wss://new.example.test/ws')
+      expect(getCurrentSession()?.chatThread?.acpSessionId).toBeNull()
+    })
+
     it('updates in-memory state and skips the DB write when no chat thread exists yet', async () => {
       // For brand-new chats (no `chat_threads` row yet) the selection is held
       // in memory until the first message is sent. Persistence happens inside

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -196,8 +196,10 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
       throw new Error('No session found')
     }
 
+    const agentChanged = session.selectedAgent.id !== agent.id
+    const threadPatch = agentChanged ? { agentId: agent.id, acpSessionId: null } : { agentId: agent.id }
     const nextSessions = new Map(sessions)
-    const nextChatThread = session.chatThread ? { ...session.chatThread, agentId: agent.id } : session.chatThread
+    const nextChatThread = session.chatThread ? { ...session.chatThread, ...threadPatch } : session.chatThread
     nextSessions.set(id, { ...session, chatThread: nextChatThread, selectedAgent: agent })
 
     set({ sessions: nextSessions })
@@ -205,7 +207,7 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
     const db = getDb()
 
     if (session.chatThread) {
-      await updateChatThread(db, session.chatThread.id, { agentId: agent.id })
+      await updateChatThread(db, session.chatThread.id, threadPatch)
     }
 
     // Persist the global last-used agent so new chats default to it (mirrors

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -69,6 +69,7 @@ type ChatStoreActions = {
   allowAlwaysForAgent(agentId: string): void
   allowAlwaysForTool(agentId: string, toolKey: string): void
   createSession(session: ChatSession): void
+  applyAgentWireIdentityChange(agent: Agent): void
   isAlwaysAllowed(agentId: string, toolKey: string): boolean
   setCurrentSessionId(id: string): void
   setGetMcpClients(getMcpClients: () => NamedMCPClient[]): void
@@ -127,6 +128,29 @@ export const useChatStore = create<ChatStore>()((set, get) => ({
     nextSessions.set(session.id, session)
 
     set({ sessions: nextSessions })
+  },
+
+  applyAgentWireIdentityChange: (agent) => {
+    const nextSessions = new Map(get().sessions)
+    let changed = false
+
+    for (const [id, session] of nextSessions) {
+      const threadMatches = session.chatThread?.agentId === agent.id
+      const agentMatches = session.selectedAgent.id === agent.id
+      if (!threadMatches && !agentMatches) {
+        continue
+      }
+      changed = true
+      nextSessions.set(id, {
+        ...session,
+        chatThread: threadMatches ? { ...session.chatThread!, acpSessionId: null } : session.chatThread,
+        selectedAgent: agentMatches ? agent : session.selectedAgent,
+      })
+    }
+
+    if (changed) {
+      set({ sessions: nextSessions })
+    }
   },
 
   setCurrentSessionId: (id) => {

--- a/src/dal/agents.test.ts
+++ b/src/dal/agents.test.ts
@@ -374,13 +374,107 @@ describe('agents DAL', () => {
       const client = makeHttpClient(async () => baseResponse)
 
       const result = await refreshSystemAgents(getDb(), 'https://api.example', client)
-      expect(result).toEqual({ refreshed: true })
+      expect(result).toEqual({ refreshed: true, wireIdentityChangedAgents: [] })
 
       const rows = await getDb().select().from(agentsSystemTable).all()
       expect(rows).toHaveLength(1)
       expect(rows[0]?.id).toBe('haystack-rag')
       expect(rows[0]?.name).toBe('RAG Chat')
       expect(rows[0]?.fetchedAt).toBeTruthy()
+    })
+
+    it('invalidates only system-agent sessions whose discovered wire identity changed', async () => {
+      const fetchedAt = new Date().toISOString()
+      await getDb()
+        .insert(agentsSystemTable)
+        .values([
+          {
+            id: 'changed-agent',
+            name: 'Changed',
+            type: 'managed-acp',
+            transport: 'websocket',
+            url: 'wss://old.example/ws',
+            fetchedAt,
+          },
+          {
+            id: 'unchanged-agent',
+            name: 'Unchanged',
+            type: 'managed-acp',
+            transport: 'websocket',
+            url: 'wss://stable.example/ws',
+            fetchedAt,
+          },
+        ])
+      await getDb()
+        .insert(chatThreadsTable)
+        .values([
+          { id: 'thread-changed-system', agentId: 'changed-agent', acpSessionId: 'session-changed' },
+          { id: 'thread-unchanged-system', agentId: 'unchanged-agent', acpSessionId: 'session-unchanged' },
+        ])
+      const changedAdapter = await seedCachedAdapter('changed-agent')
+      const unchangedAdapter = await seedCachedAdapter('unchanged-agent')
+      const response: AgentDiscoveryResponse = {
+        version: '1',
+        agents: [
+          {
+            id: 'changed-agent',
+            name: 'Changed',
+            type: 'managed-acp',
+            transport: 'websocket',
+            url: 'wss://new.example/ws',
+            description: null,
+            icon: null,
+            isSystem: 1,
+          },
+          {
+            id: 'unchanged-agent',
+            name: 'Unchanged',
+            type: 'managed-acp',
+            transport: 'websocket',
+            url: 'wss://stable.example/ws',
+            description: null,
+            icon: null,
+            isSystem: 1,
+          },
+        ],
+        allowCustomAgents: true,
+      }
+
+      const result = await refreshSystemAgents(
+        getDb(),
+        'https://api.example',
+        makeHttpClient(async () => response),
+      )
+
+      expect(result).toEqual({
+        refreshed: true,
+        wireIdentityChangedAgents: [
+          {
+            id: 'changed-agent',
+            name: 'Changed',
+            type: 'managed-acp',
+            transport: 'websocket',
+            url: 'wss://new.example/ws',
+            description: null,
+            icon: null,
+            isSystem: 1,
+            enabled: 1,
+            deletedAt: null,
+            userId: null,
+          },
+        ],
+      })
+      expect((await getChatThread(getDb(), 'thread-changed-system'))?.acpSessionId).toBeNull()
+      expect((await getChatThread(getDb(), 'thread-unchanged-system'))?.acpSessionId).toBe('session-unchanged')
+      expect(changedAdapter.disconnectCount()).toBe(1)
+      expect(unchangedAdapter.disconnectCount()).toBe(0)
+
+      const unchangedResult = await refreshSystemAgents(
+        getDb(),
+        'https://api.example',
+        makeHttpClient(async () => response),
+      )
+      expect(unchangedResult).toEqual({ refreshed: true, wireIdentityChangedAgents: [] })
     })
 
     it('removes local rows that disappear from the discovery response', async () => {
@@ -423,7 +517,7 @@ describe('agents DAL', () => {
       const client = makeHttpClient(async () => response)
 
       const result = await refreshSystemAgents(getDb(), 'https://api.example', client)
-      expect(result).toEqual({ refreshed: true })
+      expect(result).toEqual({ refreshed: true, wireIdentityChangedAgents: [] })
       const rows = await getDb().select().from(agentsSystemTable).all()
       expect(rows).toEqual([])
     })

--- a/src/dal/agents.test.ts
+++ b/src/dal/agents.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getDb } from '@/db/database'
-import { agentsSystemTable, agentsTable } from '@/db/tables'
+import { agentsSystemTable, agentsTable, chatThreadsTable } from '@/db/tables'
 import { builtInAgent } from '@/defaults/agents'
 import { HttpError, type HttpClient, type ResponsePromise } from '@/lib/http'
 import { refreshSystemAgents } from '@/db/seeding/seed-agents'
@@ -12,6 +12,7 @@ import type { AgentAdapter } from '@/types/acp'
 import type { AgentDiscoveryResponse } from '@shared/acp-types'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { composeAllAgents, createAgent, deleteAgent, getAgentSecrets, setAgentSecrets, updateAgent } from './agents'
+import { getChatThread } from './chat-threads'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from './test-utils'
 import type { Agent } from '@/types/acp'
 
@@ -178,7 +179,31 @@ describe('agents DAL', () => {
       expect(cached.disconnectCount()).toBe(1)
     })
 
-    it('does NOT dispose the connection on a non-wire patch (rename only)', async () => {
+    it('clears ACP sessions from every thread using an agent whose wire identity changes', async () => {
+      await createAgent(getDb(), {
+        id: 'a-sessions',
+        name: 'Wired',
+        type: 'remote-acp',
+        transport: 'websocket',
+        url: 'wss://old/ws',
+        userId: 'u1',
+      })
+      await getDb()
+        .insert(chatThreadsTable)
+        .values([
+          { id: 'thread-a1', agentId: 'a-sessions', acpSessionId: 'session-a1' },
+          { id: 'thread-a2', agentId: 'a-sessions', acpSessionId: 'session-a2' },
+          { id: 'thread-other', agentId: 'other-agent', acpSessionId: 'session-other' },
+        ])
+
+      await updateAgent(getDb(), 'a-sessions', { url: 'wss://new/ws' })
+
+      expect((await getChatThread(getDb(), 'thread-a1'))?.acpSessionId).toBeNull()
+      expect((await getChatThread(getDb(), 'thread-a2'))?.acpSessionId).toBeNull()
+      expect((await getChatThread(getDb(), 'thread-other'))?.acpSessionId).toBe('session-other')
+    })
+
+    it('preserves the connection and ACP sessions when submitted wire fields are unchanged', async () => {
       await createAgent(getDb(), {
         id: 'a-name',
         name: 'Before',
@@ -188,10 +213,18 @@ describe('agents DAL', () => {
         userId: 'u1',
       })
       const cached = await seedCachedAdapter('a-name')
+      await getDb()
+        .insert(chatThreadsTable)
+        .values({ id: 'thread-same-wire', agentId: 'a-name', acpSessionId: 'session-same-wire' })
 
-      await updateAgent(getDb(), 'a-name', { name: 'After' })
+      await updateAgent(getDb(), 'a-name', {
+        name: 'After',
+        transport: 'websocket',
+        url: 'wss://keep/ws',
+      })
 
       expect(cached.disconnectCount()).toBe(0)
+      expect((await getChatThread(getDb(), 'thread-same-wire'))?.acpSessionId).toBe('session-same-wire')
     })
   })
 

--- a/src/dal/agents.ts
+++ b/src/dal/agents.ts
@@ -13,6 +13,7 @@ import { agentsSecretsTable, agentsSystemTable, agentsTable } from '../db/tables
 import { builtInAgent } from '../defaults/agents'
 import { nowIso } from '../lib/utils'
 import type { Agent } from '@/types/acp'
+import { clearAcpSessionIdsForAgent } from './chat-threads'
 
 /** Shape persisted in the local-only `agents_secrets` table. */
 export type AgentSecrets = {
@@ -147,29 +148,62 @@ export type UpdateAgentPatch = Partial<
 /** Patch fields whose change invalidates a warm ACP connection — the wire
  *  identity (endpoint + transport + agent type). Editing any of these means the
  *  next chat must reconnect, so the cached adapter is disposed. */
-const connectionInvalidatingFields: ReadonlyArray<keyof UpdateAgentPatch> = ['url', 'transport', 'type']
+const connectionInvalidatingFields = ['url', 'transport', 'type'] as const satisfies ReadonlyArray<
+  keyof UpdateAgentPatch
+>
 
 /** Patch an existing custom agent. Built-in and system agents are not editable
  *  through the DAL — built-in lives in code, system rows live in the local-only
  *  `agents_system` table which `updateAgent` never touches.
  *
  *  Editing the wire identity (url/transport/type) disposes the agent's warm ACP
- *  connection so the next chat reconnects against the new endpoint. */
-export const updateAgent = async (db: AnyDrizzleDatabase, id: string, patch: UpdateAgentPatch): Promise<void> => {
+ *  connection so the next chat reconnects against the new endpoint.
+ *
+ *  Returns whether the persisted wire identity changed so callers can refresh
+ *  any active in-memory chat sessions for the agent. */
+export const updateAgent = async (db: AnyDrizzleDatabase, id: string, patch: UpdateAgentPatch): Promise<boolean> => {
   if (id === builtInAgent.id) {
     throw new Error(`updateAgent: refusing to edit built-in agent "${id}"`)
   }
   if (Object.keys(patch).length === 0) {
-    return
+    return false
   }
-  await db
-    .update(agentsTable)
-    .set(patch)
-    .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+  const patchTouchesWire = connectionInvalidatingFields.some((field) => patch[field] !== undefined)
+  if (!patchTouchesWire) {
+    await db
+      .update(agentsTable)
+      .set(patch)
+      .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+    return false
+  }
 
-  if (connectionInvalidatingFields.some((field) => field in patch)) {
+  const invalidatesConnection = await db.transaction(async (tx) => {
+    const existing = await tx
+      .select({ type: agentsTable.type, transport: agentsTable.transport, url: agentsTable.url })
+      .from(agentsTable)
+      .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+      .get()
+    const wireIdentityChanged =
+      existing !== undefined &&
+      connectionInvalidatingFields.some((field) => patch[field] !== undefined && patch[field] !== existing[field])
+
+    await tx
+      .update(agentsTable)
+      .set(patch)
+      .where(and(eq(agentsTable.id, id), isNull(agentsTable.deletedAt)))
+
+    if (wireIdentityChanged) {
+      await clearAcpSessionIdsForAgent(tx, id)
+    }
+
+    return wireIdentityChanged
+  })
+
+  if (invalidatesConnection) {
     await disposeAdapter(id)
   }
+
+  return invalidatesConnection
 }
 
 /** Soft delete a custom agent. Never hard-delete — sets `deletedAt` and lets

--- a/src/dal/agents.ts
+++ b/src/dal/agents.ts
@@ -43,7 +43,7 @@ const customRowToAgent = (row: AgentCustomRow): Agent => ({
 })
 
 /** Lift a local-only system row into the unified `Agent` shape. */
-const systemRowToAgent = (row: AgentSystemRow): Agent => ({
+export const systemRowToAgent = (row: AgentSystemRow): Agent => ({
   id: row.id,
   name: row.name,
   type: row.type,

--- a/src/dal/chat-threads.test.ts
+++ b/src/dal/chat-threads.test.ts
@@ -9,6 +9,7 @@ import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import {
   createChatThread,
+  clearAcpSessionIdsForAgent,
   deleteAllChatThreads,
   deleteChatThread,
   getAllChatThreads,
@@ -61,6 +62,27 @@ describe('Chat Threads DAL', () => {
   beforeEach(async () => {
     // Reset database before each test to prevent pollution from randomized test order
     await resetTestDatabase()
+  })
+
+  describe('clearAcpSessionIdsForAgent', () => {
+    it('clears live thread sessions while preserving soft-deleted thread sessions', async () => {
+      const db = getDb()
+      await db.insert(chatThreadsTable).values([
+        { id: 'live-thread', agentId: 'agent-1', acpSessionId: 'live-session' },
+        {
+          id: 'deleted-thread',
+          agentId: 'agent-1',
+          acpSessionId: 'deleted-session',
+          deletedAt: nowIso(),
+        },
+      ])
+
+      await clearAcpSessionIdsForAgent(db, 'agent-1')
+
+      const rows = await db.select().from(chatThreadsTable).all()
+      expect(rows.find((row) => row.id === 'live-thread')?.acpSessionId).toBeNull()
+      expect(rows.find((row) => row.id === 'deleted-thread')?.acpSessionId).toBe('deleted-session')
+    })
   })
 
   describe('createChatThread', () => {

--- a/src/dal/chat-threads.ts
+++ b/src/dal/chat-threads.ts
@@ -86,6 +86,20 @@ export const updateChatThread = async (
   await db.update(chatThreadsTable).set(data).where(eq(chatThreadsTable.id, id))
 }
 
+/** Clears persisted ACP sessions for every thread routed to an agent. */
+export const clearAcpSessionIdsForAgent = async (db: AnyDrizzleDatabase, agentId: string): Promise<void> => {
+  await db
+    .update(chatThreadsTable)
+    .set({ acpSessionId: null })
+    .where(
+      and(
+        eq(chatThreadsTable.agentId, agentId),
+        isNotNull(chatThreadsTable.acpSessionId),
+        isNull(chatThreadsTable.deletedAt),
+      ),
+    )
+}
+
 /**
  * Gets a specific chat thread by ID or create a new one with the provided ID.
  *

--- a/src/db/seeding/seed-agents.ts
+++ b/src/db/seeding/seed-agents.ts
@@ -8,6 +8,10 @@ import { agentsSystemTable } from '../tables'
 import { HttpError, type HttpClient } from '@/lib/http'
 import { nowIso } from '@/lib/utils'
 import type { AgentDiscoveryResponse } from '@shared/acp-types'
+import { clearAcpSessionIdsForAgent } from '@/dal/chat-threads'
+import { systemRowToAgent } from '@/dal/agents'
+import { disposeAdapter } from '@/acp/adapter-cache'
+import type { Agent } from '@/types/acp'
 
 /** Result envelope for `refreshSystemAgents`.
  *  - `refreshed: true`  → backend returned 200, local table was upserted.
@@ -15,7 +19,7 @@ import type { AgentDiscoveryResponse } from '@shared/acp-types'
  *    rows are preserved unless `reason === 'unauthenticated'`, in which case
  *    the table was cleared (the user can no longer see system agents). */
 export type RefreshSystemAgentsResult =
-  | { refreshed: true }
+  | { refreshed: true; wireIdentityChangedAgents: Agent[] }
   | { refreshed: false; reason: 'unauthenticated' | 'network' }
 
 /**
@@ -57,6 +61,7 @@ export const refreshSystemAgents = async (
   // response is typed wider (`remote-acp | managed-acp`); `remote-acp` entries
   // belong in the synced `agents` table via user opt-in and are skipped here.
   const incoming = payload.data.agents.filter((a) => a.type === 'managed-acp')
+  const wireIdentityChangedAgentsById = new Map<string, Agent>()
 
   await db.transaction(async (tx) => {
     const existing = await tx.select({ id: agentsSystemTable.id }).from(agentsSystemTable).all()
@@ -81,14 +86,22 @@ export const refreshSystemAgents = async (
         fetchedAt,
       }
       if (row) {
+        const wireIdentityChanged = row.url !== agent.url || row.transport !== agent.transport
         await tx.update(agentsSystemTable).set(values).where(eq(agentsSystemTable.id, agent.id))
+        if (wireIdentityChanged) {
+          await clearAcpSessionIdsForAgent(tx, agent.id)
+          wireIdentityChangedAgentsById.set(agent.id, systemRowToAgent(values))
+        }
       } else {
         await tx.insert(agentsSystemTable).values(values)
       }
     }
   })
 
-  return { refreshed: true }
+  const wireIdentityChangedAgents = [...wireIdentityChangedAgentsById.values()]
+  await Promise.all(wireIdentityChangedAgents.map((agent) => disposeAdapter(agent.id)))
+
+  return { refreshed: true, wireIdentityChangedAgents }
 }
 
 type DiscoveryFetch = { kind: 'ok'; data: AgentDiscoveryResponse } | { kind: 'unauthenticated' } | { kind: 'error' }

--- a/src/routes/settings/agents/index.tsx
+++ b/src/routes/settings/agents/index.tsx
@@ -18,6 +18,7 @@ import { useDatabase } from '@/contexts'
 import { useAuth } from '@/contexts'
 import { selectAllowCustomAgents, useConfigStore } from '@/api/config-store'
 import { useAgentsSettingsHidden } from '@/hooks/use-agents-settings-hidden'
+import { useChatStore } from '@/chats/chat-store'
 import type { Agent } from '@/types/acp'
 
 type AgentsSettingsPageProps = {
@@ -83,12 +84,15 @@ export default function AgentsSettingsPage({ isStandalone }: AgentsSettingsPageP
     if (editingAgent) {
       // Only customs are editable; system / built-in rows never reach this
       // path (the row hides the Edit affordance).
-      await updateAgent(db, editingAgent.id, {
+      const wireIdentityChanged = await updateAgent(db, editingAgent.id, {
         name: payload.name,
         transport: payload.transport,
         url: payload.url,
         description: payload.description,
       })
+      if (wireIdentityChanged) {
+        useChatStore.getState().applyAgentWireIdentityChange({ ...editingAgent, ...payload })
+      }
       return
     }
     if (!currentUserId) {


### PR DESCRIPTION
## Summary

A chat thread kept the previous agent's `acpSessionId` when switched to a different agent, so the new agent attempted to resume a session it never owned. The same stale-session problem occurred when an agent's wire identity (url/transport/type) changed while threads still held sessions negotiated against the old endpoint.

- `setSelectedAgent` now nulls `acpSessionId` (in memory and on the `chat_threads` row) when the thread actually changes agents; re-selecting the current agent preserves the session.
- `updateAgent` compares the submitted wire fields against the persisted row inside a transaction, clears every affected thread's ACP session via the new `clearAcpSessionIdsForAgent` DAL helper, disposes the warm adapter, and reports whether the wire identity changed.
- `refreshSystemAgents` applies the same invalidation when discovery returns a changed url/transport for a system agent.
- The agents settings page propagates confirmed wire edits to active in-memory chat sessions through the new `applyAgentWireIdentityChange` store action.

## Test plan

- New coverage: no-stored-session ACP connect path, agent-switch clears session / same-agent preserves it, wire-edit clears only the edited agent's threads, unchanged wire fields preserve connection and sessions, system-agent discovery invalidates only changed agents.
- `bun test` (acp-adapter, chat-store, agents DAL) x3 randomized: 222 pass, 0 fail.
- `bun run check` (type-check, lint, format, license): clean.