### PR TITLE
fix: restore built-in web search behavior with default prompt rules

### DIFF
--- a/src/ai/eval/runner.ts
+++ b/src/ai/eval/runner.ts
@@ -79,6 +79,7 @@ const logVerbosePrompt = async (scenario: EvalScenario, skillToken: string) => {
       currency: settings.currency,
     },
     integrationStatus: 'READY',
+    hasWebTools: true,
   })
 
   console.log(`\n${cyan}--- SYSTEM PROMPT (${scenario.id}) ---${reset}`)

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -596,6 +596,7 @@ export const prepareAiRequestConfig = async ({
     ? await getAvailableTools(httpClient, sourceCollector, { settings, integrationStatus })
     : []
   const appToolset = createToolset(availableTools, toolCallCache)
+  const hasWebTools = 'search' in appToolset && 'fetch_content' in appToolset
   const merged = supportsTools
     ? await mergeMcpTools(appToolset, mcpClients, reconnectClient)
     : { toolset: appToolset, summary: undefined, mcpTools: undefined }
@@ -622,6 +623,7 @@ export const prepareAiRequestConfig = async ({
       currency: settings.currency,
     },
     integrationStatus: integrationStatuses.length > 0 ? integrationStatuses.join(', ') : 'READY',
+    hasWebTools,
     mcpServersSummary: merged.summary,
   })
 

--- a/src/ai/prompt.test.ts
+++ b/src/ai/prompt.test.ts
@@ -47,6 +47,7 @@ const baseParams: PromptParams = {
     currency: 'USD',
   },
   integrationStatus: 'READY',
+  hasWebTools: false,
 }
 
 describe('createPrompt', () => {
@@ -103,6 +104,18 @@ describe('createPrompt', () => {
     const result = createPrompt(baseParams)
     expect(result).toContain('# Conversation Style')
     expect(result).toContain('Make quick decisions')
+  })
+
+  test('includes web tool rules in the stable prompt when the web tools are available', () => {
+    const result = createPromptParts({ ...baseParams, hasWebTools: true })
+
+    expect(result.stablePrompt).toContain('Web lookups use the `search` and `fetch_content` tools')
+  })
+
+  test('omits web tool rules from the stable prompt when the web tools are unavailable', () => {
+    const result = createPromptParts({ ...baseParams, hasWebTools: false })
+
+    expect(result.stablePrompt).not.toContain('Web lookups use the `search` and `fetch_content` tools')
   })
 
   test('includes the reuse-before-search gate', () => {

--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { chatPrompt } from '@/ai/prompts/chat'
+import { webToolsPrompt } from '@/ai/prompts/web-tools'
 import { widgetPrompts } from '@/widgets'
 import type { ModelProfile } from '@/types'
 
@@ -21,6 +22,8 @@ export type PromptParams = {
   }
   /** Integration status for the model to check before showing connect widget */
   integrationStatus: string
+  /** Whether the built-in web tools (`search`, `fetch_content`) are available for this request */
+  hasWebTools: boolean
   /** Summary of connected MCP servers (name + tool count) */
   mcpServersSummary?: string
 }
@@ -33,7 +36,16 @@ export type PromptParts = {
 
 /** Build stable assistant instructions separately from per-send date/time. */
 export const createPromptParts = (
-  { modelName, profile, preferredName, location, localization, integrationStatus, mcpServersSummary }: PromptParams,
+  {
+    modelName,
+    profile,
+    preferredName,
+    location,
+    localization,
+    integrationStatus,
+    hasWebTools,
+    mcpServersSummary,
+  }: PromptParams,
   currentDate: Date = new Date(),
 ): PromptParts => {
   const toolsOverride = profile?.toolsOverride ?? undefined
@@ -110,6 +122,7 @@ If you're unsure whether to search and nothing in the conversation answers it: S
 Wait for tool results before responding—never state facts without verifying them first.
 Think about what widget components to show the user, then work backwards to the tools you need.
 Don't mention tool names unless asked.
+${hasWebTools ? `\n${webToolsPrompt}` : ''}
 ${toolsOverride ? `\n${toolsOverride}` : ''}
 ${mcpServersSummary ? `\n## Connected MCP Servers\nYou have tools from these external services (tool names prefixed by server name):\n${mcpServersSummary}\nUse these when the user asks about these services.` : ''}
 

--- a/src/ai/prompts/web-tools.ts
+++ b/src/ai/prompts/web-tools.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Default web behavior for built-in models. Interpolated into the base
+ * prompt's `# Tools` section only when the `search`/`fetch_content` tools are
+ * present in the toolset, so a session without them is never told it has them.
+ */
+export const webToolsPrompt = `Web lookups use the \`search\` and \`fetch_content\` tools.
+Quick questions: run 1–3 searches, fetch the most promising pages, and answer from them.
+Deep dives, research requests, or comprehensive reports: go beyond the default tool budget—break the question into sub-questions, search each from multiple angles, fetch several pages per sub-question, and synthesize the findings.`


### PR DESCRIPTION
## Problem

#1143 removed the chat-modes feature. The Search/Research mode prompts were the layer that told built-in models how to behave on web requests; with them gone, a built-in model asked to "search the web for X" improvises — it attempts `curl`/`wget` inside the network-less sandbox, fails, and answers from training data with zero `search`/`fetch_content` calls. This reproduces the pre-#1085 failure mode in production (all three #1085 fixes are intact; the behavioral layer they relied on was removed).

Linear: THU-746.

## Fix

- New `src/ai/prompts/web-tools.ts`: a compact default web-behavior block — which tools handle the web, quick-lookup depth (1–3 searches), and the deep-research protocol (sub-questions, multiple angles, several pages per sub-question) — distilled from the removed mode prompts. Hardcoded product behavior, not user-editable.
- Interpolated into the base prompt's `# Tools` section (`createPromptParts`) behind a new required `hasWebTools` param, alongside the existing conditional tool slots, in the stable (prefix-cacheable) half of the prompt.
- The flag is derived in `prepareAiRequestConfig` from the assembled app toolset — before the MCP merge, so an MCP server exposing a tool named `search` cannot spoof it — and is stable per session, so the Pi harness signature does not churn between sends.
- Scope: built-in agents only (the Pi harness and legacy pipelines both consume this prompt via `prepareAiRequestConfig`). ACP agents, the CLI, and the skills system are untouched.

## Validation

- `bun run type-check`, `bun run test` (4,190 tests), `bun run check` (eslint + prettier + license), and `bun run test:5x` (randomized, rerun-each 5): all green.
- Tests assert the block lands in the stable prompt when the web tools are present and is fully absent when they are not.
