### PR TITLE
fix: declare macos private api in base tauri config

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,7 +100,7 @@ pub fn create_app() -> tauri::Builder<tauri::Wry> {
     {
         std::env::set_var("JSC_useOMGJIT", "false");
     }
-  
+
     // `transparent: true` now lives only in tauri.macos.conf.json, so the iOS
     // WKWebView is opaque by default. This belt-and-suspenders call keeps it
     // opaque regardless: a non-opaque webview would let the root view

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,6 +20,7 @@
         "visible": false
       }
     ],
+    "macOSPrivateApi": true,
     "security": {
       "csp": {
         "default-src": "'self' tauri: asset:",


### PR DESCRIPTION
## Summary

- The rust CI job has been failing on main since [#1187](https://github.com/thunderbird/thunderbolt/pull/1187): the base `src-tauri/tauri.conf.json` lost `"macOSPrivateApi": true` when the macOS window config moved to the `tauri.macos.conf.json` overlay, but `Cargo.toml` still enables the `macos-private-api` feature. `tauri-build`'s manifest check validates against the base config only (overlays don't participate), so `build.rs` panics on Linux runners: "The `tauri` dependency features on the `Cargo.toml` file does not match the allowlist defined under `tauri.conf.json`." The job is change-gated, so only PRs touching rust paths surface it (e.g. [#1191](https://github.com/thunderbird/thunderbolt/pull/1191)).
- Fix: restore the flag in the base config. It is macOS-only at runtime and harmless elsewhere; #1187's actual goal (scoping transparency/vibrancy window config to macOS) stays intact — the overlay is untouched.
- Also normalizes a trailing-whitespace line in `src-tauri/src/lib.rs` so main's copy matches what the repo's own pre-commit formatter produces (it currently creates spurious rust diffs on any branch whose hooks touch the file).

## Test plan

- [x] `cargo check` + `cargo fmt --check` pass locally (macOS — note the overlay masks the bug there; Linux is the affected path)
- [x] The rust CI job on this PR (Linux) passes — this is the real validation, since this PR touches `src-tauri/**` and wakes the gated job