### PR TITLE
test: fix main CI failures from stale dialog assertion and mock ordering

### DIFF
--- a/src/components/ui/mobile-sidebar.test.tsx
+++ b/src/components/ui/mobile-sidebar.test.tsx
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Registers the framer-motion `mock.module` (side effect) so `animate` resolves
+// Registers the framer-motion `mock.module` so `animate` resolves
 // synchronously and `useMotionValue`/`useDragControls` return inert values. The
 // named import also lets tests assert on the animations the component starts.
-import { animateSpy } from '@/test-utils/framer-motion-mock'
+import { animateSpy, registerFramerMotionMock } from '@/test-utils/framer-motion-mock'
 
 import { Drawer as DrawerPrimitive } from '@base-ui/react/drawer'
 import { act, fireEvent, render, renderHook, screen } from '@testing-library/react'
@@ -16,6 +16,13 @@ import { useState, type ReactNode } from 'react'
 import { HapticsProvider } from '@/hooks/use-haptics'
 import { useLocalSettingsStore } from '@/stores/local-settings-store'
 import { getClock, webHapticsTriggerMock } from '@/testing-library'
+
+// Re-register here rather than relying on the side-effect import above: when
+// another test file evaluated framer-motion-mock first (randomized suite
+// order), this file's import is a cache hit that re-runs nothing, and a
+// registration made before real framer-motion was linked elsewhere no longer
+// intercepts new imports (see framer-motion-mock.ts).
+registerFramerMotionMock()
 
 // Import the module under test dynamically — after the framer-motion mock above
 // has registered — so the shared `mock.module('framer-motion')` intercepts its

--- a/src/skills/action-intent.test.tsx
+++ b/src/skills/action-intent.test.tsx
@@ -113,6 +113,6 @@ describe('SkillsView palette action intents', () => {
 
     const dialog = await waitForElement(() => screen.queryByRole('alertdialog'))
     expect(within(dialog).getByText('Delete Skill A?')).toBeInTheDocument()
-    expect(within(dialog).getByText('Skill B')).toBeInTheDocument()
+    expect(within(dialog).getByText(/One skill references this/)).toBeInTheDocument()
   })
 })

--- a/src/test-utils/framer-motion-mock.ts
+++ b/src/test-utils/framer-motion-mock.ts
@@ -22,6 +22,18 @@ import { createElement, useRef, type ReactNode } from 'react'
  * suite against the real animation runtime. Load the module under test with a
  * top-level `await import(...)` placed after this import instead.
  *
+ * IMPORTANT: the side-effect import is NOT enough when the whole suite runs
+ * in one process (`bun test --randomize`): whichever test file evaluates this
+ * module first triggers the `mock.module` call, and every later importer gets
+ * a cache hit that re-runs nothing. If real framer-motion was already linked
+ * by files that ran in between, the registration no longer intercepts new
+ * imports and the suite silently falls back to the real runtime — an
+ * order-dependent CI failure that surfaces on unrelated PRs. Tests that must
+ * be shielded — anything asserting on `animateSpy` —
+ * should call `registerFramerMotionMock()` in their own module scope,
+ * before dynamically importing the module under test, to force a fresh
+ * registration regardless of which file evaluated this module first.
+ *
  * The motion-tag Proxy caches the per-tag component so React sees a stable
  * component identity across renders — without this, `<m.ul>` was returning a
  * fresh function on every access, which produced "Maximum update depth
@@ -95,17 +107,23 @@ export const animateSpy = mock((value: MockMotionValue, target: unknown, _transi
 /** Spy for gestures started through Framer Motion's external drag controls. */
 const dragControlsStartSpy = mock(() => {})
 
-mock.module('framer-motion', () => ({
-  AnimatePresence: ({ children }: { children: ReactNode }) => children,
-  LayoutGroup: ({ children }: { children: ReactNode }) => children,
-  LazyMotion: ({ children }: { children: ReactNode }) => children,
-  domAnimation: {},
-  domMax: {},
-  m: motionTagProxy,
-  motion: motionTagProxy,
-  animate: animateSpy,
-  useDragControls: () => ({ start: dragControlsStartSpy }),
-  useMotionValue: (initial: unknown) => useStableMotionValue(initial),
-  useReducedMotion: () => false,
-  useTransform: () => useStableMotionValue(0),
-}))
+/** (Re-)registers the `framer-motion` module mock. See the module docs above
+ *  for when the side-effect import alone is not enough. */
+export const registerFramerMotionMock = () => {
+  mock.module('framer-motion', () => ({
+    AnimatePresence: ({ children }: { children: ReactNode }) => children,
+    LayoutGroup: ({ children }: { children: ReactNode }) => children,
+    LazyMotion: ({ children }: { children: ReactNode }) => children,
+    domAnimation: {},
+    domMax: {},
+    m: motionTagProxy,
+    motion: motionTagProxy,
+    animate: animateSpy,
+    useDragControls: () => ({ start: dragControlsStartSpy }),
+    useMotionValue: (initial: unknown) => useStableMotionValue(initial),
+    useReducedMotion: () => false,
+    useTransform: () => useStableMotionValue(0),
+  }))
+}
+
+registerFramerMotionMock()


### PR DESCRIPTION
## Summary

Fixes the two test failures currently breaking `main` CI (surfaced on unrelated PRs, e.g. [this run](https://github.com/thunderbird/thunderbolt/actions/runs/31113371301/job/92656794610)):

- **`SkillsView palette action intents › routes a remove intent through the dependents-aware confirm when referenced`** — deterministic failure from two PRs crossing: #1179 (merged Aug 3) replaced the dependents dialog's clickable dependent list with prose, updating `skills-view.test.tsx`, while #1176 (merged Aug 5, authored before that) added `action-intent.test.tsx` still asserting the old dialog content ("Skill B" listed). The assertion now targets the prose copy (`/One skill references this/`), matching the sibling test updated in #1179, and still proves the remove intent routes through the dependents-aware confirm.

- **`MobileSidebar › supports Escape dismissal and reports when closing settles`** — order-dependent failure under `bun test --randomize`. The framer-motion `mock.module` registration is a side effect of importing `framer-motion-mock`, which only evaluates once per process. When another test file evaluates it first (after real framer-motion was already linked by earlier files), the registration no longer intercepts new imports, and `mobile-sidebar.test.tsx`'s import becomes a cache hit that re-runs nothing — its dynamic `import('./mobile-sidebar')` then links the real animation runtime and `animateSpy` never records. The registration is now extracted into an exported `registerFramerMotionMock()` (the side-effect import still works), and `mobile-sidebar.test.tsx` — the only suite asserting on `animateSpy` — calls it explicitly before the dynamic import, forcing a fresh registration regardless of evaluation order. The hazard is documented in the mock's module docs.

## Test plan

- [x] `bun test --cwd=src --randomize --seed=647566972` (the exact seed of the failing CI run): 0 failures (was 2)
- [x] 11 additional runs with random seeds: all green
- [x] `bun run test` (src + shared): green
- [x] `bun run type-check`: green
