### PR TITLE
fix(THU-770): add NSCameraUsageDescription to prevent iOS camera crash

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -15,5 +15,10 @@
              macOS/iOS TCC — without it the OS blocks (and can crash) mic access. -->
         <key>NSMicrophoneUsageDescription</key>
         <string>Thunderbolt uses your microphone for voice mode, so you can talk to the assistant.</string>
+        <!-- Attachments: the image-accepting file input surfaces iOS's "Take Photo"
+             option, which opens the camera. Required by macOS/iOS TCC — without it
+             the OS aborts the process the instant the camera is invoked (THU-770). -->
+        <key>NSCameraUsageDescription</key>
+        <string>Thunderbolt uses your camera so you can take a photo to attach to a message.</string>
     </dict>
 </plist>


### PR DESCRIPTION
## Bug (THU-770)

On the iOS app, tapping **"Take a photo"** crashes the application immediately.

## Root cause

The app is a Tauri v2 iOS WKWebView build. The attachment `<input type="file">` accepts image MIME types (`src/components/chat/chat-prompt-input.tsx`), so iOS surfaces its native "Take Photo" action-sheet option, which opens the camera. Invoking the camera requires `NSCameraUsageDescription` in Info.plist — it was missing (only `NSMicrophoneUsageDescription` existed), so iOS TCC aborts the process with `SIGABRT` the instant the camera launches.

## Fix

Add `NSCameraUsageDescription` to `src-tauri/Info.plist`, mirroring the existing microphone key. Tauri merges this source plist into the generated iOS project at build, so no hand-editing of `gen/apple` is needed.

## Verification
- `plutil -lint src-tauri/Info.plist` → OK; key extracts correctly.
- ⚠️ Not verified on-device (no iOS simulator/device available in this environment). Please confirm by building the iOS app and tapping "Take Photo" — it should now prompt for camera permission instead of crashing.

## Scope note
Covers the reported "Take a photo" (camera) crash. The "Photo Library" option uses iOS's out-of-process PHPicker, which needs no usage key, so `NSPhotoLibraryUsageDescription` isn't required here.