### PR TITLE
feat(THU-683): voice mode (STT/TTS) via Thunderbolt + custom providers

### DIFF
--- a/public/voice/capture-worklet.js
+++ b/public/voice/capture-worklet.js
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Mic capture worklet (THU-684). The AudioContext runs at the mic's native rate
+// (browsers won't connect a MediaStreamSource across sample rates), so this
+// linearly resamples to 16 kHz — what the energy VAD and STT expect — and emits
+// fixed 512-sample frames. Plain JS in /public so `audioWorklet.addModule` loads
+// it with the correct MIME (no bundler transform).
+const TARGET_RATE = 16000
+const FRAME_SAMPLES = 512
+
+class CaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super()
+    // Input samples per output sample, e.g. 3.0 at a 48 kHz context.
+    this._ratio = sampleRate / TARGET_RATE
+    this._frame = new Float32Array(FRAME_SAMPLES)
+    this._fill = 0
+    this._pending = new Float32Array(0)
+    this._pos = 0 // fractional read position within _pending
+  }
+
+  process(inputs) {
+    const channel = inputs[0] && inputs[0][0]
+    if (!channel) return true
+
+    const merged = new Float32Array(this._pending.length + channel.length)
+    merged.set(this._pending, 0)
+    merged.set(channel, this._pending.length)
+    this._pending = merged
+
+    while (this._pos + 1 < this._pending.length) {
+      const i = Math.floor(this._pos)
+      const frac = this._pos - i
+      this._frame[this._fill++] = this._pending[i] * (1 - frac) + this._pending[i + 1] * frac
+      if (this._fill === FRAME_SAMPLES) {
+        this.port.postMessage(this._frame.slice())
+        this._fill = 0
+      }
+      this._pos += this._ratio
+    }
+
+    const consumed = Math.floor(this._pos)
+    if (consumed > 0) {
+      this._pending = this._pending.slice(consumed)
+      this._pos -= consumed
+    }
+    return true
+  }
+}
+
+registerProcessor('capture-processor', CaptureProcessor)

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -11,5 +11,9 @@
         <true />
         <key>ITSAppUsesNonExemptEncryption</key>
         <false />
+        <!-- Voice mode: capture the microphone for speech-to-text. Required by
+             macOS/iOS TCC — without it the OS blocks (and can crash) mic access. -->
+        <key>NSMicrophoneUsageDescription</key>
+        <string>Thunderbolt uses your microphone for voice mode, so you can talk to the assistant.</string>
     </dict>
 </plist>

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Voice mode: record from the microphone for speech-to-text. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+
     <!-- AndroidTV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
 

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -154,7 +154,7 @@ export const runSystemModelPrewarm = async (model: Pick<Model, 'provider' | 'isS
  *  a new attestation context. Use when a key-config error keeps repeating
  *  inside the SDK's own reset+retry — the cached client's transport is wedged
  *  and only a brand-new instance breaks the cycle. */
-const evictSystemTinfoilClient = (): void => {
+export const evictSystemTinfoilClient = (): void => {
   const cloudUrl = getLocalSetting('cloudUrl').replace(/\/$/, '')
   systemTinfoilClients.delete(cloudUrl)
 }
@@ -175,7 +175,7 @@ const evictUserTinfoilClient = (): void => {
 /** A KeyConfigMismatchError that survives the SDK's internal reset+retry means
  *  our cached `SecureClient` has a wedged transport. Evict it so the next call
  *  builds a fresh instance with a brand-new attestation context. */
-const isKeyConfigMismatchError = (err: unknown): boolean =>
+export const isKeyConfigMismatchError = (err: unknown): boolean =>
   err instanceof Error && err.name === 'KeyConfigMismatchError'
 
 /** Reconnect a dropped MCP client; returns a fresh client or null. Supplied by

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -106,6 +106,10 @@ const SkillsPage = lazy(routeChunkLoaders.skills)
 const AgentsSettingsPage = lazy(routeChunkLoaders.agents)
 const DeviceApproval = lazy(routeChunkLoaders.deviceApproval)
 
+// Voice settings is feature-flagged and hidden by default, so it's a
+// deliberately-cold chunk (outside routeChunkLoaders) — lazy but not warmed.
+const VoiceSettingsPage = lazy(() => import('@/settings/voice'))
+
 // Lazily import SSO components so non-enterprise deployments don't pay
 // for the extra bundle size and attack surface.
 const SsoRedirect = lazy(() => import('@/components/sso-redirect'))
@@ -203,8 +207,9 @@ const AppRoutes = ({ initData }: { initData: InitData }) => {
   usePageTracking()
   useDeepLinkListener()
 
-  const { experimentalFeatureTasks } = useSettings({
+  const { experimentalFeatureTasks, experimentalFeatureVoice } = useSettings({
     experimental_feature_tasks: initData.experimentalFeatureTasks,
+    experimental_feature_voice: initData.experimentalFeatureVoice,
   })
 
   const ssoMode = isSsoMode()
@@ -247,6 +252,7 @@ const AppRoutes = ({ initData }: { initData: InitData }) => {
               <Route index element={<Settings />} />
               <Route path="preferences" element={<PreferencesSettingsPage />} />
               <Route path="models" element={<ModelsPage />} />
+              {experimentalFeatureVoice.value && <Route path="voice" element={<VoiceSettingsPage />} />}
               <Route path="devices" element={<DevicesSettingsPage />} />
               <Route path="connections" element={<ConnectionsPage />} />
               {/* Legacy routes — MCP servers and integrations merged into Connections. */}

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -832,6 +832,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
                 state={voice.state}
                 error={voice.error}
                 levelRef={voice.levelRef}
+                outputLevelRef={voice.outputLevelRef}
                 onClose={voice.stop}
               />
             )}

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -44,6 +44,9 @@ import { buildAttachmentPart } from '@/lib/attachments'
 import { buildQuotePart } from '@/lib/quotes'
 import { QuoteChip } from './quote-chip'
 import { deleteAttachment, putAttachment } from '@/lib/file-blob-storage'
+import { VoiceModeButton } from '@/voice/ui/voice-mode-button'
+import { VoiceModeComposer } from '@/voice/ui/voice-mode-composer'
+import { useVoiceSession } from '@/voice/ui/use-voice-session'
 import { FileCard } from './file-card'
 import { loadChatMessageList } from './chat-messages-loader'
 
@@ -563,6 +566,8 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
       setInput,
     }))
 
+    const voice = useVoiceSession()
+
     const footerStartElements = (
       <div className="flex items-center gap-2">
         <ChatAddMenu
@@ -792,9 +797,15 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             // autofocus: browsers won't show the keyboard for it anyway.
             autoFocus={!isMobile || (isPlatformMobile() && isNewChat)}
             submitOnEnter={!isStreaming && !shouldInsertNewlineOnEnter}
+            // Voice mode covers the composer with an overlay; make the underlying
+            // input non-interactive so Tab/Enter can't reach the hidden textarea.
+            inert={voice.active}
             className="relative z-10 flex flex-col w-full gap-0 rounded-3xl border border-transparent focus-within:border-border bg-sidebar p-2 shadow-glow dark:shadow-none transition-colors"
             footerStartElements={footerStartElements}
             footerEndElements={footerEndElements}
+            // Empty + idle composer shows the voice-mode trigger in the send
+            // slot; it swaps back to Send as soon as there's text or an attachment.
+            emptyStateAction={<VoiceModeButton onStart={voice.start} />}
             renderOverlay={(value) =>
               renderHighlightedSkillTokens(value, classifySkill, { displayNameToSlug, onCreateSkill: openCreateSkill })
             }
@@ -813,6 +824,18 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             onTextareaSelect={(e) => setCursorPos(e.currentTarget.selectionStart)}
             onTextareaPaste={handlePaste}
           />
+          {/* Voice mode morphs the composer in-place: the overlay covers the
+              PromptInput box while a session is active. */}
+          <AnimatePresence>
+            {voice.active && (
+              <VoiceModeComposer
+                state={voice.state}
+                error={voice.error}
+                levelRef={voice.levelRef}
+                onClose={voice.stop}
+              />
+            )}
+          </AnimatePresence>
         </div>
         <ContextOverflowModal
           isOpen={showOverflowModal}

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -36,11 +36,18 @@ type PromptInputProps = {
   className?: string
   submitOnEnter?: boolean
   noForm?: boolean
+  /** Makes the whole composer non-interactive (blocks focus/Tab/Enter) — e.g.
+   *  while voice mode covers it with an overlay. */
+  inert?: boolean
   isStreaming?: boolean
   onStop?: () => void
   footerStartElements?: ReactNode
   /** Rendered in the footer's right cluster, just before the submit button. */
   footerEndElements?: ReactNode
+  /** Rendered in place of the (disabled) submit button when the composer is
+   *  empty and idle (nothing to send, not streaming) — e.g. the voice-mode
+   *  button that occupies the send slot until the user types or attaches. */
+  emptyStateAction?: ReactNode
   // Model selection props - optional, only used in automation modal
   chatThread?: ChatThread | null
   models?: Model[]
@@ -89,10 +96,12 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
       className = 'flex flex-col w-full gap-0 p-2',
       submitOnEnter = false,
       noForm = false,
+      inert = false,
       isStreaming = false,
       onStop,
       footerStartElements,
       footerEndElements,
+      emptyStateAction,
       chatThread = null,
       models,
       selectedModel,
@@ -157,6 +166,8 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         >
           <Square className="size-[var(--icon-size-default)]" />
         </Button>
+      ) : !submittable && emptyStateAction ? (
+        emptyStateAction
       ) : (
         <Button
           type="submit"
@@ -226,9 +237,11 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
     )
 
     const formElement = noForm ? (
-      <div className={className}>{content}</div>
+      <div className={className} inert={inert}>
+        {content}
+      </div>
     ) : (
-      <form ref={ref} onSubmit={handleSubmit} className={className}>
+      <form ref={ref} onSubmit={handleSubmit} className={className} inert={inert}>
         {content}
       </form>
     )

--- a/src/defaults/settings.test.ts
+++ b/src/defaults/settings.test.ts
@@ -22,8 +22,8 @@ const computeSnapshotHash = () =>
   defaultSettings.map((setting, index) => `${index}:${setting.key}:${hashSetting(setting)}`).join('|')
 
 const expected = {
-  version: 1,
-  hash: '0:data_collection:9xnigq|1:is_triggers_enabled:eonvmh|2:experimental_feature_tasks:-zg8zmz|3:preferred_name:-5w6dil|4:location_name:27rtqf|5:location_lat:-tpss8p|6:location_lng:-tpsiwv|7:distance_unit:-3esuvm|8:temperature_unit:-dmzg9f|9:date_format:52oyc|10:time_format:we6fw3|11:currency:avihzf|12:integrations_pro_is_enabled:bbnpv0|13:user_has_completed_onboarding:-hxwxxt|14:content_view_width:8pnzc5|15:integrations_do_not_ask_again:yv9tj5',
+  version: 2,
+  hash: '0:data_collection:9xnigq|1:is_triggers_enabled:eonvmh|2:experimental_feature_tasks:-zg8zmz|3:experimental_feature_voice:6l2ce1|4:preferred_name:-5w6dil|5:location_name:27rtqf|6:location_lat:-tpss8p|7:location_lng:-tpsiwv|8:distance_unit:-3esuvm|9:temperature_unit:-dmzg9f|10:date_format:52oyc|11:time_format:we6fw3|12:currency:avihzf|13:integrations_pro_is_enabled:bbnpv0|14:user_has_completed_onboarding:-hxwxxt|15:content_view_width:8pnzc5|16:integrations_do_not_ask_again:yv9tj5',
 }
 
 describe('defaultSettings version snapshot', () => {

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -50,6 +50,14 @@ export const defaultSettingExperimentalFeatureTasks: Setting = {
   userId: null,
 }
 
+export const defaultSettingExperimentalFeatureVoice: Setting = {
+  key: 'experimental_feature_voice',
+  value: 'false',
+  updatedAt: null,
+  defaultHash: null,
+  userId: null,
+}
+
 export const defaultSettingPreferredName: Setting = {
   key: 'preferred_name',
   value: null,
@@ -161,6 +169,7 @@ export const defaultSettings: ReadonlyArray<Setting> = [
   defaultSettingDataCollection,
   defaultSettingTriggersEnabled,
   defaultSettingExperimentalFeatureTasks,
+  defaultSettingExperimentalFeatureVoice,
   defaultSettingPreferredName,
   defaultSettingLocationName,
   defaultSettingLocationLat,
@@ -187,4 +196,4 @@ export const defaultSettings: ReadonlyArray<Setting> = [
  * The paired snapshot test in `settings.test.ts` fails on any change to this
  * file's defaults without a matching version bump.
  */
-export const defaultSettingsVersion = 1
+export const defaultSettingsVersion = 2

--- a/src/hooks/use-app-initialization.ts
+++ b/src/hooks/use-app-initialization.ts
@@ -288,9 +288,10 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
 
   // Step 5: Get cloud url and experimental feature tasks
   const cloudUrl = getLocalSetting('cloudUrl')
-  const { experimentalFeatureTasks } = await time('step5_get_settings', () =>
+  const { experimentalFeatureTasks, experimentalFeatureVoice } = await time('step5_get_settings', () =>
     getSettings(db, {
       experimental_feature_tasks: false,
+      experimental_feature_voice: false,
     }),
   )
 
@@ -343,6 +344,7 @@ const executeInitializationSteps = async (httpClient?: HttpClient): Promise<Hand
       db,
       cloudUrl,
       experimentalFeatureTasks,
+      experimentalFeatureVoice,
       posthogClient,
       httpClient: client,
       ...tray,

--- a/src/layout/sidebar/settings-sidebar.tsx
+++ b/src/layout/sidebar/settings-sidebar.tsx
@@ -13,8 +13,9 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from '@/components/ui/sidebar'
+import { useSettings } from '@/hooks/use-settings'
 import { cn } from '@/lib/utils'
-import { Bot, Cpu, Plug, SlidersHorizontal, Smartphone, Zap, type LucideIcon } from 'lucide-react'
+import { AudioLines, Bot, Cpu, Plug, SlidersHorizontal, Smartphone, Zap, type LucideIcon } from 'lucide-react'
 import { Fragment } from 'react'
 import { useLocation } from 'react-router'
 import { SidebarNavToggle } from './nav-toggle'
@@ -41,6 +42,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
       { path: '/settings/skills', label: 'Skills', icon: Zap },
       { path: '/settings/connections', label: 'Connections', icon: Plug },
       { path: '/settings/models', label: 'Models', icon: Cpu, matchPrefix: true },
+      { path: '/settings/voice', label: 'Voice', icon: AudioLines },
     ],
   },
   {
@@ -65,9 +67,16 @@ export const SettingsSidebarContent = ({
 }: SettingsSidebarContentProps) => {
   const { isMobile, toggleSidebar } = useSidebar()
   const location = useLocation()
+  const { experimentalFeatureVoice } = useSettings({ experimental_feature_voice: false })
 
   const isItemActive = ({ path, matchPrefix }: NavItem) =>
     matchPrefix ? location.pathname.startsWith(path) : location.pathname === path
+
+  // Voice settings only exist to configure a custom (non-Thunderbolt) provider,
+  // which is gated behind the experimental flag — hide the nav item otherwise.
+  const groups = experimentalFeatureVoice.value
+    ? navGroups
+    : navGroups.map((group) => ({ ...group, items: group.items.filter((item) => item.path !== '/settings/voice') }))
 
   return (
     <SidebarContent className="flex flex-col h-full">
@@ -87,7 +96,7 @@ export const SettingsSidebarContent = ({
         </SidebarGroup>
       )}
 
-      {navGroups.map((group, index) => (
+      {groups.map((group, index) => (
         <Fragment key={group.label}>
           {/* Collapsed rail: the group labels are hidden, so a hairline
               divider takes over as the section boundary. */}
@@ -97,7 +106,7 @@ export const SettingsSidebarContent = ({
               it. The last group keeps its bottom padding against the footer. */}
           <SidebarGroup
             className={cn(
-              isCollapsed ? (index === navGroups.length - 1 ? 'pt-0' : 'py-0') : undefined,
+              isCollapsed ? (index === groups.length - 1 ? 'pt-0' : 'py-0') : undefined,
               isMobile && index === 0 && 'pt-[calc(var(--header-safe-area-top)+0.5rem)]',
             )}
           >

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -25,6 +25,8 @@ export type RequestOptions = {
   searchParams?: Record<string, string | number | boolean | undefined> | URLSearchParams
   timeout?: number
   json?: unknown
+  /** Raw request body (e.g. FormData, Blob) for non-JSON posts. Ignored if `json` is set. */
+  body?: BodyInit
   credentials?: RequestCredentials
   signal?: AbortSignal
   fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
@@ -100,6 +102,10 @@ export const createClient = (config: HttpClientConfig = {}): HttpClient => {
     if (options.json !== undefined) {
       headers.set('Content-Type', 'application/json')
       body = JSON.stringify(options.json)
+    } else if (options.body !== undefined) {
+      // Raw body (FormData/Blob/…) — leave Content-Type to the caller/browser
+      // (e.g. FormData needs the auto-generated multipart boundary).
+      body = options.body
     }
 
     const fetchFn = options.fetch ?? config.fetch ?? globalThis.fetch

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -110,12 +110,19 @@ export const createClient = (config: HttpClientConfig = {}): HttpClient => {
 
     const fetchFn = options.fetch ?? config.fetch ?? globalThis.fetch
 
+    // Honor `timeout` even when the caller also passes a `signal` — compose the
+    // two so an aborted turn AND an elapsed timeout both cancel the request.
+    // (Without this, a slow/hung server on a request that carries a signal would
+    // never time out, e.g. a voice STT/TTS turn stuck indefinitely.)
     let signal = options.signal
     let timeoutId: ReturnType<typeof setTimeout> | undefined
-    if (options.timeout && !signal) {
+    if (options.timeout) {
       const controller = new AbortController()
-      signal = controller.signal
-      timeoutId = setTimeout(() => controller.abort(), options.timeout)
+      timeoutId = setTimeout(
+        () => controller.abort(new DOMException('Request timed out', 'TimeoutError')),
+        options.timeout,
+      )
+      signal = options.signal ? AbortSignal.any([options.signal, controller.signal]) : controller.signal
     }
 
     const req = new Request(fullUrl, {

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -194,6 +194,7 @@ export default function PreferencesSettingsPage() {
     locationLng,
     dataCollection,
     experimentalFeatureTasks,
+    experimentalFeatureVoice,
     distanceUnit,
     temperatureUnit,
     dateFormat,
@@ -206,6 +207,7 @@ export default function PreferencesSettingsPage() {
     location_lng: '',
     data_collection: false,
     experimental_feature_tasks: false,
+    experimental_feature_voice: false,
     distance_unit: 'imperial',
     temperature_unit: 'f',
     date_format: 'MM/DD/YYYY',
@@ -804,6 +806,24 @@ export default function PreferencesSettingsPage() {
                 checked={experimentalFeatureTasks.value}
                 onCheckedChange={handleExperimentalFeaturesToggle}
                 aria-label="Tasks"
+              />
+            </div>
+
+            <div className="flex-row flex items-center gap-4">
+              <div className="flex-1">
+                <ModificationIndicator
+                  as="label"
+                  className="text-sm font-medium"
+                  hasModifications={experimentalFeatureVoice.isModified}
+                  onReset={experimentalFeatureVoice.reset}
+                >
+                  Custom voice provider
+                </ModificationIndicator>
+              </div>
+              <Switch
+                checked={experimentalFeatureVoice.value}
+                onCheckedChange={(value) => experimentalFeatureVoice.setValue(value)}
+                aria-label="Custom voice provider"
               />
             </div>
           </div>

--- a/src/settings/voice.tsx
+++ b/src/settings/voice.tsx
@@ -70,8 +70,9 @@ const ComboField = ({
   options: string[]
   onChange: (value: string) => void
 }) => {
-  if (options.length === 0)
+  if (options.length === 0) {
     return <Field id={id} label={label} hint={hint} value={value} placeholder={placeholder} onChange={onChange} />
+  }
   const items = value && !options.includes(value) ? [value, ...options] : options
   return (
     <div className="flex flex-col gap-1.5">

--- a/src/settings/voice.tsx
+++ b/src/settings/voice.tsx
@@ -1,0 +1,234 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Voice provider settings (THU-718). Pick the hosted Thunderbolt engine or point
+ * voice mode at any OpenAI-compatible `/v1/audio/*` endpoint — another provider
+ * or a self-hosted local server (Kokoro-FastAPI, speaches, LocalAI, …). Config is
+ * device-local (holds a key + machine-specific URL) and applies on the next voice
+ * turn.
+ */
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { PageHeader } from '@/components/ui/page-header'
+import { SectionCard } from '@/components/ui/section-card'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { type DiscoveredModels, fetchOpenAiModels, testOpenAiConnection } from '@/voice/engine/openai-compatible-engine'
+import { type VoiceProviderConfig, useLocalSettingsStore } from '@/stores/local-settings-store'
+import { CheckCircle2, Loader2, XCircle } from 'lucide-react'
+import { useState } from 'react'
+
+type ConnState = { status: 'idle' | 'testing' | 'ok' | 'error'; detail?: string }
+
+const Field = ({
+  id,
+  label,
+  hint,
+  value,
+  placeholder,
+  type = 'text',
+  onChange,
+}: {
+  id: string
+  label: string
+  hint?: string
+  value: string
+  placeholder?: string
+  type?: string
+  onChange: (value: string) => void
+}) => (
+  <div className="flex flex-col gap-1.5">
+    <Label htmlFor={id}>{label}</Label>
+    <Input id={id} type={type} value={value} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+    {hint && <p className="text-[length:var(--font-size-xs)] text-muted-foreground">{hint}</p>}
+  </div>
+)
+
+/**
+ * A model/voice picker: a dropdown once the server's models are discovered,
+ * degrading to the free-text {@link Field} when nothing was returned (server
+ * unreachable, or a plain server that doesn't list models). The current value
+ * is always selectable even if it isn't in the discovered set (e.g. a value
+ * persisted before discovery, or a manually entered id).
+ */
+const ComboField = ({
+  id,
+  label,
+  hint,
+  value,
+  placeholder,
+  options,
+  onChange,
+}: {
+  id: string
+  label: string
+  hint?: string
+  value: string
+  placeholder?: string
+  options: string[]
+  onChange: (value: string) => void
+}) => {
+  if (options.length === 0)
+    return <Field id={id} label={label} hint={hint} value={value} placeholder={placeholder} onChange={onChange} />
+  const items = value && !options.includes(value) ? [value, ...options] : options
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger id={id} className="w-full">
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {items.map((item) => (
+            <SelectItem key={item} value={item}>
+              {item}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {hint && <p className="text-[length:var(--font-size-xs)] text-muted-foreground">{hint}</p>}
+    </div>
+  )
+}
+
+export const VoiceSettingsPage = () => {
+  const config = useLocalSettingsStore((s) => s.voiceProvider)
+  const setLocalSetting = useLocalSettingsStore((s) => s.setLocalSetting)
+  const [ui, setUi] = useState<{ conn: ConnState; models: DiscoveredModels | null; loadingModels: boolean }>({
+    conn: { status: 'idle' },
+    models: null,
+    loadingModels: false,
+  })
+
+  const update = (patch: Partial<VoiceProviderConfig>) => setLocalSetting('voiceProvider', { ...config, ...patch })
+  const isCustom = config.kind === 'openai-compatible'
+  const canTest = isCustom && config.baseUrl.trim().length > 0
+
+  const runTest = async () => {
+    setUi((s) => ({ ...s, conn: { status: 'testing' } }))
+    const result = await testOpenAiConnection(config)
+    setUi((s) => ({ ...s, conn: { status: result.ok ? 'ok' : 'error', detail: result.detail } }))
+  }
+
+  const loadModels = async () => {
+    setUi((s) => ({ ...s, loadingModels: true }))
+    const models = await fetchOpenAiModels(config.baseUrl, config.apiKey)
+    setUi((s) => ({ ...s, models, loadingModels: false }))
+  }
+
+  const sttOptions = ui.models?.stt ?? []
+  const ttsOptions = (ui.models?.tts ?? []).map((m) => m.id)
+  const voiceOptions = ui.models?.tts.find((m) => m.id === config.ttsModel)?.voices ?? []
+
+  return (
+    <div className="mx-auto flex w-full max-w-[760px] flex-col gap-6 p-4 pb-12">
+      <PageHeader title="Voice" />
+
+      <SectionCard title="Voice engine">
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="voice-provider">Provider</Label>
+            <Select value={config.kind} onValueChange={(kind) => update({ kind: kind as VoiceProviderConfig['kind'] })}>
+              <SelectTrigger id="voice-provider" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="thunderbolt">Thunderbolt (hosted, private)</SelectItem>
+                <SelectItem value="openai-compatible">Custom — OpenAI-compatible endpoint</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-[length:var(--font-size-xs)] text-muted-foreground">
+              {isCustom
+                ? 'Point at any server exposing /v1/audio/transcriptions and /v1/audio/speech. Its CORS must allow this app’s origin.'
+                : 'Speech-to-text and text-to-speech run in Thunderbolt’s confidential enclave.'}
+            </p>
+          </div>
+
+          {isCustom && (
+            <>
+              <Field
+                id="voice-base-url"
+                label="Base URL"
+                placeholder="http://localhost:8880/v1"
+                hint="Include the version prefix (e.g. /v1). Then hit “Load models” to populate the pickers below."
+                value={config.baseUrl}
+                onChange={(baseUrl) => update({ baseUrl })}
+              />
+              <Field
+                id="voice-api-key"
+                label="API key"
+                type="password"
+                hint="Optional — leave blank for local servers that don’t require auth."
+                value={config.apiKey}
+                onChange={(apiKey) => update({ apiKey })}
+              />
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <ComboField
+                  id="voice-stt-model"
+                  label="STT model"
+                  placeholder="whisper-large-v3-turbo"
+                  options={sttOptions}
+                  value={config.sttModel}
+                  onChange={(sttModel) => update({ sttModel })}
+                />
+                <ComboField
+                  id="voice-tts-model"
+                  label="TTS model"
+                  placeholder="kokoro"
+                  options={ttsOptions}
+                  value={config.ttsModel}
+                  onChange={(ttsModel) => update({ ttsModel })}
+                />
+              </div>
+              <ComboField
+                id="voice-tts-voice"
+                label="TTS voice"
+                placeholder="af_bella"
+                options={voiceOptions}
+                value={config.ttsVoice}
+                onChange={(ttsVoice) => update({ ttsVoice })}
+              />
+
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" variant="outline" onClick={loadModels} disabled={!canTest || ui.loadingModels}>
+                    {ui.loadingModels && <Loader2 className="size-4 animate-spin" />}
+                    Load models
+                  </Button>
+                  <Button type="button" onClick={runTest} disabled={!canTest || ui.conn.status === 'testing'}>
+                    {ui.conn.status === 'testing' && <Loader2 className="size-4 animate-spin" />}
+                    Test connection
+                  </Button>
+                </div>
+
+                {ui.models !== null && ui.models.stt.length === 0 && ui.models.tts.length === 0 && (
+                  <p className="text-[length:var(--font-size-xs)] text-muted-foreground">
+                    No models returned (server unreachable, or it doesn’t list models). Enter model and voice ids
+                    manually.
+                  </p>
+                )}
+
+                {ui.conn.status === 'ok' && (
+                  <p className="flex items-center gap-1.5 text-[length:var(--font-size-sm)] text-primary">
+                    <CheckCircle2 className="size-4 shrink-0" />
+                    {ui.conn.detail}
+                  </p>
+                )}
+                {ui.conn.status === 'error' && (
+                  <p className="flex items-start gap-1.5 text-[length:var(--font-size-sm)] text-destructive">
+                    <XCircle className="mt-0.5 size-4 shrink-0" />
+                    <span className="min-w-0 break-words">{ui.conn.detail}</span>
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </SectionCard>
+    </div>
+  )
+}
+
+export default VoiceSettingsPage

--- a/src/stores/local-settings-store.ts
+++ b/src/stores/local-settings-store.ts
@@ -5,6 +5,31 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
+/**
+ * Voice engine selection (THU-718). `thunderbolt` uses the hosted enclave STT/TTS
+ * (via the /tinfoil proxy); `openai-compatible` points at any OpenAI-shaped
+ * `/v1/audio/*` endpoint — another provider or a self-hosted local server.
+ * Device-local (not synced): holds a key and a machine-specific URL.
+ */
+export type VoiceProviderConfig = {
+  kind: 'thunderbolt' | 'openai-compatible'
+  /** Base URL including the version prefix, e.g. http://localhost:8000/v1. */
+  baseUrl: string
+  apiKey: string
+  sttModel: string
+  ttsModel: string
+  ttsVoice: string
+}
+
+export const defaultVoiceProvider: VoiceProviderConfig = {
+  kind: 'thunderbolt',
+  baseUrl: '',
+  apiKey: '',
+  sttModel: 'whisper-large-v3-turbo',
+  ttsModel: 'qwen3-tts',
+  ttsVoice: 'aiden',
+}
+
 type LocalSettingsState = {
   cloudUrl: string
   debugPosthog: boolean
@@ -12,6 +37,7 @@ type LocalSettingsState = {
   hapticsEnabled: boolean
   syncEnabled: boolean
   theme: 'light' | 'dark' | 'system'
+  voiceProvider: VoiceProviderConfig
 }
 
 type LocalSettingsActions = {
@@ -27,6 +53,7 @@ export const initialLocalSettings: LocalSettingsState = {
   hapticsEnabled: true,
   syncEnabled: false,
   theme: 'system',
+  voiceProvider: defaultVoiceProvider,
 }
 
 export const useLocalSettingsStore = create<LocalSettingsStore>()(
@@ -47,6 +74,7 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
         hapticsEnabled: s.hapticsEnabled,
         syncEnabled: s.syncEnabled,
         theme: s.theme,
+        voiceProvider: s.voiceProvider,
       }),
     },
   ),

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export type InitData = {
   posthogClient: PostHog | null
   httpClient: HttpClient
   experimentalFeatureTasks: boolean
+  experimentalFeatureVoice: boolean
 }
 
 /**
@@ -245,6 +246,7 @@ export type PreferencesSettings = {
   preferredName: string
   dataCollection: boolean
   experimentalFeatureTasks: boolean
+  experimentalFeatureVoice: boolean
   distanceUnit: string
   temperatureUnit: string
   dateFormat: string

--- a/src/voice/aggregator.test.ts
+++ b/src/voice/aggregator.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { SentenceAggregator } from './aggregator'
+
+/** Push text one character at a time (worst-case token granularity), then flush. */
+const runStreamed = (text: string): string[] => {
+  const agg = new SentenceAggregator()
+  const chunks: string[] = []
+  for (const ch of text) chunks.push(...agg.push(ch))
+  chunks.push(...agg.flush())
+  return chunks
+}
+
+describe('SentenceAggregator', () => {
+  test('emits the first chunk at the earliest clause break past the floor', () => {
+    const chunks = runStreamed('Well, that is a genuinely interesting question, and here is the answer. ')
+    // First clause after the 20-char floor is the comma after "question".
+    expect(chunks[0]).toBe('Well, that is a genuinely interesting question,')
+    expect(chunks[1]).toBe('and here is the answer.')
+  })
+
+  test('splits subsequent chunks on sentence boundaries', () => {
+    const chunks = runStreamed('The first sentence is here. The second follows. The third ends it. ')
+    expect(chunks).toEqual(['The first sentence is here.', 'The second follows.', 'The third ends it.'])
+  })
+
+  test('flush emits a trailing sentence with no terminating whitespace', () => {
+    const chunks = runStreamed('No trailing space here.')
+    expect(chunks).toEqual(['No trailing space here.'])
+  })
+
+  test('does not split decimals', () => {
+    const chunks = runStreamed('The value is 3.14 and pi is 3.14159 exactly. ')
+    expect(chunks).toEqual(['The value is 3.14 and pi is 3.14159 exactly.'])
+  })
+
+  // The guard cases below lead with a full sentence (≥20 chars, ends before the
+  // first-chunk cap) so the guard-under-test runs on a *subsequent* chunk, which
+  // has no length cap — isolating the sentence-split guard from first-chunk logic.
+  test('does not split on common title abbreviations', () => {
+    const chunks = runStreamed('Here is the plan for today. Dr. Smith met Mr. Jones this morning. ')
+    expect(chunks).toEqual(['Here is the plan for today.', 'Dr. Smith met Mr. Jones this morning.'])
+  })
+
+  test('does not split inside inline code spans', () => {
+    const chunks = runStreamed('Let me show you the command now. Run `git commit -m "v1.2. done"` and push. ')
+    expect(chunks).toEqual(['Let me show you the command now.', 'Run `git commit -m "v1.2. done"` and push.'])
+  })
+
+  test('does not split inside a URL', () => {
+    const chunks = runStreamed('Here is a useful link for you. Open example.com and read the docs. ')
+    expect(chunks).toEqual(['Here is a useful link for you.', 'Open example.com and read the docs.'])
+  })
+
+  test('keeps closing punctuation with the sentence', () => {
+    const chunks = runStreamed('She said "hello there friend." Then she left the room. ')
+    expect(chunks).toEqual(['She said "hello there friend."', 'Then she left the room.'])
+  })
+
+  test('caps a long, punctuation-free first chunk at a word boundary', () => {
+    const chunks = runStreamed('alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo. ')
+    // First chunk cut at the last word boundary before the 48-char cap.
+    expect(chunks[0].length).toBeLessThanOrEqual(48)
+    expect(chunks[0].endsWith(' ')).toBe(false)
+    // Nothing dropped across the whole stream.
+    expect(chunks.join(' ')).toContain('kilo.')
+  })
+
+  test('flush on empty buffer yields nothing', () => {
+    const agg = new SentenceAggregator()
+    expect(agg.flush()).toEqual([])
+  })
+})

--- a/src/voice/aggregator.test.ts
+++ b/src/voice/aggregator.test.ts
@@ -9,7 +9,9 @@ import { SentenceAggregator } from './aggregator'
 const runStreamed = (text: string): string[] => {
   const agg = new SentenceAggregator()
   const chunks: string[] = []
-  for (const ch of text) chunks.push(...agg.push(ch))
+  for (const ch of text) {
+    chunks.push(...agg.push(ch))
+  }
   chunks.push(...agg.flush())
   return chunks
 }

--- a/src/voice/aggregator.ts
+++ b/src/voice/aggregator.ts
@@ -14,14 +14,14 @@
  */
 
 /** Emit the first chunk once it reaches this length and hits a clause break. */
-const FIRST_MIN_CHARS = 20
+const firstMinChars = 20
 /** Hard cap on the first chunk — flush at the last word boundary by here. */
-const FIRST_MAX_CHARS = 48
+const firstMaxChars = 48
 
-const CLAUSE_PUNCT = new Set([',', ';', ':', '—', '–'])
-const SENTENCE_PUNCT = new Set(['.', '!', '?'])
+const clausePunct = new Set([',', ';', ':', '—', '–'])
+const sentencePunct = new Set(['.', '!', '?'])
 /** Lowercased tokens that end in a period but don't end a sentence. */
-const ABBREVIATIONS = new Set([
+const abbreviations = new Set([
   'mr',
   'mrs',
   'ms',
@@ -50,9 +50,11 @@ const isDigit = (ch: string): boolean => ch >= '0' && ch <= '9'
 /** True if the word ending at `dotIndex` (exclusive) is a known abbreviation. */
 const precededByAbbreviation = (buffer: string, dotIndex: number): boolean => {
   let start = dotIndex
-  while (start > 0 && /[A-Za-z]/.test(buffer[start - 1])) start--
+  while (start > 0 && /[A-Za-z]/.test(buffer[start - 1])) {
+    start--
+  }
   const word = buffer.slice(start, dotIndex).toLowerCase()
-  return word.length > 0 && ABBREVIATIONS.has(word)
+  return word.length > 0 && abbreviations.has(word)
 }
 
 export class SentenceAggregator {
@@ -65,7 +67,9 @@ export class SentenceAggregator {
     const chunks: string[] = []
     for (;;) {
       const end = this.nextBoundary()
-      if (end < 0) break
+      if (end < 0) {
+        break
+      }
       const chunk = this.buffer.slice(0, end).trim()
       this.buffer = this.buffer.slice(end)
       if (chunk.length > 0) {
@@ -80,7 +84,9 @@ export class SentenceAggregator {
   flush(): string[] {
     const rest = this.buffer.trim()
     this.buffer = ''
-    if (rest.length === 0) return []
+    if (rest.length === 0) {
+      return []
+    }
     this.firstEmitted = true
     return [rest]
   }
@@ -97,24 +103,38 @@ export class SentenceAggregator {
     let inCode = false
     for (let i = 0; i < buf.length; i++) {
       const ch = buf[i]
-      if (ch === '`') inCode = !inCode
-      if (inCode) continue
-      if (isWhitespace(ch)) lastWordBreak = i
+      if (ch === '`') {
+        inCode = !inCode
+      }
+      if (inCode) {
+        continue
+      }
+      if (isWhitespace(ch)) {
+        lastWordBreak = i
+      }
 
       if (!this.firstEmitted) {
         // First chunk: earliest clause/sentence break past the floor, else a
         // hard cap at the last word boundary — bounds time-to-first-audio.
-        if (i + 1 >= FIRST_MIN_CHARS) {
-          if (CLAUSE_PUNCT.has(ch)) return i + 1
+        if (i + 1 >= firstMinChars) {
+          if (clausePunct.has(ch)) {
+            return i + 1
+          }
           const end = this.sentenceEnd(buf, i)
-          if (end > 0) return end
+          if (end > 0) {
+            return end
+          }
         }
-        if (i + 1 >= FIRST_MAX_CHARS && lastWordBreak > 0) return lastWordBreak + 1
+        if (i + 1 >= firstMaxChars && lastWordBreak > 0) {
+          return lastWordBreak + 1
+        }
         continue
       }
 
       const end = this.sentenceEnd(buf, i)
-      if (end > 0) return end
+      if (end > 0) {
+        return end
+      }
     }
     return -1
   }
@@ -125,15 +145,25 @@ export class SentenceAggregator {
    * abbreviations, and URLs so they don't split mid-thought.
    */
   private sentenceEnd(buf: string, i: number): number {
-    if (!SENTENCE_PUNCT.has(buf[i])) return -1
+    if (!sentencePunct.has(buf[i])) {
+      return -1
+    }
     // Consume any run of terminators / closing quotes+brackets.
     let j = i
-    while (j + 1 < buf.length && (SENTENCE_PUNCT.has(buf[j + 1]) || `")']`.includes(buf[j + 1]))) j++
+    while (j + 1 < buf.length && (sentencePunct.has(buf[j + 1]) || `")']`.includes(buf[j + 1]))) {
+      j++
+    }
     // Must be followed by whitespace — excludes decimals (3.14) and URLs (a.com).
-    if (j + 1 >= buf.length || !isWhitespace(buf[j + 1])) return -1
+    if (j + 1 >= buf.length || !isWhitespace(buf[j + 1])) {
+      return -1
+    }
     if (buf[i] === '.') {
-      if (i > 0 && isDigit(buf[i - 1]) && i + 1 < buf.length && isDigit(buf[i + 1])) return -1
-      if (precededByAbbreviation(buf, i)) return -1
+      if (i > 0 && isDigit(buf[i - 1]) && i + 1 < buf.length && isDigit(buf[i + 1])) {
+        return -1
+      }
+      if (precededByAbbreviation(buf, i)) {
+        return -1
+      }
     }
     return j + 1
   }

--- a/src/voice/aggregator.ts
+++ b/src/voice/aggregator.ts
@@ -99,7 +99,11 @@ export class SentenceAggregator {
     const buf = this.buffer
     let lastWordBreak = -1
     // Reset per scan: the buffer always begins outside a code span, because we
-    // never cut at a boundary found while inside one.
+    // never cut at a boundary found while inside one. This relies on backticks
+    // being balanced within the reply — a lone/unmatched backtick would flip
+    // `inCode` and suppress all further splitting until `flush()`, delaying
+    // time-to-audio for the rest of the turn. LLM inline code is reliably
+    // balanced, so this is an accepted edge case rather than a guarded one.
     let inCode = false
     for (let i = 0; i < buf.length; i++) {
       const ch = buf[i]

--- a/src/voice/aggregator.ts
+++ b/src/voice/aggregator.ts
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Sentence/clause aggregator (THU-687) — engine-agnostic, so both the
+ * in-webview and native TTS backends reuse it.
+ *
+ * Buffers streaming LLM tokens and flushes speakable chunks to TTS. The
+ * first chunk is split aggressively (at the earliest clause boundary past a
+ * small floor, or a hard word-boundary cap) to minimize time-to-first-audio;
+ * later chunks flush on sentence boundaries. Guards avoid false splits on
+ * decimals, common abbreviations, and inline code.
+ */
+
+/** Emit the first chunk once it reaches this length and hits a clause break. */
+const FIRST_MIN_CHARS = 20
+/** Hard cap on the first chunk — flush at the last word boundary by here. */
+const FIRST_MAX_CHARS = 48
+
+const CLAUSE_PUNCT = new Set([',', ';', ':', '—', '–'])
+const SENTENCE_PUNCT = new Set(['.', '!', '?'])
+/** Lowercased tokens that end in a period but don't end a sentence. */
+const ABBREVIATIONS = new Set([
+  'mr',
+  'mrs',
+  'ms',
+  'dr',
+  'prof',
+  'sr',
+  'jr',
+  'st',
+  'vs',
+  'etc',
+  'inc',
+  'ltd',
+  'co',
+  'eg',
+  'ie',
+  'ph',
+  'approx',
+  'no',
+  'fig',
+  'al',
+])
+
+const isWhitespace = (ch: string): boolean => ch === ' ' || ch === '\n' || ch === '\t' || ch === '\r'
+const isDigit = (ch: string): boolean => ch >= '0' && ch <= '9'
+
+/** True if the word ending at `dotIndex` (exclusive) is a known abbreviation. */
+const precededByAbbreviation = (buffer: string, dotIndex: number): boolean => {
+  let start = dotIndex
+  while (start > 0 && /[A-Za-z]/.test(buffer[start - 1])) start--
+  const word = buffer.slice(start, dotIndex).toLowerCase()
+  return word.length > 0 && ABBREVIATIONS.has(word)
+}
+
+export class SentenceAggregator {
+  private buffer = ''
+  private firstEmitted = false
+
+  /** Feed streaming text; returns any chunks that became ready to synthesize. */
+  push(text: string): string[] {
+    this.buffer += text
+    const chunks: string[] = []
+    for (;;) {
+      const end = this.nextBoundary()
+      if (end < 0) break
+      const chunk = this.buffer.slice(0, end).trim()
+      this.buffer = this.buffer.slice(end)
+      if (chunk.length > 0) {
+        chunks.push(chunk)
+        this.firstEmitted = true
+      }
+    }
+    return chunks
+  }
+
+  /** Flush the remaining buffer at end-of-stream (e.g. after the LLM finishes). */
+  flush(): string[] {
+    const rest = this.buffer.trim()
+    this.buffer = ''
+    if (rest.length === 0) return []
+    this.firstEmitted = true
+    return [rest]
+  }
+
+  /**
+   * Index (exclusive) at which to cut the next chunk from the buffer, or -1
+   * if no complete chunk is available yet.
+   */
+  private nextBoundary(): number {
+    const buf = this.buffer
+    let lastWordBreak = -1
+    // Reset per scan: the buffer always begins outside a code span, because we
+    // never cut at a boundary found while inside one.
+    let inCode = false
+    for (let i = 0; i < buf.length; i++) {
+      const ch = buf[i]
+      if (ch === '`') inCode = !inCode
+      if (inCode) continue
+      if (isWhitespace(ch)) lastWordBreak = i
+
+      if (!this.firstEmitted) {
+        // First chunk: earliest clause/sentence break past the floor, else a
+        // hard cap at the last word boundary — bounds time-to-first-audio.
+        if (i + 1 >= FIRST_MIN_CHARS) {
+          if (CLAUSE_PUNCT.has(ch)) return i + 1
+          const end = this.sentenceEnd(buf, i)
+          if (end > 0) return end
+        }
+        if (i + 1 >= FIRST_MAX_CHARS && lastWordBreak > 0) return lastWordBreak + 1
+        continue
+      }
+
+      const end = this.sentenceEnd(buf, i)
+      if (end > 0) return end
+    }
+    return -1
+  }
+
+  /**
+   * Exclusive end index if `buf[i]` closes a sentence (terminal punct, any
+   * trailing quotes/brackets, then whitespace), or -1. Rejects decimals,
+   * abbreviations, and URLs so they don't split mid-thought.
+   */
+  private sentenceEnd(buf: string, i: number): number {
+    if (!SENTENCE_PUNCT.has(buf[i])) return -1
+    // Consume any run of terminators / closing quotes+brackets.
+    let j = i
+    while (j + 1 < buf.length && (SENTENCE_PUNCT.has(buf[j + 1]) || `")']`.includes(buf[j + 1]))) j++
+    // Must be followed by whitespace — excludes decimals (3.14) and URLs (a.com).
+    if (j + 1 >= buf.length || !isWhitespace(buf[j + 1])) return -1
+    if (buf[i] === '.') {
+      if (i > 0 && isDigit(buf[i - 1]) && i + 1 < buf.length && isDigit(buf[i + 1])) return -1
+      if (precededByAbbreviation(buf, i)) return -1
+    }
+    return j + 1
+  }
+}

--- a/src/voice/audio/playback.ts
+++ b/src/voice/audio/playback.ts
@@ -60,10 +60,14 @@ export const createPlaybackQueue = (audioContext?: AudioContext): PlaybackQueue 
   }
 
   const close = () => {
-    if (closed) return // ctx.close() throws if called twice
+    if (closed) {
+      return
+    } // ctx.close() throws if called twice
     closed = true
     flush()
-    if (ownsCtx) void ctx.close()
+    if (ownsCtx) {
+      void ctx.close()
+    }
   }
 
   return {

--- a/src/voice/audio/playback.ts
+++ b/src/voice/audio/playback.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Gapless playback queue (THU-684).
+ *
+ * Schedules TTS audio chunks back-to-back on a Web Audio graph routed to the
+ * **default output** — that placement is what lets the browser/OS AEC use our
+ * playout as its echo reference (so the mic doesn't hear the assistant and
+ * self-trigger barge-in), even when the PCM was produced natively. `flush()`
+ * stops everything immediately (<100 ms) for barge-in.
+ */
+import type { AudioChunk } from '@/voice/engine/types'
+
+export type PlaybackQueue = {
+  /** Schedule a chunk to play after whatever is already queued. */
+  enqueue: (chunk: AudioChunk) => void
+  /** Stop and drop all scheduled/playing audio immediately (barge-in). */
+  flush: () => void
+  /** Permanently release the audio graph — closes the owned AudioContext. */
+  close: () => void
+  readonly isPlaying: boolean
+  readonly audioContext: AudioContext
+}
+
+export const createPlaybackQueue = (audioContext?: AudioContext): PlaybackQueue => {
+  const ctx = audioContext ?? new AudioContext()
+  const ownsCtx = !audioContext // only close a context we created
+  const active = new Set<AudioBufferSourceNode>()
+  let nextStartTime = 0
+  let closed = false
+
+  const enqueue = (chunk: AudioChunk) => {
+    void ctx.resume() // no-op once running; needed after the user-gesture start
+    const buffer = ctx.createBuffer(1, chunk.pcm.length, chunk.sampleRate)
+    buffer.copyToChannel(new Float32Array(chunk.pcm), 0)
+    const source = ctx.createBufferSource()
+    source.buffer = buffer
+    source.connect(ctx.destination)
+    const startAt = Math.max(ctx.currentTime, nextStartTime)
+    source.start(startAt)
+    nextStartTime = startAt + buffer.duration
+    active.add(source)
+    source.onended = () => active.delete(source)
+  }
+
+  const flush = () => {
+    for (const source of active) {
+      source.onended = null
+      try {
+        source.stop()
+      } catch {
+        // already stopped/ended — fine
+      }
+      source.disconnect()
+    }
+    active.clear()
+    nextStartTime = 0
+  }
+
+  const close = () => {
+    if (closed) return // ctx.close() throws if called twice
+    closed = true
+    flush()
+    if (ownsCtx) void ctx.close()
+  }
+
+  return {
+    enqueue,
+    flush,
+    close,
+    get isPlaying() {
+      return active.size > 0
+    },
+    audioContext: ctx,
+  }
+}

--- a/src/voice/audio/playback.ts
+++ b/src/voice/audio/playback.ts
@@ -20,6 +20,9 @@ export type PlaybackQueue = {
   flush: () => void
   /** Permanently release the audio graph — closes the owned AudioContext. */
   close: () => void
+  /** Current output RMS (~[0,1]) of what's playing, for the reactive waveform;
+   *  0 when nothing is queued. */
+  getLevel: () => number
   readonly isPlaying: boolean
   readonly audioContext: AudioContext
 }
@@ -28,6 +31,14 @@ export const createPlaybackQueue = (audioContext?: AudioContext): PlaybackQueue 
   const ctx = audioContext ?? new AudioContext()
   const ownsCtx = !audioContext // only close a context we created
   const active = new Set<AudioBufferSourceNode>()
+  // Tap the output so the waveform can react to the assistant's actual voice.
+  // Sources route through the analyser to `destination`, which passes audio
+  // through unchanged — so the browser/OS AEC still sees our playout as its echo
+  // reference (see the module note), it just also feeds level readings.
+  const analyser = ctx.createAnalyser()
+  analyser.fftSize = 256
+  analyser.connect(ctx.destination)
+  const levelBuf = new Float32Array(analyser.fftSize)
   let nextStartTime = 0
   let closed = false
 
@@ -37,12 +48,24 @@ export const createPlaybackQueue = (audioContext?: AudioContext): PlaybackQueue 
     buffer.copyToChannel(new Float32Array(chunk.pcm), 0)
     const source = ctx.createBufferSource()
     source.buffer = buffer
-    source.connect(ctx.destination)
+    source.connect(analyser)
     const startAt = Math.max(ctx.currentTime, nextStartTime)
     source.start(startAt)
     nextStartTime = startAt + buffer.duration
     active.add(source)
     source.onended = () => active.delete(source)
+  }
+
+  const getLevel = (): number => {
+    if (active.size === 0) {
+      return 0 // nothing playing — don't report residual analyser data
+    }
+    analyser.getFloatTimeDomainData(levelBuf)
+    let sum = 0
+    for (let i = 0; i < levelBuf.length; i++) {
+      sum += levelBuf[i] * levelBuf[i]
+    }
+    return Math.sqrt(sum / levelBuf.length)
   }
 
   const flush = () => {
@@ -74,6 +97,7 @@ export const createPlaybackQueue = (audioContext?: AudioContext): PlaybackQueue 
     enqueue,
     flush,
     close,
+    getLevel,
     get isPlaying() {
       return active.size > 0
     },

--- a/src/voice/audio/vad.ts
+++ b/src/voice/audio/vad.ts
@@ -39,21 +39,23 @@ export type VadGate = {
 }
 
 /** Frames are 512 samples (~32 ms) — set by the capture worklet. */
-const SPEECH_RMS_THRESHOLD = 0.015 // normalized [-1,1] amplitude; tune for the mic
-const MIN_SPEECH_FRAMES = 8 // ~256 ms — shorter is a misfire
+const speechRmsThreshold = 0.015 // normalized [-1,1] amplitude; tune for the mic
+const minSpeechFrames = 8 // ~256 ms — shorter is a misfire
 // ~1.4 s of trailing silence ends the turn. Long enough to think mid-sentence
 // without it firing on a natural pause; a streaming STT with semantic
 // endpointing would let us shorten this later.
-const END_SILENCE_FRAMES = 45
-const PREROLL_FRAMES = 4 // keep a little audio before onset so we don't clip it
+const endSilenceFrames = 45
+const prerollFrames = 4 // keep a little audio before onset so we don't clip it
 
-const AEC_CONSTRAINTS: MediaStreamConstraints = {
+const aecConstraints: MediaStreamConstraints = {
   audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
 }
 
 const rms = (frame: Float32Array): number => {
   let sum = 0
-  for (let i = 0; i < frame.length; i++) sum += frame[i] * frame[i]
+  for (let i = 0; i < frame.length; i++) {
+    sum += frame[i] * frame[i]
+  }
   return Math.sqrt(sum / frame.length)
 }
 
@@ -82,7 +84,7 @@ export const createVadGate = (handlers: VadHandlers): VadGate => {
     reset()
     // Gate on real speech only — `collected` also holds preroll + the ~1.4 s of
     // trailing silence, so counting frames.length would never detect a misfire.
-    if (speech < MIN_SPEECH_FRAMES) {
+    if (speech < minSpeechFrames) {
       handlers.onMisfire?.()
       return
     }
@@ -92,7 +94,7 @@ export const createVadGate = (handlers: VadHandlers): VadGate => {
   const processFrame = (frame: Float32Array) => {
     const level = rms(frame)
     handlers.onLevel?.(level)
-    if (level >= SPEECH_RMS_THRESHOLD) {
+    if (level >= speechRmsThreshold) {
       if (!speaking) {
         speaking = true
         collected = [...preroll]
@@ -104,10 +106,14 @@ export const createVadGate = (handlers: VadHandlers): VadGate => {
     } else if (speaking) {
       collected.push(frame)
       silenceRun++
-      if (silenceRun >= END_SILENCE_FRAMES) endUtterance()
+      if (silenceRun >= endSilenceFrames) {
+        endUtterance()
+      }
     } else {
       preroll.push(frame)
-      if (preroll.length > PREROLL_FRAMES) preroll.shift()
+      if (preroll.length > prerollFrames) {
+        preroll.shift()
+      }
     }
   }
 
@@ -118,33 +124,43 @@ export const createVadGate = (handlers: VadHandlers): VadGate => {
     if (!navigator.mediaDevices?.getUserMedia) {
       throw new MediaDevicesUnavailableError()
     }
-    stream = await navigator.mediaDevices.getUserMedia(AEC_CONSTRAINTS)
+    stream = await navigator.mediaDevices.getUserMedia(aecConstraints)
     // Native mic rate (can't connect a MediaStreamSource across rates); the
     // worklet resamples to 16 kHz.
     ctx = new AudioContext()
     // Mobile webviews create the context suspended even inside a gesture; resume
     // so the capture graph actually pulls frames.
-    if (ctx.state === 'suspended') await ctx.resume()
+    if (ctx.state === 'suspended') {
+      await ctx.resume()
+    }
     await ctx.audioWorklet.addModule('/voice/capture-worklet.js')
     node = new AudioWorkletNode(ctx, 'capture-processor')
     ctx.createMediaStreamSource(stream).connect(node)
     node.connect(ctx.destination) // worklet has no output; keeps the graph pulling
     node.port.onmessage = (event: MessageEvent<Float32Array>) => {
-      if (listening) processFrame(event.data)
+      if (listening) {
+        processFrame(event.data)
+      }
     }
   }
 
   const pause = async () => {
-    if (node) node.port.onmessage = null
+    if (node) {
+      node.port.onmessage = null
+    }
     node?.disconnect()
     await ctx?.suspend()
   }
 
   const destroy = async () => {
-    if (node) node.port.onmessage = null
+    if (node) {
+      node.port.onmessage = null
+    }
     node?.disconnect()
     node = null
-    for (const track of stream?.getTracks() ?? []) track.stop()
+    for (const track of stream?.getTracks() ?? []) {
+      track.stop()
+    }
     stream = null
     await ctx?.close()
     ctx = null

--- a/src/voice/audio/vad.ts
+++ b/src/voice/audio/vad.ts
@@ -17,6 +17,7 @@
  * trigger (unused while half-duplex, but kept for when full-duplex returns).
  */
 import { concatFrames } from '@/voice/engine/audio-engine'
+import { MediaDevicesUnavailableError } from '@/voice/voice-error'
 
 export type VadHandlers = {
   onSpeechStart?: () => void
@@ -111,6 +112,12 @@ export const createVadGate = (handlers: VadHandlers): VadGate => {
   }
 
   const start = async () => {
+    // WKWebView hides `navigator.mediaDevices` outside a secure context (a Tauri
+    // dev build over http://localhost), so guard before dereferencing it — a raw
+    // "undefined is not an object" TypeError isn't actionable.
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new MediaDevicesUnavailableError()
+    }
     stream = await navigator.mediaDevices.getUserMedia(AEC_CONSTRAINTS)
     // Native mic rate (can't connect a MediaStreamSource across rates); the
     // worklet resamples to 16 kHz.

--- a/src/voice/audio/vad.ts
+++ b/src/voice/audio/vad.ts
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * VAD gate (THU-684) — mic capture + energy-based endpointing, zero in-browser ML.
+ *
+ * The capture worklet resamples the mic to 16 kHz frames; we detect speech by
+ * frame RMS energy and end the turn after a trailing-silence window, emitting the
+ * committed utterance for the STT engine. This is deliberately simple (no models
+ * on the client) — a lightweight gate so we only send *speech* to the STT
+ * provider, not a continuous mic stream. A streaming STT with server-side
+ * endpointing (e.g. Tinfoil voxtral-realtime) can supersede it later; energy VAD
+ * is the crude-but-dependency-free MVP.
+ *
+ * `getUserMedia` runs with echo cancellation on; `onSpeechStart` is the barge-in
+ * trigger (unused while half-duplex, but kept for when full-duplex returns).
+ */
+import { concatFrames } from '@/voice/engine/audio-engine'
+
+export type VadHandlers = {
+  onSpeechStart?: () => void
+  /** A committed utterance (mono Float32Array @ 16 kHz) ready for transcription. */
+  onUtterance: (audio: Float32Array) => void
+  /** Speech started but was too short to be a real utterance. */
+  onMisfire?: () => void
+  /** Per-frame mic RMS [0,1] while listening — drives the live waveform. */
+  onLevel?: (rms: number) => void
+}
+
+export type VadGate = {
+  start: () => Promise<void>
+  pause: () => Promise<void>
+  destroy: () => Promise<void>
+  /** Gate frame processing. Paused = no self-triggering while the assistant
+   *  speaks (half-duplex). */
+  setListening: (value: boolean) => void
+}
+
+/** Frames are 512 samples (~32 ms) — set by the capture worklet. */
+const SPEECH_RMS_THRESHOLD = 0.015 // normalized [-1,1] amplitude; tune for the mic
+const MIN_SPEECH_FRAMES = 8 // ~256 ms — shorter is a misfire
+// ~1.4 s of trailing silence ends the turn. Long enough to think mid-sentence
+// without it firing on a natural pause; a streaming STT with semantic
+// endpointing would let us shorten this later.
+const END_SILENCE_FRAMES = 45
+const PREROLL_FRAMES = 4 // keep a little audio before onset so we don't clip it
+
+const AEC_CONSTRAINTS: MediaStreamConstraints = {
+  audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+}
+
+const rms = (frame: Float32Array): number => {
+  let sum = 0
+  for (let i = 0; i < frame.length; i++) sum += frame[i] * frame[i]
+  return Math.sqrt(sum / frame.length)
+}
+
+export const createVadGate = (handlers: VadHandlers): VadGate => {
+  let stream: MediaStream | null = null
+  let ctx: AudioContext | null = null
+  let node: AudioWorkletNode | null = null
+
+  let listening = true
+  let speaking = false
+  let collected: Float32Array[] = []
+  let preroll: Float32Array[] = []
+  let silenceRun = 0
+  let speechFrames = 0 // frames actually above threshold (excludes trailing silence)
+
+  const reset = () => {
+    speaking = false
+    collected = []
+    silenceRun = 0
+    speechFrames = 0
+  }
+
+  const endUtterance = () => {
+    const frames = collected
+    const speech = speechFrames
+    reset()
+    // Gate on real speech only — `collected` also holds preroll + the ~1.4 s of
+    // trailing silence, so counting frames.length would never detect a misfire.
+    if (speech < MIN_SPEECH_FRAMES) {
+      handlers.onMisfire?.()
+      return
+    }
+    handlers.onUtterance(concatFrames(frames))
+  }
+
+  const processFrame = (frame: Float32Array) => {
+    const level = rms(frame)
+    handlers.onLevel?.(level)
+    if (level >= SPEECH_RMS_THRESHOLD) {
+      if (!speaking) {
+        speaking = true
+        collected = [...preroll]
+        handlers.onSpeechStart?.()
+      }
+      collected.push(frame)
+      silenceRun = 0
+      speechFrames++
+    } else if (speaking) {
+      collected.push(frame)
+      silenceRun++
+      if (silenceRun >= END_SILENCE_FRAMES) endUtterance()
+    } else {
+      preroll.push(frame)
+      if (preroll.length > PREROLL_FRAMES) preroll.shift()
+    }
+  }
+
+  const start = async () => {
+    stream = await navigator.mediaDevices.getUserMedia(AEC_CONSTRAINTS)
+    // Native mic rate (can't connect a MediaStreamSource across rates); the
+    // worklet resamples to 16 kHz.
+    ctx = new AudioContext()
+    // Mobile webviews create the context suspended even inside a gesture; resume
+    // so the capture graph actually pulls frames.
+    if (ctx.state === 'suspended') await ctx.resume()
+    await ctx.audioWorklet.addModule('/voice/capture-worklet.js')
+    node = new AudioWorkletNode(ctx, 'capture-processor')
+    ctx.createMediaStreamSource(stream).connect(node)
+    node.connect(ctx.destination) // worklet has no output; keeps the graph pulling
+    node.port.onmessage = (event: MessageEvent<Float32Array>) => {
+      if (listening) processFrame(event.data)
+    }
+  }
+
+  const pause = async () => {
+    if (node) node.port.onmessage = null
+    node?.disconnect()
+    await ctx?.suspend()
+  }
+
+  const destroy = async () => {
+    if (node) node.port.onmessage = null
+    node?.disconnect()
+    node = null
+    for (const track of stream?.getTracks() ?? []) track.stop()
+    stream = null
+    await ctx?.close()
+    ctx = null
+    reset()
+    preroll = []
+  }
+
+  const setListening = (value: boolean) => {
+    listening = value
+    if (!value) {
+      reset()
+      preroll = []
+    }
+  }
+
+  return { start, pause, destroy, setListening }
+}

--- a/src/voice/chat-reply.test.ts
+++ b/src/voice/chat-reply.test.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { type ReplyChat, createChatReply } from './chat-reply'
+
+// The happydom test env doesn't run real `setTimeout`, so stream + poll on
+// microtasks: the fake appends a token per microtask, and we inject a microtask
+// `wait` into createChatReply.
+const microtask = () => Promise.resolve()
+
+type MutableMessage = { role: string; parts: Array<{ type: string; text: string }> }
+
+/**
+ * A fake `Chat` that streams `tokens` into a NEW assistant message over
+ * microtasks — and seeds a stale prior assistant message, so tests catch the
+ * "reads the previous turn" bug.
+ */
+const makeFakeChat = (tokens: string[]) => {
+  const state = {
+    messages: [{ role: 'assistant', parts: [{ type: 'text', text: 'stale previous reply' }] }] as MutableMessage[],
+    stopped: false,
+  }
+  const chat: ReplyChat = {
+    get messages() {
+      return state.messages
+    },
+    stop: async () => {
+      state.stopped = true
+    },
+    sendMessage: async () => {
+      state.messages.push({ role: 'user', parts: [{ type: 'text', text: 'ignored' }] })
+      const part = { type: 'text', text: '' }
+      state.messages.push({ role: 'assistant', parts: [part] })
+      for (const token of tokens) {
+        if (state.stopped) break
+        await microtask()
+        part.text += token
+      }
+    },
+  }
+  return { chat, state }
+}
+
+const collect = async (iter: AsyncIterable<string>): Promise<string[]> => {
+  const out: string[] = []
+  for await (const chunk of iter) out.push(chunk)
+  return out
+}
+
+describe('createChatReply', () => {
+  test('streams the assistant text and reassembles it fully', async () => {
+    const { chat } = makeFakeChat(['Hello', ', ', 'there', '.'])
+    const reply = createChatReply(chat, microtask)
+    const chunks = await collect(reply('hi', new AbortController().signal))
+    expect(chunks.join('')).toBe('Hello, there.')
+  })
+
+  test('stops the chat and ends early on abort (turn supersede / stop)', async () => {
+    const { chat, state } = makeFakeChat(['one ', 'two ', 'three ', 'four ', 'five'])
+    const ac = new AbortController()
+    const reply = createChatReply(chat, microtask)
+    const chunks: string[] = []
+    for await (const chunk of reply('go', ac.signal)) {
+      chunks.push(chunk)
+      ac.abort() // abort as soon as we get audio
+    }
+    expect(state.stopped).toBe(true)
+    expect(chunks.join('')).not.toContain('five')
+  })
+
+  test('empty assistant reply yields nothing', async () => {
+    const { chat } = makeFakeChat([])
+    const reply = createChatReply(chat, microtask)
+    const chunks = await collect(reply('hi', new AbortController().signal))
+    expect(chunks).toEqual([])
+  })
+
+  test('surfaces a sendMessage failure by throwing (not a silent empty turn)', async () => {
+    const chat: ReplyChat = {
+      messages: [],
+      stop: async () => {},
+      sendMessage: async () => {
+        throw new Error('network down')
+      },
+    }
+    const reply = createChatReply(chat, microtask)
+    await expect(collect(reply('hi', new AbortController().signal))).rejects.toThrow('network down')
+  })
+
+  test('does not throw when the failure is our own abort', async () => {
+    const { chat } = makeFakeChat(['one ', 'two ', 'three'])
+    const ac = new AbortController()
+    const reply = createChatReply(chat, microtask)
+    // Aborting rejects the in-flight send via chat.stop(); that must not surface
+    // as a turn error.
+    for await (const _ of reply('go', ac.signal)) ac.abort()
+    // Reaching here without throwing is the assertion.
+  })
+})

--- a/src/voice/chat-reply.test.ts
+++ b/src/voice/chat-reply.test.ts
@@ -34,7 +34,9 @@ const makeFakeChat = (tokens: string[]) => {
       const part = { type: 'text', text: '' }
       state.messages.push({ role: 'assistant', parts: [part] })
       for (const token of tokens) {
-        if (state.stopped) break
+        if (state.stopped) {
+          break
+        }
         await microtask()
         part.text += token
       }
@@ -45,7 +47,9 @@ const makeFakeChat = (tokens: string[]) => {
 
 const collect = async (iter: AsyncIterable<string>): Promise<string[]> => {
   const out: string[] = []
-  for await (const chunk of iter) out.push(chunk)
+  for await (const chunk of iter) {
+    out.push(chunk)
+  }
   return out
 }
 
@@ -95,7 +99,9 @@ describe('createChatReply', () => {
     const reply = createChatReply(chat, microtask)
     // Aborting rejects the in-flight send via chat.stop(); that must not surface
     // as a turn error.
-    for await (const _ of reply('go', ac.signal)) ac.abort()
+    for await (const _ of reply('go', ac.signal)) {
+      ac.abort()
+    }
     // Reaching here without throwing is the assertion.
   })
 })

--- a/src/voice/chat-reply.ts
+++ b/src/voice/chat-reply.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Chat-backed reply for the voice session (THU-688).
+ *
+ * Turns a voice turn into a real chat turn: sends the transcript through the
+ * app's existing `Chat` instance (model, tools, history, persistence all reused)
+ * and streams *this turn's* assistant message text back as deltas, so TTS starts
+ * speaking mid-generation. Aborting the turn (a newer utterance supersedes it, or
+ * the session stops) cancels the in-flight send via `chat.stop()`.
+ *
+ * We baseline on the message count before sending so we read the NEW assistant
+ * message, not the previous turn's (which is still `messages[last]` until the
+ * send appends).
+ */
+import type { ReplyFn } from '@/voice/session'
+
+/** The slice of the AI SDK `Chat` this needs — kept structural so it's testable. */
+export type ReplyChat = {
+  sendMessage: (message: { text: string }) => Promise<void>
+  readonly messages: ReadonlyArray<{ role: string; parts: ReadonlyArray<{ type: string; text?: string }> }>
+  stop: () => Promise<void>
+}
+
+const POLL_MS = 40
+
+/** Text of the assistant message for the turn that started at `baseline`, or ''. */
+const turnAssistantText = (chat: ReplyChat, baseline: number): string => {
+  const { messages } = chat
+  if (messages.length <= baseline) return '' // no new messages yet
+  const last = messages[messages.length - 1]
+  if (last.role !== 'assistant') return '' // user message added, assistant not started
+  return last.parts.reduce((text, part) => (part.type === 'text' ? text + (part.text ?? '') : text), '')
+}
+
+const timerWait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * @param wait poll scheduler between reads — defaults to a real timer; inject a
+ *   microtask resolver in tests (the happydom test env doesn't run `setTimeout`).
+ */
+export const createChatReply = (chat: ReplyChat, wait: (ms: number) => Promise<void> = timerWait): ReplyFn =>
+  async function* (userText, signal) {
+    const onAbort = () => void chat.stop()
+    signal.addEventListener('abort', onAbort, { once: true })
+    const baseline = chat.messages.length
+    let emitted = 0
+    let done = false
+    let sendError: unknown = null
+    void chat
+      .sendMessage({ text: userText })
+      .catch((error) => {
+        sendError = error
+      })
+      .finally(() => {
+        done = true
+      })
+    try {
+      while (!signal.aborted) {
+        const text = turnAssistantText(chat, baseline)
+        if (text.length > emitted) {
+          yield text.slice(emitted)
+          emitted = text.length
+        }
+        if (done) {
+          const finalText = turnAssistantText(chat, baseline)
+          if (finalText.length > emitted) yield finalText.slice(emitted)
+          // Surface a send failure so the session hits its error state instead of
+          // returning a silent empty turn (no audio, no error). Skipped on abort —
+          // there the rejection is our own chat.stop(), not a real failure.
+          if (sendError && !signal.aborted) throw sendError
+          return
+        }
+        await wait(POLL_MS)
+      }
+    } finally {
+      signal.removeEventListener('abort', onAbort)
+    }
+  }

--- a/src/voice/chat-reply.ts
+++ b/src/voice/chat-reply.ts
@@ -24,14 +24,18 @@ export type ReplyChat = {
   stop: () => Promise<void>
 }
 
-const POLL_MS = 40
+const pollMs = 40
 
 /** Text of the assistant message for the turn that started at `baseline`, or ''. */
 const turnAssistantText = (chat: ReplyChat, baseline: number): string => {
   const { messages } = chat
-  if (messages.length <= baseline) return '' // no new messages yet
+  if (messages.length <= baseline) {
+    return ''
+  } // no new messages yet
   const last = messages[messages.length - 1]
-  if (last.role !== 'assistant') return '' // user message added, assistant not started
+  if (last.role !== 'assistant') {
+    return ''
+  } // user message added, assistant not started
   return last.parts.reduce((text, part) => (part.type === 'text' ? text + (part.text ?? '') : text), '')
 }
 
@@ -66,14 +70,18 @@ export const createChatReply = (chat: ReplyChat, wait: (ms: number) => Promise<v
         }
         if (done) {
           const finalText = turnAssistantText(chat, baseline)
-          if (finalText.length > emitted) yield finalText.slice(emitted)
+          if (finalText.length > emitted) {
+            yield finalText.slice(emitted)
+          }
           // Surface a send failure so the session hits its error state instead of
           // returning a silent empty turn (no audio, no error). Skipped on abort —
           // there the rejection is our own chat.stop(), not a real failure.
-          if (sendError && !signal.aborted) throw sendError
+          if (sendError && !signal.aborted) {
+            throw sendError
+          }
           return
         }
-        await wait(POLL_MS)
+        await wait(pollMs)
       }
     } finally {
       signal.removeEventListener('abort', onAbort)

--- a/src/voice/engine/audio-engine.ts
+++ b/src/voice/engine/audio-engine.ts
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared OpenAI-compatible audio engine (THU-718).
+ *
+ * The STT/TTS request/response shapes (`/audio/transcriptions`, `/audio/speech`)
+ * are identical across providers — only the *transport* differs: the Thunderbolt
+ * engine tunnels through the attested `/tinfoil` HPKE proxy, while a custom or
+ * self-hosted engine does a plain authenticated fetch. This factory owns the
+ * common orchestration + audio codec; each engine just supplies a `transport`.
+ */
+import type { AudioChunk, PcmFrame, Transcript, VoiceEngine } from './types'
+
+/** Sample rate the capture worklet emits and STT expects. */
+export const STT_SAMPLE_RATE = 16000
+
+/** Sends one request to an `/audio/*` path and returns the raw Response (does
+ *  NOT throw on non-2xx — the factory inspects status + body itself). The
+ *  per-turn `signal` must be forwarded to the underlying fetch so an aborted turn
+ *  (barge-in supersede / Exit voice mode) cancels the in-flight request rather
+ *  than running it to completion against the provider. */
+export type AudioTransport = (
+  path: string,
+  body: BodyInit,
+  headers?: Record<string, string>,
+  signal?: AbortSignal,
+) => Promise<Response>
+
+export type AudioEngineOptions = {
+  id: string
+  transport: AudioTransport
+  sttModel: string
+  ttsModel: string
+  ttsVoice: string
+  /** Style/emotion steering (vLLM-Omni extension) — omit for stricter servers. */
+  ttsInstructions?: string
+  /** wav/mp3/… — `decodeAudioData` handles whatever comes back. Defaults to wav. */
+  ttsFormat?: string
+  ttsSpeed?: number
+  /** Optional warmup on `load()` (e.g. prime enclave attestation). */
+  warm?: () => Promise<void>
+}
+
+/** Encode mono 16 kHz float PCM as a 16-bit WAV for the transcription endpoint. */
+export const encodeWav = (samples: Float32Array, sampleRate: number): Blob => {
+  const buffer = new ArrayBuffer(44 + samples.length * 2)
+  const view = new DataView(buffer)
+  const writeStr = (offset: number, s: string) => {
+    for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i))
+  }
+  writeStr(0, 'RIFF')
+  view.setUint32(4, 36 + samples.length * 2, true)
+  writeStr(8, 'WAVE')
+  writeStr(12, 'fmt ')
+  view.setUint32(16, 16, true) // PCM chunk size
+  view.setUint16(20, 1, true) // PCM
+  view.setUint16(22, 1, true) // mono
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, sampleRate * 2, true) // byte rate
+  view.setUint16(32, 2, true) // block align
+  view.setUint16(34, 16, true) // bits per sample
+  writeStr(36, 'data')
+  view.setUint32(40, samples.length * 2, true)
+  let offset = 44
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true)
+    offset += 2
+  }
+  return new Blob([buffer], { type: 'audio/wav' })
+}
+
+export const concatFrames = (frames: PcmFrame[]): Float32Array => {
+  const merged = new Float32Array(frames.reduce((n, f) => n + f.length, 0))
+  frames.reduce((offset, f) => (merged.set(f, offset), offset + f.length), 0)
+  return merged
+}
+
+const errorText = async (res: Response): Promise<string> => `${res.status} ${await res.text().catch(() => '')}`.trim()
+
+export const createAudioEngine = (opts: AudioEngineOptions): VoiceEngine => {
+  const ttsFormat = opts.ttsFormat ?? 'wav'
+  let decodeCtx: AudioContext | null = null
+
+  const load = async () => {
+    await opts.warm?.()
+  }
+
+  const transcribe = async function* (audio: AsyncIterable<PcmFrame>, signal?: AbortSignal): AsyncIterable<Transcript> {
+    const frames: PcmFrame[] = []
+    for await (const frame of audio) {
+      if (signal?.aborted) return
+      frames.push(frame)
+    }
+    if (frames.length === 0) return
+    // The session feeds one already-merged utterance frame; skip the redundant
+    // full-length copy in that common case.
+    const merged = frames.length === 1 ? frames[0] : concatFrames(frames)
+    const form = new FormData()
+    form.append('file', encodeWav(merged, STT_SAMPLE_RATE), 'utterance.wav')
+    form.append('model', opts.sttModel)
+    const res = await opts.transport('/audio/transcriptions', form, undefined, signal)
+    if (!res.ok) throw new Error(`STT failed: ${await errorText(res)}`)
+    const data = (await res.json()) as { text?: string }
+    if (signal?.aborted) return
+    yield { text: (data.text ?? '').trim(), isFinal: true }
+  }
+
+  const synthesize = async function* (text: AsyncIterable<string>, signal?: AbortSignal): AsyncIterable<AudioChunk> {
+    decodeCtx ??= new AudioContext()
+    for await (const chunk of text) {
+      if (signal?.aborted) return
+      const payload: Record<string, unknown> = {
+        model: opts.ttsModel,
+        input: chunk,
+        voice: opts.ttsVoice,
+        response_format: ttsFormat,
+      }
+      if (opts.ttsSpeed !== undefined) payload.speed = opts.ttsSpeed
+      if (opts.ttsInstructions) payload.instructions = opts.ttsInstructions
+      const res = await opts.transport(
+        '/audio/speech',
+        JSON.stringify(payload),
+        { 'content-type': 'application/json' },
+        signal,
+      )
+      if (!res.ok) throw new Error(`TTS failed: ${await errorText(res)}`)
+      // Re-check before decoding: a response that resolved right as the turn was
+      // aborted must not be decoded, and dispose() nulls decodeCtx concurrently.
+      if (signal?.aborted || !decodeCtx) return
+      const decoded = await decodeCtx.decodeAudioData(await res.arrayBuffer())
+      if (signal?.aborted) return
+      yield { pcm: decoded.getChannelData(0).slice(), sampleRate: decoded.sampleRate }
+    }
+  }
+
+  const dispose = () => {
+    void decodeCtx?.close()
+    decodeCtx = null
+  }
+
+  return { id: opts.id, load, transcribe, synthesize, dispose }
+}

--- a/src/voice/engine/audio-engine.ts
+++ b/src/voice/engine/audio-engine.ts
@@ -14,7 +14,7 @@
 import type { AudioChunk, PcmFrame, Transcript, VoiceEngine } from './types'
 
 /** Sample rate the capture worklet emits and STT expects. */
-export const STT_SAMPLE_RATE = 16000
+export const sttSampleRate = 16000
 
 /** Sends one request to an `/audio/*` path and returns the raw Response (does
  *  NOT throw on non-2xx — the factory inspects status + body itself). The
@@ -48,7 +48,9 @@ export const encodeWav = (samples: Float32Array, sampleRate: number): Blob => {
   const buffer = new ArrayBuffer(44 + samples.length * 2)
   const view = new DataView(buffer)
   const writeStr = (offset: number, s: string) => {
-    for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i))
+    for (let i = 0; i < s.length; i++) {
+      view.setUint8(offset + i, s.charCodeAt(i))
+    }
   }
   writeStr(0, 'RIFF')
   view.setUint32(4, 36 + samples.length * 2, true)
@@ -91,47 +93,67 @@ export const createAudioEngine = (opts: AudioEngineOptions): VoiceEngine => {
   const transcribe = async function* (audio: AsyncIterable<PcmFrame>, signal?: AbortSignal): AsyncIterable<Transcript> {
     const frames: PcmFrame[] = []
     for await (const frame of audio) {
-      if (signal?.aborted) return
+      if (signal?.aborted) {
+        return
+      }
       frames.push(frame)
     }
-    if (frames.length === 0) return
+    if (frames.length === 0) {
+      return
+    }
     // The session feeds one already-merged utterance frame; skip the redundant
     // full-length copy in that common case.
     const merged = frames.length === 1 ? frames[0] : concatFrames(frames)
     const form = new FormData()
-    form.append('file', encodeWav(merged, STT_SAMPLE_RATE), 'utterance.wav')
+    form.append('file', encodeWav(merged, sttSampleRate), 'utterance.wav')
     form.append('model', opts.sttModel)
     const res = await opts.transport('/audio/transcriptions', form, undefined, signal)
-    if (!res.ok) throw new Error(`STT failed: ${await errorText(res)}`)
+    if (!res.ok) {
+      throw new Error(`STT failed: ${await errorText(res)}`)
+    }
     const data = (await res.json()) as { text?: string }
-    if (signal?.aborted) return
+    if (signal?.aborted) {
+      return
+    }
     yield { text: (data.text ?? '').trim(), isFinal: true }
   }
 
   const synthesize = async function* (text: AsyncIterable<string>, signal?: AbortSignal): AsyncIterable<AudioChunk> {
     decodeCtx ??= new AudioContext()
     for await (const chunk of text) {
-      if (signal?.aborted) return
+      if (signal?.aborted) {
+        return
+      }
       const payload: Record<string, unknown> = {
         model: opts.ttsModel,
         input: chunk,
         voice: opts.ttsVoice,
         response_format: ttsFormat,
       }
-      if (opts.ttsSpeed !== undefined) payload.speed = opts.ttsSpeed
-      if (opts.ttsInstructions) payload.instructions = opts.ttsInstructions
+      if (opts.ttsSpeed !== undefined) {
+        payload.speed = opts.ttsSpeed
+      }
+      if (opts.ttsInstructions) {
+        payload.instructions = opts.ttsInstructions
+      }
       const res = await opts.transport(
         '/audio/speech',
         JSON.stringify(payload),
         { 'content-type': 'application/json' },
         signal,
       )
-      if (!res.ok) throw new Error(`TTS failed: ${await errorText(res)}`)
+      if (!res.ok) {
+        throw new Error(`TTS failed: ${await errorText(res)}`)
+      }
       // Re-check before decoding: a response that resolved right as the turn was
       // aborted must not be decoded, and dispose() nulls decodeCtx concurrently.
-      if (signal?.aborted || !decodeCtx) return
+      if (signal?.aborted || !decodeCtx) {
+        return
+      }
       const decoded = await decodeCtx.decodeAudioData(await res.arrayBuffer())
-      if (signal?.aborted) return
+      if (signal?.aborted) {
+        return
+      }
       yield { pcm: decoded.getChannelData(0).slice(), sampleRate: decoded.sampleRate }
     }
   }

--- a/src/voice/engine/openai-compatible-engine.test.ts
+++ b/src/voice/engine/openai-compatible-engine.test.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { classifyModels } from './openai-compatible-engine'
+
+describe('classifyModels', () => {
+  test('splits STT and TTS by task and maps embedded voices', () => {
+    const result = classifyModels([
+      { id: 'Systran/faster-whisper-small', task: 'automatic-speech-recognition' },
+      {
+        id: 'speaches-ai/Kokoro-82M-v1.0-ONNX',
+        task: 'text-to-speech',
+        voices: [{ id: 'af_heart' }, { id: 'am_adam' }],
+      },
+    ])
+    expect(result.stt).toEqual(['Systran/faster-whisper-small'])
+    expect(result.tts).toEqual([{ id: 'speaches-ai/Kokoro-82M-v1.0-ONNX', voices: ['af_heart', 'am_adam'] }])
+  })
+
+  test('TTS model with no voices yields an empty voice list', () => {
+    const result = classifyModels([{ id: 'kokoro', task: 'text-to-speech' }])
+    expect(result.tts).toEqual([{ id: 'kokoro', voices: [] }])
+  })
+
+  test('untagged models (generic servers) are offered under both STT and TTS', () => {
+    const result = classifyModels([{ id: 'whisper-1' }, { id: 'tts-1' }])
+    expect(result.stt).toEqual(['whisper-1', 'tts-1'])
+    expect(result.tts).toEqual([
+      { id: 'whisper-1', voices: [] },
+      { id: 'tts-1', voices: [] },
+    ])
+  })
+
+  test('empty input yields empty lists', () => {
+    expect(classifyModels([])).toEqual({ stt: [], tts: [] })
+  })
+})

--- a/src/voice/engine/openai-compatible-engine.ts
+++ b/src/voice/engine/openai-compatible-engine.ts
@@ -22,7 +22,9 @@ const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '')
 
 const withAuth = (apiKey: string, headers?: Record<string, string>): Record<string, string> => {
   const merged: Record<string, string> = { ...headers }
-  if (apiKey) merged.Authorization = `Bearer ${apiKey}`
+  if (apiKey) {
+    merged.Authorization = `Bearer ${apiKey}`
+  }
   return merged
 }
 
@@ -39,7 +41,9 @@ export const createOpenAiCompatibleEngine = (config: VoiceProviderConfig): Voice
     } catch (err) {
       // The http client throws on non-2xx; hand the Response back so the engine
       // can surface the server's error body (bad voice/model, etc.).
-      if (err instanceof HttpError) return err.response
+      if (err instanceof HttpError) {
+        return err.response
+      }
       throw err
     }
   }
@@ -96,8 +100,8 @@ export type DiscoveredModels = {
   tts: Array<{ id: string; voices: string[] }>
 }
 
-const TASK_STT = 'automatic-speech-recognition'
-const TASK_TTS = 'text-to-speech'
+const taskStt = 'automatic-speech-recognition'
+const taskTts = 'text-to-speech'
 
 /**
  * Partition raw `/v1/models` entries into STT and TTS lists using each model's
@@ -110,9 +114,11 @@ export const classifyModels = (models: RawModel[]): DiscoveredModels => {
   const tts: DiscoveredModels['tts'] = []
   for (const model of models) {
     const voices = (model.voices ?? []).map((voice) => voice.id)
-    if (model.task === TASK_TTS) tts.push({ id: model.id, voices })
-    else if (model.task === TASK_STT) stt.push(model.id)
-    else {
+    if (model.task === taskTts) {
+      tts.push({ id: model.id, voices })
+    } else if (model.task === taskStt) {
+      stt.push(model.id)
+    } else {
       stt.push(model.id)
       tts.push({ id: model.id, voices })
     }

--- a/src/voice/engine/openai-compatible-engine.ts
+++ b/src/voice/engine/openai-compatible-engine.ts
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Configurable OpenAI-compatible VoiceEngine (THU-718) — the "standalone" story.
+ *
+ * Points at any server exposing OpenAI-shaped `/v1/audio/{transcriptions,speech}`:
+ * another provider or a self-hosted local model (Kokoro-FastAPI, speaches,
+ * LocalAI, vLLM, …). Unlike the Thunderbolt engine there's no HPKE proxy — just a
+ * plain authenticated fetch (app `http` client + optional Bearer key). Because
+ * the base URL is user-supplied and external, its own CORS must allow the app
+ * origin (and it must be reachable — http localhost is mixed-content-blocked from
+ * an https page).
+ */
+import { HttpError, http } from '@/lib/http'
+import type { VoiceProviderConfig } from '@/stores/local-settings-store'
+import { type AudioTransport, createAudioEngine } from './audio-engine'
+import type { VoiceEngine } from './types'
+
+const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '')
+
+const withAuth = (apiKey: string, headers?: Record<string, string>): Record<string, string> => {
+  const merged: Record<string, string> = { ...headers }
+  if (apiKey) merged.Authorization = `Bearer ${apiKey}`
+  return merged
+}
+
+export const createOpenAiCompatibleEngine = (config: VoiceProviderConfig): VoiceEngine => {
+  const baseUrl = stripTrailingSlash(config.baseUrl)
+  const transport: AudioTransport = async (path, body, headers, signal) => {
+    try {
+      return await http.post(`${baseUrl}${path}`, {
+        body,
+        headers: withAuth(config.apiKey, headers),
+        timeout: 30_000,
+        signal,
+      })
+    } catch (err) {
+      // The http client throws on non-2xx; hand the Response back so the engine
+      // can surface the server's error body (bad voice/model, etc.).
+      if (err instanceof HttpError) return err.response
+      throw err
+    }
+  }
+  return createAudioEngine({
+    id: 'openai-compatible',
+    transport,
+    sttModel: config.sttModel,
+    ttsModel: config.ttsModel,
+    ttsVoice: config.ttsVoice,
+    ttsSpeed: 1,
+    // No `instructions`: it's a vLLM-Omni extension; stricter servers 400 on it.
+  })
+}
+
+/**
+ * Validate a config end-to-end by asking the server to synthesize a short line —
+ * exercises the base URL, auth, TTS model and voice in one shot. Returns the
+ * server's error body on failure (bad voice/model, unreachable, CORS, …).
+ */
+export const testOpenAiConnection = async (config: VoiceProviderConfig): Promise<{ ok: boolean; detail: string }> => {
+  try {
+    await http.post(`${stripTrailingSlash(config.baseUrl)}/audio/speech`, {
+      json: {
+        model: config.ttsModel,
+        input: 'Connection test.',
+        voice: config.ttsVoice,
+        response_format: 'wav',
+      },
+      headers: withAuth(config.apiKey),
+      timeout: 20_000,
+    })
+    return { ok: true, detail: 'Connected — synthesis succeeded.' }
+  } catch (err) {
+    if (err instanceof HttpError) {
+      return { ok: false, detail: `${err.response.status} ${await err.response.text().catch(() => '')}`.trim() }
+    }
+    return { ok: false, detail: String(err) }
+  }
+}
+
+/** A model as returned by the OpenAI-standard `GET /v1/models`. speaches adds
+ * `task` (to distinguish STT from TTS) and, on TTS models, an embedded `voices`
+ * array — both are extensions, absent on plainer servers. */
+type RawModel = {
+  id: string
+  task?: string
+  voices?: Array<{ id: string }>
+}
+
+/** Discovered models split for the two settings dropdowns. Each TTS model
+ * carries its own preset voices (empty when the server doesn't advertise any). */
+export type DiscoveredModels = {
+  stt: string[]
+  tts: Array<{ id: string; voices: string[] }>
+}
+
+const TASK_STT = 'automatic-speech-recognition'
+const TASK_TTS = 'text-to-speech'
+
+/**
+ * Partition raw `/v1/models` entries into STT and TTS lists using each model's
+ * `task` tag. A model with no `task` (generic OpenAI-compatible servers only
+ * return `{id}`) can't be classified, so it's offered under both — the user
+ * picks the right one. Pure and synchronous so it's unit-testable without HTTP.
+ */
+export const classifyModels = (models: RawModel[]): DiscoveredModels => {
+  const stt: string[] = []
+  const tts: DiscoveredModels['tts'] = []
+  for (const model of models) {
+    const voices = (model.voices ?? []).map((voice) => voice.id)
+    if (model.task === TASK_TTS) tts.push({ id: model.id, voices })
+    else if (model.task === TASK_STT) stt.push(model.id)
+    else {
+      stt.push(model.id)
+      tts.push({ id: model.id, voices })
+    }
+  }
+  return { stt, tts }
+}
+
+/**
+ * Discover the server's models for the settings dropdowns via the OpenAI-standard
+ * `GET /v1/models`. Returns empty lists on any failure (unreachable, CORS, older
+ * server) so the UI falls back to free-text model/voice fields.
+ */
+export const fetchOpenAiModels = async (baseUrl: string, apiKey: string): Promise<DiscoveredModels> => {
+  try {
+    const data = await http
+      .get(`${stripTrailingSlash(baseUrl)}/models`, { headers: withAuth(apiKey), timeout: 10_000 })
+      .json<{ data?: RawModel[] }>()
+    return classifyModels(data.data ?? [])
+  } catch {
+    return { stt: [], tts: [] }
+  }
+}

--- a/src/voice/engine/router.ts
+++ b/src/voice/engine/router.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Voice engine selection (THU-700 / THU-718).
+ *
+ * The default is the Thunderbolt-hosted STT/TTS (Tinfoil-backed, enclave-private)
+ * and it is hard-wired: pointing voice at a custom OpenAI-compatible endpoint is
+ * gated behind the `experimental_feature_voice` flag (the same flag that reveals
+ * the Voice settings page). When the flag is off we always use Thunderbolt, even
+ * if a stale custom config lingers in device-local settings. Read at session
+ * start, so a settings change applies on the next voice turn.
+ */
+import { getLocalSetting } from '@/stores/local-settings-store'
+import { createOpenAiCompatibleEngine } from './openai-compatible-engine'
+import { createThunderboltEngine } from './thunderbolt-engine'
+import type { VoiceEngine } from './types'
+
+export const createVoiceEngine = (customProviderEnabled: boolean): VoiceEngine => {
+  const config = getLocalSetting('voiceProvider')
+  if (customProviderEnabled && config.kind === 'openai-compatible' && config.baseUrl.trim().length > 0) {
+    return createOpenAiCompatibleEngine(config)
+  }
+  return createThunderboltEngine()
+}

--- a/src/voice/engine/thunderbolt-engine.ts
+++ b/src/voice/engine/thunderbolt-engine.ts
@@ -17,22 +17,22 @@ import { getAuthToken } from '@/lib/auth-token'
 import { type AudioTransport, createAudioEngine } from './audio-engine'
 import type { VoiceEngine } from './types'
 
-const STT_MODEL = 'whisper-large-v3-turbo' // batch transcription; voxtral-realtime (streaming) is a follow-up
+const sttModel = 'whisper-large-v3-turbo' // batch transcription; voxtral-realtime (streaming) is a follow-up
 
 type TtsProfile = { model: string; voice: string }
 // TTS model + its preset voice. voxtral-tts + casual_male is the verified-working
 // combo; qwen3-tts is steadier/less improvisational. qwen3 voices on this enclave
 // (from /audio/speech error bodies): aiden, dylan, eric, ono_anna, ryan, serena,
-// sohee, uncle_fu, vivian. Flip TTS to A/B; user-selectable engines land in the
-// voice settings (THU-718) via createOpenAiCompatibleEngine.
-const TTS_PROFILES = {
+// sohee, uncle_fu, vivian. Flip ttsProfile to A/B; user-selectable engines land in
+// the voice settings (THU-718) via createOpenAiCompatibleEngine.
+const ttsProfiles = {
   voxtral: { model: 'voxtral-tts', voice: 'casual_male' },
   qwen3: { model: 'qwen3-tts', voice: 'aiden' },
 } satisfies Record<string, TtsProfile>
-const TTS: TtsProfile = TTS_PROFILES.qwen3
+const ttsProfile: TtsProfile = ttsProfiles.qwen3
 // Expressive models improvise emphasis/pacing/laughter; steer delivery via the
 // `instructions` style control (honored by qwen3-tts / voxtral-tts).
-const TTS_INSTRUCTIONS =
+const ttsInstructions =
   'Speak naturally and conversationally, like a warm, helpful friend. Relaxed and ' +
   'clear, with an even, moderate pace. Sound genuinely engaged but never theatrical ' +
   '— no shouting, exaggerated emphasis, or laughter.'
@@ -50,7 +50,9 @@ const tinfoilTransport: AudioTransport = async (path, body, headers, signal) => 
   const attempt = async (): Promise<Response> => {
     const client = await getSystemTinfoilClient() // awaits attestation (`ready()`)
     const baseUrl = client.getBaseURL()
-    if (!baseUrl) throw new Error('Tinfoil client has no base URL')
+    if (!baseUrl) {
+      throw new Error('Tinfoil client has no base URL')
+    }
     const reqHeaders = new Headers(headers)
     const init: RequestInit = { method: 'POST', body, headers: reqHeaders, signal }
     if (sso && !token) {
@@ -71,7 +73,9 @@ const tinfoilTransport: AudioTransport = async (path, body, headers, signal) => 
     }
     return res
   } catch (err) {
-    if (!isKeyConfigMismatchError(err)) throw err
+    if (!isKeyConfigMismatchError(err)) {
+      throw err
+    }
     evictSystemTinfoilClient()
     return attempt()
   }
@@ -84,9 +88,9 @@ export const createThunderboltEngine = (): VoiceEngine =>
     warm: async () => {
       await getSystemTinfoilClient() // prime attestation
     },
-    sttModel: STT_MODEL,
-    ttsModel: TTS.model,
-    ttsVoice: TTS.voice,
-    ttsInstructions: TTS_INSTRUCTIONS,
+    sttModel,
+    ttsModel: ttsProfile.model,
+    ttsVoice: ttsProfile.voice,
+    ttsInstructions,
     ttsSpeed: 1,
   })

--- a/src/voice/engine/thunderbolt-engine.ts
+++ b/src/voice/engine/thunderbolt-engine.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Thunderbolt (Tinfoil) VoiceEngine (THU-717) — the default provider.
+ *
+ * STT + TTS run in Tinfoil's confidential enclave via the OpenAI-compatible
+ * `/v1/audio/*` endpoints, reached through the *existing* attested `/tinfoil`
+ * HPKE proxy (`SecureClient`) — so no new backend route is needed and the audio
+ * is processed enclave-private. Only the *transport* is Tinfoil-specific; the
+ * request/response orchestration is shared via `createAudioEngine`.
+ */
+import { evictSystemTinfoilClient, getSystemTinfoilClient, isKeyConfigMismatchError } from '@/ai/fetch'
+import { isSsoMode } from '@/lib/auth-mode'
+import { getAuthToken } from '@/lib/auth-token'
+import { type AudioTransport, createAudioEngine } from './audio-engine'
+import type { VoiceEngine } from './types'
+
+const STT_MODEL = 'whisper-large-v3-turbo' // batch transcription; voxtral-realtime (streaming) is a follow-up
+
+type TtsProfile = { model: string; voice: string }
+// TTS model + its preset voice. voxtral-tts + casual_male is the verified-working
+// combo; qwen3-tts is steadier/less improvisational. qwen3 voices on this enclave
+// (from /audio/speech error bodies): aiden, dylan, eric, ono_anna, ryan, serena,
+// sohee, uncle_fu, vivian. Flip TTS to A/B; user-selectable engines land in the
+// voice settings (THU-718) via createOpenAiCompatibleEngine.
+const TTS_PROFILES = {
+  voxtral: { model: 'voxtral-tts', voice: 'casual_male' },
+  qwen3: { model: 'qwen3-tts', voice: 'aiden' },
+} satisfies Record<string, TtsProfile>
+const TTS: TtsProfile = TTS_PROFILES.qwen3
+// Expressive models improvise emphasis/pacing/laughter; steer delivery via the
+// `instructions` style control (honored by qwen3-tts / voxtral-tts).
+const TTS_INSTRUCTIONS =
+  'Speak naturally and conversationally, like a warm, helpful friend. Relaxed and ' +
+  'clear, with an even, moderate pace. Sound genuinely engaged but never theatrical ' +
+  '— no shouting, exaggerated emphasis, or laughter.'
+
+/**
+ * POST to a Tinfoil `/v1/audio/*` endpoint via the attested `SecureClient`,
+ * attaching the app's session auth (the `/tinfoil` route's guard needs the real
+ * token/SSO cookies, not the SDK placeholder). On a `KeyConfigMismatchError`
+ * that survives the SDK's own retry the cached client is wedged — evict it and
+ * retry once with a fresh attestation context (mirrors the chat path).
+ */
+const tinfoilTransport: AudioTransport = async (path, body, headers, signal) => {
+  const sso = isSsoMode()
+  const token = getAuthToken()
+  const attempt = async (): Promise<Response> => {
+    const client = await getSystemTinfoilClient() // awaits attestation (`ready()`)
+    const baseUrl = client.getBaseURL()
+    if (!baseUrl) throw new Error('Tinfoil client has no base URL')
+    const reqHeaders = new Headers(headers)
+    const init: RequestInit = { method: 'POST', body, headers: reqHeaders, signal }
+    if (sso && !token) {
+      init.credentials = 'include'
+      reqHeaders.delete('authorization')
+    } else if (token) {
+      reqHeaders.set('Authorization', `Bearer ${token}`)
+    }
+    return client.fetch(`${baseUrl}${path}`, init)
+  }
+  // Retry once on a wedged attestation key — whether the SDK throws
+  // KeyConfigMismatchError or the enclave returns it as a 422.
+  try {
+    const res = await attempt()
+    if (res.status === 422) {
+      evictSystemTinfoilClient()
+      return await attempt()
+    }
+    return res
+  } catch (err) {
+    if (!isKeyConfigMismatchError(err)) throw err
+    evictSystemTinfoilClient()
+    return attempt()
+  }
+}
+
+export const createThunderboltEngine = (): VoiceEngine =>
+  createAudioEngine({
+    id: 'thunderbolt',
+    transport: tinfoilTransport,
+    warm: async () => {
+      await getSystemTinfoilClient() // prime attestation
+    },
+    sttModel: STT_MODEL,
+    ttsModel: TTS.model,
+    ttsVoice: TTS.voice,
+    ttsInstructions: TTS_INSTRUCTIONS,
+    ttsSpeed: 1,
+  })

--- a/src/voice/engine/types.ts
+++ b/src/voice/engine/types.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * The platform-swappable STT+TTS backend (THU-700).
+ *
+ * Everything else in the voice loop — mic capture, VAD, turn detection,
+ * playback, barge-in — is shared webview code that talks only to this
+ * interface. Two implementations exist: an in-webview JS engine (web +
+ * Windows) and a native `sherpa-onnx` engine over Tauri IPC (macOS; Linux
+ * fallback). Swapping the engine never touches the realtime loop, which is
+ * what makes barge-in parity automatic across surfaces.
+ */
+
+/** Mono PCM at 16 kHz (the rate STT and VAD expect), as produced by capture. */
+export type PcmFrame = Float32Array
+
+/** A synthesized audio chunk headed for the shared playback queue. */
+export type AudioChunk = {
+  pcm: Float32Array
+  sampleRate: number
+}
+
+/** An STT result. `isFinal` marks the committed transcript for a turn. */
+export type Transcript = {
+  text: string
+  isFinal: boolean
+}
+
+/** First-run model download / warm-up progress, per model file. */
+export type EngineLoadProgress = {
+  model: string
+  loaded: number
+  total: number
+}
+
+export type VoiceEngine = {
+  /** Stable identifier for logging/telemetry, e.g. `webview` or `sherpa`. */
+  readonly id: string
+  /** Load and warm the models. Idempotent — safe to call more than once. */
+  load: (onProgress?: (progress: EngineLoadProgress) => void) => Promise<void>
+  /**
+   * Streaming transcription: consume 16 kHz mono PCM frames, yield partial
+   * then final transcripts. Aborting stops decoding promptly (barge-in).
+   */
+  transcribe: (audio: AsyncIterable<PcmFrame>, signal?: AbortSignal) => AsyncIterable<Transcript>
+  /**
+   * Streaming synthesis: consume already-aggregated text chunks (see
+   * {@link ../aggregator}), yield audio for playback. Aborting cancels
+   * in-flight synthesis (barge-in).
+   */
+  synthesize: (text: AsyncIterable<string>, signal?: AbortSignal) => AsyncIterable<AudioChunk>
+  /** Release models/sessions. */
+  dispose: () => void
+}

--- a/src/voice/session.test.ts
+++ b/src/voice/session.test.ts
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { PlaybackQueue } from '@/voice/audio/playback'
+import type { VadGate, VadHandlers } from '@/voice/audio/vad'
+import type { AudioChunk, PcmFrame, Transcript, VoiceEngine } from '@/voice/engine/types'
+import type { ReplyFn, SessionState } from '@/voice/session'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// The session creates its VAD gate and playback queue internally; mock both so a
+// test can drive utterances through the loop without a mic or AudioContext. The
+// captured `onUtterance` is the handle used to simulate the user speaking.
+let vadGateCalls = 0
+let gateStartCalls = 0
+let gateDestroyCalls = 0
+let vadHandlers: VadHandlers | null = null
+
+const resetVad = () => {
+  vadGateCalls = 0
+  gateStartCalls = 0
+  gateDestroyCalls = 0
+  vadHandlers = null
+}
+
+mock.module('@/voice/audio/vad', () => ({
+  createVadGate: (handlers: VadHandlers): VadGate => {
+    vadGateCalls++
+    vadHandlers = handlers
+    return {
+      start: async () => {
+        gateStartCalls++
+      },
+      pause: async () => {},
+      destroy: async () => {
+        gateDestroyCalls++
+      },
+      setListening: () => {},
+    }
+  },
+}))
+
+let enqueued: AudioChunk[] = []
+mock.module('@/voice/audio/playback', () => ({
+  createPlaybackQueue: (): PlaybackQueue =>
+    ({
+      enqueue: (chunk: AudioChunk) => enqueued.push(chunk),
+      flush: () => {},
+      close: () => {},
+      // Always drained so the session's "wait for playback" loop exits at once
+      // (the real loop polls a timer we don't want to run in tests).
+      get isPlaying() {
+        return false
+      },
+    }) as unknown as PlaybackQueue,
+}))
+
+const { createVoiceSession } = await import('@/voice/session')
+
+/** Engine that transcribes to a fixed string and synthesizes one chunk per text chunk. */
+const makeEngine = (transcript: string, overrides: Partial<VoiceEngine> = {}): VoiceEngine => ({
+  id: 'fake',
+  load: async () => {},
+  transcribe: async function* (_audio: AsyncIterable<PcmFrame>): AsyncIterable<Transcript> {
+    yield { text: transcript, isFinal: true }
+  },
+  synthesize: async function* (text: AsyncIterable<string>): AsyncIterable<AudioChunk> {
+    for await (const _chunk of text) {
+      yield { pcm: new Float32Array(1), sampleRate: 16000 }
+    }
+  },
+  dispose: () => {},
+  ...overrides,
+})
+
+const makeReply = (tokens: string[]): ReplyFn =>
+  async function* (_userText, signal) {
+    for (const token of tokens) {
+      if (signal.aborted) {
+        return
+      }
+      yield token
+    }
+  }
+
+describe('createVoiceSession', () => {
+  beforeEach(() => {
+    resetVad()
+    enqueued = []
+  })
+
+  test('runs a full turn: listen → think → speak → listen and reports both transcripts', async () => {
+    const states: SessionState[] = []
+    const transcripts: Array<[string, string]> = []
+    const session = createVoiceSession({
+      engine: makeEngine('hello world'),
+      reply: makeReply(['Hi', ' there.']),
+      onState: (s) => states.push(s),
+      onTranscript: (text, role) => transcripts.push([role, text]),
+    })
+
+    await session.start()
+    expect(vadHandlers).not.toBeNull()
+    await vadHandlers!.onUtterance(new Float32Array(16000))
+
+    expect(states).toEqual(['listening', 'thinking', 'speaking', 'listening'])
+    expect(transcripts).toContainEqual(['user', 'hello world'])
+    expect(transcripts).toContainEqual(['assistant', 'Hi there.'])
+    expect(enqueued.length).toBeGreaterThan(0)
+  })
+
+  test('drops a Whisper silence-hallucination without replying', async () => {
+    const states: SessionState[] = []
+    const transcripts: Array<[string, string]> = []
+    const session = createVoiceSession({
+      engine: makeEngine('thanks for watching'),
+      reply: makeReply(['should not run']),
+      onState: (s) => states.push(s),
+      onTranscript: (text, role) => transcripts.push([role, text]),
+    })
+
+    await session.start()
+    await vadHandlers!.onUtterance(new Float32Array(16000))
+
+    expect(states).toEqual(['listening', 'thinking', 'listening'])
+    expect(transcripts).toEqual([])
+    expect(enqueued).toEqual([])
+  })
+
+  test('a newer utterance supersedes an in-flight turn (abort)', async () => {
+    const transcripts: Array<[string, string]> = []
+    // First transcription hangs until its turn is aborted; the second resolves
+    // normally. So when the second utterance arrives and calls turn.abort(), the
+    // first turn unwinds without producing a transcript and only the second speaks.
+    let transcribeCalls = 0
+    const engine: VoiceEngine = {
+      ...makeEngine('unused'),
+      transcribe: async function* (_audio, signal) {
+        transcribeCalls++
+        if (transcribeCalls === 1) {
+          await new Promise<void>((resolve) => signal!.addEventListener('abort', () => resolve(), { once: true }))
+          return
+        }
+        yield { text: 'second turn', isFinal: true }
+      },
+    }
+    const session = createVoiceSession({
+      engine,
+      reply: makeReply(['done.']),
+      onTranscript: (text, role) => transcripts.push([role, text]),
+    })
+
+    await session.start()
+    const first = vadHandlers!.onUtterance(new Float32Array(16000))
+    const second = vadHandlers!.onUtterance(new Float32Array(16000))
+    await Promise.all([first, second])
+
+    // The superseded turn produced nothing; only the second turn's transcripts land.
+    expect(transcripts).toEqual([
+      ['user', 'second turn'],
+      ['assistant', 'done.'],
+    ])
+  })
+
+  test('stop() during startup does not open an orphaned mic (stopped guard)', async () => {
+    // Hold engine.load() open to land stop() squarely in the startup window,
+    // before start() has created/assigned the VAD gate.
+    let resolveLoad: () => void = () => {}
+    const engine = makeEngine('hi', { load: () => new Promise<void>((resolve) => (resolveLoad = resolve)) })
+    const session = createVoiceSession({ engine, reply: makeReply(['hi']) })
+
+    const startPromise = session.start()
+    await session.stop()
+    resolveLoad()
+    await startPromise
+
+    // With the guard, start() bails after load() resolves — the gate is never
+    // even created, so no mic is opened and no gate is left running.
+    expect(vadGateCalls).toBe(0)
+    expect(gateStartCalls).toBe(0)
+    expect(session.state).toBe('idle')
+  })
+
+  test('stop() after the gate is running tears it down', async () => {
+    const session = createVoiceSession({ engine: makeEngine('hi'), reply: makeReply(['hi']) })
+    await session.start()
+    expect(gateStartCalls).toBe(1)
+    await session.stop()
+    expect(gateDestroyCalls).toBe(1)
+    expect(session.state).toBe('idle')
+  })
+})

--- a/src/voice/session.test.ts
+++ b/src/voice/session.test.ts
@@ -47,6 +47,7 @@ mock.module('@/voice/audio/playback', () => ({
       enqueue: (chunk: AudioChunk) => enqueued.push(chunk),
       flush: () => {},
       close: () => {},
+      getLevel: () => 0,
       // Always drained so the session's "wait for playback" loop exits at once
       // (the real loop polls a timer we don't want to run in tests).
       get isPlaying() {

--- a/src/voice/session.ts
+++ b/src/voice/session.ts
@@ -60,6 +60,11 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
   let state: SessionState = 'idle'
   let turn: AbortController | null = null
   let vadGate: Awaited<ReturnType<typeof createVadGate>> | null = null
+  // Guards a stop() that lands mid-startup: start() awaits engine.load() and gate
+  // creation before assigning vadGate, so a stop during 'Starting…' would no-op
+  // (vadGate still null) and then start() would resume and open an orphaned mic
+  // with no session reference. start() checks this after each await and tears down.
+  let stopped = false
 
   const setState = (next: SessionState) => {
     state = next
@@ -79,8 +84,12 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
       setState('thinking')
 
       let userText = ''
-      for await (const t of engine.transcribe(singleFrame(audio), ac.signal)) userText = t.text
-      if (ac.signal.aborted) return
+      for await (const t of engine.transcribe(singleFrame(audio), ac.signal)) {
+        userText = t.text
+      }
+      if (ac.signal.aborted) {
+        return
+      }
       userText = userText.trim()
       // Drop empty turns and Whisper silence-hallucinations ("Thank you", "Bye")
       // so background noise the VAD misfired on never becomes a phantom turn.
@@ -120,14 +129,20 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
           }
           const delta = full.slice(emitted.length)
           emitted = full
-          if (!delta) return
+          if (!delta) {
+            return
+          }
           for (const chunk of aggregator.push(delta)) {
             const speakable = toSpeakable(chunk)
-            if (speakable) yield speakable
+            if (speakable) {
+              yield speakable
+            }
           }
         }
         for await (const token of reply(userText, ac.signal)) {
-          if (ac.signal.aborted) return
+          if (ac.signal.aborted) {
+            return
+          }
           assistantText += token
           accumulated += token
           yield* pushClean(speechSoFar())
@@ -135,38 +150,67 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
         yield* pushClean(speechSoFar())
         for (const chunk of aggregator.flush()) {
           const speakable = toSpeakable(chunk)
-          if (speakable) yield speakable
+          if (speakable) {
+            yield speakable
+          }
         }
       })()
 
       setState('speaking')
       for await (const audioChunk of engine.synthesize(chunks, ac.signal)) {
-        if (ac.signal.aborted) return
+        if (ac.signal.aborted) {
+          return
+        }
         playback.enqueue(audioChunk)
       }
-      if (ac.signal.aborted) return
-      if (assistantText.trim().length > 0) onTranscript?.(assistantText.trim(), 'assistant')
+      if (ac.signal.aborted) {
+        return
+      }
+      if (assistantText.trim().length > 0) {
+        onTranscript?.(assistantText.trim(), 'assistant')
+      }
       // Stay in `speaking` until the queued audio has actually finished playing —
       // synthesis enqueues faster than playback drains, and flipping to `listening`
       // early makes the VAD treat the assistant's own audio as a user turn.
-      while (playback.isPlaying && !ac.signal.aborted) await tick(80)
-      if (ac.signal.aborted) return
+      while (playback.isPlaying && !ac.signal.aborted) {
+        await tick(80)
+      }
+      if (ac.signal.aborted) {
+        return
+      }
       setState('listening')
     } catch (error) {
-      if (ac.signal.aborted) return
+      if (ac.signal.aborted) {
+        return
+      }
       onError?.(error)
       setState('listening')
     }
   }
 
   const start = async () => {
+    stopped = false
     await engine.load()
-    vadGate = await createVadGate({ onUtterance, onLevel })
+    if (stopped) {
+      return
+    }
+    const gate = await createVadGate({ onUtterance, onLevel })
+    if (stopped) {
+      await gate.destroy()
+      return
+    }
+    vadGate = gate
     await vadGate.start()
+    if (stopped) {
+      await vadGate.destroy()
+      vadGate = null
+      return
+    }
     setState('listening')
   }
 
   const stop = async () => {
+    stopped = true
     turn?.abort()
     // Release every audio resource: VAD mic/ctx, the playback ctx, and the
     // engine's decode ctx. Missing any leaks an AudioContext per start/stop and

--- a/src/voice/session.ts
+++ b/src/voice/session.ts
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Voice session orchestrator (THU-688) — the shared realtime loop.
+ *
+ * Wires the VAD gate → engine STT → a `reply` function → the sentence
+ * aggregator → engine TTS → playback. It's engine- and chat-agnostic: the
+ * `reply` callback is where the app plugs in the real chat/LLM flow (or an echo,
+ * for testing). Nothing here is platform-specific, so web and desktop share it
+ * verbatim — only the injected `VoiceEngine` differs.
+ *
+ * Deliberately half-duplex: the mic is gated off while the assistant thinks or
+ * speaks (see `setState`), so there is no barge-in — the user waits for the reply
+ * to finish before the next turn. Full-duplex barge-in (cut the assistant off
+ * mid-reply) is a future addition; the VAD keeps an `onSpeechStart` hook for it.
+ *
+ * Not yet layered on: Smart Turn semantic endpointing (VAD silence endpointing
+ * is used for now).
+ */
+import { type ContentPartsState, parseContentPartsIncremental } from '@/ai/widget-parser'
+import { SentenceAggregator } from '@/voice/aggregator'
+import { createPlaybackQueue } from '@/voice/audio/playback'
+import { createVadGate } from '@/voice/audio/vad'
+import type { VoiceEngine } from '@/voice/engine/types'
+import { partsToSpeech, toSpeakable } from '@/voice/speakable'
+import { isHallucinatedTranscript } from '@/voice/transcript-filter'
+
+export type SessionState = 'idle' | 'listening' | 'thinking' | 'speaking'
+
+/** Produces the assistant's reply text as a token stream for the given user turn. */
+export type ReplyFn = (userText: string, signal: AbortSignal) => AsyncIterable<string>
+
+export type VoiceSessionOptions = {
+  engine: VoiceEngine
+  reply: ReplyFn
+  onState?: (state: SessionState) => void
+  onTranscript?: (text: string, role: 'user' | 'assistant') => void
+  onError?: (error: unknown) => void
+  /** Live mic level [0,1] per frame while listening — for the reactive waveform. */
+  onLevel?: (level: number) => void
+}
+
+export type VoiceSession = {
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  readonly state: SessionState
+}
+
+const singleFrame = async function* (audio: Float32Array): AsyncIterable<Float32Array> {
+  yield audio
+}
+
+const tick = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession => {
+  const { engine, reply, onState, onTranscript, onError, onLevel } = options
+  const playback = createPlaybackQueue()
+  let state: SessionState = 'idle'
+  let turn: AbortController | null = null
+  let vadGate: Awaited<ReturnType<typeof createVadGate>> | null = null
+
+  const setState = (next: SessionState) => {
+    state = next
+    // Half-duplex: only run the mic/VAD while actually listening, so the
+    // assistant can't hear its own audio and trigger a runaway self-reply loop
+    // (echo cancellation isn't reliable across browsers). Also frees the main
+    // thread while thinking/speaking.
+    vadGate?.setListening(next === 'listening')
+    onState?.(next)
+  }
+
+  const onUtterance = async (audio: Float32Array) => {
+    turn?.abort() // supersede any in-flight turn
+    const ac = new AbortController()
+    turn = ac
+    try {
+      setState('thinking')
+
+      let userText = ''
+      for await (const t of engine.transcribe(singleFrame(audio), ac.signal)) userText = t.text
+      if (ac.signal.aborted) return
+      userText = userText.trim()
+      // Drop empty turns and Whisper silence-hallucinations ("Thank you", "Bye")
+      // so background noise the VAD misfired on never becomes a phantom turn.
+      if (isHallucinatedTranscript(userText)) {
+        setState('listening')
+        return
+      }
+      onTranscript?.(userText, 'user')
+
+      // reply tokens → widget-strip → aggregator → sanitize → synthesizable chunks.
+      const aggregator = new SentenceAggregator()
+      let assistantText = ''
+      // Parse the accumulated reply into content parts FIRST and feed only the
+      // clean speech source (text + widget announcements, never widget internals)
+      // into the aggregator. Doing this pre-aggregation is what stops a widget tag
+      // full of punctuation (e.g. an `ask`/quiz) from being split into fragments
+      // whose guts leak to TTS. Each aggregated sentence is then sanitized
+      // (markdown/latex/emoji) before synthesis.
+      const chunks = (async function* () {
+        let accumulated = ''
+        let emitted = ''
+        // Thread the incremental parser's state so each streamed token parses
+        // only the appended tail, not the whole growing string (avoids O(n²)).
+        let parseState: ContentPartsState | null = null
+        const speechSoFar = (): string => {
+          const { parts, state } = parseContentPartsIncremental(accumulated, parseState)
+          parseState = state
+          return partsToSpeech(parts)
+        }
+        const pushClean = function* (full: string) {
+          // Content parts only grow at the tail; guard the rare reinterpretation
+          // (a trailing "<" or open "【" that resolves later) so we never corrupt
+          // the aggregator's buffer with a non-monotonic rewrite.
+          if (!full.startsWith(emitted)) {
+            emitted = full
+            return
+          }
+          const delta = full.slice(emitted.length)
+          emitted = full
+          if (!delta) return
+          for (const chunk of aggregator.push(delta)) {
+            const speakable = toSpeakable(chunk)
+            if (speakable) yield speakable
+          }
+        }
+        for await (const token of reply(userText, ac.signal)) {
+          if (ac.signal.aborted) return
+          assistantText += token
+          accumulated += token
+          yield* pushClean(speechSoFar())
+        }
+        yield* pushClean(speechSoFar())
+        for (const chunk of aggregator.flush()) {
+          const speakable = toSpeakable(chunk)
+          if (speakable) yield speakable
+        }
+      })()
+
+      setState('speaking')
+      for await (const audioChunk of engine.synthesize(chunks, ac.signal)) {
+        if (ac.signal.aborted) return
+        playback.enqueue(audioChunk)
+      }
+      if (ac.signal.aborted) return
+      if (assistantText.trim().length > 0) onTranscript?.(assistantText.trim(), 'assistant')
+      // Stay in `speaking` until the queued audio has actually finished playing —
+      // synthesis enqueues faster than playback drains, and flipping to `listening`
+      // early makes the VAD treat the assistant's own audio as a user turn.
+      while (playback.isPlaying && !ac.signal.aborted) await tick(80)
+      if (ac.signal.aborted) return
+      setState('listening')
+    } catch (error) {
+      if (ac.signal.aborted) return
+      onError?.(error)
+      setState('listening')
+    }
+  }
+
+  const start = async () => {
+    await engine.load()
+    vadGate = await createVadGate({ onUtterance, onLevel })
+    await vadGate.start()
+    setState('listening')
+  }
+
+  const stop = async () => {
+    turn?.abort()
+    // Release every audio resource: VAD mic/ctx, the playback ctx, and the
+    // engine's decode ctx. Missing any leaks an AudioContext per start/stop and
+    // the browser cap (~6) breaks voice after a few toggles.
+    playback.close()
+    engine.dispose()
+    await vadGate?.destroy()
+    vadGate = null
+    setState('idle')
+  }
+
+  return {
+    start,
+    stop,
+    get state() {
+      return state
+    },
+  }
+}

--- a/src/voice/session.ts
+++ b/src/voice/session.ts
@@ -46,6 +46,8 @@ export type VoiceSession = {
   start: () => Promise<void>
   stop: () => Promise<void>
   readonly state: SessionState
+  /** Current TTS output RMS (~[0,1]) for the speaking-state waveform. */
+  getOutputLevel: () => number
 }
 
 const singleFrame = async function* (audio: Float32Array): AsyncIterable<Float32Array> {
@@ -228,5 +230,6 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
     get state() {
       return state
     },
+    getOutputLevel: () => playback.getLevel(),
   }
 }

--- a/src/voice/speakable.test.ts
+++ b/src/voice/speakable.test.ts
@@ -73,6 +73,11 @@ describe('toSpeakable', () => {
     expect(toSpeakable('So $x$ equals the value \\(y\\) we found.')).toBe('So equals the value we found.')
     expect(toSpeakable('Use \\frac{a}{b} for the ratio.')).toBe('Use for the ratio.')
   })
+
+  test('keeps dollar-sign currency amounts (not mistaken for inline math)', () => {
+    expect(toSpeakable('it costs $5 and $10 apiece')).toBe('it costs $5 and $10 apiece')
+    expect(toSpeakable('the total was $1,234.56 today')).toBe('the total was $1,234.56 today')
+  })
 })
 
 describe('partsToSpeech', () => {

--- a/src/voice/speakable.test.ts
+++ b/src/voice/speakable.test.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { parseContentParts } from '@/ai/widget-parser'
+import { partsToSpeech, toSpeakable } from './speakable'
+
+describe('toSpeakable', () => {
+  test('strips bold/italic emphasis, keeps words', () => {
+    expect(toSpeakable('This is **really** _very_ important.')).toBe('This is really very important.')
+  })
+
+  test('drops fenced code blocks entirely', () => {
+    expect(toSpeakable('Here you go:\n```js\nconst x = 1\n```\nThat runs it.')).toBe('Here you go: That runs it.')
+  })
+
+  test('keeps inline code words, drops backticks', () => {
+    expect(toSpeakable('Call `saveThing()` to save.')).toBe('Call saveThing() to save.')
+  })
+
+  test('turns links into their text and bare URLs into "link"', () => {
+    expect(toSpeakable('See [the docs](https://x.com/a/b) here.')).toBe('See the docs here.')
+    expect(toSpeakable('Go to https://example.com/page now.')).toBe('Go to link now.')
+  })
+
+  test('strips headings, list markers, and blockquotes', () => {
+    expect(toSpeakable('# Title\n- one\n- two\n> a quote')).toBe('Title one two a quote')
+  })
+
+  test('removes emoji (so they are not read as unicode)', () => {
+    expect(toSpeakable('Done ✅ and shipped 🚀🎉')).toBe('Done and shipped')
+    expect(toSpeakable('Family 👨‍👩‍👧 flag 🇺🇸 here')).toBe('Family flag here')
+  })
+
+  test('returns empty for chunks that are only markup/code', () => {
+    expect(toSpeakable('```\ncode only\n```')).toBe('')
+    expect(toSpeakable('🚀🎉')).toBe('')
+    expect(toSpeakable('---')).toBe('')
+  })
+
+  test('collapses table pipes and whitespace', () => {
+    expect(toSpeakable('| a | b |\n\n\ndone')).toBe('a b done')
+  })
+
+  test('announces substantive/interactive widgets instead of reading the tag', () => {
+    expect(toSpeakable('Here you go: <widget:weather-forecast location="Seattle" region="WA" country="USA" />')).toBe(
+      'Here you go: Take a look at the weather forecast on screen.',
+    )
+    expect(toSpeakable('<widget:connect-integration provider="google" service="email" reason="" override="" />')).toBe(
+      'Use the connection prompt on screen to continue.',
+    )
+    expect(toSpeakable('<widget:ask question="Pick one" />')).toBe('Please choose one of the options on screen.')
+  })
+
+  test('drops inline-reference widgets and citation markers', () => {
+    expect(toSpeakable('This is true. <widget:citation sources=\'[{"id":"1"}]\' />')).toBe('This is true.')
+    expect(toSpeakable('See more <widget:link-preview url="https://example.com" /> here.')).toBe('See more here.')
+    expect(toSpeakable('The AI Act passed【2†title】 today [1].')).toBe('The AI Act passed today.')
+  })
+
+  test('drops a dangling partial widget tag from mid-stream chunking', () => {
+    expect(toSpeakable('Here you go <widget:weather-fo')).toBe('Here you go')
+  })
+
+  test('turns display math into a pointer and removes inline LaTeX', () => {
+    expect(toSpeakable('The result is $$E = mc^2$$ exactly.')).toBe(
+      'The result is See the equation on screen. exactly.',
+    )
+    expect(toSpeakable('We know that \\[a^2 + b^2 = c^2\\] holds.')).toBe(
+      'We know that See the equation on screen. holds.',
+    )
+    expect(toSpeakable('So $x$ equals the value \\(y\\) we found.')).toBe('So equals the value we found.')
+    expect(toSpeakable('Use \\frac{a}{b} for the ratio.')).toBe('Use for the ratio.')
+  })
+})
+
+describe('partsToSpeech', () => {
+  test('replaces a quiz/ask widget with an announcement, never its guts', () => {
+    const text =
+      'Here is a quiz: <widget:ask prompt="What is 5 > 3?" mode="single" ' +
+      'options=\'[{"id":"a","text":"True","isCorrect":true},{"id":"b","text":"False"}]\' />'
+    const speech = partsToSpeech(parseContentParts(text))
+    expect(speech).toBe('Here is a quiz: Please choose one of the options on screen.')
+    expect(speech).not.toContain('True')
+    expect(speech).not.toContain('isCorrect')
+  })
+
+  test('keeps prose and drops reference-only widgets', () => {
+    const text = 'This is true. <widget:citation sources=\'[{"id":"1"}]\' /> And more.'
+    expect(partsToSpeech(parseContentParts(text))).toBe('This is true. And more.')
+  })
+
+  test('announces a weather widget between prose', () => {
+    const text = 'Weather: <widget:weather-forecast location="Seattle" region="WA" country="USA" /> Enjoy!'
+    expect(partsToSpeech(parseContentParts(text))).toBe(
+      'Weather: Take a look at the weather forecast on screen. Enjoy!',
+    )
+  })
+})

--- a/src/voice/speakable.ts
+++ b/src/voice/speakable.ts
@@ -79,7 +79,10 @@ export const toSpeakable = (input: string): string => {
   text = text.replace(/\$\$[\s\S]*?\$\$/g, ' See the equation on screen. ')
   text = text.replace(/\\\[[\s\S]*?\\\]/g, ' See the equation on screen. ')
   text = text.replace(/\\\([\s\S]*?\\\)/g, ' ')
-  text = text.replace(/\$[^$\n]+\$/g, ' ')
+  // Inline math `$…$` → dropped. The negative lookahead skips a `$` that opens a
+  // currency amount ("it costs $5 and $10 apiece"), which would otherwise be
+  // mis-read as one math span and mangled; TTS speaks a bare "$5" correctly.
+  text = text.replace(/\$(?![\s\d])[^$\n]+\$/g, ' ')
   text = text.replace(/\\[a-zA-Z]+\s*(?:\{[^{}]*\})*/g, ' ')
   // Images: ![alt](url) → drop. Links: [text](url) → text.
   text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')

--- a/src/voice/speakable.ts
+++ b/src/voice/speakable.ts
@@ -15,8 +15,11 @@
  */
 import type { ContentPart } from '@/ai/widget-parser'
 
-/** Emoji, pictographs, variation selectors, ZWJ, regional indicators. */
-const EMOJI = /[\p{Extended_Pictographic}\u{1F1E6}-\u{1F1FF}\u{FE0F}\u{200D}\u{20E3}]/gu
+// Emoji, pictographs, regional indicators, plus the variation selector (FE0F),
+// ZWJ (200D) and combining enclosing keycap (20E3). The combining/joining code
+// points live in alternation branches, not the character class, to avoid the
+// no-misleading-character-class rule (combining marks inside `[...]` are flagged).
+const emoji = /\p{Extended_Pictographic}|[\u{1F1E6}-\u{1F1FF}]|\u{FE0F}|\u{200D}|\u{20E3}/gu
 
 /**
  * Widget tags (`<widget:NAME .../>`) render as rich UI, so reading the raw tag
@@ -24,7 +27,7 @@ const EMOJI = /[\p{Extended_Pictographic}\u{1F1E6}-\u{1F1FF}\u{FE0F}\u{200D}\u{2
  * the on-screen UI; inline-reference widgets (citation, link-preview) and their
  * bracket markers are dropped — they're visual footnotes, not speech.
  */
-const WIDGET_ANNOUNCEMENT: Record<string, string> = {
+const widgetAnnouncement: Record<string, string> = {
   'weather-forecast': 'Take a look at the weather forecast on screen.',
   map: 'Take a look at the map on screen.',
   'connect-integration': 'Use the connection prompt on screen to continue.',
@@ -33,7 +36,7 @@ const WIDGET_ANNOUNCEMENT: Record<string, string> = {
 }
 
 /** Spoken pointer for a widget, or '' for reference-only widgets (citation, link-preview). */
-export const announceWidget = (name: string): string => WIDGET_ANNOUNCEMENT[name.toLowerCase()] ?? ''
+export const announceWidget = (name: string): string => widgetAnnouncement[name.toLowerCase()] ?? ''
 
 /**
  * Flatten parsed content parts into clean speech source: text verbatim, widgets
@@ -92,7 +95,7 @@ export const toSpeakable = (input: string): string => {
   text = text.replace(/^\s*[-*_]{3,}\s*$/gm, ' ')
   text = text.replace(/\|/g, ' ')
   // Emoji + stray symbol noise.
-  text = text.replace(EMOJI, '')
+  text = text.replace(emoji, '')
   // Collapse whitespace, then close up any space left before punctuation
   // (e.g. from a removed citation marker: "today [1]." → "today .").
   text = text.replace(/\s+/g, ' ')

--- a/src/voice/speakable.ts
+++ b/src/voice/speakable.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Turn an assistant text chunk into speakable text (THU-715).
+ *
+ * The model writes for the eye — markdown, code, emoji, links, tables. Fed raw
+ * to TTS that becomes gibberish ("asterisk asterisk", read-aloud code, emoji
+ * names). This strips the visual scaffolding down to what a person would
+ * actually say, and returns '' for chunks that are nothing but markup/code (so
+ * the caller can skip synthesizing them).
+ *
+ * Runs per aggregated sentence chunk, after the aggregator's sentence splitting.
+ */
+import type { ContentPart } from '@/ai/widget-parser'
+
+/** Emoji, pictographs, variation selectors, ZWJ, regional indicators. */
+const EMOJI = /[\p{Extended_Pictographic}\u{1F1E6}-\u{1F1FF}\u{FE0F}\u{200D}\u{20E3}]/gu
+
+/**
+ * Widget tags (`<widget:NAME .../>`) render as rich UI, so reading the raw tag
+ * aloud is nonsense. Substantive/interactive widgets become a spoken pointer to
+ * the on-screen UI; inline-reference widgets (citation, link-preview) and their
+ * bracket markers are dropped — they're visual footnotes, not speech.
+ */
+const WIDGET_ANNOUNCEMENT: Record<string, string> = {
+  'weather-forecast': 'Take a look at the weather forecast on screen.',
+  map: 'Take a look at the map on screen.',
+  'connect-integration': 'Use the connection prompt on screen to continue.',
+  'document-result': 'See the document on screen.',
+  ask: 'Please choose one of the options on screen.',
+}
+
+/** Spoken pointer for a widget, or '' for reference-only widgets (citation, link-preview). */
+export const announceWidget = (name: string): string => WIDGET_ANNOUNCEMENT[name.toLowerCase()] ?? ''
+
+/**
+ * Flatten parsed content parts into clean speech source: text verbatim, widgets
+ * as their spoken announcement, skipping loading placeholders. Widget *internals*
+ * (quiz options, JSON, urls) never appear — they live only inside widget parts,
+ * which we replace wholesale. Run this on the accumulated reply BEFORE sentence
+ * aggregation so a tag full of punctuation can't be split into leaking fragments.
+ */
+export const partsToSpeech = (parts: ContentPart[]): string =>
+  parts
+    .map((part) =>
+      part.type === 'text' ? part.content : part.type === 'widget' ? announceWidget(part.widget.widget) : '',
+    )
+    .filter(Boolean)
+    .join(' ')
+
+export const toSpeakable = (input: string): string => {
+  let text = input
+
+  // Widget tags → a spoken pointer (or dropped for reference widgets). Do this
+  // first, before the tag's attribute URLs/quotes get mangled by later passes.
+  text = text.replace(/<widget:([\w-]+)[\s\S]*?\/?>/gi, (_m, name: string) => {
+    const announcement = announceWidget(name)
+    return announcement ? ` ${announcement} ` : ' '
+  })
+  // Drop any dangling partial widget tag left by mid-stream chunking.
+  text = text.replace(/<widget:[\s\S]*$/i, ' ')
+  // Inline citation markers (【2†title】, 【3】, [1]) — footnotes, not speech.
+  text = text.replace(/【\d+[^】]*】/g, '')
+  text = text.replace(/\[\d+\]/g, '')
+
+  // Fenced code blocks — drop entirely (don't read code aloud).
+  text = text.replace(/```[\s\S]*?```/g, ' ')
+  // Inline code — keep the words, drop the backticks.
+  text = text.replace(/`([^`]*)`/g, '$1')
+  // LaTeX/math — read aloud it's gibberish ("dollar backslash frac..."). Display
+  // math becomes a spoken pointer (it renders in the bubble); inline math and
+  // stray commands (\frac{a}{b}, \alpha) are removed. Verbalizing equations
+  // properly (LaTeX→speech) is a follow-up.
+  text = text.replace(/\$\$[\s\S]*?\$\$/g, ' See the equation on screen. ')
+  text = text.replace(/\\\[[\s\S]*?\\\]/g, ' See the equation on screen. ')
+  text = text.replace(/\\\([\s\S]*?\\\)/g, ' ')
+  text = text.replace(/\$[^$\n]+\$/g, ' ')
+  text = text.replace(/\\[a-zA-Z]+\s*(?:\{[^{}]*\})*/g, ' ')
+  // Images: ![alt](url) → drop. Links: [text](url) → text.
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+  // Bare URLs → a short spoken token rather than reading the whole path.
+  text = text.replace(/https?:\/\/[^\s)]+/g, 'link')
+  // Emphasis / headings / blockquote / list markers / rules / table pipes.
+  text = text.replace(/(\*\*|__|\*|_|~~)/g, '')
+  text = text.replace(/^\s{0,3}#{1,6}\s+/gm, '')
+  text = text.replace(/^\s{0,3}>\s?/gm, '')
+  text = text.replace(/^\s*[-*+]\s+/gm, '')
+  text = text.replace(/^\s*\d+\.\s+/gm, '')
+  text = text.replace(/^\s*[-*_]{3,}\s*$/gm, ' ')
+  text = text.replace(/\|/g, ' ')
+  // Emoji + stray symbol noise.
+  text = text.replace(EMOJI, '')
+  // Collapse whitespace, then close up any space left before punctuation
+  // (e.g. from a removed citation marker: "today [1]." → "today .").
+  text = text.replace(/\s+/g, ' ')
+  text = text.replace(/\s+([.,!?;:])/g, '$1').trim()
+
+  // If nothing pronounceable survived (letters/digits), skip it.
+  return /[\p{L}\p{N}]/u.test(text) ? text : ''
+}

--- a/src/voice/transcript-filter.test.ts
+++ b/src/voice/transcript-filter.test.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { isHallucinatedTranscript } from './transcript-filter'
+
+describe('isHallucinatedTranscript', () => {
+  test('flags empty / whitespace / punctuation-only transcripts', () => {
+    expect(isHallucinatedTranscript('')).toBe(true)
+    expect(isHallucinatedTranscript('   ')).toBe(true)
+    expect(isHallucinatedTranscript('...')).toBe(true)
+  })
+
+  test('flags unmistakable video-caption hallucination phrases', () => {
+    expect(isHallucinatedTranscript('Thanks for watching!')).toBe(true)
+    expect(isHallucinatedTranscript('Please subscribe.')).toBe(true)
+    expect(isHallucinatedTranscript('See you next time.')).toBe(true)
+    expect(isHallucinatedTranscript('you')).toBe(true) // bare "you" — classic silence emit
+  })
+
+  test('flags several caption phrases concatenated', () => {
+    expect(isHallucinatedTranscript('Thanks for watching. Please subscribe.')).toBe(true)
+    expect(isHallucinatedTranscript('Thank you for watching. See you next time.')).toBe(true)
+  })
+
+  test('keeps genuine conversational courtesies the user actually says', () => {
+    // These are real sign-offs to the assistant — dropping them (silent no-reply)
+    // is worse than occasionally answering a noise-triggered "thank you".
+    expect(isHallucinatedTranscript('thank you')).toBe(false)
+    expect(isHallucinatedTranscript('thanks')).toBe(false)
+    expect(isHallucinatedTranscript('bye')).toBe(false)
+    expect(isHallucinatedTranscript('goodbye')).toBe(false)
+  })
+
+  test('keeps genuine short utterances', () => {
+    expect(isHallucinatedTranscript('yes')).toBe(false)
+    expect(isHallucinatedTranscript('stop')).toBe(false)
+    expect(isHallucinatedTranscript('what is the weather in Seattle')).toBe(false)
+  })
+
+  test('keeps utterances that merely contain a filler word', () => {
+    expect(isHallucinatedTranscript('thank you for the summary, can you expand it')).toBe(false)
+  })
+})

--- a/src/voice/transcript-filter.ts
+++ b/src/voice/transcript-filter.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Whisper silence-hallucination filter (THU-688).
+ *
+ * When Whisper is handed near-silent or noise-only audio (an over-eager VAD
+ * endpointing on background noise), it doesn't return empty — it emits its most
+ * common training-caption phrases: "Thank you", "Thanks for watching", "Bye".
+ * Those become phantom voice turns the user never spoke. This flags a transcript
+ * that is nothing but such filler so the session can drop it instead of replying.
+ *
+ * Deliberately conservative: only whole-utterance matches of unmistakable
+ * video-caption phrases (plus the bare "you" Whisper loves to emit on silence)
+ * are dropped. Bare conversational courtesies a user actually says to the
+ * assistant — "thank you", "thanks", "bye", "goodbye" — are intentionally NOT
+ * here: dropping a real sign-off (assistant goes silent) is worse than very
+ * occasionally replying to a noise-triggered "thank you".
+ */
+
+const NOISE_PHRASES = [
+  'thanks for watching',
+  'thank you for watching',
+  'thank you for your watching',
+  'please subscribe',
+  'like and subscribe',
+  'see you next time',
+  'see you in the next video',
+  'you',
+]
+
+// Longest first, so "thank you for watching" is removed before "thank you"
+// leaves an orphaned "for watching".
+const NOISE_PHRASES_BY_LENGTH = [...NOISE_PHRASES].sort((a, b) => b.length - a.length)
+
+const normalize = (text: string): string =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+/**
+ * True when a transcript is empty or consists solely of Whisper caption-filler
+ * (possibly a few concatenated, e.g. "Thank you. Bye.") — i.e. almost certainly
+ * a silence hallucination rather than something the user said.
+ */
+export const isHallucinatedTranscript = (text: string): boolean => {
+  const normalized = normalize(text)
+  if (!normalized) return true
+  let rest = ` ${normalized} `
+  let prev = ''
+  while (rest !== prev) {
+    prev = rest
+    for (const phrase of NOISE_PHRASES_BY_LENGTH) rest = rest.split(` ${phrase} `).join(' ')
+  }
+  return rest.trim().length === 0
+}

--- a/src/voice/transcript-filter.ts
+++ b/src/voice/transcript-filter.ts
@@ -19,7 +19,7 @@
  * occasionally replying to a noise-triggered "thank you".
  */
 
-const NOISE_PHRASES = [
+const noisePhrases = [
   'thanks for watching',
   'thank you for watching',
   'thank you for your watching',
@@ -32,7 +32,7 @@ const NOISE_PHRASES = [
 
 // Longest first, so "thank you for watching" is removed before "thank you"
 // leaves an orphaned "for watching".
-const NOISE_PHRASES_BY_LENGTH = [...NOISE_PHRASES].sort((a, b) => b.length - a.length)
+const noisePhrasesByLength = [...noisePhrases].sort((a, b) => b.length - a.length)
 
 const normalize = (text: string): string =>
   text
@@ -48,12 +48,16 @@ const normalize = (text: string): string =>
  */
 export const isHallucinatedTranscript = (text: string): boolean => {
   const normalized = normalize(text)
-  if (!normalized) return true
+  if (!normalized) {
+    return true
+  }
   let rest = ` ${normalized} `
   let prev = ''
   while (rest !== prev) {
     prev = rest
-    for (const phrase of NOISE_PHRASES_BY_LENGTH) rest = rest.split(` ${phrase} `).join(' ')
+    for (const phrase of noisePhrasesByLength) {
+      rest = rest.split(` ${phrase} `).join(' ')
+    }
   }
   return rest.trim().length === 0
 }

--- a/src/voice/ui/use-voice-session.ts
+++ b/src/voice/ui/use-voice-session.ts
@@ -45,7 +45,9 @@ export const useVoiceSession = () => {
   )
 
   const start = async () => {
-    if (sessionRef.current) return // already running — never stack a second session
+    if (sessionRef.current) {
+      return
+    } // already running — never stack a second session
     patch({ active: true, error: null, state: 'idle' })
     try {
       // Read the flag authoritatively from the DB at start time (not via a

--- a/src/voice/ui/use-voice-session.ts
+++ b/src/voice/ui/use-voice-session.ts
@@ -10,11 +10,27 @@
 import { useCurrentChatSession } from '@/chats/chat-store'
 import { useDatabase } from '@/contexts'
 import { getSettings } from '@/dal'
+import type { ThunderboltUIMessage } from '@/types'
 import { type ReplyChat, createChatReply } from '@/voice/chat-reply'
 import { createVoiceEngine } from '@/voice/engine/router'
 import { type SessionState, type VoiceSession, createVoiceSession } from '@/voice/session'
 import { toVoiceErrorMessage } from '@/voice/voice-error'
+import type { Chat } from '@ai-sdk/react'
 import { useEffect, useReducer, useRef } from 'react'
+
+/**
+ * Adapt the AI SDK `Chat` to the structural `ReplyChat` slice the voice session
+ * needs. `Chat` provides `sendMessage`/`messages`/`stop`, but its broader method
+ * signatures mean TS won't infer the match — an explicit adapter keeps chat-reply
+ * decoupled from the SDK and avoids an `as unknown as` cast at the call site.
+ */
+const toReplyChat = (chat: Chat<ThunderboltUIMessage>): ReplyChat => ({
+  sendMessage: (message) => chat.sendMessage(message),
+  get messages() {
+    return chat.messages
+  },
+  stop: () => chat.stop(),
+})
 
 type VoiceUiState = {
   active: boolean
@@ -56,10 +72,9 @@ export const useVoiceSession = () => {
       const { experimentalFeatureVoice } = await getSettings(db, { experimental_feature_voice: false })
       const voice = createVoiceSession({
         engine: createVoiceEngine(experimentalFeatureVoice),
-        // The AI SDK Chat structurally satisfies ReplyChat (sendMessage/messages/stop).
         // The transcript + reply render as normal chat bubbles via sendMessage, so
         // the UI itself only needs the session state.
-        reply: createChatReply(session.chatInstance as unknown as ReplyChat),
+        reply: createChatReply(toReplyChat(session.chatInstance)),
         onState: (state) => patch({ state }),
         onError: (error) => {
           console.error('[voice]', error)

--- a/src/voice/ui/use-voice-session.ts
+++ b/src/voice/ui/use-voice-session.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * React lifecycle wrapper around the voice session (THU-689). Builds the session
+ * from the current chat's `Chat` instance so a voice turn is a real chat turn,
+ * and exposes the state/transcripts the overlay renders.
+ */
+import { useCurrentChatSession } from '@/chats/chat-store'
+import { useDatabase } from '@/contexts'
+import { getSettings } from '@/dal'
+import { type ReplyChat, createChatReply } from '@/voice/chat-reply'
+import { createVoiceEngine } from '@/voice/engine/router'
+import { type SessionState, type VoiceSession, createVoiceSession } from '@/voice/session'
+import { toVoiceErrorMessage } from '@/voice/voice-error'
+import { useEffect, useReducer, useRef } from 'react'
+
+type VoiceUiState = {
+  active: boolean
+  state: SessionState
+  error: string | null
+}
+
+const initial: VoiceUiState = { active: false, state: 'idle', error: null }
+
+export const useVoiceSession = () => {
+  const session = useCurrentChatSession()
+  const db = useDatabase()
+  const [ui, patch] = useReducer((s: VoiceUiState, p: Partial<VoiceUiState>): VoiceUiState => ({ ...s, ...p }), initial)
+  const sessionRef = useRef<VoiceSession | null>(null)
+  // Live mic level, updated ~30×/s. A ref (not state) so the waveform can read it
+  // in a rAF loop without re-rendering the composer on every frame.
+  const levelRef = useRef(0)
+
+  // Tear the session down when the composer unmounts (chat navigation, HMR).
+  // Without this the mic/VAD/AudioContext survive as an orphan bound to the old
+  // chat — start again elsewhere and one utterance hits two chats at once.
+  useEffect(
+    () => () => {
+      void sessionRef.current?.stop()
+      sessionRef.current = null
+    },
+    [],
+  )
+
+  const start = async () => {
+    if (sessionRef.current) return // already running — never stack a second session
+    patch({ active: true, error: null, state: 'idle' })
+    try {
+      // Read the flag authoritatively from the DB at start time (not via a
+      // reactive hook that returns `false` until its query resolves) so a custom
+      // provider is never bypassed for the hardwired engine on a cold start.
+      const { experimentalFeatureVoice } = await getSettings(db, { experimental_feature_voice: false })
+      const voice = createVoiceSession({
+        engine: createVoiceEngine(experimentalFeatureVoice),
+        // The AI SDK Chat structurally satisfies ReplyChat (sendMessage/messages/stop).
+        // The transcript + reply render as normal chat bubbles via sendMessage, so
+        // the UI itself only needs the session state.
+        reply: createChatReply(session.chatInstance as unknown as ReplyChat),
+        onState: (state) => patch({ state }),
+        onError: (error) => {
+          console.error('[voice]', error)
+          patch({ error: String(error) })
+        },
+        onLevel: (level) => {
+          levelRef.current = level
+        },
+      })
+      sessionRef.current = voice
+      await voice.start()
+    } catch (error) {
+      // Startup failures are usually getUserMedia (mic blocked / missing / in use)
+      // — surface an actionable message instead of a raw DOMException name. Tear
+      // the partial session down (its playback ctx already exists) and clear the
+      // ref so the mic button can start a fresh one.
+      console.error('[voice]', error)
+      await sessionRef.current?.stop()
+      sessionRef.current = null
+      patch({ error: toVoiceErrorMessage(error) })
+    }
+  }
+
+  const stop = async () => {
+    await sessionRef.current?.stop()
+    sessionRef.current = null
+    patch({ active: false, state: 'idle' })
+  }
+
+  return { ...ui, start, stop, levelRef }
+}

--- a/src/voice/ui/use-voice-session.ts
+++ b/src/voice/ui/use-voice-session.ts
@@ -11,10 +11,8 @@ import { useCurrentChatSession } from '@/chats/chat-store'
 import { useDatabase } from '@/contexts'
 import { getSettings } from '@/dal'
 import type { ThunderboltUIMessage } from '@/types'
-import { type ReplyChat, createChatReply } from '@/voice/chat-reply'
-import { createVoiceEngine } from '@/voice/engine/router'
-import { type SessionState, type VoiceSession, createVoiceSession } from '@/voice/session'
-import { toVoiceErrorMessage } from '@/voice/voice-error'
+import type { ReplyChat } from '@/voice/chat-reply'
+import type { SessionState, VoiceSession } from '@/voice/session'
 import type { Chat } from '@ai-sdk/react'
 import { useEffect, useReducer, useRef } from 'react'
 
@@ -66,10 +64,19 @@ export const useVoiceSession = () => {
     } // already running — never stack a second session
     patch({ active: true, error: null, state: 'idle' })
     try {
-      // Read the flag authoritatively from the DB at start time (not via a
+      // Lazy-load the voice runtime (session + engines + VAD/playback/aggregator
+      // graph) only when the user actually starts voice — it's a non-critical
+      // feature and must stay out of the always-mounted chat composer's entry
+      // bundle. Read the flag authoritatively from the DB here too (not via a
       // reactive hook that returns `false` until its query resolves) so a custom
       // provider is never bypassed for the hardwired engine on a cold start.
-      const { experimentalFeatureVoice } = await getSettings(db, { experimental_feature_voice: false })
+      const [{ createVoiceSession }, { createVoiceEngine }, { createChatReply }, { experimentalFeatureVoice }] =
+        await Promise.all([
+          import('@/voice/session'),
+          import('@/voice/engine/router'),
+          import('@/voice/chat-reply'),
+          getSettings(db, { experimental_feature_voice: false }),
+        ])
       const voice = createVoiceSession({
         engine: createVoiceEngine(experimentalFeatureVoice),
         // The transcript + reply render as normal chat bubbles via sendMessage, so
@@ -94,6 +101,7 @@ export const useVoiceSession = () => {
       console.error('[voice]', error)
       await sessionRef.current?.stop()
       sessionRef.current = null
+      const { toVoiceErrorMessage } = await import('@/voice/voice-error')
       patch({ error: toVoiceErrorMessage(error) })
     }
   }

--- a/src/voice/ui/use-voice-session.ts
+++ b/src/voice/ui/use-voice-session.ts
@@ -14,7 +14,7 @@ import type { ThunderboltUIMessage } from '@/types'
 import type { ReplyChat } from '@/voice/chat-reply'
 import type { SessionState, VoiceSession } from '@/voice/session'
 import type { Chat } from '@ai-sdk/react'
-import { useEffect, useReducer, useRef } from 'react'
+import { useEffect, useMemo, useReducer, useRef } from 'react'
 
 /**
  * Adapt the AI SDK `Chat` to the structural `ReplyChat` slice the voice session
@@ -46,6 +46,17 @@ export const useVoiceSession = () => {
   // Live mic level, updated ~30×/s. A ref (not state) so the waveform can read it
   // in a rAF loop without re-rendering the composer on every frame.
   const levelRef = useRef(0)
+  // Live TTS output level for the speaking-state waveform. A stable object whose
+  // getter pulls from the current session's playback analyser on each rAF read
+  // (pull, not push — mirrors how `levelRef` carries the mic level via onLevel).
+  const outputLevelRef = useMemo<{ readonly current: number }>(
+    () => ({
+      get current() {
+        return sessionRef.current?.getOutputLevel() ?? 0
+      },
+    }),
+    [],
+  )
 
   // Tear the session down when the composer unmounts (chat navigation, HMR).
   // Without this the mic/VAD/AudioContext survive as an orphan bound to the old
@@ -112,5 +123,5 @@ export const useVoiceSession = () => {
     patch({ active: false, state: 'idle' })
   }
 
-  return { ...ui, start, stop, levelRef }
+  return { ...ui, start, stop, levelRef, outputLevelRef }
 }

--- a/src/voice/ui/voice-mode-button.tsx
+++ b/src/voice/ui/voice-mode-button.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Voice-mode entry button (THU-689). Occupies the composer's send-button slot
+ * while the composer is empty (see PromptInput's `emptyStateAction`), so it
+ * mirrors the send button's footprint. The session + active-mode UI live in the
+ * composer (which morphs into the voice surface), so this is just the trigger.
+ */
+import { Button } from '@/components/ui/button'
+import { AudioLines } from 'lucide-react'
+
+type VoiceModeButtonProps = {
+  onStart: () => void
+}
+
+export const VoiceModeButton = ({ onStart }: VoiceModeButtonProps) => (
+  <Button
+    type="button"
+    variant="default"
+    onClick={onStart}
+    aria-label="Start voice mode"
+    title="Start voice mode"
+    className="size-[var(--touch-height-control)] rounded-[var(--radius-control)] flex items-center justify-center flex-shrink-0"
+  >
+    <AudioLines className="size-[var(--icon-size-default)]" />
+  </Button>
+)

--- a/src/voice/ui/voice-mode-composer.tsx
+++ b/src/voice/ui/voice-mode-composer.tsx
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Voice-mode composer overlay (THU-689). Voice replaces typing, so the composer
+ * *becomes* the voice surface: this covers the prompt box in-place (matching its
+ * rounded box + background) with the waveform, current state, and an exit — no
+ * detached floating widget. The conversation still streams into normal chat
+ * bubbles above, Claude-Desktop style.
+ */
+import type { SessionState } from '@/voice/session'
+import { VoiceWaveform } from '@/voice/ui/voice-waveform'
+import { m } from 'framer-motion'
+import { MicOff, X } from 'lucide-react'
+
+const STATUS_LABEL: Record<SessionState, string> = {
+  idle: 'Starting…',
+  listening: 'Listening',
+  thinking: 'Thinking',
+  speaking: 'Speaking',
+}
+
+type VoiceModeComposerProps = {
+  state: SessionState
+  error?: string | null
+  levelRef?: { readonly current: number }
+  onClose: () => void
+}
+
+export const VoiceModeComposer = ({ state, error, levelRef, onClose }: VoiceModeComposerProps) => (
+  <m.div
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 1 }}
+    exit={{ opacity: 0 }}
+    transition={{ duration: 0.18, ease: 'easeOut' }}
+    // Mirror the PromptInput box (rounded-2xl border bg-card …) so it reads as the
+    // same composer, just in voice mode. z-20 sits above the PromptInput (z-10).
+    className="absolute inset-0 z-20 flex items-center gap-3 rounded-2xl border bg-card py-2 pl-4 pr-2 dark:border-input dark:bg-[oklch(0.182_0_0)]"
+    role="status"
+    aria-label={`Voice mode: ${STATUS_LABEL[state]}`}
+  >
+    {error ? (
+      <div className="flex min-w-0 flex-1 items-center gap-2 text-destructive">
+        <MicOff className="size-[var(--icon-size-sm)] shrink-0" />
+        <span className="line-clamp-2 min-w-0 select-text text-[length:var(--font-size-sm)] font-medium" title={error}>
+          {error}
+        </span>
+      </div>
+    ) : (
+      <>
+        <VoiceWaveform state={state} levelRef={levelRef} className="min-w-0 flex-1" />
+        <span className="shrink-0 text-[length:var(--font-size-xs)] font-medium text-muted-foreground">
+          {STATUS_LABEL[state]}
+        </span>
+      </>
+    )}
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label="Exit voice mode"
+      title="Exit voice mode"
+      className="flex size-[var(--touch-height-sm)] shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-transform hover:scale-105"
+    >
+      <X className="size-[var(--icon-size-sm)]" />
+    </button>
+  </m.div>
+)

--- a/src/voice/ui/voice-mode-composer.tsx
+++ b/src/voice/ui/voice-mode-composer.tsx
@@ -34,9 +34,10 @@ export const VoiceModeComposer = ({ state, error, levelRef, onClose }: VoiceMode
     animate={{ opacity: 1 }}
     exit={{ opacity: 0 }}
     transition={{ duration: 0.18, ease: 'easeOut' }}
-    // Mirror the PromptInput box (rounded-2xl border bg-card …) so it reads as the
-    // same composer, just in voice mode. z-20 sits above the PromptInput (z-10).
-    className="absolute inset-0 z-20 flex items-center gap-3 rounded-2xl border bg-card py-2 pl-4 pr-2 dark:border-input dark:bg-[oklch(0.182_0_0)]"
+    // Mirror the PromptInput box (rounded-3xl border bg-sidebar) so it reads as the
+    // same composer, just in voice mode — same radius/fill means no corners peek
+    // out underneath. z-20 sits above the PromptInput (z-10).
+    className="absolute inset-0 z-20 flex items-center gap-3 rounded-3xl border bg-sidebar py-2 pl-4 pr-2 dark:border-input"
     role="status"
     aria-label={`Voice mode: ${statusLabel[state]}`}
   >

--- a/src/voice/ui/voice-mode-composer.tsx
+++ b/src/voice/ui/voice-mode-composer.tsx
@@ -25,10 +25,11 @@ type VoiceModeComposerProps = {
   state: SessionState
   error?: string | null
   levelRef?: { readonly current: number }
+  outputLevelRef?: { readonly current: number }
   onClose: () => void
 }
 
-export const VoiceModeComposer = ({ state, error, levelRef, onClose }: VoiceModeComposerProps) => (
+export const VoiceModeComposer = ({ state, error, levelRef, outputLevelRef, onClose }: VoiceModeComposerProps) => (
   <m.div
     initial={{ opacity: 0 }}
     animate={{ opacity: 1 }}
@@ -50,7 +51,7 @@ export const VoiceModeComposer = ({ state, error, levelRef, onClose }: VoiceMode
       </div>
     ) : (
       <>
-        <VoiceWaveform state={state} levelRef={levelRef} className="min-w-0 flex-1" />
+        <VoiceWaveform state={state} levelRef={levelRef} outputLevelRef={outputLevelRef} className="min-w-0 flex-1" />
         <span className="shrink-0 text-[length:var(--font-size-xs)] font-medium text-muted-foreground">
           {statusLabel[state]}
         </span>

--- a/src/voice/ui/voice-mode-composer.tsx
+++ b/src/voice/ui/voice-mode-composer.tsx
@@ -14,7 +14,7 @@ import { VoiceWaveform } from '@/voice/ui/voice-waveform'
 import { m } from 'framer-motion'
 import { MicOff, X } from 'lucide-react'
 
-const STATUS_LABEL: Record<SessionState, string> = {
+const statusLabel: Record<SessionState, string> = {
   idle: 'Starting…',
   listening: 'Listening',
   thinking: 'Thinking',
@@ -38,7 +38,7 @@ export const VoiceModeComposer = ({ state, error, levelRef, onClose }: VoiceMode
     // same composer, just in voice mode. z-20 sits above the PromptInput (z-10).
     className="absolute inset-0 z-20 flex items-center gap-3 rounded-2xl border bg-card py-2 pl-4 pr-2 dark:border-input dark:bg-[oklch(0.182_0_0)]"
     role="status"
-    aria-label={`Voice mode: ${STATUS_LABEL[state]}`}
+    aria-label={`Voice mode: ${statusLabel[state]}`}
   >
     {error ? (
       <div className="flex min-w-0 flex-1 items-center gap-2 text-destructive">
@@ -51,7 +51,7 @@ export const VoiceModeComposer = ({ state, error, levelRef, onClose }: VoiceMode
       <>
         <VoiceWaveform state={state} levelRef={levelRef} className="min-w-0 flex-1" />
         <span className="shrink-0 text-[length:var(--font-size-xs)] font-medium text-muted-foreground">
-          {STATUS_LABEL[state]}
+          {statusLabel[state]}
         </span>
       </>
     )}

--- a/src/voice/ui/voice-waveform.tsx
+++ b/src/voice/ui/voice-waveform.tsx
@@ -5,10 +5,11 @@
 /**
  * Animated voice waveform (THU-689) — a full-width equalizer that makes it
  * obvious you're in voice mode. Bars stretch edge-to-edge and behave per session
- * state. While listening it reacts to your real mic level; the other states play
- * a canned animation (a traveling "thinking" shimmer, a lively speaking
- * equalizer, a calm idle line). Bar shapes are derived deterministically from the
- * index (no per-render randomness) so the animation is stable across re-renders.
+ * state. While listening it reacts to your real mic level, and while speaking to
+ * the assistant's actual TTS output level; idle/thinking play a canned animation
+ * (a traveling "thinking" shimmer, a calm idle line). Bar shapes are derived
+ * deterministically from the index (no per-render randomness) so the animation is
+ * stable across re-renders.
  */
 import type { SessionState } from '@/voice/session'
 import { m } from 'framer-motion'
@@ -30,14 +31,22 @@ const barPeak = (i: number): number => {
 
 type LevelRef = { readonly current: number }
 
-type VoiceWaveformProps = { state: SessionState; levelRef?: LevelRef; className?: string }
+type VoiceWaveformProps = {
+  state: SessionState
+  levelRef?: LevelRef
+  outputLevelRef?: LevelRef
+  className?: string
+}
 
-export const VoiceWaveform = ({ state, levelRef, className = '' }: VoiceWaveformProps) =>
-  state === 'listening' && levelRef ? (
-    <ReactiveBars levelRef={levelRef} className={className} />
-  ) : (
-    <CannedBars state={state} className={className} />
-  )
+export const VoiceWaveform = ({ state, levelRef, outputLevelRef, className = '' }: VoiceWaveformProps) => {
+  if (state === 'listening' && levelRef) {
+    return <ReactiveBars levelRef={levelRef} className={className} />
+  }
+  if (state === 'speaking' && outputLevelRef) {
+    return <ReactiveBars levelRef={outputLevelRef} className={className} />
+  }
+  return <CannedBars state={state} className={className} />
+}
 
 /**
  * Mic-reactive bars. A single rAF loop smooths the level and writes ONE CSS

--- a/src/voice/ui/voice-waveform.tsx
+++ b/src/voice/ui/voice-waveform.tsx
@@ -14,16 +14,16 @@ import type { SessionState } from '@/voice/session'
 import { m } from 'framer-motion'
 import { type CSSProperties, useEffect, useRef } from 'react'
 
-const BAR_COUNT = 40
-const MIN_HEIGHT = 12 // % of track — the resting line
+const barCount = 40
+const minHeight = 12 // % of track — the resting line
 
-/** Per-state peak amplitude (fraction of track added on top of MIN_HEIGHT). */
-const AMPLITUDE: Record<SessionState, number> = { idle: 0, listening: 0.45, thinking: 0, speaking: 0.85 }
-const DURATIONS: Record<SessionState, number> = { idle: 1.2, listening: 1.0, thinking: 1.1, speaking: 0.42 }
+/** Per-state peak amplitude (fraction of track added on top of minHeight). */
+const amplitude: Record<SessionState, number> = { idle: 0, listening: 0.45, thinking: 0, speaking: 0.85 }
+const durations: Record<SessionState, number> = { idle: 1.2, listening: 1.0, thinking: 1.1, speaking: 0.42 }
 
 /** Deterministic 0..1 shape for bar `i`: a center hump plus fine wiggle. */
 const barPeak = (i: number): number => {
-  const hump = Math.sin(((i + 0.5) / BAR_COUNT) * Math.PI) // taller toward the middle
+  const hump = Math.sin(((i + 0.5) / barCount) * Math.PI) // taller toward the middle
   const wiggle = 0.5 + 0.5 * Math.sin(i * 1.7) // stable per-bar detail
   return 0.4 * hump + 0.6 * wiggle
 }
@@ -61,7 +61,7 @@ const ReactiveBars = ({ levelRef, className }: { levelRef: LevelRef; className: 
   }, [levelRef])
   return (
     <div ref={ref} className={`flex h-full w-full items-center justify-between ${className}`} aria-hidden>
-      {Array.from({ length: BAR_COUNT }, (_, i) => (
+      {Array.from({ length: barCount }, (_, i) => (
         <span
           key={i}
           className="h-full w-[3px] shrink-0 origin-center rounded-full bg-primary"
@@ -81,19 +81,19 @@ const CannedBars = ({ state, className }: { state: SessionState; className: stri
   const isFlat = state === 'idle' || state === 'thinking'
   return (
     <div className={`flex h-full w-full items-center justify-between ${className}`} aria-hidden>
-      {Array.from({ length: BAR_COUNT }, (_, i) => {
-        const high = Math.round(MIN_HEIGHT + AMPLITUDE[state] * barPeak(i) * (100 - MIN_HEIGHT))
+      {Array.from({ length: barCount }, (_, i) => {
+        const high = Math.round(minHeight + amplitude[state] * barPeak(i) * (100 - minHeight))
         return (
           <m.span
             key={i}
             className="w-[3px] shrink-0 rounded-full bg-primary"
             animate={
               isFlat
-                ? { height: `${MIN_HEIGHT}%`, opacity: state === 'thinking' ? [0.3, 1, 0.3] : 0.5 }
-                : { height: [`${MIN_HEIGHT}%`, `${high}%`, `${Math.round(high * 0.55)}%`] }
+                ? { height: `${minHeight}%`, opacity: state === 'thinking' ? [0.3, 1, 0.3] : 0.5 }
+                : { height: [`${minHeight}%`, `${high}%`, `${Math.round(high * 0.55)}%`] }
             }
             transition={{
-              duration: DURATIONS[state],
+              duration: durations[state],
               repeat: Number.POSITIVE_INFINITY,
               repeatType: 'mirror',
               ease: 'easeInOut',

--- a/src/voice/ui/voice-waveform.tsx
+++ b/src/voice/ui/voice-waveform.tsx
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Animated voice waveform (THU-689) — a full-width equalizer that makes it
+ * obvious you're in voice mode. Bars stretch edge-to-edge and behave per session
+ * state. While listening it reacts to your real mic level; the other states play
+ * a canned animation (a traveling "thinking" shimmer, a lively speaking
+ * equalizer, a calm idle line). Bar shapes are derived deterministically from the
+ * index (no per-render randomness) so the animation is stable across re-renders.
+ */
+import type { SessionState } from '@/voice/session'
+import { m } from 'framer-motion'
+import { type CSSProperties, useEffect, useRef } from 'react'
+
+const BAR_COUNT = 40
+const MIN_HEIGHT = 12 // % of track — the resting line
+
+/** Per-state peak amplitude (fraction of track added on top of MIN_HEIGHT). */
+const AMPLITUDE: Record<SessionState, number> = { idle: 0, listening: 0.45, thinking: 0, speaking: 0.85 }
+const DURATIONS: Record<SessionState, number> = { idle: 1.2, listening: 1.0, thinking: 1.1, speaking: 0.42 }
+
+/** Deterministic 0..1 shape for bar `i`: a center hump plus fine wiggle. */
+const barPeak = (i: number): number => {
+  const hump = Math.sin(((i + 0.5) / BAR_COUNT) * Math.PI) // taller toward the middle
+  const wiggle = 0.5 + 0.5 * Math.sin(i * 1.7) // stable per-bar detail
+  return 0.4 * hump + 0.6 * wiggle
+}
+
+type LevelRef = { readonly current: number }
+
+type VoiceWaveformProps = { state: SessionState; levelRef?: LevelRef; className?: string }
+
+export const VoiceWaveform = ({ state, levelRef, className = '' }: VoiceWaveformProps) =>
+  state === 'listening' && levelRef ? (
+    <ReactiveBars levelRef={levelRef} className={className} />
+  ) : (
+    <CannedBars state={state} className={className} />
+  )
+
+/**
+ * Mic-reactive bars. A single rAF loop smooths the level and writes ONE CSS
+ * variable (`--level`) on the container; every bar's `scaleY` reads it via
+ * `calc()`, so all 40 update without any React re-render or per-bar JS.
+ */
+const ReactiveBars = ({ levelRef, className }: { levelRef: LevelRef; className: string }) => {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    let raf = 0
+    let smoothed = 0
+    const tick = () => {
+      // sqrt curve lifts quiet speech into visible range; then ease toward it.
+      const target = Math.min(1, Math.sqrt(Math.max(0, levelRef.current) * 6))
+      smoothed += (target - smoothed) * 0.35
+      ref.current?.style.setProperty('--level', smoothed.toFixed(3))
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [levelRef])
+  return (
+    <div ref={ref} className={`flex h-full w-full items-center justify-between ${className}`} aria-hidden>
+      {Array.from({ length: BAR_COUNT }, (_, i) => (
+        <span
+          key={i}
+          className="h-full w-[3px] shrink-0 origin-center rounded-full bg-primary"
+          style={
+            {
+              '--peak': barPeak(i).toFixed(3),
+              transform: 'scaleY(clamp(0.1, calc(var(--level, 0) * var(--peak) * 0.95 + 0.08), 1))',
+            } as CSSProperties
+          }
+        />
+      ))}
+    </div>
+  )
+}
+
+const CannedBars = ({ state, className }: { state: SessionState; className: string }) => {
+  const isFlat = state === 'idle' || state === 'thinking'
+  return (
+    <div className={`flex h-full w-full items-center justify-between ${className}`} aria-hidden>
+      {Array.from({ length: BAR_COUNT }, (_, i) => {
+        const high = Math.round(MIN_HEIGHT + AMPLITUDE[state] * barPeak(i) * (100 - MIN_HEIGHT))
+        return (
+          <m.span
+            key={i}
+            className="w-[3px] shrink-0 rounded-full bg-primary"
+            animate={
+              isFlat
+                ? { height: `${MIN_HEIGHT}%`, opacity: state === 'thinking' ? [0.3, 1, 0.3] : 0.5 }
+                : { height: [`${MIN_HEIGHT}%`, `${high}%`, `${Math.round(high * 0.55)}%`] }
+            }
+            transition={{
+              duration: DURATIONS[state],
+              repeat: Number.POSITIVE_INFINITY,
+              repeatType: 'mirror',
+              ease: 'easeInOut',
+              delay: (i % 12) * (state === 'thinking' ? 0.06 : 0.035),
+            }}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/src/voice/voice-error.test.ts
+++ b/src/voice/voice-error.test.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { toVoiceErrorMessage } from './voice-error'
+
+describe('toVoiceErrorMessage', () => {
+  test('explains a blocked microphone', () => {
+    expect(toVoiceErrorMessage(new DOMException('denied', 'NotAllowedError'))).toContain('Microphone access is blocked')
+    expect(toVoiceErrorMessage(new DOMException('insecure', 'SecurityError'))).toContain('Microphone access is blocked')
+  })
+
+  test('explains a missing microphone', () => {
+    expect(toVoiceErrorMessage(new DOMException('none', 'NotFoundError'))).toContain('No microphone found')
+  })
+
+  test('explains a microphone in use', () => {
+    expect(toVoiceErrorMessage(new DOMException('busy', 'NotReadableError'))).toContain('being used by another app')
+  })
+
+  test('passes other errors through verbatim (keeps provider bodies debuggable)', () => {
+    expect(toVoiceErrorMessage(new Error('TTS failed: 400 {"error":"bad voice"}'))).toBe(
+      'Error: TTS failed: 400 {"error":"bad voice"}',
+    )
+  })
+})

--- a/src/voice/voice-error.test.ts
+++ b/src/voice/voice-error.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, test } from 'bun:test'
-import { toVoiceErrorMessage } from './voice-error'
+import { MediaDevicesUnavailableError, toVoiceErrorMessage } from './voice-error'
 
 describe('toVoiceErrorMessage', () => {
   test('explains a blocked microphone', () => {
@@ -17,6 +17,12 @@ describe('toVoiceErrorMessage', () => {
 
   test('explains a microphone in use', () => {
     expect(toVoiceErrorMessage(new DOMException('busy', 'NotReadableError'))).toContain('being used by another app')
+  })
+
+  test('explains an unavailable media API (insecure webview context)', () => {
+    const message = toVoiceErrorMessage(new MediaDevicesUnavailableError())
+    expect(message).toContain('isn’t available in this window')
+    expect(message).toContain('secure context')
   })
 
   test('passes other errors through verbatim (keeps provider bodies debuggable)', () => {

--- a/src/voice/voice-error.ts
+++ b/src/voice/voice-error.ts
@@ -3,6 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
+ * The webview doesn't expose the media-capture API at all — `navigator.mediaDevices`
+ * is undefined, so we can't even call `getUserMedia`. Distinct from a getUserMedia
+ * rejection: WKWebView only exposes `mediaDevices` in a secure context (https or a
+ * bundle-loaded app), so a Tauri *dev* build served over `http://localhost` hits
+ * this, while a packaged build does not.
+ */
+export class MediaDevicesUnavailableError extends Error {
+  constructor() {
+    super('navigator.mediaDevices is unavailable in this context')
+    this.name = 'MediaDevicesUnavailableError'
+  }
+}
+
+/**
  * Map a voice-session failure to a human message (THU-689).
  *
  * `getUserMedia` rejects with `DOMException`s whose `.name` says what went wrong
@@ -11,6 +25,9 @@
  * through verbatim so provider error bodies stay debuggable.
  */
 export const toVoiceErrorMessage = (error: unknown): string => {
+  if (error instanceof MediaDevicesUnavailableError) {
+    return 'Microphone isn’t available in this window. Voice mode needs a secure context — try again over https, or use the packaged desktop app rather than the dev server.'
+  }
   const name = error instanceof DOMException ? error.name : ''
   switch (name) {
     case 'NotAllowedError':

--- a/src/voice/voice-error.ts
+++ b/src/voice/voice-error.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Map a voice-session failure to a human message (THU-689).
+ *
+ * `getUserMedia` rejects with `DOMException`s whose `.name` says what went wrong
+ * (blocked, no device, in use). We turn those into a clear, actionable line
+ * instead of a raw "NotAllowedError". Anything else (STT/TTS/network) is passed
+ * through verbatim so provider error bodies stay debuggable.
+ */
+export const toVoiceErrorMessage = (error: unknown): string => {
+  const name = error instanceof DOMException ? error.name : ''
+  switch (name) {
+    case 'NotAllowedError':
+    case 'SecurityError':
+      return 'Microphone access is blocked. Allow microphone access in your browser or system settings, then try again.'
+    case 'NotFoundError':
+    case 'OverconstrainedError':
+      return 'No microphone found. Connect a microphone and try again.'
+    case 'NotReadableError':
+      return 'Your microphone is being used by another app. Close it and try again.'
+    default:
+      return String(error)
+  }
+}


### PR DESCRIPTION
## Summary

Adds voice mode — a half-duplex "talk to the assistant" loop (mic → VAD → STT → chat reply → TTS → playback) that reuses the existing chat/model/tools/persistence stack. The composer *becomes* the voice surface: the send button turns into a waveform trigger when the composer is empty, and the conversation still streams into normal chat bubbles.

- **Default engine: Thunderbolt / Tinfoil enclave STT+TTS**, hardwired so audio stays enclave-private. Runs through the existing attested `/tinfoil` HPKE proxy — no new backend route.
- **Custom OpenAI-compatible provider** (base URL + key + `/v1/models` discovery for Kokoro/Whisper-style servers like speaches) behind the new `experimental_feature_voice` flag. The Voice settings page is hidden by default, and the engine falls back to Thunderbolt whenever the flag is off (read authoritatively at turn start, not via a racy reactive read).
- Engine-agnostic core in `src/voice/` shared across web/desktop/mobile; only the injected `VoiceEngine` differs.

## Testing

- ✅ **Web** — full voice turn works end to end.
- ✅ **macOS desktop** (`tauri build --debug` bundle) — works, including the mic TCC prompt.
- ⚠️ **iOS** — builds and runs in the Simulator and **fails gracefully** (clean mic-unavailable error). The Simulator doesn't deliver real mic audio, so on-device capture (which needs signing) is a follow-up.
- Unit tests cover the aggregator, transcript filter, chat-reply lifecycle (incl. send-failure surfacing), model discovery, and error mapping.

## Notes for reviewers

- **Half-duplex by design** — no barge-in yet; the VAD keeps an `onSpeechStart` hook for a future full-duplex pass.
- Custom **cloud** providers work on native today (Rust HTTP bypasses CORS); web would need routing through the universal `/v1/proxy` — deferred until we commit to shipping a paid third-party.
- Mic permissions: `NSMicrophoneUsageDescription` (`src-tauri/Info.plist`, merged into macOS + iOS) and `RECORD_AUDIO` (Android manifest).
- New synced setting `experimental_feature_voice` (adds a default row; `defaultSettingsVersion` bumped — no schema/sync-rule change, no two-PR flow).