### PR TITLE
fix(deploy): cache the PowerSync wasm and stop caching the SPA shell

### DIFF
--- a/deploy/config/nginx.conf.template
+++ b/deploy/config/nginx.conf.template
@@ -55,6 +55,30 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # PowerSync's wa-sqlite wasm/worker assets, copied into public/@powersync by
+    # the `copy-powersync-assets` Vite plugin. Content-hashed filenames like
+    # `3322bc84de986b63c2cd.wasm`, so they are as immutable as /assets/ -- and they
+    # total ~17MB, which is worth not revalidating on every boot. Without this they
+    # fall through to `location /`, which sets no caching directives at all.
+    location /@powersync/ {
+        include /etc/nginx/snippets/security-headers.conf;
+        expires 1y;
+        # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+        add_header Cache-Control "public, immutable";
+    }
+
+    # The SPA shell decides which hashed entry chunk a client loads, so a cached
+    # copy pins the client to an old build. `no-cache` (not `no-store`) still
+    # allows a conditional request, so the common case stays a cheap 304.
+    #
+    # The `/index.html` fallback below is a URI, so nginx does an internal redirect
+    # and re-runs location matching: deep links like /settings land here too.
+    location = /index.html {
+        include /etc/nginx/snippets/security-headers.conf;
+        # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+        add_header Cache-Control "no-cache" always;
+    }
+
     # Block source maps (they are uploaded to PostHog for error tracking, not served publicly)
     location ~* \.map$ {
         return 404;

--- a/deploy/config/nginx.conf.template
+++ b/deploy/config/nginx.conf.template
@@ -55,11 +55,25 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # PowerSync's wa-sqlite wasm/worker assets, copied into public/@powersync by
-    # the `copy-powersync-assets` Vite plugin. Content-hashed filenames like
-    # `3322bc84de986b63c2cd.wasm`, so they are as immutable as /assets/ -- and they
-    # total ~17MB, which is worth not revalidating on every boot. Without this they
-    # fall through to `location /`, which sets no caching directives at all.
+    # PowerSync's wa-sqlite workers, copied into public/@powersync by the
+    # `copy-powersync-assets` Vite plugin. Unlike the wasm below, the .umd.js files
+    # (worker/WASQLiteDB.umd.js, worker/SharedSyncImplementation.umd.js,
+    # index.umd.js) have STABLE names and are loaded by fixed path in
+    # src/db/powersync/database.ts, so `immutable` would pin a client to an old
+    # worker across a @powersync/web upgrade -- the same stale-build problem the
+    # index.html block below fixes. Revalidate them like index.html; the common
+    # case stays a cheap 304. This regex overrides the prefix block below.
+    location ~ ^/@powersync/.*\.umd\.js$ {
+        include /etc/nginx/snippets/security-headers.conf;
+        # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+        add_header Cache-Control "no-cache" always;
+    }
+
+    # The wasm alongside those workers IS content-hashed (e.g.
+    # `3322bc84de986b63c2cd.wasm`), so it is as immutable as /assets/ -- roughly
+    # 10MB of servable content worth not revalidating on every boot (the larger
+    # on-disk figure includes .map files the rule below already 404s). Without this
+    # it falls through to `location /`, which sets no caching directives at all.
     location /@powersync/ {
         include /etc/nginx/snippets/security-headers.conf;
         expires 1y;
@@ -74,6 +88,19 @@ server {
     # The `/index.html` fallback below is a URI, so nginx does an internal redirect
     # and re-runs location matching: deep links like /settings land here too.
     location = /index.html {
+        include /etc/nginx/snippets/security-headers.conf;
+        # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+        add_header Cache-Control "no-cache" always;
+    }
+
+    # The OAuth callback is a standalone HTML entry document. Like index.html it
+    # should always reflect the latest deploy, so it revalidates (cheap 304)
+    # rather than being served from a stale cache. The remaining public/ statics
+    # (favicons, icons, capture-worklet.js) intentionally fall through to
+    # `location /`: they are not content-hashed, so `immutable` would be wrong,
+    # and the worklet is loaded by fixed path -- browser heuristic caching is the
+    # safe default there.
+    location = /oauth-callback.html {
         include /etc/nginx/snippets/security-headers.conf;
         # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
         add_header Cache-Control "no-cache" always;


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Two nginx caching gaps that pull in opposite directions.

**`/@powersync/` was matched by no location block**, so PowerSync's wa-sqlite assets fell through to `location /` with no caching directives at all. That is roughly 17MB of content-hashed files revalidated on every boot, when they are as immutable as anything under `/assets/`.

**`index.html` had the opposite problem.** It is the shell that names the hashed entry chunk, so a cached copy pins a client to an old build after a deploy. It now sends `no-cache`, which still permits a conditional request, so the common case is a 304 rather than a re-download.

Deep links pick this up too: the SPA fallback is a URI, so nginx does an internal redirect and re-runs location matching, and a request for `/settings` ends up in the `location = /index.html` block.