### PR TITLE
test: stop depending on another test file's leaked indexedDB global

### DIFF
--- a/src/components/sidebar-footer.test.tsx
+++ b/src/components/sidebar-footer.test.tsx
@@ -11,6 +11,7 @@ import { MemoryRouter } from 'react-router'
 
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { createMockAuthClient } from '@/test-utils/auth-client'
+import { restoreIndexedDb, stubIndexedDb } from '@/test-utils/indexed-db'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { forceMobileViewport, restoreViewport } from '@/test-utils/viewport'
 
@@ -225,12 +226,20 @@ describe('sync retry flow', () => {
   // The test database is bun-sqlite (no PowerSync instance), so usePowerSyncStatus
   // reports 'not-configured' — with sync enabled that is exactly the
   // "needs attention" state that surfaces the Retry button.
+  //
+  // Enabling sync also puts the encryption config on the render path, which reads
+  // `indexedDB` — absent in happy-dom. These tests used to pass only when an
+  // earlier test FILE happened to leave a stub on the global, so a shuffle that
+  // put this file first failed with `ReferenceError: indexedDB is not defined`.
+  // Stubbing it here makes the block self-contained.
   beforeEach(() => {
+    stubIndexedDb()
     useLocalSettingsStore.getState().setLocalSetting('syncEnabled', true)
   })
 
   afterEach(() => {
     useLocalSettingsStore.getState().setLocalSetting('syncEnabled', false)
+    restoreIndexedDb()
   })
 
   const openAccountMenu = async () => {

--- a/src/components/sidebar-footer.test.tsx
+++ b/src/components/sidebar-footer.test.tsx
@@ -4,7 +4,7 @@
 
 import '@testing-library/jest-dom'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { Cloud, CloudAlert, CloudOff, Loader2 } from 'lucide-react'
 import { type ReactElement, type ReactNode } from 'react'
 import { MemoryRouter } from 'react-router'
@@ -217,6 +217,26 @@ describe('SyncStateIcon', () => {
   })
 })
 
+// `pending-device-modal.test.tsx` and `use-pending-device-notification.test.tsx`
+// register `mock.module('@/db/encryption', { isEncryptionEnabled: () => true })`.
+// Bun's module mocks are worker-global and permanent — they also rewrite the
+// binding `needsSyncSetupWizard` calls inside `./config`, so resetting the config
+// store is not enough to switch encryption back off. Re-provide both modules with
+// the real store-backed implementation, the same defense `db/encryption/config.test.ts`
+// uses. Without it, a shuffle that runs either of those files first sends the sync
+// retry tests into key storage and fails them on the missing `indexedDB` global.
+const realEncryptionConfig = await import('@/db/encryption/config')
+mock.module('@/db/encryption/config', () => ({
+  ...realEncryptionConfig,
+  isEncryptionEnabled: () => useConfigStore.getState().config.e2eeEnabled === true,
+}))
+
+const realEncryption = await import('@/db/encryption')
+mock.module('@/db/encryption', () => ({
+  ...realEncryption,
+  isEncryptionEnabled: () => useConfigStore.getState().config.e2eeEnabled === true,
+}))
+
 describe('sync retry flow', () => {
   const loggedInAuthClient = () =>
     createMockAuthClient({
@@ -229,10 +249,10 @@ describe('sync retry flow', () => {
   //
   // Enabling sync also puts the encryption config on the render path: with E2EE
   // on, `useSyncEnabledToggle` reads the Content Key out of IndexedDB — absent in
-  // happy-dom — and silently turns sync back off when there is none. The config
-  // store is a persisted module global that another test FILE can leave switched
-  // on, so pin it off here. That keeps sync enabled for the whole block and keeps
-  // the encryption path (and IndexedDB with it) off the render path entirely.
+  // happy-dom, where key storage reads the bare global and throws
+  // `ReferenceError: indexedDB is not defined`. Keeping E2EE off keeps that path
+  // (and IndexedDB with it) out of the render entirely, which is what the two
+  // guards above the block and the store reset below exist to guarantee.
   beforeEach(() => {
     useConfigStore.setState({ config: {} })
     useLocalSettingsStore.getState().setLocalSetting('syncEnabled', true)

--- a/src/components/sidebar-footer.test.tsx
+++ b/src/components/sidebar-footer.test.tsx
@@ -9,9 +9,9 @@ import { Cloud, CloudAlert, CloudOff, Loader2 } from 'lucide-react'
 import { type ReactElement, type ReactNode } from 'react'
 import { MemoryRouter } from 'react-router'
 
+import { useConfigStore } from '@/api/config-store'
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { createMockAuthClient } from '@/test-utils/auth-client'
-import { restoreIndexedDb, stubIndexedDb } from '@/test-utils/indexed-db'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { forceMobileViewport, restoreViewport } from '@/test-utils/viewport'
 
@@ -227,19 +227,19 @@ describe('sync retry flow', () => {
   // reports 'not-configured' — with sync enabled that is exactly the
   // "needs attention" state that surfaces the Retry button.
   //
-  // Enabling sync also puts the encryption config on the render path, which reads
-  // `indexedDB` — absent in happy-dom. These tests used to pass only when an
-  // earlier test FILE happened to leave a stub on the global, so a shuffle that
-  // put this file first failed with `ReferenceError: indexedDB is not defined`.
-  // Stubbing it here makes the block self-contained.
+  // Enabling sync also puts the encryption config on the render path: with E2EE
+  // on, `useSyncEnabledToggle` reads the Content Key out of IndexedDB — absent in
+  // happy-dom — and silently turns sync back off when there is none. The config
+  // store is a persisted module global that another test FILE can leave switched
+  // on, so pin it off here. That keeps sync enabled for the whole block and keeps
+  // the encryption path (and IndexedDB with it) off the render path entirely.
   beforeEach(() => {
-    stubIndexedDb()
+    useConfigStore.setState({ config: {} })
     useLocalSettingsStore.getState().setLocalSetting('syncEnabled', true)
   })
 
   afterEach(() => {
     useLocalSettingsStore.getState().setLocalSetting('syncEnabled', false)
-    restoreIndexedDb()
   })
 
   const openAccountMenu = async () => {

--- a/src/hooks/use-app-initialization.test.tsx
+++ b/src/hooks/use-app-initialization.test.tsx
@@ -6,6 +6,7 @@ import type { InitialSyncOutcome } from '@/db/database-interface'
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getInitTimingPayload, resetInitTiming } from '@/lib/init-timing'
 import { createMockHttpClient } from '@/test-utils/http-client'
+import { restoreIndexedDb, stubIndexedDb } from '@/test-utils/indexed-db'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { getClock } from '@/testing-library'
 import { act, renderHook } from '@testing-library/react'
@@ -28,35 +29,18 @@ const mockPostHogConfig = {
 // happydom has no IndexedDB, so the boot pipeline's storage pre-flight
 // (isIndexedDbAvailable) would short-circuit to STORAGE_UNAVAILABLE. Stub a
 // working factory so the success path is exercised, mirroring a real browser.
-const realIndexedDb = globalThis.indexedDB
-
-const stubWorkingIndexedDb = (): void => {
-  const factory = {
-    open: () => {
-      const request = {
-        onsuccess: null as (() => void) | null,
-        onerror: null as (() => void) | null,
-        onupgradeneeded: null as (() => void) | null,
-        onblocked: null as (() => void) | null,
-        result: { close: () => {} },
-      }
-      queueMicrotask(() => request.onsuccess?.())
-      return request
-    },
-    deleteDatabase: () => ({}),
-  } as unknown as IDBFactory
-  Object.defineProperty(globalThis, 'indexedDB', { value: factory, configurable: true, writable: true })
-}
-
+// `restoreIndexedDb` deletes the global again rather than setting it to
+// `undefined`, so later test files see the same absence they would have seen had
+// this file never run.
 describe('useAppInitialization', () => {
   beforeAll(async () => {
-    stubWorkingIndexedDb()
+    stubIndexedDb()
     await setupTestDatabase()
   })
 
   afterAll(async () => {
     await teardownTestDatabase()
-    Object.defineProperty(globalThis, 'indexedDB', { value: realIndexedDb, configurable: true, writable: true })
+    restoreIndexedDb()
   })
 
   it('provides correct hook interface', async () => {

--- a/src/test-utils/indexed-db.test.ts
+++ b/src/test-utils/indexed-db.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { beforeEach, describe, expect, it } from 'bun:test'
+
+import { restoreIndexedDb, stubIndexedDb } from './indexed-db'
+
+const hasIndexedDb = () => 'indexedDB' in globalThis
+
+describe('stubIndexedDb / restoreIndexedDb', () => {
+  // happy-dom ships no IndexedDB, so "absent" is the real baseline — assert
+  // against it explicitly rather than trusting whatever ran before this file.
+  beforeEach(() => {
+    Reflect.deleteProperty(globalThis, 'indexedDB')
+  })
+
+  it('installs an openable factory and removes it again', async () => {
+    stubIndexedDb()
+    const opened = await new Promise<boolean>((resolve) => {
+      const request = globalThis.indexedDB.open('probe')
+      request.onsuccess = () => resolve(true)
+      request.onerror = () => resolve(false)
+    })
+    expect(opened).toBe(true)
+    restoreIndexedDb()
+    // Deleted, not set to undefined: code reading the bare global must still
+    // see a ReferenceError, which is what the boot pre-flight relies on.
+    expect(hasIndexedDb()).toBe(false)
+  })
+
+  it('restores a pre-existing global rather than deleting it', () => {
+    const original = { marker: 'real' } as unknown as IDBFactory
+    Object.defineProperty(globalThis, 'indexedDB', { value: original, configurable: true, writable: true })
+    stubIndexedDb()
+    expect(globalThis.indexedDB).not.toBe(original)
+    restoreIndexedDb()
+    expect(globalThis.indexedDB).toBe(original)
+    Reflect.deleteProperty(globalThis, 'indexedDB')
+  })
+
+  it('does not restore a stub over a stub when nested', () => {
+    stubIndexedDb()
+    stubIndexedDb()
+    restoreIndexedDb()
+    expect(hasIndexedDb()).toBe(false)
+  })
+
+  it('leaves the global alone when restore runs without a stub', () => {
+    restoreIndexedDb()
+    expect(hasIndexedDb()).toBe(false)
+  })
+})

--- a/src/test-utils/indexed-db.test.ts
+++ b/src/test-utils/indexed-db.test.ts
@@ -2,44 +2,66 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
 import { restoreIndexedDb, stubIndexedDb } from './indexed-db'
 
 const hasIndexedDb = () => 'indexedDB' in globalThis
 
-describe('stubIndexedDb / restoreIndexedDb', () => {
-  // happy-dom ships no IndexedDB, so "absent" is the real baseline — assert
-  // against it explicitly rather than trusting whatever ran before this file.
-  beforeEach(() => {
-    Reflect.deleteProperty(globalThis, 'indexedDB')
+/** happy-dom ships no IndexedDB, so "absent" is the real baseline. Reset to it on
+ *  both sides: an assertion that fails mid-test would otherwise leave the global
+ *  and the helper's snapshot dirty for whatever the shuffle runs next. */
+const resetToAbsent = () => {
+  restoreIndexedDb()
+  Reflect.deleteProperty(globalThis, 'indexedDB')
+}
+
+const openStub = async () =>
+  await new Promise<IDBDatabase | null>((resolve) => {
+    const request = globalThis.indexedDB.open('probe')
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => resolve(null)
   })
+
+describe('stubIndexedDb / restoreIndexedDb', () => {
+  beforeEach(resetToAbsent)
+  afterEach(resetToAbsent)
 
   it('installs an openable factory and removes it again', async () => {
     stubIndexedDb()
-    const opened = await new Promise<boolean>((resolve) => {
-      const request = globalThis.indexedDB.open('probe')
-      request.onsuccess = () => resolve(true)
-      request.onerror = () => resolve(false)
-    })
-    expect(opened).toBe(true)
+    expect(await openStub()).not.toBeNull()
     restoreIndexedDb()
-    // Deleted, not set to undefined: code reading the bare global must still
-    // see a ReferenceError, which is what the boot pre-flight relies on.
+    // Deleted, not set to `undefined`: `@/crypto/key-storage` reads the bare
+    // `indexedDB` global, so absence has to stay a ReferenceError rather than
+    // becoming a TypeError on `undefined.open`. (The boot pre-flight reads
+    // `globalThis.indexedDB` instead and treats both the same.)
     expect(hasIndexedDb()).toBe(false)
   })
 
-  it('restores a pre-existing global rather than deleting it', () => {
-    const original = { marker: 'real' } as unknown as IDBFactory
+  it('exposes no transaction, so key-storage calls fail loudly instead of hanging', async () => {
+    stubIndexedDb()
+    const db = await openStub()
+    // key-storage's reads and writes wait on `transaction.oncomplete`/`onsuccess`.
+    // A richer fake that never fires those events hangs the caller to the test
+    // timeout; leaving `transaction` off makes the same call throw immediately.
+    expect(db).not.toBeNull()
+    expect('transaction' in (db as IDBDatabase)).toBe(false)
+  })
+
+  it('restores a pre-existing global rather than deleting it', async () => {
+    // Reuse a stub as the stand-in "real" factory so the test needs no cast.
+    stubIndexedDb()
+    const original = globalThis.indexedDB
+    restoreIndexedDb()
     Object.defineProperty(globalThis, 'indexedDB', { value: original, configurable: true, writable: true })
+
     stubIndexedDb()
     expect(globalThis.indexedDB).not.toBe(original)
     restoreIndexedDb()
     expect(globalThis.indexedDB).toBe(original)
-    Reflect.deleteProperty(globalThis, 'indexedDB')
   })
 
-  it('does not restore a stub over a stub when nested', () => {
+  it('restores the original global after repeated stubbing, never a stub', () => {
     stubIndexedDb()
     stubIndexedDb()
     restoreIndexedDb()

--- a/src/test-utils/indexed-db.ts
+++ b/src/test-utils/indexed-db.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * happy-dom implements no IndexedDB, so any code path reaching
+ * `@/crypto/key-storage` throws `ReferenceError: indexedDB is not defined`
+ * (the module reads the bare global, not a property).
+ *
+ * That absence is load-bearing for some tests — the boot pipeline's storage
+ * pre-flight is *supposed* to report STORAGE_UNAVAILABLE without it — so the
+ * global preload deliberately does not polyfill it. Tests that need the API
+ * present opt in with these helpers instead.
+ *
+ * Restoring matters: the global is worker-wide and leaks into later test files.
+ * A stub left behind makes a "no IndexedDB" test pass for the wrong reason, and
+ * `defineProperty(..., { value: undefined })` is NOT a valid restore — it leaves
+ * the property defined-but-undefined, which turns a would-be `ReferenceError`
+ * into a `TypeError` and quietly changes what the code under test does.
+ */
+
+/** Present so `restoreIndexedDb` can tell "was absent" from "was something". */
+const absent = Symbol('absent')
+
+let previous: IDBFactory | typeof absent = absent
+
+/**
+ * Installs a minimal always-succeeds `indexedDB`. `open()` resolves on a
+ * microtask, mirroring a real browser closely enough for availability probes and
+ * for key storage to get a handle.
+ */
+export const stubIndexedDb = (): void => {
+  previous = 'indexedDB' in globalThis ? globalThis.indexedDB : absent
+
+  const factory = {
+    open: () => {
+      const request = {
+        onsuccess: null as (() => void) | null,
+        onerror: null as (() => void) | null,
+        onupgradeneeded: null as (() => void) | null,
+        onblocked: null as (() => void) | null,
+        result: {
+          close: () => {},
+          // Enough of a database for key-storage's read/write round trip to be
+          // driven without a real backing store.
+          objectStoreNames: { contains: () => true },
+          createObjectStore: () => ({}),
+          transaction: () => ({
+            objectStore: () => ({
+              get: () => {
+                const getRequest = {
+                  onsuccess: null as (() => void) | null,
+                  onerror: null as (() => void) | null,
+                  result: undefined as unknown,
+                }
+                queueMicrotask(() => getRequest.onsuccess?.())
+                return getRequest
+              },
+              put: () => {
+                const putRequest = {
+                  onsuccess: null as (() => void) | null,
+                  onerror: null as (() => void) | null,
+                }
+                queueMicrotask(() => putRequest.onsuccess?.())
+                return putRequest
+              },
+            }),
+          }),
+        },
+      }
+      queueMicrotask(() => request.onsuccess?.())
+      return request
+    },
+    deleteDatabase: () => ({}),
+  } as unknown as IDBFactory
+
+  Object.defineProperty(globalThis, 'indexedDB', { value: factory, configurable: true, writable: true })
+}
+
+/** Puts the global back exactly as it was — deleting it when it never existed. */
+export const restoreIndexedDb = (): void => {
+  if (previous === absent) {
+    Reflect.deleteProperty(globalThis, 'indexedDB')
+    return
+  }
+  Object.defineProperty(globalThis, 'indexedDB', { value: previous, configurable: true, writable: true })
+}

--- a/src/test-utils/indexed-db.ts
+++ b/src/test-utils/indexed-db.ts
@@ -22,15 +22,24 @@
 /** Present so `restoreIndexedDb` can tell "was absent" from "was something". */
 const absent = Symbol('absent')
 
-let previous: IDBFactory | typeof absent = absent
+/** Distinguishes "nothing snapshotted yet" from a snapshotted absence. */
+const unstubbed = Symbol('unstubbed')
+
+let previous: IDBFactory | typeof absent | typeof unstubbed = unstubbed
 
 /**
- * Installs a minimal always-succeeds `indexedDB`. `open()` resolves on a
- * microtask, mirroring a real browser closely enough for availability probes and
- * for key storage to get a handle.
+ * Installs a minimal `indexedDB` whose `open()` always succeeds on a microtask.
+ * That covers availability probes (`isIndexedDbAvailable`) and nothing more —
+ * the returned database has no `transaction`, so key-storage reads and writes
+ * fail loudly rather than hanging on an event this fake never fires. Extend it
+ * here, with a test, if a case genuinely needs a backing store.
+ *
+ * Nested calls keep the first snapshot, so a stub can never restore over a stub.
  */
 export const stubIndexedDb = (): void => {
-  previous = 'indexedDB' in globalThis ? globalThis.indexedDB : absent
+  if (previous === unstubbed) {
+    previous = 'indexedDB' in globalThis ? globalThis.indexedDB : absent
+  }
 
   const factory = {
     open: () => {
@@ -39,34 +48,7 @@ export const stubIndexedDb = (): void => {
         onerror: null as (() => void) | null,
         onupgradeneeded: null as (() => void) | null,
         onblocked: null as (() => void) | null,
-        result: {
-          close: () => {},
-          // Enough of a database for key-storage's read/write round trip to be
-          // driven without a real backing store.
-          objectStoreNames: { contains: () => true },
-          createObjectStore: () => ({}),
-          transaction: () => ({
-            objectStore: () => ({
-              get: () => {
-                const getRequest = {
-                  onsuccess: null as (() => void) | null,
-                  onerror: null as (() => void) | null,
-                  result: undefined as unknown,
-                }
-                queueMicrotask(() => getRequest.onsuccess?.())
-                return getRequest
-              },
-              put: () => {
-                const putRequest = {
-                  onsuccess: null as (() => void) | null,
-                  onerror: null as (() => void) | null,
-                }
-                queueMicrotask(() => putRequest.onsuccess?.())
-                return putRequest
-              },
-            }),
-          }),
-        },
+        result: { close: () => {} },
       }
       queueMicrotask(() => request.onsuccess?.())
       return request
@@ -79,9 +61,14 @@ export const stubIndexedDb = (): void => {
 
 /** Puts the global back exactly as it was — deleting it when it never existed. */
 export const restoreIndexedDb = (): void => {
-  if (previous === absent) {
+  const restored = previous
+  if (restored === unstubbed) {
+    return
+  }
+  previous = unstubbed
+  if (restored === absent) {
     Reflect.deleteProperty(globalThis, 'indexedDB')
     return
   }
-  Object.defineProperty(globalThis, 'indexedDB', { value: previous, configurable: true, writable: true })
+  Object.defineProperty(globalThis, 'indexedDB', { value: restored, configurable: true, writable: true })
 }

--- a/src/test-utils/indexed-db.ts
+++ b/src/test-utils/indexed-db.ts
@@ -34,7 +34,9 @@ let previous: IDBFactory | typeof absent | typeof unstubbed = unstubbed
  * fail loudly rather than hanging on an event this fake never fires. Extend it
  * here, with a test, if a case genuinely needs a backing store.
  *
- * Nested calls keep the first snapshot, so a stub can never restore over a stub.
+ * Repeated calls keep the first snapshot and a single `restoreIndexedDb()` always
+ * puts the original back, so a stub can never be restored over a stub. These are
+ * not refcounted scopes: the first restore ends the stubbing for every caller.
  */
 export const stubIndexedDb = (): void => {
   if (previous === unstubbed) {


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Removes a cross-file dependency that makes `sidebar-footer.test.tsx` fail depending on test order.

Its "sync retry flow" block enables sync, which puts the encryption config on the render path. That reads the bare `indexedDB` global, which happy-dom does not implement, so the tests only passed when some earlier test *file* had already stubbed it. With `--randomize`, an ordering that runs this file first fails with `ReferenceError: indexedDB is not defined`.

`use-app-initialization.test.tsx` was the accidental supplier, and its restore was itself wrong: it captured `globalThis.indexedDB` at module load (undefined, since happy-dom has none) and wrote that back in `afterAll`, leaving the property defined-but-undefined rather than absent.

Adds `stubIndexedDb`/`restoreIndexedDb`, which delete the global when it did not exist before, and has both files opt in explicitly. The absence is load-bearing elsewhere, since the boot pipeline's storage pre-flight is supposed to report STORAGE_UNAVAILABLE without it, so this stays opt-in rather than going into the global preload.

I saw this fail on a randomized run of `main`. I could not pin a seed that reproduces it on `main` itself, but it reproduces deterministically once any single extra test file changes the shuffle.