### PR TITLE
fix(THU-778): auto-focus search input when palette opens on mobile

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -69,7 +69,10 @@ const CommandDialog = ({
         onOpenChange={onOpenChange ?? (() => {})}
         side="top"
         title={title}
-        initialFocus={false}
+        // Focus the search input on open, matching the desktop dialog (which
+        // Radix auto-focuses). `true` targets the drawer's first tabbable
+        // element — the CommandInput — so the keyboard is ready to type.
+        initialFocus
       >
         {command}
       </MobileCardMenu>


### PR DESCRIPTION
The mobile search palette (Base UI top drawer) was passed `initialFocus={false}`, so the input wasn't focused on open — unlike desktop, where Radix's dialog auto-focuses it. Switched to `initialFocus` (default behavior) so the drawer focuses its first tabbable element, the search input, matching desktop.