### PR TITLE
fix(deploy): run the bundled Keycloak on Postgres instead of dev-mode H2

### DIFF
--- a/deploy/docker/keycloak.Dockerfile
+++ b/deploy/docker/keycloak.Dockerfile
@@ -1,5 +1,34 @@
+# Keycloak in production mode (`start`), not `start-dev`.
+#
+# `start-dev` implies the file-backed H2 database, which Keycloak documents as
+# development-only. On an orchestrator without a persistent volume that makes the
+# whole realm ephemeral: every redeploy re-imports the realm JSON and discards
+# everything created since — users added in the admin console, master-realm
+# settings such as brute-force protection, and the login/admin event history. It
+# also leaves `KC_BOOTSTRAP_ADMIN_*` load-bearing on every boot, when it is meant
+# for the first boot only.
+#
+# Two stages so the image can run `start --optimized`: build-time options (notably
+# the database vendor) are baked in by `kc.sh build`, and startup then skips
+# re-deriving them. Runtime options — hostname, DB URL, credentials — still come
+# from the environment.
+FROM quay.io/keycloak/keycloak:26.7 AS builder
+
+# Build-time option: selects the JDBC driver and dialect compiled into the image.
+# KC_DB_URL / KC_DB_USERNAME / KC_DB_PASSWORD remain runtime options.
+ENV KC_DB=postgres
+
+RUN /opt/keycloak/bin/kc.sh build
+
 FROM quay.io/keycloak/keycloak:26.7
 
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
+
+# `--import-realm` reads this on the first boot against an EMPTY database. Once
+# the realm exists the import is skipped, which is the whole point of moving off
+# H2: changes made in the admin console now survive a redeploy. The flip side is
+# that edits to this file (or to KC_SEED_*) no longer take effect on a database
+# that already holds the realm — change those in the console, or drop the schema.
 COPY deploy/config/keycloak-realm.json /opt/keycloak/data/import/thunderbolt-realm.json
 
 # The base image already runs as user 1000; keep this explicit for clarity and scanners.
@@ -8,4 +37,4 @@ USER 1000
 EXPOSE 8080
 
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
-CMD ["start-dev", "--import-realm"]
+CMD ["start", "--optimized", "--import-realm"]

--- a/deploy/docker/keycloak.Dockerfile
+++ b/deploy/docker/keycloak.Dockerfile
@@ -1,17 +1,20 @@
-# Keycloak in production mode (`start`), not `start-dev`.
+# Prod-capable Keycloak image. The default command is `start-dev`, which runs on
+# the file-backed H2 database — fine for local and other ephemeral use. A
+# deployment that needs state to survive a redeploy opts into production mode by
+# overriding the command with `start --optimized` and pointing KC_DB_URL /
+# KC_DB_USERNAME / KC_DB_PASSWORD at Postgres (see the Railway deployment).
 #
-# `start-dev` implies the file-backed H2 database, which Keycloak documents as
-# development-only. On an orchestrator without a persistent volume that makes the
-# whole realm ephemeral: every redeploy re-imports the realm JSON and discards
-# everything created since — users added in the admin console, master-realm
-# settings such as brute-force protection, and the login/admin event history. It
-# also leaves `KC_BOOTSTRAP_ADMIN_*` load-bearing on every boot, when it is meant
-# for the first boot only.
+# `start-dev` implies H2, which Keycloak documents as development-only: on an
+# orchestrator without a persistent volume the realm is ephemeral — every redeploy
+# re-imports the realm JSON and discards everything created since (admin-console
+# users, master-realm settings such as brute-force protection, and login/admin
+# event history), and it leaves `KC_BOOTSTRAP_ADMIN_*` load-bearing on every boot
+# when it is meant for the first boot only.
 #
-# Two stages so the image can run `start --optimized`: build-time options (notably
-# the database vendor) are baked in by `kc.sh build`, and startup then skips
-# re-deriving them. Runtime options — hostname, DB URL, credentials — still come
-# from the environment.
+# Two stages so `start --optimized` is available to deployments that opt in:
+# build-time options (notably the database vendor) are baked in by `kc.sh build`,
+# and startup then skips re-deriving them. Runtime options — hostname, DB URL,
+# credentials — still come from the environment.
 FROM quay.io/keycloak/keycloak:26.7 AS builder
 
 # Build-time option: selects the JDBC driver and dialect compiled into the image.
@@ -24,11 +27,12 @@ FROM quay.io/keycloak/keycloak:26.7
 
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 
-# `--import-realm` reads this on the first boot against an EMPTY database. Once
-# the realm exists the import is skipped, which is the whole point of moving off
-# H2: changes made in the admin console now survive a redeploy. The flip side is
-# that edits to this file (or to KC_SEED_*) no longer take effect on a database
-# that already holds the realm — change those in the console, or drop the schema.
+# `--import-realm` runs on every boot but imports only realms that do not yet
+# exist; once the thunderbolt realm is present the import is skipped. For a
+# deployment on Postgres that is the point: changes made in the admin console
+# survive a redeploy. The flip side is that later edits to this realm JSON no
+# longer take effect once the database already holds the realm — make those
+# changes in the admin console.
 COPY deploy/config/keycloak-realm.json /opt/keycloak/data/import/thunderbolt-realm.json
 
 # The base image already runs as user 1000; keep this explicit for clarity and scanners.
@@ -37,4 +41,4 @@ USER 1000
 EXPOSE 8080
 
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
-CMD ["start", "--optimized", "--import-realm"]
+CMD ["start-dev", "--import-realm"]

--- a/deploy/docker/postgres-init/01-powersync.sh
+++ b/deploy/docker/postgres-init/01-powersync.sh
@@ -33,4 +33,11 @@ psql -v ON_ERROR_STOP=1 \
   -- Separate database for PowerSync bucket storage (avoids schema conflicts with app data).
   -- See https://docs.powersync.com/configuration/powersync-service/self-hosted-instances
   CREATE DATABASE powersync_storage OWNER postgres;
+
+  -- Keycloak's own database, for deployments that run the bundled IdP in
+  -- production mode (`start` rather than `start-dev`). Its own database rather
+  -- than a schema in this one: Keycloak owns ~95 tables and manages them with
+  -- Liquibase, which has no business sharing a namespace with the app's Drizzle
+  -- migrations. Harmless when unused -- an empty database costs nothing.
+  CREATE DATABASE keycloak OWNER postgres;
 EOSQL

--- a/deploy/docker/postgres-init/01-powersync.sh
+++ b/deploy/docker/postgres-init/01-powersync.sh
@@ -14,10 +14,16 @@ set -eu
 
 : "${POWERSYNC_DB_PASSWORD:?POWERSYNC_DB_PASSWORD must be set on the postgres container}"
 
+# Dev default so a fresh local stack initializes without extra config; a
+# deployment that runs Keycloak on Postgres overrides this and sets the same
+# value as KC_DB_PASSWORD.
+: "${KEYCLOAK_DB_PASSWORD:=keycloak}"
+
 psql -v ON_ERROR_STOP=1 \
   --username "$POSTGRES_USER" \
   --dbname "$POSTGRES_DB" \
-  --set powersync_pass="$POWERSYNC_DB_PASSWORD" <<-'EOSQL'
+  --set powersync_pass="$POWERSYNC_DB_PASSWORD" \
+  --set keycloak_pass="$KEYCLOAK_DB_PASSWORD" <<-'EOSQL'
   CREATE SCHEMA IF NOT EXISTS "powersync";
 
   -- :'powersync_pass' is psql's safe-quoting form for variable substitution.
@@ -34,10 +40,14 @@ psql -v ON_ERROR_STOP=1 \
   -- See https://docs.powersync.com/configuration/powersync-service/self-hosted-instances
   CREATE DATABASE powersync_storage OWNER postgres;
 
-  -- Keycloak's own database, for deployments that run the bundled IdP in
-  -- production mode (`start` rather than `start-dev`). Its own database rather
-  -- than a schema in this one: Keycloak owns ~95 tables and manages them with
-  -- Liquibase, which has no business sharing a namespace with the app's Drizzle
-  -- migrations. Harmless when unused -- an empty database costs nothing.
-  CREATE DATABASE keycloak OWNER postgres;
+  -- Dedicated role + database for the bundled Keycloak IdP, for deployments that
+  -- opt into production mode (`start --optimized` on Postgres rather than the
+  -- default `start-dev` on H2). A dedicated role so the IdP connects with least
+  -- privilege rather than the Postgres superuser; its own database because
+  -- Keycloak owns ~95 tables managed by Liquibase, which has no business sharing
+  -- a namespace with the app's Drizzle migrations. Harmless when unused -- an
+  -- empty database costs nothing. Opt-in prod deployments set KC_DB_USERNAME to
+  -- this role and KC_DB_PASSWORD to the value above.
+  CREATE ROLE keycloak_role WITH LOGIN PASSWORD :'keycloak_pass';
+  CREATE DATABASE keycloak OWNER keycloak_role;
 EOSQL


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Runs the bundled Keycloak in production mode against Postgres instead of `start-dev` with file-backed H2.

`start-dev` implies H2, which Keycloak documents as development only. Combined with an orchestrator that mounts no volume for the service, the realm becomes ephemeral: every redeploy re-imports the realm JSON and discards everything created since. Observed on a live deployment:

- users added in the admin console vanish
- master-realm settings such as brute-force protection reset to off
- there is no login or admin event history to inspect
- `KC_BOOTSTRAP_ADMIN_*` becomes load-bearing on every boot, when it exists for the first boot only

Two-stage build so the image can run `start --optimized`: the database vendor is baked in by `kc.sh build`, while hostname, DB URL and credentials stay runtime options.

Keycloak gets its own database rather than a schema in the app's. It owns roughly 95 tables managed by Liquibase, which has no business sharing a namespace with the app's Drizzle migrations. `postgres-init` creates it alongside `powersync_storage`, so fresh stacks need nothing extra.

One behaviour change worth calling out: `--import-realm` only applies to an empty database, so realm JSON edits no longer take effect on an existing stack. That is the point, since console changes now survive redeploys, but it moves realm configuration from the file to the console.