### PR TITLE
fix(THU-720): restore flame icon for clear-all-chats button

### DIFF
--- a/src/layout/sidebar/chat-actions.tsx
+++ b/src/layout/sidebar/chat-actions.tsx
@@ -4,7 +4,7 @@
 
 import { SidebarMenuButton } from '@/components/ui/sidebar'
 import { cn } from '@/lib/utils'
-import { Loader2, Search, Trash2 } from 'lucide-react'
+import { Flame, Loader2, Search } from 'lucide-react'
 import type { ChatActionsProps } from './types'
 
 const actionButtonClass =
@@ -44,7 +44,7 @@ export const ChatActions = ({
         {deleteAllChatsMutation.isPending ? (
           <Loader2 className="size-[var(--icon-size-default)] animate-spin" />
         ) : (
-          <Trash2 className="size-[var(--icon-size-default)]" />
+          <Flame className="size-[var(--icon-size-default)]" />
         )}
       </SidebarMenuButton>
     </div>

--- a/src/layout/sidebar/chat-list.tsx
+++ b/src/layout/sidebar/chat-list.tsx
@@ -15,7 +15,7 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 import { cn } from '@/lib/utils'
-import { Loader2, Search, Trash2 } from 'lucide-react'
+import { Flame, Loader2, Search } from 'lucide-react'
 import { useLayoutEffect, useRef, useState, type Ref } from 'react'
 import { Virtualizer, type CustomContainerComponentProps, type CustomItemComponentProps } from 'virtua'
 import { ChatActions } from './chat-actions'
@@ -211,7 +211,7 @@ export const ChatList = ({
             {deleteAllChatsMutation.isPending ? (
               <Loader2 className="size-[var(--icon-size-default)] animate-spin" />
             ) : (
-              <Trash2 className="size-[var(--icon-size-default)]" />
+              <Flame className="size-[var(--icon-size-default)]" />
             )}
           </SidebarMenuButton>
         </SidebarMenuItem>


### PR DESCRIPTION
Reverts the THU-720 icon swap (#1178) — restores the `Flame` icon on the "Clear all chats" button in both sidebar entry points (`chat-actions.tsx`, `chat-list.tsx`).

Per follow-up: we're keeping the flame after all. Pure inverse of `9a80477f`; no other behavior changes.