### PR TITLE
fix(THU-683): STT upload as explicit multipart (fixes prod voice 422 on desktop web)

### DIFF
--- a/src/voice/engine/audio-engine.test.ts
+++ b/src/voice/engine/audio-engine.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, test } from 'bun:test'
-import { encodeWavUpload } from './audio-engine'
+import { type AudioTransport, createAudioEngine, encodeWavUpload } from './audio-engine'
 
 describe('encodeWavUpload', () => {
   test('emits an explicit boundary that matches the Content-Type header', async () => {
@@ -43,5 +43,40 @@ describe('encodeWavUpload', () => {
     const needle = [0xde, 0xad, 0xbe, 0xef]
     const found = hay.some((_, i) => needle.every((b, j) => hay[i + j] === b))
     expect(found).toBe(true)
+  })
+})
+
+describe('transcribe (regression guard for the prod 422)', () => {
+  const oneFrame = async function* (): AsyncIterable<Float32Array> {
+    yield new Float32Array([0.1, -0.1, 0.2, -0.2])
+  }
+
+  test('forwards a multipart/form-data content-type to the transport', async () => {
+    let capturedPath = ''
+    let capturedContentType: string | undefined
+    const transport: AudioTransport = async (path, _body, headers) => {
+      capturedPath = path
+      capturedContentType = headers?.['content-type']
+      return new Response(JSON.stringify({ text: 'hello there' }), { status: 200 })
+    }
+    const engine = createAudioEngine({
+      id: 'test',
+      transport,
+      sttModel: 'whisper-large-v3-turbo',
+      ttsModel: 'tts',
+      ttsVoice: 'v',
+    })
+
+    const out: string[] = []
+    for await (const t of engine.transcribe(oneFrame())) {
+      out.push(t.text)
+    }
+
+    // The actual prod regression was the enclave receiving no usable multipart
+    // Content-Type; assert transcribe hands the transport one (a FormData revert
+    // or a dropped header would fail here even if encodeWavUpload stayed correct).
+    expect(capturedPath).toBe('/audio/transcriptions')
+    expect(capturedContentType).toMatch(/^multipart\/form-data; boundary=/)
+    expect(out).toEqual(['hello there'])
   })
 })

--- a/src/voice/engine/audio-engine.test.ts
+++ b/src/voice/engine/audio-engine.test.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { encodeWavUpload } from './audio-engine'
+
+describe('encodeWavUpload', () => {
+  test('emits an explicit boundary that matches the Content-Type header', () => {
+    const wav = new Uint8Array([1, 2, 3, 4]).buffer
+    const { body, contentType } = encodeWavUpload(wav, 'whisper-large-v3-turbo')
+
+    const boundary = contentType.match(/boundary=(.+)$/)?.[1]
+    expect(boundary).toBeTruthy()
+    expect(contentType.startsWith('multipart/form-data; boundary=')).toBe(true)
+
+    const text = new TextDecoder().decode(body)
+    // The boundary in the body must match the one advertised in the header — the
+    // whole point of the fix (FormData's implicit boundary didn't survive).
+    expect(text).toContain(`--${boundary}\r\n`)
+    expect(text).toContain(`\r\n--${boundary}--\r\n`)
+  })
+
+  test('includes both required form fields with the model value', () => {
+    const wav = new Uint8Array([0]).buffer
+    const { body } = encodeWavUpload(wav, 'my-model')
+    const text = new TextDecoder().decode(body)
+
+    expect(text).toContain('Content-Disposition: form-data; name="model"')
+    expect(text).toContain('my-model')
+    expect(text).toContain('Content-Disposition: form-data; name="file"; filename="utterance.wav"')
+    expect(text).toContain('Content-Type: audio/wav')
+  })
+
+  test('embeds the wav bytes verbatim between the part headers', () => {
+    const wav = new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer
+    const { body } = encodeWavUpload(wav, 'm')
+    // The 4 wav bytes appear contiguously somewhere in the multipart body.
+    const hay = Array.from(body)
+    const needle = [0xde, 0xad, 0xbe, 0xef]
+    const found = hay.some((_, i) => needle.every((b, j) => hay[i + j] === b))
+    expect(found).toBe(true)
+  })
+})

--- a/src/voice/engine/audio-engine.test.ts
+++ b/src/voice/engine/audio-engine.test.ts
@@ -6,25 +6,28 @@ import { describe, expect, test } from 'bun:test'
 import { encodeWavUpload } from './audio-engine'
 
 describe('encodeWavUpload', () => {
-  test('emits an explicit boundary that matches the Content-Type header', () => {
+  test('emits an explicit boundary that matches the Content-Type header', async () => {
     const wav = new Uint8Array([1, 2, 3, 4]).buffer
     const { body, contentType } = encodeWavUpload(wav, 'whisper-large-v3-turbo')
 
     const boundary = contentType.match(/boundary=(.+)$/)?.[1]
     expect(boundary).toBeTruthy()
     expect(contentType.startsWith('multipart/form-data; boundary=')).toBe(true)
+    // The Blob's own type must also carry the boundary, so it stays consistent
+    // even if a caller forwards the Blob without our explicit header.
+    expect(body.type).toBe(contentType)
 
-    const text = new TextDecoder().decode(body)
+    const text = new TextDecoder().decode(await body.arrayBuffer())
     // The boundary in the body must match the one advertised in the header — the
     // whole point of the fix (FormData's implicit boundary didn't survive).
     expect(text).toContain(`--${boundary}\r\n`)
     expect(text).toContain(`\r\n--${boundary}--\r\n`)
   })
 
-  test('includes both required form fields with the model value', () => {
+  test('includes both required form fields with the model value', async () => {
     const wav = new Uint8Array([0]).buffer
     const { body } = encodeWavUpload(wav, 'my-model')
-    const text = new TextDecoder().decode(body)
+    const text = new TextDecoder().decode(await body.arrayBuffer())
 
     expect(text).toContain('Content-Disposition: form-data; name="model"')
     expect(text).toContain('my-model')
@@ -32,11 +35,11 @@ describe('encodeWavUpload', () => {
     expect(text).toContain('Content-Type: audio/wav')
   })
 
-  test('embeds the wav bytes verbatim between the part headers', () => {
+  test('embeds the wav bytes verbatim between the part headers', async () => {
     const wav = new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer
     const { body } = encodeWavUpload(wav, 'm')
     // The 4 wav bytes appear contiguously somewhere in the multipart body.
-    const hay = Array.from(body)
+    const hay = Array.from(new Uint8Array(await body.arrayBuffer()))
     const needle = [0xde, 0xad, 0xbe, 0xef]
     const found = hay.some((_, i) => needle.every((b, j) => hay[i + j] === b))
     expect(found).toBe(true)

--- a/src/voice/engine/audio-engine.ts
+++ b/src/voice/engine/audio-engine.ts
@@ -94,21 +94,18 @@ export const concatFrames = (frames: PcmFrame[]): Float32Array => {
  * header ourselves — exactly like the JSON TTS path, which works everywhere —
  * makes the upload deterministic across browsers and proxies.
  */
-export const encodeWavUpload = (wav: ArrayBuffer, model: string): { body: Uint8Array; contentType: string } => {
+export const encodeWavUpload = (wav: ArrayBuffer, model: string): { body: Blob; contentType: string } => {
   const boundary = `----thunderbolt-voice-${crypto.randomUUID()}`
-  const encoder = new TextEncoder()
-  const head = encoder.encode(
+  const contentType = `multipart/form-data; boundary=${boundary}`
+  const head =
     `--${boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\n${model}\r\n` +
-      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="utterance.wav"\r\n` +
-      `Content-Type: audio/wav\r\n\r\n`,
-  )
-  const tail = encoder.encode(`\r\n--${boundary}--\r\n`)
-  const wavBytes = new Uint8Array(wav)
-  const body = new Uint8Array(head.length + wavBytes.length + tail.length)
-  body.set(head, 0)
-  body.set(wavBytes, head.length)
-  body.set(tail, head.length + wavBytes.length)
-  return { body, contentType: `multipart/form-data; boundary=${boundary}` }
+    `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="utterance.wav"\r\n` +
+    `Content-Type: audio/wav\r\n\r\n`
+  const tail = `\r\n--${boundary}--\r\n`
+  // A Blob is cleanly typed as BodyInit and sends with a Content-Length (not
+  // chunked) — both needed for the fix above; the parts assemble in order.
+  const body = new Blob([head, wav, tail], { type: contentType })
+  return { body, contentType }
 }
 
 const errorText = async (res: Response): Promise<string> => `${res.status} ${await res.text().catch(() => '')}`.trim()

--- a/src/voice/engine/audio-engine.ts
+++ b/src/voice/engine/audio-engine.ts
@@ -80,6 +80,37 @@ export const concatFrames = (frames: PcmFrame[]): Float32Array => {
   return merged
 }
 
+/**
+ * Build a `multipart/form-data` STT upload as fixed-length bytes with an explicit
+ * boundary, returning the body AND the matching `Content-Type`.
+ *
+ * We deliberately avoid `FormData`: its boundary is generated implicitly by the
+ * browser only as it streams the request, and that Content-Type doesn't reliably
+ * reach the server on every path — notably desktop-browser → prod, where the
+ * request crosses the Tinfoil transport (EHBP rebuilds the request and seals the
+ * body separately from the plaintext headers) plus the prod edge. On the affected
+ * path the enclave receives body bytes with no usable boundary and rejects the
+ * upload as `file`/`model` missing (422). Materializing the body and setting the
+ * header ourselves — exactly like the JSON TTS path, which works everywhere —
+ * makes the upload deterministic across browsers and proxies.
+ */
+export const encodeWavUpload = (wav: ArrayBuffer, model: string): { body: Uint8Array; contentType: string } => {
+  const boundary = `----thunderbolt-voice-${crypto.randomUUID()}`
+  const encoder = new TextEncoder()
+  const head = encoder.encode(
+    `--${boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\n${model}\r\n` +
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="utterance.wav"\r\n` +
+      `Content-Type: audio/wav\r\n\r\n`,
+  )
+  const tail = encoder.encode(`\r\n--${boundary}--\r\n`)
+  const wavBytes = new Uint8Array(wav)
+  const body = new Uint8Array(head.length + wavBytes.length + tail.length)
+  body.set(head, 0)
+  body.set(wavBytes, head.length)
+  body.set(tail, head.length + wavBytes.length)
+  return { body, contentType: `multipart/form-data; boundary=${boundary}` }
+}
+
 const errorText = async (res: Response): Promise<string> => `${res.status} ${await res.text().catch(() => '')}`.trim()
 
 export const createAudioEngine = (opts: AudioEngineOptions): VoiceEngine => {
@@ -104,10 +135,9 @@ export const createAudioEngine = (opts: AudioEngineOptions): VoiceEngine => {
     // The session feeds one already-merged utterance frame; skip the redundant
     // full-length copy in that common case.
     const merged = frames.length === 1 ? frames[0] : concatFrames(frames)
-    const form = new FormData()
-    form.append('file', encodeWav(merged, sttSampleRate), 'utterance.wav')
-    form.append('model', opts.sttModel)
-    const res = await opts.transport('/audio/transcriptions', form, undefined, signal)
+    const wav = await encodeWav(merged, sttSampleRate).arrayBuffer()
+    const { body, contentType } = encodeWavUpload(wav, opts.sttModel)
+    const res = await opts.transport('/audio/transcriptions', body, { 'content-type': contentType }, signal)
     if (!res.ok) {
       throw new Error(`STT failed: ${await errorText(res)}`)
     }


### PR DESCRIPTION
## Hotfix

Voice speech-to-text is broken in production on **desktop-browser → prod** — speaking returns:

```
STT failed: 422 {"detail":[{"type":"missing","loc":["body","file"],...},{"type":"missing","loc":["body","model"],...}]}
```

Mobile iOS web, the desktop app, and all local paths are unaffected.

## Root cause

The STT upload used `FormData`. Its `multipart/form-data; boundary=…` Content-Type is generated **implicitly** by the browser only as it streams the request. That implicit boundary doesn't survive the desktop-web → Tinfoil → prod-edge path: `ehbp` rebuilds the request and **seals the body separately from the plaintext headers**, so the enclave receives body bytes with no usable boundary and can't find the `file`/`model` parts. Mobile Safari / the desktop app / localhost happened to preserve it, which is why only desktop-web-prod 422s.

TTS never hit this because it sets `Content-Type: application/json` **explicitly**.

## Fix

Build the multipart body as **fixed-length bytes with our own boundary** and set `Content-Type` ourselves (`encodeWavUpload`) — mirroring the always-working TTS path. Deterministic across every browser/webview/proxy; removes the reliance on `FormData`'s implicit boundary and a streamed body.

## Testing

- `encodeWavUpload` unit tests: boundary matches the header, both `file`/`model` parts present, wav bytes embedded verbatim.
- Full voice suite green (54 tests). Typecheck clean.
- Behavior unchanged for the clients that already worked (same standard multipart, just explicit).