### PR TITLE
refactor(THU-759): remove jump-to-dependent link from skill delete/disable confirm

### DIFF
--- a/src/skills/dependents-dialog.tsx
+++ b/src/skills/dependents-dialog.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { ArrowRight } from 'lucide-react'
-
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -15,7 +13,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import type { Skill } from '@/types'
-import { skillDisplayName } from './display'
 
 export type DependentsAction = 'disable' | 'delete'
 
@@ -31,7 +28,6 @@ export const DependentsDialog = ({
   targetName,
   dependents,
   onConfirm,
-  onJumpToDependent,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -40,7 +36,6 @@ export const DependentsDialog = ({
   targetName: string
   dependents: Skill[]
   onConfirm: () => void
-  onJumpToDependent: (id: string) => void
 }) => (
   <AlertDialog open={open} onOpenChange={onOpenChange}>
     <AlertDialogContent>
@@ -50,24 +45,10 @@ export const DependentsDialog = ({
         </AlertDialogTitle>
         <AlertDialogDescription>
           {dependents.length === 1
-            ? `One skill references this. If you ${action} it, that skill may no longer resolve:`
-            : `${dependents.length} skills reference this. If you ${action} it, they may no longer resolve:`}
+            ? `One skill references this. If you ${action} it, that skill may no longer resolve.`
+            : `${dependents.length} skills reference this. If you ${action} it, they may no longer resolve.`}
         </AlertDialogDescription>
       </AlertDialogHeader>
-      <ul className="flex flex-col gap-1.5">
-        {dependents.map((dep) => (
-          <li key={dep.id}>
-            <button
-              type="button"
-              onClick={() => onJumpToDependent(dep.id)}
-              className="flex w-full items-center justify-between gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground transition-colors hover:bg-accent"
-            >
-              <span className="min-w-0 truncate">{skillDisplayName(dep)}</span>
-              <ArrowRight size={14} className="shrink-0 text-muted-foreground" />
-            </button>
-          </li>
-        ))}
-      </ul>
       <AlertDialogFooter>
         <AlertDialogCancel>Cancel</AlertDialogCancel>
         <Button variant="destructive" onClick={onConfirm}>

--- a/src/skills/skills-view-state.test.ts
+++ b/src/skills/skills-view-state.test.ts
@@ -217,7 +217,7 @@ describe('skillsViewReducer', () => {
     })
   })
 
-  describe('OPEN_DEPENDENTS / JUMP_TO_DEPENDENT', () => {
+  describe('OPEN_DEPENDENTS', () => {
     it('OPEN_DEPENDENTS snapshots the action target and dependents list', () => {
       const target = skill('a', 'foo')
       const dep = skill('b', 'bar')
@@ -229,41 +229,6 @@ describe('skillsViewReducer', () => {
       expect(next.pendingDependents?.skill).toBe(target)
       expect(next.pendingDependents?.dependents).toEqual([dep])
       expect(next.activeId).toBe('a')
-    })
-
-    it('JUMP_TO_DEPENDENT switches to edit on the dependent, closes the dialog', () => {
-      const open: SkillsViewState = {
-        ...initialSkillsViewState,
-        pendingDependents: { action: 'disable', skill: skill('a', 'foo'), dependents: [skill('b', 'bar')] },
-      }
-      const next = skillsViewReducer(open, { type: 'JUMP_TO_DEPENDENT', id: 'b' })
-      expect(next.mode).toBe('edit')
-      expect(next.activeId).toBe('b')
-      expect(next.pendingDependents).toBeNull()
-    })
-
-    it('JUMP_TO_DEPENDENT opens read-only detail when the dependent is a widget skill', () => {
-      const open: SkillsViewState = {
-        ...initialSkillsViewState,
-        pendingDependents: { action: 'disable', skill: skill('a', 'foo'), dependents: [] },
-      }
-      const next = skillsViewReducer(open, { type: 'JUMP_TO_DEPENDENT', id: defaultSkillWeather.id })
-
-      expect(next.mode).toBe('detail')
-      expect(next.activeId).toBe(defaultSkillWeather.id)
-      expect(next.pendingDependents).toBeNull()
-    })
-
-    it('opens the panel so the edit form is visible even when jumping from a list-row action', () => {
-      // The dependents dialog can open from the list (panelView 'list') on
-      // both mobile and desktop — the jump must reveal the edit surface.
-      const open: SkillsViewState = {
-        ...initialSkillsViewState,
-        panelView: 'list',
-        pendingDependents: { action: 'delete', skill: skill('a', 'foo'), dependents: [skill('b', 'bar')] },
-      }
-      const next = skillsViewReducer(open, { type: 'JUMP_TO_DEPENDENT', id: 'b' })
-      expect(next.panelView).toBe('panel')
     })
   })
 

--- a/src/skills/skills-view-state.ts
+++ b/src/skills/skills-view-state.ts
@@ -69,8 +69,8 @@ const modeForSkillEdit = (id: string): Mode => (isWidgetSkillId(id) ? 'detail' :
  * Action type for the SkillsView state machine. Each action describes a
  * user-meaningful event (a click, a confirm, a successful mutation) — the
  * reducer maps it to the minimal state delta and any compound transitions
- * (e.g. `JUMP_TO_DEPENDENT` clears the dialog, sets active, sets mode,
- * and on mobile slides the panel in, all in one dispatch).
+ * (e.g. `SUBMIT_SUCCESS` clears form state, sets active, and returns to
+ * detail mode, all in one dispatch).
  */
 export type SkillsViewAction =
   /** User selected a skill in the list while in `detail` mode. */
@@ -94,8 +94,6 @@ export type SkillsViewAction =
   | { type: 'CLOSE_DELETE' }
   /** Close the dependents confirm dialog (cancelled or confirmed). */
   | { type: 'CLOSE_DEPENDENTS' }
-  /** User clicked a row in the dependents dialog — open that skill. */
-  | { type: 'JUMP_TO_DEPENDENT'; id: string }
   /** Form reports its dirty state changed. */
   | { type: 'DIRTY_CHANGED'; dirty: boolean }
   /** Form submit succeeded — return to detail mode on the (possibly new) skill. */
@@ -188,22 +186,6 @@ export const skillsViewReducer = (state: SkillsViewState, action: SkillsViewActi
 
     case 'CLOSE_DEPENDENTS':
       return { ...state, pendingDependents: null }
-
-    case 'JUMP_TO_DEPENDENT':
-      // Clear form state before opening the dependent. Editable skills get a
-      // fresh form; widget contracts stay in read-only detail.
-      return {
-        ...state,
-        activeId: action.id,
-        mode: modeForSkillEdit(action.id),
-        pendingDependents: null,
-        isDirty: false,
-        slugError: null,
-        submitError: null,
-        // The dependents dialog can be opened from a list-row action while
-        // panelView is still 'list'; opening the panel here reveals the target.
-        panelView: 'panel',
-      }
 
     case 'DIRTY_CHANGED':
       return { ...state, isDirty: action.dirty }

--- a/src/skills/skills-view.test.tsx
+++ b/src/skills/skills-view.test.tsx
@@ -169,12 +169,11 @@ describe('SkillsView state machine', () => {
       fireEvent.click(switchA)
       await flush()
 
-      // Scope dialog assertions to the dialog itself — "Skill B" also appears
-      // in the list row underneath, which makes a bare getByText ambiguous.
-      // Both the title and dependent rows use display names only.
+      // Scope dialog assertions to the dialog itself, since the skill list
+      // underneath repeats display names.
       const dialog = await waitForElement(() => screen.queryByRole('alertdialog'))
       expect(within(dialog).getByText('Disable Skill A?')).toBeInTheDocument()
-      expect(within(dialog).getByText('Skill B')).toBeInTheDocument()
+      expect(within(dialog).getByText(/One skill references this/)).toBeInTheDocument()
       expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
 
       // /a is still enabled — the user hasn't confirmed.

--- a/src/skills/skills-view.tsx
+++ b/src/skills/skills-view.tsx
@@ -167,10 +167,6 @@ export const SkillsView = () => {
     })
   }
 
-  const onJumpToDependent = (id: string) => {
-    dispatch({ type: 'JUMP_TO_DEPENDENT', id })
-  }
-
   const handleSubmit = async (values: SkillFormValues) => {
     try {
       if (mode === 'create') {
@@ -290,7 +286,6 @@ export const SkillsView = () => {
           targetName={skillDisplayName(pendingDependents.skill)}
           dependents={pendingDependents.dependents}
           onConfirm={confirmPendingDependents}
-          onJumpToDependent={onJumpToDependent}
         />
       )}
       {pendingDelete && (

--- a/src/stories/DependentsDialog.stories.tsx
+++ b/src/stories/DependentsDialog.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
     },
   },
   tags: ['autodocs'],
-  args: { onConfirm: fn(), onOpenChange: fn(), onJumpToDependent: fn() },
+  args: { onConfirm: fn(), onOpenChange: fn() },
 } satisfies Meta<typeof DependentsDialog>
 
 export default meta


### PR DESCRIPTION
## What & why

THU-759: the delete/disable skill confirmation modal rendered each referencing skill as a clickable row with an arrow that navigated you *away* mid-confirmation — an odd affordance inside a destructive-action dialog (Chris flagged it as a "weird link").

Removed that list. The dialog now shows just the title, a description stating how many skills reference the target, and Cancel / confirm. The description's trailing colon became a period since no list follows.

## Scope of removal

The clickable rows were the only trigger for the `JUMP_TO_DEPENDENT` flow, so this removes the whole dead thread rather than leaving orphaned code:
- `dependents-dialog.tsx` — dropped the `<ul>` of dependent buttons, the `onJumpToDependent` prop, and the now-unused `ArrowRight` / `skillDisplayName` imports.
- `skills-view.tsx` — removed the `onJumpToDependent` handler and prop wiring.
- `skills-view-state.ts` — removed the `JUMP_TO_DEPENDENT` action from the union and reducer.
- `skills-view-state.test.ts` / `skills-view.test.tsx` — dropped the jump-specific tests; the "opens the dependents-aware confirm dialog" coverage remains.
- `stories/DependentsDialog.stories.tsx` — dropped the `onJumpToDependent` arg.

## Testing
- Full frontend suite green (4107 pass, 0 fail); tsc + eslint clean.