### PR TITLE
fix(THU-757): force webview opaque so status bar matches theme

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,7 +68,7 @@ rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] 
 tauri-plugin-single-instance = "2"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-objc2-ui-kit = { version = "0.3.2", features = ["UIApplication", "UIWindow", "UIInterface", "UIScene", "UIWindowScene"] }
+objc2-ui-kit = { version = "0.3.2", features = ["UIApplication", "UIWindow", "UIView", "UIInterface", "UIScene", "UIWindowScene"] }
 objc2-foundation = "0.3.2"
 
 [profile.dev]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,6 +82,30 @@ pub fn create_app() -> tauri::Builder<tauri::Wry> {
         });
     }
 
+    // The shared `transparent: true` window config exists only for the macOS
+    // sidebar vibrancy (`.mac-vibrancy` in index.css), but it also makes the
+    // WKWebView non-opaque on iOS. A non-opaque webview lets the root view
+    // controller's systemBackgroundColor — white in light mode, black in dark —
+    // bleed through the status-bar and home-indicator safe areas, so the status
+    // bar reads as white on the light theme. Force the webview opaque so those
+    // regions paint the web canvas (the themed --color-background) instead.
+    #[cfg(target_os = "ios")]
+    {
+        builder = builder.setup(|app| {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.with_webview(|webview| {
+                    use objc2_ui_kit::UIView;
+                    // SAFETY: on iOS `inner()` returns the WKWebView, a UIView subclass.
+                    unsafe {
+                        let view = &*(webview.inner() as *const UIView);
+                        view.setOpaque(true);
+                    }
+                });
+            }
+            Ok(())
+        });
+    }
+
     builder
 }
 


### PR DESCRIPTION
## Problem

The mobile status bar renders **white on the light theme**. The web layer is fine — `theme-color`, the `<html>` background, and the header scrim all resolve consistently to `#f5f2ee` (light) / `#1b1e1f` (dark), and the design system bans pure white.

The cause is in the native iOS layer. The shared `transparent: true` window config exists only for the macOS sidebar vibrancy (`.mac-vibrancy`, applied to `<html>` on macOS only), but it also makes the iOS `WKWebView` non-opaque. A non-opaque webview lets the root view controller's `systemBackgroundColor` bleed through the status-bar / home-indicator safe areas:

- **Light** → `systemBackgroundColor` is white → white status bar (the bug).
- **Dark** → it's black (`≈#1b1e1f`), which blends with the dark UI, so it looked fine.

## Fix

`src-tauri/src/lib.rs` — an iOS-only `setup` hook that forces the `WKWebView` opaque, so the safe-area regions paint the web canvas (`--color-background`) instead of the native background. Mirrors the existing `objc2` UIKit usage in `commands.rs`. `Cargo.toml` adds the `UIView` feature to `objc2-ui-kit` for the `setOpaque` call.