### PR TITLE
fix: deliver images to vision-capable hosted models

### DIFF
--- a/shared/agent-core/build-app-harness.ts
+++ b/shared/agent-core/build-app-harness.ts
@@ -94,6 +94,9 @@ export type PiModelDescriptor =
       readonly reasoning: boolean
       /** Optional upstream context window. */
       readonly contextWindow?: number
+      /** Whether the model accepts image input; drives the synthetic descriptor's
+       *  input modalities (text-only strips images before the wire). */
+      readonly supportsImages: boolean
     }
 
 /** Inputs for {@link buildAppHarness}. */
@@ -150,6 +153,7 @@ export const buildAppHarness = async (options: BuildAppHarnessOptions): Promise<
           fetch: options.model.fetch,
           reasoning: options.model.reasoning,
           contextWindow: options.model.contextWindow,
+          supportsImages: options.model.supportsImages,
         })
 
   const tools: AgentTool[] = [...createBrowserCodingTools(env, { cwd: workspaceDir }), ...(options.tools ?? [])]

--- a/shared/agent-core/openai-compat-model.test.ts
+++ b/shared/agent-core/openai-compat-model.test.ts
@@ -74,6 +74,7 @@ describe('buildOpenAiCompatModel — withInjectedFetch', () => {
       apiKey: 'test-key',
       fetch: injectedFetch,
       reasoning: false,
+      supportsImages: false,
     })
 
     const provider = models.getProvider('openai')
@@ -99,5 +100,27 @@ describe('buildOpenAiCompatModel — withInjectedFetch', () => {
     expect(injectedCalls).toBe(1)
     expect(injectedUrl).toContain('upstream.example')
     expect(sentinelCalls).toBe(0)
+  })
+})
+
+describe('buildOpenAiCompatModel — image modality', () => {
+  const noopFetch = (async () => new Response('')) as Parameters<typeof buildOpenAiCompatModel>[0]['fetch']
+  const build = (supportsImages: boolean) =>
+    buildOpenAiCompatModel({
+      providerId: 'thunderbolt',
+      modelId: 'opus-4.8',
+      baseURL: 'https://cloud.example/v1',
+      apiKey: 'k',
+      fetch: noopFetch,
+      reasoning: false,
+      supportsImages,
+    }).model
+
+  it('advertises image input when the model supports images, so Pi keeps image blocks', () => {
+    expect(build(true).input).toEqual(['text', 'image'])
+  })
+
+  it('advertises text-only when the model does not support images', () => {
+    expect(build(false).input).toEqual(['text'])
   })
 })

--- a/shared/agent-core/openai-compat-model.ts
+++ b/shared/agent-core/openai-compat-model.ts
@@ -90,6 +90,10 @@ export type BuildOpenAiCompatModelOptions = {
   readonly reasoning: boolean
   /** Optional upstream context window for the synthetic model descriptor. */
   readonly contextWindow?: number
+  /** Whether the upstream model accepts image input. When false, the synthetic
+   *  descriptor advertises text-only and Pi strips image blocks before the wire
+   *  (`downgradeUnsupportedImages`), so a vision model would never see the bytes. */
+  readonly supportsImages: boolean
 }
 
 /**
@@ -136,7 +140,7 @@ const synthesizeModel = (opts: BuildOpenAiCompatModelOptions): Model<typeof apiN
   provider: opts.providerId,
   baseUrl: opts.baseURL,
   reasoning: opts.reasoning,
-  input: ['text'],
+  input: opts.supportsImages ? ['text', 'image'] : ['text'],
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   contextWindow: opts.contextWindow ?? defaultContextWindow,
   maxTokens: defaultMaxTokens,

--- a/shared/defaults/models.test.ts
+++ b/shared/defaults/models.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { hashValues } from '../lib/hash'
-import { defaultModels, defaultModelsVersion, hashModel } from './models'
+import { defaultModels, defaultModelsVersion, hashModel, vendorSupportsImages } from './models'
 
 /**
  * Snapshot pinning the shipped defaults to their declared version. When you
@@ -41,5 +41,20 @@ describe('defaultModels version snapshot', () => {
       hash: computeSnapshotHash(),
       metadataHash: computeMetadataHash(),
     }).toEqual(expected)
+  })
+})
+
+describe('vendorSupportsImages', () => {
+  test('true for known vision vendors', () => {
+    expect(vendorSupportsImages('anthropic')).toBe(true)
+    expect(vendorSupportsImages('openai')).toBe(true)
+    expect(vendorSupportsImages('google')).toBe(true)
+  })
+
+  test('false for unknown or absent vendors (no guessing for custom/local)', () => {
+    expect(vendorSupportsImages(null)).toBe(false)
+    expect(vendorSupportsImages(undefined)).toBe(false)
+    expect(vendorSupportsImages('ollama')).toBe(false)
+    expect(vendorSupportsImages('')).toBe(false)
   })
 })

--- a/shared/defaults/models.ts
+++ b/shared/defaults/models.ts
@@ -36,6 +36,21 @@ export type SharedModel = {
 }
 
 /**
+ * Vendors whose models accept image input. The built-in Pi openai-compat
+ * transport can't know an arbitrary custom endpoint's capabilities, so it
+ * advertises text-only by default and strips image blocks. For the providers we
+ * host/control we instead key image support off the model's `vendor` — otherwise
+ * images are silently dropped before reaching a vision-capable hosted model
+ * (e.g. Thunderbolt-hosted Opus, `vendor: 'anthropic'`).
+ */
+export const imageCapableVendors: ReadonlySet<string> = new Set(['anthropic', 'openai', 'google'])
+
+/** Whether a model's vendor is known to accept image input. Unknown/absent
+ *  vendors (custom or local endpoints) return false — we don't guess. */
+export const vendorSupportsImages = (vendor: string | null | undefined): boolean =>
+  vendor != null && imageCapableVendors.has(vendor)
+
+/**
  * Compute hash of user-editable fields for a model.
  * Includes deletedAt to treat soft-delete as a user configuration choice.
  */

--- a/src/acp/built-in-adapter.test.ts
+++ b/src/acp/built-in-adapter.test.ts
@@ -19,6 +19,7 @@ import type { Model } from '@/types'
 import {
   createBuiltInAdapter,
   harnessSignature,
+  resolvePiModel,
   type BuiltInAdapterOptions,
   type ResolvedPiModel,
 } from './built-in-adapter'
@@ -44,6 +45,7 @@ const openaiCompat = (
     apiKey: 'sk-o',
     fetch: noopFetch,
     reasoning: false,
+    supportsImages: false,
     ...overrides,
   },
   thinkingLevel: 'medium',
@@ -100,6 +102,30 @@ describe('harnessSignature', () => {
 
   it('does not embed the plaintext api key', () => {
     expect(harnessSignature(anthropic({ apiKey: 'super-secret-key' }), 'sys')).not.toContain('super-secret-key')
+  })
+
+  it('changes when the openai-compat image capability changes', () => {
+    expect(harnessSignature(openaiCompat(), 'sys')).not.toBe(
+      harnessSignature(openaiCompat({ supportsImages: true }), 'sys'),
+    )
+  })
+})
+
+describe('resolvePiModel — image capability (vendor-gated)', () => {
+  const contextFor = (model: Model): AgentAdapterContext =>
+    ({ selectedModel: model, getProxyFetch: () => noopFetch }) as unknown as AgentAdapterContext
+  const agentCore = {} as Parameters<typeof resolvePiModel>[0]
+  const openaiModel = (vendor: string | null): Model =>
+    ({ id: 'm', name: 'M', provider: 'openai', model: 'gpt-4o', apiKey: 'sk-o', vendor, toolUsage: 1 }) as Model
+
+  it('advertises image support for a vision-vendor model', () => {
+    const resolved = resolvePiModel(agentCore, contextFor(openaiModel('openai')), null)
+    expect(resolved?.descriptor).toMatchObject({ kind: 'openai-compat', supportsImages: true })
+  })
+
+  it('does not advertise image support when the vendor is unknown (custom/local)', () => {
+    const resolved = resolvePiModel(agentCore, contextFor(openaiModel(null)), null)
+    expect(resolved?.descriptor).toMatchObject({ kind: 'openai-compat', supportsImages: false })
   })
 })
 

--- a/src/acp/built-in-adapter.ts
+++ b/src/acp/built-in-adapter.ts
@@ -57,6 +57,7 @@ import type { Model, ModelProfile, ThunderboltUIMessage } from '@/types'
 import { extractLastUserText, resolveSkillTokenInstructions } from '@/skills/resolve-skill-system-messages'
 import type { PiModelDescriptor, SeedTurn } from '@shared/agent-core'
 import { appHarnessEnvironmentPrompt } from '@shared/agent-core/environment-prompt'
+import { vendorSupportsImages } from '@shared/defaults/models'
 import type { AgentHarness, AgentTool, ThinkingLevel } from '@earendil-works/pi-agent-core'
 import { prepareBuiltInConversation } from './built-in-conversation'
 
@@ -227,7 +228,7 @@ export type ResolvedPiModel = {
  *  fall back to legacy. Anthropic ids must exist in Pi's built-in catalog;
  *  OpenAI-wire providers must resolve a connection (api key / url present). The
  *  thinking level is derived from the model's profile for both families. */
-const resolvePiModel = (
+export const resolvePiModel = (
   agentCore: AgentCoreModule,
   context: AgentAdapterContext,
   profile: ModelProfile | null,
@@ -266,6 +267,10 @@ const resolvePiModel = (
       fetch: connection.fetch,
       reasoning: hasExplicitReasoning(profile),
       contextWindow: model.contextWindow ?? undefined,
+      // Pi's openai-compat descriptor is text-only by default; without this a
+      // vision-capable hosted model (e.g. Thunderbolt Opus) has its image blocks
+      // stripped before the wire and only sees the `[Attachment: …]` text label.
+      supportsImages: vendorSupportsImages(model.vendor),
     },
     thinkingLevel,
   }
@@ -298,7 +303,7 @@ export const harnessSignature = (
   const model =
     d.kind === 'anthropic'
       ? `anthropic|${d.modelId}|${hashSecret(d.apiKey)}`
-      : `openai-compat|${d.providerId}|${d.modelId}|${d.baseURL}|${hashSecret(d.apiKey)}|${d.reasoning}|${d.contextWindow ?? ''}`
+      : `openai-compat|${d.providerId}|${d.modelId}|${d.baseURL}|${hashSecret(d.apiKey)}|${d.reasoning}|${d.contextWindow ?? ''}|${d.supportsImages}`
   return `${model}|${resolved.thinkingLevel}|${stableSystemPrompt}|regenerate:${regenerationRevision}`
 }
 


### PR DESCRIPTION
## Bug

Uploading an image to a **Thunderbolt-hosted** vision model (e.g. the default Opus 4.8) resulted in the model seeing only the `[Attachment: <filename>]` text label, not the image — it would say it "can only see a filename." Direct-to-Anthropic worked.

## Root cause

Thunderbolt-hosted models (`provider: 'thunderbolt'`) run through the built-in Pi agent's **openai-compatible** transport. Its synthesized model descriptor hardcoded `input: ['text']`, so Pi's `downgradeUnsupportedImages` stripped every image block before the wire — the bytes were hydrated correctly upstream but never sent. Direct Anthropic takes a different fork that resolves Pi's catalog model (`['text','image']`), so it was unaffected.

## Fix

Thread a `supportsImages` flag through the openai-compat descriptor, gated on the model's `vendor`:

- `shared/defaults/models.ts` — new `vendorSupportsImages()` (anthropic/openai/google → true; unknown/absent vendor → false, so we don't guess for arbitrary custom/local endpoints).
- `shared/agent-core/openai-compat-model.ts` — `synthesizeModel` emits `input: opts.supportsImages ? ['text','image'] : ['text']`.
- `shared/agent-core/build-app-harness.ts` — `supportsImages` added to the openai-compat descriptor + passed through.
- `src/acp/built-in-adapter.ts` — `resolvePiModel` sets `supportsImages: vendorSupportsImages(model.vendor)`; also added to `harnessSignature` so a vendor change rebuilds the harness.

Text-only / unknown-vendor endpoints are unchanged (safe default). No `defaultModels` rows changed, so no `defaultModelsVersion` bump.

## Tests
- `synthesizeModel` modality (true→`['text','image']`, false→`['text']`), `vendorSupportsImages`, and a `resolvePiModel` wiring test (vendor→descriptor). Full suite green (4126 pass, 0 fail); tsc + eslint clean.

## Follow-up (not in this PR)
Supporting images for **all** vendors optimistically needs the content-rejection failsafe (`use-attachment-remediation.ts`) to work on the Pi transport — today a 400 is flattened to a bare `"400: …"` string so the status is lost and remediation never fires. A separate change will preserve the status through `pi-to-aisdk-stream.ts` (mirroring `serializeStreamError`), then advertise images for all openai-compat models and let the failsafe downgrade text-only endpoints.