### PR TITLE
fix: redact raw provider errors in posthog ai generation events

### DIFF
--- a/backend/src/posthog/client.test.ts
+++ b/backend/src/posthog/client.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { clearSettingsCache } from '@/config/settings'
 import { isPosthogRequest } from '@/test-utils/posthog'
 import { OpenAI as PostHogOpenAI } from '@posthog/ai'
 import { afterEach, beforeEach, describe, expect, it, jest, spyOn } from 'bun:test'
@@ -12,6 +13,20 @@ type FetchCall = {
   url: string
   options: RequestInit
   body: any
+}
+
+const parsePostHogRequestBody = async (body: BodyInit | null | undefined): Promise<unknown> => {
+  if (!body) {
+    return null
+  }
+  if (typeof body === 'string') {
+    return JSON.parse(body)
+  }
+  if (body instanceof Blob) {
+    const compressed = new Uint8Array(await body.arrayBuffer())
+    return JSON.parse(new TextDecoder().decode(Bun.gunzipSync(compressed)))
+  }
+  return body
 }
 
 /**
@@ -318,6 +333,175 @@ describe('PostHog Privacy Mode', () => {
       expect((clientWithPrivacy as any).privacy_mode || false).toBe(true)
       expect((clientWithoutPrivacy as any).privacy_mode || false).toBe(false)
     })
+  })
+})
+
+describe('redactAiError', () => {
+  it('keeps API error identifiers and drops provider response content', () => {
+    const rawError = JSON.stringify({
+      status: 400,
+      error: {
+        message: 'prompt is too long and contains sensitive content',
+        type: 'invalid_request_error',
+      },
+      message: 'prompt is too long and contains sensitive content',
+      code: null,
+      requestID: 'req_1',
+      type: 'invalid_request_error',
+    })
+
+    expect(client.redactAiError(rawError)).toBe(
+      JSON.stringify({
+        status: 400,
+        code: null,
+        type: 'invalid_request_error',
+        requestID: 'req_1',
+      }),
+    )
+  })
+
+  it('drops future provider error details from object input', () => {
+    expect(
+      client.redactAiError({
+        name: 'APIError',
+        statusCode: 429,
+        httpStatus: 429,
+        message: 'sensitive prompt fragment',
+        stack: 'APIError: sensitive prompt fragment',
+        cause: { message: 'sensitive prompt fragment' },
+        headers: { authorization: 'secret' },
+        param: 'messages',
+      }),
+    ).toBe(
+      JSON.stringify({
+        name: 'APIError',
+        statusCode: 429,
+        httpStatus: 429,
+        param: 'messages',
+      }),
+    )
+  })
+
+  it('drops an unparseable string', () => {
+    expect(client.redactAiError('not-json')).toBeUndefined()
+  })
+
+  it('drops non-object values', () => {
+    expect(client.redactAiError(400)).toBeUndefined()
+    expect(client.redactAiError(null)).toBeUndefined()
+  })
+
+  it('drops an error with no whitelisted identifiers', () => {
+    expect(client.redactAiError({ message: 'sensitive prompt fragment' })).toBeUndefined()
+    expect(client.redactAiError({ code: undefined })).toBeUndefined()
+  })
+})
+
+describe('PostHog AI error egress privacy', () => {
+  let capturedFetches: FetchCall[] = []
+  let mockFetch: typeof fetch
+  let phClient: PostHog | undefined
+  let originalPostHogApiKey: string | undefined
+  let originalPostHogHost: string | undefined
+
+  beforeEach(() => {
+    capturedFetches = []
+    originalPostHogApiKey = process.env.POSTHOG_API_KEY
+    originalPostHogHost = process.env.POSTHOG_HOST
+    process.env.POSTHOG_API_KEY = 'test-key'
+    process.env.POSTHOG_HOST = 'https://us.i.posthog.com'
+    clearSettingsCache()
+
+    const captureFetch = async (input: RequestInfo | URL, options: RequestInit = {}): Promise<Response> => {
+      const url = input instanceof Request ? input.url : input.toString()
+      capturedFetches.push({
+        url,
+        options,
+        body: await parsePostHogRequestBody(options.body),
+      })
+
+      return new Response(JSON.stringify({ status: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    mockFetch = Object.assign(captureFetch, { preconnect: () => {} })
+  })
+
+  afterEach(async () => {
+    await phClient?.shutdown(100)
+    if (originalPostHogApiKey === undefined) {
+      delete process.env.POSTHOG_API_KEY
+    } else {
+      process.env.POSTHOG_API_KEY = originalPostHogApiKey
+    }
+    if (originalPostHogHost === undefined) {
+      delete process.env.POSTHOG_HOST
+    } else {
+      process.env.POSTHOG_HOST = originalPostHogHost
+    }
+    clearSettingsCache()
+    client.clearPostHogClient()
+    capturedFetches = []
+  })
+
+  it('redacts AI errors while preserving other event payloads', async () => {
+    phClient = client.getPostHogClient(mockFetch)
+    const rawError = JSON.stringify({
+      status: 400,
+      code: 'context_length_exceeded',
+      message: 'sensitive prompt fragment',
+      error: { message: 'sensitive prompt fragment' },
+    })
+
+    phClient.capture({
+      distinctId: 'user-1',
+      event: '$ai_generation',
+      properties: {
+        $ai_error: rawError,
+        $ai_model: 'gpt-4',
+        safeProperty: 'unchanged',
+      },
+    })
+    phClient.capture({
+      distinctId: 'user-1',
+      event: 'inference_upstream_error',
+      properties: {
+        $ai_error: rawError,
+        safeProperty: 'unchanged',
+      },
+    })
+    phClient.capture({
+      distinctId: 'user-1',
+      event: '$ai_generation',
+      properties: {
+        $ai_error: 'not-json',
+        redactionCase: 'drop',
+        safeProperty: 'still-unchanged',
+      },
+    })
+
+    await Bun.sleep(0)
+    await phClient.flush()
+
+    const events = capturedFetches
+      .filter((call) => isPosthogRequest(call.url))
+      .flatMap((call) => call.body?.batch || [call.body])
+    const aiEvent = events.find(
+      (event) => event.event === '$ai_generation' && event.properties.redactionCase === undefined,
+    )
+    const droppedAiErrorEvent = events.find(
+      (event) => event.event === '$ai_generation' && event.properties.redactionCase === 'drop',
+    )
+    const inferenceErrorEvent = events.find((event) => event.event === 'inference_upstream_error')
+
+    expect(aiEvent.properties.$ai_error).toBe(JSON.stringify({ status: 400, code: 'context_length_exceeded' }))
+    expect(aiEvent.properties.$ai_model).toBe('gpt-4')
+    expect(aiEvent.properties.safeProperty).toBe('unchanged')
+    expect('$ai_error' in droppedAiErrorEvent.properties).toBe(false)
+    expect(droppedAiErrorEvent.properties.safeProperty).toBe('still-unchanged')
+    expect(inferenceErrorEvent.properties.$ai_error).toBe(rawError)
+    expect(inferenceErrorEvent.properties.safeProperty).toBe('unchanged')
   })
 })
 

--- a/backend/src/posthog/client.ts
+++ b/backend/src/posthog/client.ts
@@ -8,6 +8,37 @@ import { PostHog } from 'posthog-node'
 
 let phClient: PostHog | null = null
 
+const aiErrorKeys = ['name', 'status', 'statusCode', 'httpStatus', 'code', 'type', 'param', 'requestID'] as const
+
+const parseAiError = (value: string): unknown => {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Removes provider error content while preserving machine-readable identifiers.
+ */
+export const redactAiError = (value: unknown): string | undefined => {
+  const error = typeof value === 'string' ? parseAiError(value) : value
+  if (error === null || typeof error !== 'object') {
+    return undefined
+  }
+
+  const errorRecord = error as Record<string, unknown>
+  const redactedEntries = aiErrorKeys
+    .filter((key) => Object.hasOwn(errorRecord, key) && errorRecord[key] !== undefined)
+    .map((key) => [key, errorRecord[key]] as const)
+
+  if (redactedEntries.length === 0) {
+    return undefined
+  }
+
+  return JSON.stringify(Object.fromEntries(redactedEntries))
+}
+
 /**
  * Initialize and get the PostHog analytics client
  * Uses lazy initialization with settings from environment
@@ -35,6 +66,26 @@ export const getPostHogClient = (fetchFn?: typeof fetch): PostHog => {
   // Manually set it so the AI library can detect it
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(client as any).privacy_mode = true
+
+  // THU-771: @posthog/ai bypasses privacyMode for raw provider $ai_error; redact it at our single egress seam.
+  const originalCapture: PostHog['capture'] = client.capture.bind(client)
+  client.capture = (message: Parameters<PostHog['capture']>[0]): void => {
+    const { event, properties } = message
+    if (event !== '$ai_generation' || !properties || !Object.hasOwn(properties, '$ai_error')) {
+      originalCapture(message)
+      return
+    }
+
+    const redactedProperties = { ...properties }
+    const redactedError = redactAiError(properties.$ai_error)
+    if (redactedError === undefined) {
+      delete redactedProperties.$ai_error
+    } else {
+      redactedProperties.$ai_error = redactedError
+    }
+
+    originalCapture({ ...message, properties: redactedProperties })
+  }
 
   // Only cache if no custom fetchFn was provided
   if (!fetchFn) {


### PR DESCRIPTION
## Summary

THU-771. When PostHog is configured, inference calls go through the `@posthog/ai` wrapper, which emits `$ai_generation` error events whose `$ai_error` carries the raw serialized provider error — including the provider's `message`, which can echo user prompt fragments. `privacyMode` gates only `$ai_input`/`$ai_output_choices`, never `$ai_error`, and upgrading does not help (7.19.0+ serializes even more: message/stack/cause).

This PR adds a single egress privacy seam in `getPostHogClient`:

- **`redactAiError`** — pure function that rebuilds `$ai_error` keeping only machine identifiers (`name`, `status`, `statusCode`, `httpStatus`, `code`, `type`, `param`, `requestID`) and dropping `message`/`stack`/`cause`/provider body/`headers`. Unparseable or identifier-less values are dropped entirely.
- **`capture` wrapper** — every `$ai_generation` event leaving the process passes the redaction; all other events and properties pass through byte-identical. Version-agnostic (works on 7.16.0 and 8.x) and preserves all usage analytics.

Exception autocapture was verified off by config (the wrapper only calls `captureException` when `enableExceptionAutocapture` is set — it is not), satisfying the ticket's second acceptance criterion. Server-side logs are untouched: `safeErrorHandler` still records the real upstream message locally (THU-672 runbook).

## Validation

- `bun run test:backend`: 1015 pass, 0 fail (includes new unit + outgoing-payload integration coverage)
- `bun run type-check` (root + backend): green
- ESLint on touched files: 0 errors

Made with [Cursor](https://cursor.com)