### PR TITLE
fix(makefile): lowercase path segments in COMPOSE_PROJECT_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ COMPOSE ?= $(shell command -v podman-compose > /dev/null 2>&1 && podman info > /
 # override with `COMPOSE_PROJECT_NAME=foo make up` if you want a fixed name.
 # Sanitize each segment so paths with spaces or other special characters (e.g. "~/My Projects/thunderbolt")
 # produce a valid Docker Compose project name.
-COMPOSE_PROJECT_NAME ?= $(shell basename "$$(cd .. && pwd)" | sed 's/[^a-zA-Z0-9._-]/-/g')-$(shell basename "$$(pwd)" | sed 's/[^a-zA-Z0-9._-]/-/g')
+COMPOSE_PROJECT_NAME ?= $(shell basename "$$(cd .. && pwd)" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')-$(shell basename "$$(pwd)" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')
 export COMPOSE_PROJECT_NAME
 
 # Default target

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ COMPOSE ?= $(shell command -v podman-compose > /dev/null 2>&1 && podman info > /
 # Isolate Docker volumes/networks per clone so sibling working trees (e.g. ~/code/thunderbolt
 # and ~/code/some-test-dir/thunderbolt) don't share Postgres data. Defaults to "<parent>-<repo>";
 # override with `COMPOSE_PROJECT_NAME=foo make up` if you want a fixed name.
-# Sanitize each segment so paths with spaces or other special characters (e.g. "~/My Projects/thunderbolt")
-# produce a valid Docker Compose project name.
+# Sanitize each segment so paths with spaces, uppercase letters, or other special
+# characters (e.g. "~/My Projects/Thunderbolt") produce a valid Docker Compose
+# project name. Lowercase first so the sed step can assert a-z only, instead of
+# allowing A-Z through and relying on tr to have already run.
 COMPOSE_PROJECT_NAME ?= $(shell basename "$$(cd .. && pwd)" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')-$(shell basename "$$(pwd)" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')
 export COMPOSE_PROJECT_NAME
 


### PR DESCRIPTION
## Summary
- `make up` fails with `invalid project name "...": must consist only of lowercase alphanumeric characters, hyphens, and underscores...` whenever the repo's parent directory contains an uppercase letter (e.g. `~/Projects/thunderbolt`).
- The auto-generated `COMPOSE_PROJECT_NAME` (`<parent>-<repo>`) already sanitized special characters via `sed`, but never lowercased the segments, so Docker Compose rejected the result.
- Adds `tr '[:upper:]' '[:lower:]'` before sanitizing each path segment so the generated project name is always valid.

## Test plan
- [x] Reproduced the original failure with a capitalized parent directory and confirmed `make up` errored with the exact message from the issue.
- [x] Applied the fix and confirmed the derived name (`fake-parent-dir-thunderbolt-test`) is fully lowercase for a mixed-case path.
- [x] Ran `make up` / `make down` in the real repo (parent dir `~/Projects`) with no `COMPOSE_PROJECT_NAME` override — containers started successfully as `projects-thunderbolt-*`.