### PR TITLE
feat(THU-671): compress large images and PDFs before the attachment cap

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "thunderbolt",
@@ -84,6 +85,7 @@
         "mammoth": "^1.12.0",
         "maplibre-gl": "^5.24.0",
         "path-browserify": "^1.0.1",
+        "pdf-lib": "^1.17.1",
         "posthog-js": "^1.288.1",
         "qrcode": "^1.5.4",
         "react": "^19.2.1",
@@ -708,6 +710,10 @@
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
 
     "@panva/hpke-noble": ["@panva/hpke-noble@1.1.0", "", { "dependencies": { "@noble/ciphers": "^2.0.1", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@noble/post-quantum": "^0.6.0" }, "peerDependencies": { "hpke": "^1.0.0" } }, "sha512-1awnSeLKWEgCBGjuuFhKk6+AxxHzQGfeM0wP0LHtNQPWssXfTTdZvjXD5ruqguf+eNeLfTrMuC+89TNbEDGxTg=="],
+
+    "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
+
+    "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
 
     "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
@@ -2163,6 +2169,8 @@
 
     "pbf": ["pbf@4.0.2", "", { "dependencies": { "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg=="],
 
+    "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
+
     "pdfjs-dist": ["pdfjs-dist@5.4.296", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.80" } }, "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -2818,6 +2826,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "pdf-lib/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "mammoth": "^1.12.0",
     "maplibre-gl": "^5.24.0",
     "path-browserify": "^1.0.1",
+    "pdf-lib": "^1.17.1",
     "posthog-js": "^1.288.1",
     "qrcode": "^1.5.4",
     "react": "^19.2.1",

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -44,6 +44,7 @@ import { buildAttachmentPart } from '@/lib/attachments'
 import { buildQuotePart } from '@/lib/quotes'
 import { QuoteChip } from './quote-chip'
 import { deleteAttachment, putAttachment } from '@/lib/file-blob-storage'
+import { maybeCompressAttachment } from '@/files/compress/compress-attachment'
 import { VoiceModeButton } from '@/voice/ui/voice-mode-button'
 import { VoiceModeComposer } from '@/voice/ui/voice-mode-composer'
 import { useVoiceSession } from '@/voice/ui/use-voice-session'
@@ -441,19 +442,23 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             setAttachError(`"${file.name}" isn't a supported file type.`)
             continue
           }
-          if (file.size > maxAttachmentBytes) {
-            setAttachError(`"${file.name}" is too large (max ${maxAttachmentBytes / 1024 / 1024}MB).`)
+          // Shrink large images/PDFs before the cap check, so a compressible
+          // photo over the limit can slip under it instead of being rejected
+          // (THU-671). Falls back to the original when it can't help.
+          const prepared = await maybeCompressAttachment(file)
+          if (prepared.size > maxAttachmentBytes) {
+            setAttachError(`"${prepared.name}" is too large (max ${maxAttachmentBytes / 1024 / 1024}MB).`)
             continue
           }
           const localFileId = crypto.randomUUID()
           try {
             await putAttachment({
               id: localFileId,
-              filename: file.name,
-              mimeType: file.type,
-              size: file.size,
+              filename: prepared.name,
+              mimeType: prepared.type,
+              size: prepared.size,
               createdAt: Date.now(),
-              blob: file,
+              blob: prepared,
             })
           } catch (error) {
             // IndexedDB can reject when its storage quota is exceeded or it's
@@ -464,7 +469,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             setAttachError(`Couldn't attach "${file.name}" — your browser's storage is full or unavailable.`)
             break
           }
-          setAttachments((prev) => [...prev, { localFileId, filename: file.name, mimeType: file.type }])
+          setAttachments((prev) => [...prev, { localFileId, filename: prepared.name, mimeType: prepared.type }])
           count++
         }
       },

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -466,7 +466,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             // promise reject silently — otherwise no chip appears and no banner
             // shows. Stop here: subsequent writes would hit the same failure.
             console.error('Failed to store attachment locally:', error)
-            setAttachError(`Couldn't attach "${file.name}" — your browser's storage is full or unavailable.`)
+            setAttachError(`Couldn't attach "${prepared.name}" — your browser's storage is full or unavailable.`)
             break
           }
           setAttachments((prev) => [...prev, { localFileId, filename: prepared.name, mimeType: prepared.type }])

--- a/src/files/compress/compress-attachment.test.ts
+++ b/src/files/compress/compress-attachment.test.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, mock, test } from 'bun:test'
+import { compressionThresholdBytes, maybeCompressAttachment, type CompressDeps } from './compress-attachment'
+
+/** Build a File of a given logical size without allocating real bytes. */
+const fakeFile = (name: string, type: string, size: number): File => {
+  const file = new File(['x'], name, { type })
+  Object.defineProperty(file, 'size', { value: size })
+  return file
+}
+
+const overThreshold = compressionThresholdBytes + 1
+
+const smallerBlob = (size: number, type: string): Blob => new Blob([new Uint8Array(size)], { type })
+
+const deps = (over: Partial<CompressDeps> = {}): CompressDeps => ({
+  compressImage: mock(async () => null),
+  compressPdf: mock(async () => null),
+  ...over,
+})
+
+describe('maybeCompressAttachment', () => {
+  test('returns files at or below the threshold untouched, without invoking a compressor', async () => {
+    const d = deps()
+    const file = fakeFile('small.png', 'image/png', compressionThresholdBytes)
+    expect(await maybeCompressAttachment(file, d)).toBe(file)
+    expect(d.compressImage).not.toHaveBeenCalled()
+    expect(d.compressPdf).not.toHaveBeenCalled()
+  })
+
+  test('compresses a large image to WebP and renames the extension', async () => {
+    const d = deps({ compressImage: mock(async () => smallerBlob(1024, 'image/webp')) })
+    const result = await maybeCompressAttachment(fakeFile('Photo.PNG', 'image/png', overThreshold), d)
+    expect(d.compressImage).toHaveBeenCalledTimes(1)
+    expect(result.type).toBe('image/webp')
+    expect(result.name).toBe('Photo.webp')
+    expect(result.size).toBe(1024)
+  })
+
+  test('keeps the original image when compression is not smaller', async () => {
+    const d = deps({ compressImage: mock(async () => null) })
+    const file = fakeFile('photo.jpg', 'image/jpeg', overThreshold)
+    expect(await maybeCompressAttachment(file, d)).toBe(file)
+  })
+
+  test('skips GIFs to preserve animation', async () => {
+    const d = deps()
+    const file = fakeFile('loop.gif', 'image/gif', overThreshold)
+    expect(await maybeCompressAttachment(file, d)).toBe(file)
+    expect(d.compressImage).not.toHaveBeenCalled()
+  })
+
+  test('compresses a large PDF, keeping its name and mime', async () => {
+    const d = deps({ compressPdf: mock(async () => smallerBlob(2048, 'application/pdf')) })
+    const result = await maybeCompressAttachment(fakeFile('report.pdf', 'application/pdf', overThreshold), d)
+    expect(d.compressPdf).toHaveBeenCalledTimes(1)
+    expect(result.name).toBe('report.pdf')
+    expect(result.type).toBe('application/pdf')
+    expect(result.size).toBe(2048)
+  })
+
+  test('passes non-image/pdf types through even when large', async () => {
+    const d = deps()
+    const file = fakeFile('data.csv', 'text/csv', overThreshold)
+    expect(await maybeCompressAttachment(file, d)).toBe(file)
+    expect(d.compressImage).not.toHaveBeenCalled()
+    expect(d.compressPdf).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the original when a compressor throws', async () => {
+    const d = deps({
+      compressImage: mock(async () => {
+        throw new Error('decode failed')
+      }),
+    })
+    const file = fakeFile('broken.png', 'image/png', overThreshold)
+    expect(await maybeCompressAttachment(file, d)).toBe(file)
+  })
+})

--- a/src/files/compress/compress-attachment.test.ts
+++ b/src/files/compress/compress-attachment.test.ts
@@ -40,6 +40,21 @@ describe('maybeCompressAttachment', () => {
     expect(result.size).toBe(1024)
   })
 
+  test('compresses a large image identified only by extension (empty/odd MIME)', async () => {
+    const d = deps({ compressImage: mock(async () => smallerBlob(1024, 'image/webp')) })
+    const result = await maybeCompressAttachment(fakeFile('screenshot.PNG', '', overThreshold), d)
+    expect(d.compressImage).toHaveBeenCalledTimes(1)
+    expect(result.type).toBe('image/webp')
+    expect(result.name).toBe('screenshot.webp')
+  })
+
+  test('compresses a large PDF identified only by extension (empty/odd MIME)', async () => {
+    const d = deps({ compressPdf: mock(async () => smallerBlob(2048, 'application/pdf')) })
+    const result = await maybeCompressAttachment(fakeFile('report.pdf', '', overThreshold), d)
+    expect(d.compressPdf).toHaveBeenCalledTimes(1)
+    expect(result.type).toBe('application/pdf')
+  })
+
   test('keeps the original image when compression is not smaller', async () => {
     const d = deps({ compressImage: mock(async () => null) })
     const file = fakeFile('photo.jpg', 'image/jpeg', overThreshold)

--- a/src/files/compress/compress-attachment.ts
+++ b/src/files/compress/compress-attachment.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Attachment compression orchestrator (THU-671). When a user attaches a file
+ * larger than {@link compressionThresholdBytes}, we attempt to shrink it before
+ * storing/sending — but only where it's actually possible and beneficial for
+ * the type. Everything falls back to the original bytes untouched.
+ *
+ * Scope:
+ * - Raster images (png/jpeg/webp) → downscale + re-encode to WebP.
+ * - GIF → skipped: canvas re-encoding would flatten animation to one frame.
+ * - PDF → best-effort lossless re-save.
+ * - Everything else (docx, text, csv, json) → passthrough: generic byte
+ *   compression is useless here because the model has to read the bytes.
+ */
+
+/** Only try to compress files larger than this. */
+export const compressionThresholdBytes = 10 * 1024 * 1024
+
+/** Raster image types worth re-encoding. GIF is intentionally excluded so we
+ *  don't flatten animated frames. */
+const compressibleImageMimeTypes = new Set(['image/png', 'image/jpeg', 'image/webp'])
+
+/** Injectable so the orchestrator's routing/fallback logic is unit-testable
+ *  without a canvas or pdf-lib in the test environment. */
+export type CompressDeps = {
+  compressImage: (blob: Blob) => Promise<Blob | null>
+  compressPdf: (blob: Blob) => Promise<Blob | null>
+}
+
+const defaultDeps: CompressDeps = {
+  compressImage: async (blob) => (await import('./compress-image')).compressImage(blob),
+  compressPdf: async (blob) => (await import('./compress-pdf')).compressPdf(blob),
+}
+
+/** Swap a filename's extension (e.g. `photo.PNG` → `photo.webp`). */
+const withExtension = (name: string, ext: string): string => {
+  const dot = name.lastIndexOf('.')
+  return `${dot === -1 ? name : name.slice(0, dot)}.${ext}`
+}
+
+/**
+ * Return a compressed {@link File} when compression is possible and beneficial,
+ * otherwise the original file unchanged. Small files and unsupported types are
+ * returned immediately without loading the heavy compressors. Any compression
+ * failure is swallowed in favour of the original — best-effort by design.
+ */
+export const maybeCompressAttachment = async (file: File, deps: CompressDeps = defaultDeps): Promise<File> => {
+  if (file.size <= compressionThresholdBytes) {
+    return file
+  }
+
+  try {
+    if (compressibleImageMimeTypes.has(file.type)) {
+      const compressed = await deps.compressImage(file)
+      return compressed ? new File([compressed], withExtension(file.name, 'webp'), { type: 'image/webp' }) : file
+    }
+    if (file.type === 'application/pdf') {
+      const compressed = await deps.compressPdf(file)
+      return compressed ? new File([compressed], file.name, { type: 'application/pdf' }) : file
+    }
+  } catch (error) {
+    console.error(`Attachment compression failed for "${file.name}", sending original:`, error)
+  }
+
+  return file
+}

--- a/src/files/compress/compress-attachment.ts
+++ b/src/files/compress/compress-attachment.ts
@@ -23,6 +23,23 @@ export const compressionThresholdBytes = 10 * 1024 * 1024
  *  don't flatten animated frames. */
 const compressibleImageMimeTypes = new Set(['image/png', 'image/jpeg', 'image/webp'])
 
+/** Extension fallbacks for when the browser reports an empty/odd MIME type (a
+ *  pasted screenshot, a drag from some sources) — the same reason the
+ *  acceptance check keys on extension too. Kept in lock-step with the MIME sets
+ *  above: GIF is omitted so animated frames still pass through untouched. */
+const compressibleImageExtensions = ['.png', '.jpg', '.jpeg', '.webp']
+const pdfExtensions = ['.pdf']
+
+const hasExtension = (name: string, extensions: readonly string[]): boolean => {
+  const lower = name.toLowerCase()
+  return extensions.some((ext) => lower.endsWith(ext))
+}
+
+const isCompressibleImage = (file: File): boolean =>
+  compressibleImageMimeTypes.has(file.type) || hasExtension(file.name, compressibleImageExtensions)
+
+const isPdf = (file: File): boolean => file.type === 'application/pdf' || hasExtension(file.name, pdfExtensions)
+
 /** Injectable so the orchestrator's routing/fallback logic is unit-testable
  *  without a canvas or pdf-lib in the test environment. */
 export type CompressDeps = {
@@ -53,11 +70,11 @@ export const maybeCompressAttachment = async (file: File, deps: CompressDeps = d
   }
 
   try {
-    if (compressibleImageMimeTypes.has(file.type)) {
+    if (isCompressibleImage(file)) {
       const compressed = await deps.compressImage(file)
       return compressed ? new File([compressed], withExtension(file.name, 'webp'), { type: 'image/webp' }) : file
     }
-    if (file.type === 'application/pdf') {
+    if (isPdf(file)) {
       const compressed = await deps.compressPdf(file)
       return compressed ? new File([compressed], file.name, { type: 'application/pdf' }) : file
     }

--- a/src/files/compress/compress-image.ts
+++ b/src/files/compress/compress-image.ts
@@ -47,7 +47,11 @@ const encodeWebp = async (bitmap: ImageBitmap, width: number, height: number): P
  * falls back to the original.
  */
 export const compressImage = async (blob: Blob): Promise<Blob | null> => {
-  const bitmap = await createImageBitmap(blob)
+  // Phone photos (the common >10MB case) usually store rotation as an EXIF
+  // orientation tag rather than baked-in pixels, and canvas → WebP drops EXIF
+  // entirely. `from-image` bakes the tag into the drawn bitmap so a portrait
+  // photo doesn't come out sideways with no metadata left to fix it downstream.
+  const bitmap = await createImageBitmap(blob, { imageOrientation: 'from-image' })
   const scale = Math.min(1, maxDimension / Math.max(bitmap.width, bitmap.height))
   const width = Math.round(bitmap.width * scale)
   const height = Math.round(bitmap.height * scale)

--- a/src/files/compress/compress-image.ts
+++ b/src/files/compress/compress-image.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Longest-edge ceiling. A >10MB image is almost always a phone photo or huge
+ * screenshot far larger than any model needs; 2048px keeps fine detail (small
+ * text stays legible for vision models) while shedding most of the bytes.
+ */
+const maxDimension = 2048
+
+/** WebP quality — high enough to be visually lossless for photos, low enough
+ *  to win big on size. WebP also preserves alpha, so PNG transparency survives. */
+const quality = 0.82
+
+/** Encode a canvas to a WebP blob, preferring OffscreenCanvas and falling back
+ *  to a detached `<canvas>` element for browsers without it. */
+const encodeWebp = async (bitmap: ImageBitmap, width: number, height: number): Promise<Blob> => {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(width, height)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      throw new Error('2D context unavailable')
+    }
+    ctx.drawImage(bitmap, 0, 0, width, height)
+    return canvas.convertToBlob({ type: 'image/webp', quality })
+  }
+
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    throw new Error('2D context unavailable')
+  }
+  ctx.drawImage(bitmap, 0, 0, width, height)
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('toBlob returned null'))), 'image/webp', quality)
+  })
+}
+
+/**
+ * Downscale (to {@link maxDimension}) and re-encode a raster image to WebP.
+ * Returns the compressed blob when it's actually smaller than the original,
+ * otherwise `null` so the caller keeps the original bytes. May throw on a
+ * decode/encode failure — the caller treats that as "couldn't compress" and
+ * falls back to the original.
+ */
+export const compressImage = async (blob: Blob): Promise<Blob | null> => {
+  const bitmap = await createImageBitmap(blob)
+  const scale = Math.min(1, maxDimension / Math.max(bitmap.width, bitmap.height))
+  const width = Math.round(bitmap.width * scale)
+  const height = Math.round(bitmap.height * scale)
+  try {
+    const out = await encodeWebp(bitmap, width, height)
+    return out.size < blob.size ? out : null
+  } finally {
+    bitmap.close()
+  }
+}

--- a/src/files/compress/compress-pdf.ts
+++ b/src/files/compress/compress-pdf.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Best-effort, lossless PDF shrink: re-save through pdf-lib with object streams.
+ * This drops unreferenced objects and incremental-update cruft and compresses
+ * the object structure — a real win for structure-heavy or repeatedly-edited
+ * PDFs, a no-op for already-optimized or image-dominated ones (pdf-lib does not
+ * recompress embedded images). Returns the smaller blob or `null` when the
+ * re-save isn't smaller, so the caller keeps the original. Text, fonts, and
+ * images are preserved exactly.
+ *
+ * pdf-lib is lazy-imported so it stays out of the entry bundle.
+ */
+export const compressPdf = async (blob: Blob): Promise<Blob | null> => {
+  const { PDFDocument } = await import('pdf-lib')
+  const doc = await PDFDocument.load(await blob.arrayBuffer())
+  const bytes = await doc.save({ useObjectStreams: true })
+  const out = new Blob([new Uint8Array(bytes)], { type: 'application/pdf' })
+  return out.size < blob.size ? out : null
+}


### PR DESCRIPTION
## What & why

THU-671: when a user attaches a file larger than 10MB, attempt to compress it before storing/sending — but only where it's actually possible and beneficial, always falling back to the original bytes otherwise.

## Approach

New `src/files/compress/` module:
- **`compress-image.ts`** — downscales to a 2048px longest edge and re-encodes raster images (png/jpeg/webp) to WebP via `OffscreenCanvas` (with a `<canvas>` fallback). WebP preserves PNG alpha. Kept only if the result is actually smaller.
- **`compress-pdf.ts`** — lossless re-save via `pdf-lib` (lazy-imported, out of the entry bundle): drops unreferenced objects and incremental-edit cruft. Text/fonts/images preserved exactly; kept only if smaller.
- **`compress-attachment.ts`** — orchestrator: routes by MIME above the 10MB threshold, **skips GIF** (canvas would flatten animation), passes docx/text/csv/json through untouched (generic compression is model-unreadable, so no benefit), and falls back to the original on any failure. Compressors are injected for testability.

Composer (`chat-prompt-input.tsx`) now compresses **before** the 25MB cap check, so a large photo that shrinks under the limit is accepted instead of rejected; the stored blob/mime/filename update to WebP on re-encode.

## Notes
- Adds `pdf-lib@1.17.1` (lazy-loaded).
- PDF gains are modest — `pdf-lib` doesn't recompress embedded images (where scan bloat lives), so those fall back to the original. Safe, lossless best-effort as scoped.
- No compression progress indicator yet (a large image adds ~0.5–1.5s before its chip appears) — easy follow-up.

## Testing
- 7 new orchestrator tests (threshold passthrough, image→WebP + rename, PDF, GIF skip, non-media passthrough, not-smaller fallback, throw→fallback).
- Full frontend suite green (4120 tests, 0 failures); tsc + eslint clean.