### PR TITLE
build(deps): bump actions group (ruby/setup-ruby, claude-code-action)

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -196,7 +196,7 @@ jobs:
           echo "✅ Metal Toolchain removed"
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8e41b362d2589a22a44c1cfa214b3c83052c195b # v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1
         with:
           ruby-version: '3.0'
           bundler-cache: true

--- a/.github/workflows/thunder-deep-review.yml
+++ b/.github/workflows/thunder-deep-review.yml
@@ -196,7 +196,7 @@ jobs:
       # ─────────────────────────────────────────────────────────────────────
       - name: thunder-deep-review (step 1 — recall pass, candidate findings)
         id: review_model
-        uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1
+        uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Pass the workflow token so the action authenticates to GitHub WITH it
@@ -398,7 +398,7 @@ jobs:
         if: >-
           steps.persist_candidates.outputs.count != '' &&
           steps.persist_candidates.outputs.count != '0'
-        uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1
+        uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adopts #1108. Two same-major GitHub Actions SHA re-pins, no input changes:
- `ruby/setup-ruby` 1.318.0 → 1.319.0 (`# v1`)
- `anthropics/claude-code-action` 1.0.174 → 1.0.175 (`# v1`, both usages in thunder-deep-review.yml)

Workflow-YAML only — no app code or dependencies. Supersedes #1108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)