### PR TITLE
feat: upgrade default Opus model to version 5

### DIFF
--- a/backend/src/inference/instrumentation.test.ts
+++ b/backend/src/inference/instrumentation.test.ts
@@ -62,7 +62,7 @@ describe('inference attempt instrumentation', () => {
       apiKey: 'test-fireworks-key',
     },
     {
-      model: 'opus-4.8',
+      model: 'opus-5',
       provider: 'anthropic' as const,
       host: 'api.anthropic.com',
       apiKey: 'test-anthropic-key',

--- a/backend/src/inference/routes.test.ts
+++ b/backend/src/inference/routes.test.ts
@@ -140,6 +140,14 @@ describe('Inference Routes', () => {
       )
     })
 
+    it('configures Opus 5 for Anthropic without temperature', () => {
+      expect(supportedModels['opus-5']).toEqual({
+        provider: 'anthropic',
+        internalName: 'claude-opus-5',
+        omitTemperature: true,
+      })
+    })
+
     it('should handle request with tools and tool_choice', async () => {
       const mockCompletion = createMockStream()
       mockCreateCompletion.mockImplementation(() => Promise.resolve(mockCompletion))
@@ -323,7 +331,7 @@ describe('Inference Routes', () => {
         new Request('http://localhost/chat/completions', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ...validRequestBody, model: 'opus-4.8' }),
+          body: JSON.stringify({ ...validRequestBody, model: 'opus-5' }),
         }),
       )
 
@@ -333,7 +341,7 @@ describe('Inference Routes', () => {
       expect(captureInferenceErrorMock).toHaveBeenCalledWith({
         provider: 'anthropic',
         status: 529,
-        model: 'opus-4.8',
+        model: 'opus-5',
         errorKind: 'upstream_error',
         errorType: 'overloaded_error',
         errorCode: undefined,
@@ -592,7 +600,7 @@ describe('Inference Routes', () => {
     })
 
     it('should validate all supported models', () => {
-      const expectedModels = ['mistral-medium-3.1', 'mistral-large-3', 'opus-4.8', 'deepseek-v4-flash']
+      const expectedModels = ['mistral-medium-3.1', 'mistral-large-3', 'opus-5', 'deepseek-v4-flash']
       expect(Object.keys(supportedModels)).toEqual(expectedModels)
     })
 

--- a/backend/src/inference/routes.ts
+++ b/backend/src/inference/routes.ts
@@ -35,7 +35,7 @@ const sanitizeMessageRoles = (messages: Message[]): Message[] =>
 type ModelConfig = {
   provider: InferenceProvider
   internalName: string
-  /** Newer reasoning-tuned models (e.g. Claude Opus 4.8) reject `temperature`
+  /** Newer reasoning-tuned models (e.g. Claude Opus 5) reject `temperature`
    *  with a 400. Set true to drop the field from the upstream payload. */
   omitTemperature?: boolean
 }
@@ -49,9 +49,9 @@ export const supportedModels: Record<string, ModelConfig> = {
     provider: 'mistral',
     internalName: 'mistral-large-2512',
   },
-  'opus-4.8': {
+  'opus-5': {
     provider: 'anthropic',
-    internalName: 'claude-opus-4-8',
+    internalName: 'claude-opus-5',
     omitTemperature: true,
   },
   'deepseek-v4-flash': {

--- a/shared/defaults/models.test.ts
+++ b/shared/defaults/models.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { hashValues } from '../lib/hash'
-import { defaultModels, defaultModelsVersion, hashModel, vendorSupportsImages } from './models'
+import { defaultModelOpus5, defaultModels, defaultModelsVersion, hashModel, vendorSupportsImages } from './models'
 
 /**
  * Snapshot pinning the shipped defaults to their declared version. When you
@@ -29,12 +29,28 @@ const computeMetadataHash = () =>
   defaultModels.map((model, index) => `${index}:${hashValues([model.vendor, model.description])}`).join('|')
 
 const expected = {
-  version: 3,
-  hash: '0:019af08a-c27b-7074-8aac-95315d1ef3fd:-1vf2pk|1:019f227e-d640-727d-ba12-d51bd7d0a3d6:bvaax2|2:019e7580-2b0e-719c-a43f-d2b56e7f31b4:-g7x2jr',
+  version: 4,
+  hash: '0:019af08a-c27b-7074-8aac-95315d1ef3fd:-lo3iv3|1:019f227e-d640-727d-ba12-d51bd7d0a3d6:bvaax2|2:019e7580-2b0e-719c-a43f-d2b56e7f31b4:-g7x2jr',
   metadataHash: '0:vzhyk4|1:-x2wlw2|2:-cajkcl',
 }
 
 describe('defaultModels version snapshot', () => {
+  test('ships Opus 5 as the sole model using its canonical id', () => {
+    expect(defaultModelOpus5).toMatchObject({
+      id: '019af08a-c27b-7074-8aac-95315d1ef3fd',
+      name: 'Opus 5',
+      provider: 'thunderbolt',
+      model: 'opus-5',
+      contextWindow: 1_000_000,
+      isSystem: 1,
+      enabled: 1,
+      toolUsage: 1,
+      supportsParallelToolCalls: 1,
+      isConfidential: 0,
+    })
+    expect(defaultModels.filter(({ id }) => id === defaultModelOpus5.id)).toEqual([defaultModelOpus5])
+  })
+
   test('version and content are in sync — read the file header if this fails', () => {
     expect({
       version: defaultModelsVersion,

--- a/shared/defaults/models.ts
+++ b/shared/defaults/models.ts
@@ -78,18 +78,18 @@ export const hashModel = (model: SharedModel): string => {
  */
 
 /**
- * Opus 4.8 reuses the row id originally assigned to Sonnet 4.5 (and inherited by 4.7).
- * Reconciliation upgrades unmodified rows in place; edited rows survive.
+ * Opus 5 reuses the row id originally assigned to Sonnet 4.5 and inherited by prior upgrades.
+ * Generic defaults reconciliation upgrades unmodified rows in place.
  */
-export const defaultModelOpus48: SharedModel = {
+export const defaultModelOpus5: SharedModel = {
   id: '019af08a-c27b-7074-8aac-95315d1ef3fd',
-  name: 'Opus 4.8',
+  name: 'Opus 5',
   provider: 'thunderbolt',
-  model: 'opus-4.8',
+  model: 'opus-5',
   isSystem: 1,
   enabled: 1,
   isConfidential: 0,
-  contextWindow: 200000,
+  contextWindow: 1_000_000,
   toolUsage: 1,
   startWithReasoning: 0,
   supportsParallelToolCalls: 1,
@@ -169,7 +169,7 @@ export const defaultModelGlm52: SharedModel = {
  * will surface upstream errors when used.
  */
 export const defaultModels: ReadonlyArray<SharedModel> = [
-  defaultModelOpus48,
+  defaultModelOpus5,
   defaultModelDeepseekV4Flash,
   defaultModelGlm52,
 ] as const
@@ -184,4 +184,4 @@ export const defaultModels: ReadonlyArray<SharedModel> = [
  * The paired snapshot test in `models.test.ts` fails on any change to this
  * file's defaults without a matching version bump.
  */
-export const defaultModelsVersion = 3
+export const defaultModelsVersion = 4

--- a/src/ai/eval/debug-single.ts
+++ b/src/ai/eval/debug-single.ts
@@ -9,7 +9,7 @@
 import { aiFetchStreamingResponse } from '@/ai/fetch'
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getLocalSetting } from '@/stores/local-settings-store'
-import { defaultModelOpus48 } from '@shared/defaults/models'
+import { defaultModelOpus5 } from '@shared/defaults/models'
 import { isSsoMode } from '@/lib/auth-mode'
 import { getAuthToken } from '@/lib/auth-token'
 import { createAuthenticatedClient } from '@/lib/http'
@@ -25,7 +25,7 @@ const run = async () => {
   await setupTestDatabase()
   console.log('[1/5] Database ready.\n')
 
-  const modelId = defaultModelOpus48.id
+  const modelId = defaultModelOpus5.id
   const prompt = "What's the current price of Bitcoin?"
 
   const body = JSON.stringify({
@@ -33,7 +33,7 @@ const run = async () => {
     id: uuidv7(),
   })
 
-  console.log(`[2/5] Model: ${defaultModelOpus48.name} (${modelId})`)
+  console.log(`[2/5] Model: ${defaultModelOpus5.name} (${modelId})`)
   console.log(`[2/5] Prompt: "${prompt}"\n`)
 
   const cloudUrl = getLocalSetting('cloudUrl')

--- a/src/ai/eval/scenarios.ts
+++ b/src/ai/eval/scenarios.ts
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { defaultModelOpus48 } from '@shared/defaults/models'
+import { defaultModelOpus5 } from '@shared/defaults/models'
 import type { EvalCriteria, EvalScenario } from './types'
 
-const models = [{ name: 'opus', id: defaultModelOpus48.id }] as const
+const models = [{ name: 'opus', id: defaultModelOpus5.id }] as const
 
 /** Default criteria applied to all Chat mode scenarios */
 const chatCriteria: EvalCriteria = {

--- a/src/dal/model-profiles.test.ts
+++ b/src/dal/model-profiles.test.ts
@@ -4,7 +4,8 @@
 
 import { getDb } from '@/db/database'
 import { modelProfilesTable, modelsTable } from '@/db/tables'
-import { defaultModelOpus48 } from '@shared/defaults/models'
+import { defaultModelProfileOpus5, hashModelProfile } from '@/defaults/model-profiles'
+import { defaultModelOpus5 } from '@shared/defaults/models'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
@@ -207,35 +208,36 @@ describe('Model Profiles DAL', () => {
   describe('resetModelProfileToDefault', () => {
     it('should restore default values for a known model', async () => {
       const db = getDb()
-      const { defaultModelProfileOpus48 } = await import('@/defaults/model-profiles')
 
       // Insert the actual default model first to satisfy FK constraint
       await db.insert(modelsTable).values({
-        id: defaultModelOpus48.id,
-        provider: defaultModelOpus48.provider,
-        name: defaultModelOpus48.name,
-        model: defaultModelOpus48.model,
-        isSystem: defaultModelOpus48.isSystem,
-        enabled: defaultModelOpus48.enabled,
+        id: defaultModelOpus5.id,
+        provider: defaultModelOpus5.provider,
+        name: defaultModelOpus5.name,
+        model: defaultModelOpus5.model,
+        isSystem: defaultModelOpus5.isSystem,
+        enabled: defaultModelOpus5.enabled,
       })
 
       // Insert a profile with modified values
       await db.insert(modelProfilesTable).values({
-        modelId: defaultModelOpus48.id,
+        modelId: defaultModelOpus5.id,
         temperature: 0.99,
         maxSteps: 1,
         deletedAt: new Date().toISOString(),
       })
 
       // Reset to defaults
-      await resetModelProfileToDefault(getDb(), defaultModelOpus48.id)
+      await resetModelProfileToDefault(getDb(), defaultModelOpus5.id)
 
-      const profile = await getModelProfile(getDb(), defaultModelOpus48.id)
+      const profile = await getModelProfile(getDb(), defaultModelOpus5.id)
       expect(profile).not.toBe(null)
-      expect(profile?.temperature).toBe(defaultModelProfileOpus48.temperature)
-      expect(profile?.maxSteps).toBe(defaultModelProfileOpus48.maxSteps)
-      expect(profile?.maxAttempts).toBe(defaultModelProfileOpus48.maxAttempts)
-      expect(profile?.nudgeThreshold).toBe(defaultModelProfileOpus48.nudgeThreshold)
+      expect(defaultModelProfileOpus5.modelId).toBe(defaultModelOpus5.id)
+      expect(defaultModelProfileOpus5.temperature).toBeNull()
+      expect(profile?.temperature).toBeNull()
+      expect(profile?.maxSteps).toBe(defaultModelProfileOpus5.maxSteps)
+      expect(profile?.maxAttempts).toBe(defaultModelProfileOpus5.maxAttempts)
+      expect(profile?.nudgeThreshold).toBe(defaultModelProfileOpus5.nudgeThreshold)
       expect(profile?.deletedAt).toBe(null)
     })
 
@@ -268,31 +270,30 @@ describe('Model Profiles DAL', () => {
   describe('createDefaultModelProfile', () => {
     it('should create a profile for a known default model', async () => {
       const db = getDb()
-      const { defaultModelProfileOpus48, hashModelProfile } = await import('@/defaults/model-profiles')
 
       await db.insert(modelsTable).values({
-        id: defaultModelOpus48.id,
-        provider: defaultModelOpus48.provider,
-        name: defaultModelOpus48.name,
-        model: defaultModelOpus48.model,
-        isSystem: defaultModelOpus48.isSystem,
-        enabled: defaultModelOpus48.enabled,
+        id: defaultModelOpus5.id,
+        provider: defaultModelOpus5.provider,
+        name: defaultModelOpus5.name,
+        model: defaultModelOpus5.model,
+        isSystem: defaultModelOpus5.isSystem,
+        enabled: defaultModelOpus5.enabled,
       })
 
-      await createDefaultModelProfile(getDb(), defaultModelOpus48.id)
+      await createDefaultModelProfile(getDb(), defaultModelOpus5.id)
 
-      const profile = await getModelProfile(getDb(), defaultModelOpus48.id)
+      const profile = await getModelProfile(getDb(), defaultModelOpus5.id)
       expect(profile).not.toBe(null)
-      expect(profile?.modelId).toBe(defaultModelOpus48.id)
-      expect(profile?.temperature).toBe(defaultModelProfileOpus48.temperature)
+      expect(profile?.modelId).toBe(defaultModelOpus5.id)
+      expect(profile?.temperature).toBeNull()
 
       // Should store the defaultHash
       const rawProfile = await db
         .select()
         .from(modelProfilesTable)
-        .where(eq(modelProfilesTable.modelId, defaultModelOpus48.id))
+        .where(eq(modelProfilesTable.modelId, defaultModelOpus5.id))
         .get()
-      expect(rawProfile?.defaultHash).toBe(hashModelProfile(defaultModelProfileOpus48))
+      expect(rawProfile?.defaultHash).toBe(hashModelProfile(defaultModelProfileOpus5))
     })
 
     it('should do nothing for a model without seed data', async () => {
@@ -318,24 +319,24 @@ describe('Model Profiles DAL', () => {
       const db = getDb()
 
       await db.insert(modelsTable).values({
-        id: defaultModelOpus48.id,
-        provider: defaultModelOpus48.provider,
-        name: defaultModelOpus48.name,
-        model: defaultModelOpus48.model,
-        isSystem: defaultModelOpus48.isSystem,
-        enabled: defaultModelOpus48.enabled,
+        id: defaultModelOpus5.id,
+        provider: defaultModelOpus5.provider,
+        name: defaultModelOpus5.name,
+        model: defaultModelOpus5.model,
+        isSystem: defaultModelOpus5.isSystem,
+        enabled: defaultModelOpus5.enabled,
       })
 
       // Insert a custom profile first
       await db.insert(modelProfilesTable).values({
-        modelId: defaultModelOpus48.id,
+        modelId: defaultModelOpus5.id,
         temperature: 0.99,
       })
 
       // Calling createDefaultModelProfile should not overwrite
-      await createDefaultModelProfile(getDb(), defaultModelOpus48.id)
+      await createDefaultModelProfile(getDb(), defaultModelOpus5.id)
 
-      const profile = await getModelProfile(getDb(), defaultModelOpus48.id)
+      const profile = await getModelProfile(getDb(), defaultModelOpus5.id)
       expect(profile?.temperature).toBe(0.99)
     })
   })

--- a/src/dal/models.test.ts
+++ b/src/dal/models.test.ts
@@ -15,7 +15,7 @@ import {
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
-import { defaultModelOpus48, hashModel } from '@shared/defaults/models'
+import { defaultModelOpus5, hashModel } from '@shared/defaults/models'
 import { isModelModified } from '@/defaults/utils'
 import type { Model } from '@/types'
 import {
@@ -933,7 +933,7 @@ describe('Models DAL', () => {
   describe('resetModelToDefault', () => {
     it('restores default fields and refreshes defaultHash', async () => {
       const db = getDb()
-      const defaultModel = defaultModelOpus48
+      const defaultModel = defaultModelOpus5
 
       await db.insert(modelsTable).values({
         ...defaultModel,
@@ -956,7 +956,7 @@ describe('Models DAL', () => {
 
     it('clears the local-only api key on reset', async () => {
       const db = getDb()
-      const defaultModel = defaultModelOpus48
+      const defaultModel = defaultModelOpus5
 
       await db.insert(modelsTable).values({ ...defaultModel })
       await db.insert(modelsSecretsTable).values({ modelId: defaultModel.id, apiKey: 'sk-user-supplied' })
@@ -973,7 +973,7 @@ describe('Models DAL', () => {
 
     it('preserves the row userId (does not overwrite with null from the default template)', async () => {
       const db = getDb()
-      const defaultModel = defaultModelOpus48
+      const defaultModel = defaultModelOpus5
 
       // The default template carries `userId: null`. A row that has already
       // been synced has a real user_id — reset must not overwrite it, otherwise
@@ -1046,22 +1046,22 @@ describe('Models DAL', () => {
     it('should auto-create a default profile for a known seeded model', async () => {
       const db = getDb()
 
-      // Create a model with the same ID as a seeded default (Opus 4.8)
+      // Create a model with the same ID as a seeded default (Opus 5)
       await createModel(getDb(), {
-        id: defaultModelOpus48.id,
+        id: defaultModelOpus5.id,
         provider: 'thunderbolt',
-        name: 'Opus 4.8',
-        model: 'opus-4.8',
+        name: 'Opus 5',
+        model: 'opus-5',
       })
 
       // Verify a profile was auto-created
       const profile = await db
         .select()
         .from(modelProfilesTable)
-        .where(eq(modelProfilesTable.modelId, defaultModelOpus48.id))
+        .where(eq(modelProfilesTable.modelId, defaultModelOpus5.id))
         .get()
       expect(profile).not.toBeUndefined()
-      expect(profile?.temperature).toBe(0.2)
+      expect(profile?.temperature).toBeNull()
     })
 
     it('should not create a profile for an unknown model ID', async () => {

--- a/src/defaults/automations.ts
+++ b/src/defaults/automations.ts
@@ -4,7 +4,7 @@
 
 import { hashValues } from '@/lib/utils'
 import type { Prompt } from '@/types'
-import { defaultModelOpus48 } from '@shared/defaults/models'
+import { defaultModelOpus5 } from '@shared/defaults/models'
 
 /**
  * Compute hash of user-editable fields for a prompt
@@ -24,7 +24,7 @@ export const defaultAutomationDailyBrief: Prompt = {
   deletedAt: null,
   defaultHash: null,
   userId: null,
-  modelId: defaultModelOpus48.id,
+  modelId: defaultModelOpus5.id,
   prompt: `Create a daily brief with the following sections. Do not ask me for any missing information - just skip sections for which you are missing information or tools.
 
 1. If you know my location, show me the 7-day forecast. If not, skip this section.
@@ -68,7 +68,7 @@ export const defaultAutomationImportantEmails: Prompt = {
   deletedAt: null,
   defaultHash: null,
   userId: null,
-  modelId: defaultModelOpus48.id,
+  modelId: defaultModelOpus5.id,
   prompt: `Review my inbox and summarize the 5 most important emails that need my attention today. Include sender, subject, and why each is important.`,
 }
 

--- a/src/defaults/model-profiles.ts
+++ b/src/defaults/model-profiles.ts
@@ -5,7 +5,7 @@
 export {
   defaultModelProfileDeepseekV4Flash,
   defaultModelProfileGlm52,
-  defaultModelProfileOpus48,
+  defaultModelProfileOpus5,
   defaultModelProfiles,
   hashModelProfile,
 } from './model-profiles/index'

--- a/src/defaults/model-profiles/index.ts
+++ b/src/defaults/model-profiles/index.ts
@@ -6,11 +6,11 @@ import { hashValues } from '@/lib/utils'
 import type { ModelProfile } from '@/types'
 import { defaultModelProfileDeepseekV4Flash } from './deepseek'
 import { defaultModelProfileGlm52 } from './glm'
-import { defaultModelProfileOpus48 } from './opus'
+import { defaultModelProfileOpus5 } from './opus'
 
 export { defaultModelProfileDeepseekV4Flash } from './deepseek'
 export { defaultModelProfileGlm52 } from './glm'
-export { defaultModelProfileOpus48 } from './opus'
+export { defaultModelProfileOpus5 } from './opus'
 
 /**
  * Compute hash of user-editable fields for a model profile.
@@ -43,7 +43,7 @@ export const hashModelProfile = (profile: ModelProfile): string =>
 
 /** All default model profiles for iteration */
 export const defaultModelProfiles: ReadonlyArray<ModelProfile> = [
-  defaultModelProfileOpus48,
+  defaultModelProfileOpus5,
   defaultModelProfileDeepseekV4Flash,
   defaultModelProfileGlm52,
 ] as const

--- a/src/defaults/model-profiles/opus.ts
+++ b/src/defaults/model-profiles/opus.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { ModelProfile } from '@/types'
-import { defaultModelOpus48 } from '@shared/defaults/models'
+import { defaultModelOpus5 } from '@shared/defaults/models'
 
-export const defaultModelProfileOpus48: ModelProfile = {
-  modelId: defaultModelOpus48.id,
-  temperature: 0.2,
+export const defaultModelProfileOpus5: ModelProfile = {
+  modelId: defaultModelOpus5.id,
+  temperature: null,
   maxSteps: 20,
   maxAttempts: 2,
   nudgeThreshold: 6,

--- a/src/lib/pick-defaults.test.ts
+++ b/src/lib/pick-defaults.test.ts
@@ -3,12 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, test } from 'bun:test'
-import { defaultModelOpus48, defaultModels, defaultModelsVersion } from '@shared/defaults/models'
+import { defaultModelOpus5, defaultModels, defaultModelsVersion } from '@shared/defaults/models'
 import { pickModelsDefaults } from './pick-defaults'
 
 const serverPayload = (version: number) => ({
   version,
-  data: [{ ...defaultModelOpus48, name: `Server v${version}` }],
+  data: [{ ...defaultModelOpus5, name: `Server v${version}` }],
 })
 
 describe('pickModelsDefaults', () => {
@@ -74,8 +74,8 @@ describe('pickModelsDefaults', () => {
     const disjointPayload = {
       version: defaultModelsVersion + 5,
       data: [
-        { ...defaultModelOpus48, id: 'disjoint-id-1', name: 'Fully Different Model 1' },
-        { ...defaultModelOpus48, id: 'disjoint-id-2', name: 'Fully Different Model 2' },
+        { ...defaultModelOpus5, id: 'disjoint-id-1', name: 'Fully Different Model 1' },
+        { ...defaultModelOpus5, id: 'disjoint-id-2', name: 'Fully Different Model 2' },
       ],
     }
     const picked = pickModelsDefaults(disjointPayload)
@@ -90,8 +90,8 @@ describe('pickModelsDefaults', () => {
     const partialOverlap = {
       version: defaultModelsVersion + 1,
       data: [
-        defaultModelOpus48, // in bundle
-        { ...defaultModelOpus48, id: 'new-id', name: 'Server-only New Model' },
+        defaultModelOpus5, // in bundle
+        { ...defaultModelOpus5, id: 'new-id', name: 'Server-only New Model' },
       ],
     }
     const picked = pickModelsDefaults(partialOverlap)

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -14,6 +14,7 @@ import { defaultAutomations, hashPrompt } from '../defaults/automations'
 import { defaultModelProfiles, hashModelProfile } from '../defaults/model-profiles'
 import {
   defaultModelGlm52,
+  defaultModelOpus5,
   defaultModels,
   defaultModelsVersion,
   hashModel,
@@ -802,6 +803,30 @@ describe('reconcileDefaultsForTable', () => {
       // The critical assertion — must not be flipped false by the
       // wouldOverwriteUserValue branch.
       expect(result.everyBundleRowAtTarget).toBe(true)
+    })
+  })
+})
+
+describe('Opus 5 data migration', () => {
+  test('upgrades the active legacy row in place even when the defaults marker is current', async () => {
+    const db = getDb()
+    await db.insert(modelsTable).values({
+      ...defaultModelOpus5,
+      name: 'Customized legacy Opus',
+      model: 'opus-4.8',
+      contextWindow: 200_000,
+      defaultHash: 'customized',
+    })
+    await db.insert(settingsTable).values({
+      key: versionMarkerKeys.models,
+      value: String(defaultModelsVersion),
+    })
+
+    await reconcileDefaults(db, { initialSyncCompleted: false })
+
+    expect(await db.select().from(modelsTable).where(eq(modelsTable.id, defaultModelOpus5.id)).get()).toEqual({
+      ...defaultModelOpus5,
+      defaultHash: hashModel(defaultModelOpus5),
     })
   })
 })

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -810,7 +810,7 @@ describe('reconcileDefaultsForTable', () => {
 describe('Opus 5 data migration', () => {
   test('preserves user customizations while upgrading the legacy model slug', async () => {
     const db = getDb()
-    const legacyDefault = {
+    const legacyDefault: SharedModel = {
       ...defaultModelOpus5,
       name: 'Opus 4.8',
       model: 'opus-4.8',
@@ -861,6 +861,81 @@ describe('Opus 5 data migration', () => {
       ...defaultModelOpus5,
       defaultHash: hashModel(defaultModelOpus5),
     })
+  })
+
+  test.each([
+    {
+      customizedField: 'name',
+      name: 'My customized Opus',
+      contextWindow: 200_000,
+      expectedName: 'My customized Opus',
+      expectedContextWindow: 1_000_000,
+    },
+    {
+      customizedField: 'context window',
+      name: 'Opus 4.8',
+      contextWindow: 123_456,
+      expectedName: 'Opus 5',
+      expectedContextWindow: 123_456,
+    },
+  ])('preserves a custom $customizedField under an open defaults gate', async (scenario) => {
+    const db = getDb()
+    const legacyDefault: SharedModel = {
+      ...defaultModelOpus5,
+      name: 'Opus 4.8',
+      model: 'opus-4.8',
+      contextWindow: 200_000,
+    }
+    const customizedLegacy = {
+      ...legacyDefault,
+      name: scenario.name,
+      contextWindow: scenario.contextWindow,
+      defaultHash: hashModel(legacyDefault),
+    }
+    await db.insert(modelsTable).values(customizedLegacy)
+    await db.insert(settingsTable).values({
+      key: versionMarkerKeys.models,
+      value: String(defaultModelsVersion - 1),
+    })
+
+    await reconcileDefaults(db)
+
+    expect(await db.select().from(modelsTable).where(eq(modelsTable.id, defaultModelOpus5.id)).get()).toEqual({
+      ...customizedLegacy,
+      model: defaultModelOpus5.model,
+      name: scenario.expectedName,
+      contextWindow: scenario.expectedContextWindow,
+    })
+  })
+
+  test('prevents a newer OTA payload from restoring the legacy model slug', async () => {
+    const db = getDb()
+    const legacyDefault: SharedModel = {
+      ...defaultModelOpus5,
+      name: 'Opus 4.8',
+      model: 'opus-4.8',
+      contextWindow: 200_000,
+    }
+    await db.insert(modelsTable).values({
+      ...legacyDefault,
+      defaultHash: hashModel(legacyDefault),
+    })
+    await db.insert(settingsTable).values({
+      key: versionMarkerKeys.models,
+      value: String(defaultModelsVersion),
+    })
+    const otaVersion = defaultModelsVersion + 1
+    const otaModels = defaultModels.map((model) => (model.id === defaultModelOpus5.id ? legacyDefault : model))
+
+    await reconcileDefaults(db, { models: { version: otaVersion, data: otaModels } })
+
+    expect(await db.select().from(modelsTable).where(eq(modelsTable.id, defaultModelOpus5.id)).get()).toEqual({
+      ...defaultModelOpus5,
+      defaultHash: hashModel(defaultModelOpus5),
+    })
+    expect(
+      await db.select().from(settingsTable).where(eq(settingsTable.key, versionMarkerKeys.models)).get(),
+    ).toMatchObject({ value: String(otaVersion) })
   })
 })
 

--- a/src/lib/reconcile-defaults.test.ts
+++ b/src/lib/reconcile-defaults.test.ts
@@ -808,14 +808,47 @@ describe('reconcileDefaultsForTable', () => {
 })
 
 describe('Opus 5 data migration', () => {
-  test('upgrades the active legacy row in place even when the defaults marker is current', async () => {
+  test('preserves user customizations while upgrading the legacy model slug', async () => {
     const db = getDb()
-    await db.insert(modelsTable).values({
+    const legacyDefault = {
       ...defaultModelOpus5,
-      name: 'Customized legacy Opus',
+      name: 'Opus 4.8',
       model: 'opus-4.8',
       contextWindow: 200_000,
-      defaultHash: 'customized',
+    }
+    const customizedLegacy = {
+      ...legacyDefault,
+      name: 'My customized Opus',
+      enabled: 0,
+      startWithReasoning: 1,
+      contextWindow: 123_456,
+      defaultHash: hashModel(legacyDefault),
+    }
+    await db.insert(modelsTable).values(customizedLegacy)
+    await db.insert(settingsTable).values({
+      key: versionMarkerKeys.models,
+      value: String(defaultModelsVersion),
+    })
+
+    await reconcileDefaults(db, { initialSyncCompleted: false })
+
+    expect(await db.select().from(modelsTable).where(eq(modelsTable.id, defaultModelOpus5.id)).get()).toEqual({
+      ...customizedLegacy,
+      model: defaultModelOpus5.model,
+    })
+  })
+
+  test('fully upgrades an untouched legacy default and refreshes its lineage hash', async () => {
+    const db = getDb()
+    const legacyDefault = {
+      ...defaultModelOpus5,
+      name: 'Opus 4.8',
+      model: 'opus-4.8',
+      contextWindow: 200_000,
+    }
+    await db.insert(modelsTable).values({
+      ...legacyDefault,
+      defaultHash: hashModel(legacyDefault),
     })
     await db.insert(settingsTable).values({
       key: versionMarkerKeys.models,

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -455,6 +455,19 @@ export type ReconcileDefaultsOverrides = {
   initialSyncCompleted?: boolean
 }
 
+/** Normalize the reused identity so stale OTA payloads cannot restore Opus 4.8. */
+const normalizeLegacyOpusModel = (model: SharedModel): SharedModel => {
+  if (model.id !== defaultModelOpus5.id || model.model !== 'opus-4.8') {
+    return model
+  }
+  return {
+    ...model,
+    model: defaultModelOpus5.model,
+    name: model.name === 'Opus 4.8' ? defaultModelOpus5.name : model.name,
+    contextWindow: model.contextWindow === 200_000 ? defaultModelOpus5.contextWindow : model.contextWindow,
+  }
+}
+
 /** Upgrade the reused model identity so persisted chat references resolve Opus 5. */
 const migrateLegacyOpusModel = async (tx: AnyDrizzleDatabase): Promise<void> => {
   const existing = await tx.select().from(modelsTable).where(eq(modelsTable.id, defaultModelOpus5.id)).get()
@@ -463,13 +476,14 @@ const migrateLegacyOpusModel = async (tx: AnyDrizzleDatabase): Promise<void> => 
   }
 
   const legacyModel = existing as SharedModel
+  const migratedModel = normalizeLegacyOpusModel(legacyModel)
   const migratedValues = {
-    model: defaultModelOpus5.model,
-    name: legacyModel.name === 'Opus 4.8' ? defaultModelOpus5.name : legacyModel.name,
-    contextWindow: legacyModel.contextWindow === 200_000 ? defaultModelOpus5.contextWindow : legacyModel.contextWindow,
+    model: migratedModel.model,
+    name: migratedModel.name,
+    contextWindow: migratedModel.contextWindow,
   }
   const wasUnmodified = legacyModel.defaultHash !== null && hashModel(legacyModel) === legacyModel.defaultHash
-  const migratedDefaultHash = wasUnmodified ? hashModel({ ...legacyModel, ...migratedValues }) : legacyModel.defaultHash
+  const migratedDefaultHash = wasUnmodified ? hashModel(migratedModel) : legacyModel.defaultHash
 
   await tx
     .update(modelsTable)
@@ -478,7 +492,11 @@ const migrateLegacyOpusModel = async (tx: AnyDrizzleDatabase): Promise<void> => 
 }
 
 export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: ReconcileDefaultsOverrides) => {
-  const modelsSource = overrides?.models ?? bundledModelsDefaults
+  const pickedModelsSource = overrides?.models ?? bundledModelsDefaults
+  const modelsSource = {
+    ...pickedModelsSource,
+    data: pickedModelsSource.data.map(normalizeLegacyOpusModel),
+  }
   const initialSyncCompleted = overrides?.initialSyncCompleted ?? true
 
   await db.transaction(async (tx) => {

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -10,7 +10,13 @@ import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
 import { v7 as uuidv7 } from 'uuid'
 import { modelProfilesTable, modelsTable, settingsTable, skillsTable, tasksTable } from '../db/tables'
 import { defaultModelProfiles, hashModelProfile } from '../defaults/model-profiles'
-import { defaultModels, defaultModelsVersion, hashModel, type SharedModel } from '@shared/defaults/models'
+import {
+  defaultModelOpus5,
+  defaultModels,
+  defaultModelsVersion,
+  hashModel,
+  type SharedModel,
+} from '@shared/defaults/models'
 import { defaultSettings, defaultSettingsVersion, hashSetting } from '../defaults/settings'
 import { defaultSkills, defaultSkillsVersion, hashSkill, isWidgetSkillId } from '../defaults/skills'
 import { defaultTasks, defaultTasksVersion, hashTask } from '../defaults/tasks'
@@ -449,6 +455,24 @@ export type ReconcileDefaultsOverrides = {
   initialSyncCompleted?: boolean
 }
 
+/** Upgrade the reused model identity so persisted chat references resolve Opus 5. */
+const migrateLegacyOpusModel = async (tx: AnyDrizzleDatabase): Promise<void> => {
+  const existing = await tx
+    .select({ model: modelsTable.model, deletedAt: modelsTable.deletedAt })
+    .from(modelsTable)
+    .where(eq(modelsTable.id, defaultModelOpus5.id))
+    .get()
+  if (!existing || existing.deletedAt !== null || existing.model !== 'opus-4.8') {
+    return
+  }
+
+  const { id, userId, deletedAt, defaultHash, ...modelValues } = defaultModelOpus5
+  await tx
+    .update(modelsTable)
+    .set({ ...modelValues, defaultHash: hashModel(defaultModelOpus5) })
+    .where(eq(modelsTable.id, id))
+}
+
 export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: ReconcileDefaultsOverrides) => {
   const modelsSource = overrides?.models ?? bundledModelsDefaults
   const initialSyncCompleted = overrides?.initialSyncCompleted ?? true
@@ -479,6 +503,7 @@ export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: Reco
       hasAnyModelRow,
       initialSyncCompleted,
     )
+    await migrateLegacyOpusModel(tx)
 
     // OTA can ship models whose id isn't in this bundle's `defaultModelProfiles`
     // — profiles are not part of the OTA channel, so we have no profile to

--- a/src/lib/reconcile-defaults.ts
+++ b/src/lib/reconcile-defaults.ts
@@ -457,20 +457,24 @@ export type ReconcileDefaultsOverrides = {
 
 /** Upgrade the reused model identity so persisted chat references resolve Opus 5. */
 const migrateLegacyOpusModel = async (tx: AnyDrizzleDatabase): Promise<void> => {
-  const existing = await tx
-    .select({ model: modelsTable.model, deletedAt: modelsTable.deletedAt })
-    .from(modelsTable)
-    .where(eq(modelsTable.id, defaultModelOpus5.id))
-    .get()
+  const existing = await tx.select().from(modelsTable).where(eq(modelsTable.id, defaultModelOpus5.id)).get()
   if (!existing || existing.deletedAt !== null || existing.model !== 'opus-4.8') {
     return
   }
 
-  const { id, userId, deletedAt, defaultHash, ...modelValues } = defaultModelOpus5
+  const legacyModel = existing as SharedModel
+  const migratedValues = {
+    model: defaultModelOpus5.model,
+    name: legacyModel.name === 'Opus 4.8' ? defaultModelOpus5.name : legacyModel.name,
+    contextWindow: legacyModel.contextWindow === 200_000 ? defaultModelOpus5.contextWindow : legacyModel.contextWindow,
+  }
+  const wasUnmodified = legacyModel.defaultHash !== null && hashModel(legacyModel) === legacyModel.defaultHash
+  const migratedDefaultHash = wasUnmodified ? hashModel({ ...legacyModel, ...migratedValues }) : legacyModel.defaultHash
+
   await tx
     .update(modelsTable)
-    .set({ ...modelValues, defaultHash: hashModel(defaultModelOpus5) })
-    .where(eq(modelsTable.id, id))
+    .set({ ...migratedValues, defaultHash: migratedDefaultHash })
+    .where(eq(modelsTable.id, defaultModelOpus5.id))
 }
 
 export const reconcileDefaults = async (db: AnyDrizzleDatabase, overrides?: ReconcileDefaultsOverrides) => {


### PR DESCRIPTION
## Summary
- replace the shipped app default with Opus 5 while preserving its stable model UUID
- migrate active legacy rows in place so existing chats resolve Opus 5 without losing user customizations
- route the managed `opus-5` alias to `claude-opus-5` in the backend

## Test plan
- [x] `bun run test`
- [x] `bun run check`
- [x] `bun run build`
- [x] backend type-check and full test suite
- [x] focused defaults, profile, DAL, reconciliation, and inference-route tests