### PR TITLE
fix: keep built-in Opus sends routable after the opus-5 alias rename

### DIFF
--- a/backend/src/inference/routes.test.ts
+++ b/backend/src/inference/routes.test.ts
@@ -148,6 +148,34 @@ describe('Inference Routes', () => {
       })
     })
 
+    it('routes the legacy opus-4.8 alias to the same Anthropic config as opus-5', async () => {
+      expect(supportedModels['opus-4.8']).toEqual(supportedModels['opus-5'])
+
+      const mockCompletion = createMockStream()
+      mockCreateCompletion.mockImplementation(() => Promise.resolve(mockCompletion))
+
+      const response = await app.handle(
+        new Request('http://localhost/chat/completions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...validRequestBody, model: 'opus-4.8' }),
+        }),
+      )
+
+      expect(response.status).toBe(200)
+      expect(getInferenceClientMock).toHaveBeenCalledWith('anthropic')
+      // Exact (non-partial) match: omitTemperature means the key is absent from the
+      // upstream payload entirely, not just undefined — a missing `temperature` field here
+      // would fail this assertion the same way an unexpected one would.
+      expect(mockCreateCompletion).toHaveBeenCalledWith({
+        model: 'claude-opus-5',
+        messages: validRequestBody.messages,
+        tools: undefined,
+        tool_choice: undefined,
+        stream: true,
+      })
+    })
+
     it('should handle request with tools and tool_choice', async () => {
       const mockCompletion = createMockStream()
       mockCreateCompletion.mockImplementation(() => Promise.resolve(mockCompletion))
@@ -222,7 +250,7 @@ describe('Inference Routes', () => {
       expect(mockCreateCompletion).not.toHaveBeenCalled()
     })
 
-    it('should reject unsupported models', async () => {
+    it('should reject unsupported models with a 400 naming the rejected model', async () => {
       const unsupportedModelRequest = {
         ...validRequestBody,
         model: 'unsupported-model',
@@ -236,8 +264,10 @@ describe('Inference Routes', () => {
         }),
       )
 
-      expect(response.status).toBe(500)
+      expect(response.status).toBe(400)
       expect(mockCreateCompletion).not.toHaveBeenCalled()
+      const body = await response.json()
+      expect(body.error).toContain('unsupported-model')
     })
 
     it('should handle inference API errors gracefully', async () => {
@@ -586,6 +616,50 @@ describe('Inference Routes', () => {
       ])
     })
 
+    it('emits phase timing headers and a structured latency log when rejecting an unknown model', async () => {
+      const entries: Array<{ context: InferenceProxyLatencyLog; message: string }> = []
+      const timestamps = [200, 230, 310]
+      const timingApp = new Elysia().use(
+        createInferenceRoutes({
+          auth: mockAuth,
+          getClient: getInferenceClientMock,
+          logger: {
+            info: (context, message) => entries.push({ context: context as InferenceProxyLatencyLog, message }),
+          },
+          nowFn: () => timestamps.shift() ?? 0,
+        }),
+      )
+
+      const response = await timingApp.handle(
+        new Request('http://localhost/chat/completions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...validRequestBody, model: 'unsupported-model' }),
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      expect(mockCreateCompletion).not.toHaveBeenCalled()
+      expect(response.headers.get('x-proxy-timing')).toBe('pre=30;upstream=80;total=110;attempts=0')
+      expect(response.headers.get('server-timing')).toBe('pre;dur=30, upstream;dur=80, total;dur=110')
+      expect(entries).toEqual([
+        {
+          context: {
+            event: 'inference_proxy_latency',
+            route: '/chat/completions',
+            provider: 'unknown',
+            model: 'unsupported-model',
+            status: 400,
+            preMs: 30,
+            upstreamMs: 80,
+            totalMs: 110,
+            attempts: 0,
+          },
+          message: 'Inference proxy latency',
+        },
+      ])
+    })
+
     it('should handle malformed JSON requests', async () => {
       const response = await app.handle(
         new Request('http://localhost/chat/completions', {
@@ -600,7 +674,7 @@ describe('Inference Routes', () => {
     })
 
     it('exposes only Thunderbolt models handled by the inference proxy', () => {
-      expect(Object.keys(supportedModels)).toEqual(['opus-5', 'deepseek-v4-flash'])
+      expect(Object.keys(supportedModels)).toEqual(['opus-5', 'opus-4.8', 'deepseek-v4-flash'])
     })
 
     it('should handle requests with has_tools flag correctly', async () => {

--- a/backend/src/inference/routes.ts
+++ b/backend/src/inference/routes.ts
@@ -4,8 +4,9 @@
 
 import type { Auth } from '@/auth/elysia-plugin'
 import { createAuthMacro } from '@/auth/elysia-plugin'
+import { BadRequestError } from '@/errors/http-errors'
 import { classifyInferenceError } from '@/inference/error-kind'
-import { getErrorStatus, safeErrorHandler } from '@/middleware/error-handling'
+import { createErrorResponse, getErrorStatus, safeErrorHandler } from '@/middleware/error-handling'
 import { captureInferenceError, isPostHogConfigured } from '@/posthog/client'
 import { createSSEStreamFromCompletion } from '@/utils/streaming'
 import { elapsedMs } from '@/utils/timing'
@@ -45,6 +46,16 @@ export const supportedModels: Record<string, ModelConfig> = {
     internalName: 'claude-opus-5',
     omitTemperature: true,
   },
+  // Legacy alias for the pre-rename model id. Stale clients (an open tab whose session
+  // captured the old model object, a desynced device) keep sending 'opus-4.8' after the
+  // default model was renamed to 'opus-5'; routing it to the same upstream keeps those
+  // clients working instead of 500ing on every send. The rename that caused this incident
+  // shipped without this alias — any future default-model rename must add one too.
+  'opus-4.8': {
+    provider: 'anthropic',
+    internalName: 'claude-opus-5',
+    omitTemperature: true,
+  },
   'deepseek-v4-flash': {
     provider: 'fireworks',
     internalName: 'accounts/fireworks/models/deepseek-v4-flash',
@@ -54,7 +65,8 @@ export const supportedModels: Record<string, ModelConfig> = {
 export type InferenceProxyLatencyLog = {
   event: 'inference_proxy_latency'
   route: string
-  provider: InferenceProvider
+  /** 'unknown' when the request was rejected before a provider could be resolved (e.g. bad model id). */
+  provider: InferenceProvider | 'unknown'
   model: string
   status: number
   preMs: number
@@ -125,18 +137,10 @@ export const createInferenceRoutes = (options: CreateInferenceRoutesOptions) => 
         throw new Error('Non-streaming requests are not supported')
       }
 
-      const modelConfig = supportedModels[body.model]
-      if (!modelConfig) {
-        throw new Error('Model not found')
-      }
-
-      const { provider, internalName, omitTemperature } = modelConfig
-
-      const { client } = getClient(provider)
-      const attemptTracker = createInferenceAttemptTracker()
       const route = new URL(ctx.request.url).pathname
+      const attemptTracker = createInferenceAttemptTracker()
       /** Emit route phase telemetry in structured logs and response headers. */
-      const recordLatency = (status: number, completedAt: number) => {
+      const recordLatency = (provider: InferenceProvider | 'unknown', status: number, completedAt: number) => {
         const upstreamMs = elapsedMs(handlerStartedAt, completedAt)
         const totalMs = elapsedMs(ctx.inferenceRequestStartedAt, completedAt)
         const latency: InferenceProxyLatencyLog = {
@@ -156,6 +160,22 @@ export const createInferenceRoutes = (options: CreateInferenceRoutesOptions) => 
         ctx.set.headers[serverTimingHeader] = formatServerTiming(preMs, upstreamMs, totalMs)
         logger?.info(latency, 'Inference proxy latency')
       }
+
+      const modelConfig = supportedModels[body.model]
+      if (!modelConfig) {
+        // Caller error, not an upstream failure — no provider was ever reached, so this only
+        // feeds the proxy latency log (captureInferenceErrorFn's inference_upstream_error event
+        // doesn't apply). Echoing the model id back is safe: it's the caller's own input.
+        // Must NOT `throw` here — that would route through `.onError(safeErrorHandler)`, which
+        // replaces the message with a generic HTTP reason phrase and drops the model id.
+        const error = new BadRequestError(`Unknown model: ${body.model}`)
+        recordLatency('unknown', error.status, nowFn())
+        ctx.set.status = error.status
+        return createErrorResponse(error.message)
+      }
+
+      const { provider, internalName, omitTemperature } = modelConfig
+      const { client } = getClient(provider)
 
       try {
         const completion = await runWithInferenceAttemptTracking(attemptTracker, () =>
@@ -178,7 +198,7 @@ export const createInferenceRoutes = (options: CreateInferenceRoutesOptions) => 
           }),
         )
         const upstreamResolvedAt = nowFn()
-        recordLatency(200, upstreamResolvedAt)
+        recordLatency(provider, 200, upstreamResolvedAt)
 
         const stream = createSSEStreamFromCompletion(completion, {
           onError: (error) => {
@@ -211,7 +231,7 @@ export const createInferenceRoutes = (options: CreateInferenceRoutesOptions) => 
         return new Response(stream, { headers: responseHeaders })
       } catch (error) {
         const status = getErrorStatus(error)
-        recordLatency(status, nowFn())
+        recordLatency(provider, status, nowFn())
         // Keep failures diagnosable using body-free structured metadata only.
         captureInferenceErrorFn({
           provider,

--- a/src/acp/built-in-adapter.test.ts
+++ b/src/acp/built-in-adapter.test.ts
@@ -15,6 +15,7 @@ import '@/testing-library'
 import { describe, expect, it, mock } from 'bun:test'
 import type { PreparedAiRequestConfig } from '@/ai/fetch'
 import { createWebToolBudget, webToolCaps } from '@/ai/web-tool-budget'
+import { mockProxyFetch } from '@/test-utils/proxy-fetch'
 import type { Agent, AgentAdapterContext } from '@/types/acp'
 import type { Model } from '@/types'
 import {
@@ -28,7 +29,10 @@ import type { BuildAppHarnessOptions, PiModelDescriptor } from '@shared/agent-co
 import { appHarnessEnvironmentPrompt } from '@shared/agent-core/environment-prompt'
 import type { AgentHarness, AgentTool } from '@earendil-works/pi-agent-core'
 
-const noopFetch = (async () => new Response('')) as PiModelDescriptor['fetch']
+// `mockProxyFetch` is a `FetchFn`, a superset of Pi's descriptor `fetch` shape
+// (`PiModelDescriptor['fetch']` has no `preconnect`), so it satisfies both —
+// used as a descriptor's `fetch` below and as `getProxyFetch()`'s return value.
+const noopFetch = mockProxyFetch
 
 const anthropic = (overrides: Partial<Extract<PiModelDescriptor, { kind: 'anthropic' }>> = {}): ResolvedPiModel => ({
   descriptor: { kind: 'anthropic', modelId: 'claude-opus-4-8', apiKey: 'sk-a', fetch: noopFetch, ...overrides },
@@ -51,6 +55,25 @@ const openaiCompat = (
   },
   thinkingLevel: 'medium',
 })
+
+/** Adapts a stub harness's `prompt`/`waitForIdle` run into the `ReadableStream`
+ *  `piHarnessToUiMessageStream` normally returns, closing once the run settles.
+ *  Shared by every `agentCore` stub below — none of these tests assert on the
+ *  stream's bytes, only on side effects the run produces. */
+const drainPromptToStream = (_harness: AgentHarness, runPrompt: () => Promise<unknown>): ReadableStream<Uint8Array> =>
+  new ReadableStream<Uint8Array>({
+    start: (controller) => {
+      void runPrompt().then(() => controller.close())
+    },
+  })
+
+/** Fields identical across this file's `agentCore` stubs — every test overrides
+ *  at least `buildAppHarness` and `toPiAgentTools` to capture what it asserts on. */
+const sharedAgentCoreStub = {
+  isKnownAnthropicModel: () => true,
+  workspaceDirFor: (threadId: string) => `/workspace/${threadId}`,
+  piHarnessToUiMessageStream: drainPromptToStream,
+}
 
 describe('harnessSignature', () => {
   it('is stable for identical config', () => {
@@ -113,20 +136,98 @@ describe('harnessSignature', () => {
 })
 
 describe('resolvePiModel — image capability (vendor-gated)', () => {
-  const contextFor = (model: Model): AgentAdapterContext =>
-    ({ selectedModel: model, getProxyFetch: () => noopFetch }) as unknown as AgentAdapterContext
   const agentCore = {} as Parameters<typeof resolvePiModel>[0]
   const openaiModel = (vendor: string | null): Model =>
     ({ id: 'm', name: 'M', provider: 'openai', model: 'gpt-4o', apiKey: 'sk-o', vendor, toolUsage: 1 }) as Model
 
   it('advertises image support for a vision-vendor model', () => {
-    const resolved = resolvePiModel(agentCore, contextFor(openaiModel('openai')), null)
+    const resolved = resolvePiModel(agentCore, openaiModel('openai'), () => noopFetch, null)
     expect(resolved?.descriptor).toMatchObject({ kind: 'openai-compat', supportsImages: true })
   })
 
   it('does not advertise image support when the vendor is unknown (custom/local)', () => {
-    const resolved = resolvePiModel(agentCore, contextFor(openaiModel(null)), null)
+    const resolved = resolvePiModel(agentCore, openaiModel(null), () => noopFetch, null)
     expect(resolved?.descriptor).toMatchObject({ kind: 'openai-compat', supportsImages: false })
+  })
+})
+
+describe('fetchViaHarness — model resolution', () => {
+  it('resolves the wire model from the fresh DB row, not the stale session-captured selectedModel', async () => {
+    // Reproduces the production incident: the default Opus row's `model` alias
+    // was renamed server-side (opus-4.8 -> opus-5) while a thread stayed open.
+    // `context.selectedModel` is session-captured and never re-hydrates mid-thread
+    // (see use-hydrate-chat-store.ts), so it keeps reporting the dead alias for
+    // the life of the send context — only the config `prepareConfig` fetches
+    // fresh from the DB on every send should reach the wire.
+    const baseModel = { id: 'model-1', name: 'Opus', provider: 'anthropic', apiKey: 'sk-a', toolUsage: 1 } as Model
+    const staleSelectedModel: Model = { ...baseModel, model: 'opus-4.8' }
+    const agent = { id: 'built-in', type: 'built-in' } as Agent
+
+    const freshConfig = (modelAlias: string): PreparedAiRequestConfig => ({
+      model: { ...baseModel, model: modelAlias },
+      profile: null,
+      supportsTools: true,
+      sourceCollector: [],
+      toolset: {},
+      skills: [],
+      mcpToolsMetadata: undefined,
+      stableSystemPrompt: 'stable prompt',
+      volatileSystemPrompt: 'now',
+    })
+    // Two sends, each fetching its own fresh row — the second alias (opus-6)
+    // simulates a further rename mid-thread, which must drift the harness
+    // signature and rebuild rather than reuse the first send's cached harness.
+    const configs = [freshConfig('opus-5'), freshConfig('opus-6')]
+    const prepareConfig = mock(async () => configs.shift()!)
+
+    const buildModelIds: string[] = []
+    const buildHarness = async (options: BuildAppHarnessOptions): Promise<AgentHarness> => {
+      buildModelIds.push(options.model.kind === 'anthropic' ? options.model.modelId : 'n/a')
+      return {
+        getTools: () => [],
+        setTools: async () => {},
+        setActiveTools: async () => {},
+        prompt: async () => {},
+        waitForIdle: async () => {},
+        on: () => () => {},
+        abort: async () => {},
+        env: { remove: async () => {} },
+      } as unknown as AgentHarness
+    }
+    const agentCore = {
+      ...sharedAgentCoreStub,
+      buildAppHarness: buildHarness,
+      toPiAgentTools: async () => [],
+    } as unknown as Awaited<ReturnType<NonNullable<BuiltInAdapterOptions['loadAgentCore']>>>
+
+    const adapter = createBuiltInAdapter(agent, {
+      loadAgentCore: async () => agentCore,
+      prepareConfig: prepareConfig as NonNullable<BuiltInAdapterOptions['prepareConfig']>,
+    })
+    const context = {
+      threadId: 'thread-1',
+      selectedModel: staleSelectedModel,
+      mcpClients: [],
+      reconnectClient: async () => null,
+      httpClient: {},
+      getProxyFetch: () => noopFetch,
+      regenerationRevision: 0,
+    } as unknown as AgentAdapterContext
+    const send = async (): Promise<void> => {
+      const response = await adapter.fetch(
+        { body: JSON.stringify({ messages: [{ role: 'user', parts: [{ type: 'text', text: 'hi' }] }] }) },
+        context,
+      )
+      await response.text()
+    }
+
+    await send()
+    await send()
+
+    // Both sends used the fresh alias fetched for that send — never the stale
+    // 'opus-4.8' the session captured — and the second send rebuilt the harness
+    // (two build calls) because the fresh row's alias drifted between sends.
+    expect(buildModelIds).toEqual(['opus-5', 'opus-6'])
   })
 })
 
@@ -212,19 +313,12 @@ describe('createBuiltInAdapter persistent harness', () => {
       return harness
     }
     const agentCore = {
-      isKnownAnthropicModel: () => true,
+      ...sharedAgentCoreStub,
       buildAppHarness: buildHarness,
-      workspaceDirFor: (threadId: string) => `/workspace/${threadId}`,
       toPiAgentTools: async (toolset: PreparedAiRequestConfig['toolset']) => {
         toPiCalls.push(toolset)
         return Object.keys(toolset).map((name) => ({ name }) as AgentTool)
       },
-      piHarnessToUiMessageStream: (_harness: AgentHarness, runPrompt: () => Promise<unknown>) =>
-        new ReadableStream<Uint8Array>({
-          start: (controller) => {
-            void runPrompt().then(() => controller.close())
-          },
-        }),
     } as unknown as Awaited<ReturnType<NonNullable<BuiltInAdapterOptions['loadAgentCore']>>>
     const adapter = createBuiltInAdapter(agent, {
       loadAgentCore: async () => agentCore,

--- a/src/acp/built-in-adapter.ts
+++ b/src/acp/built-in-adapter.ts
@@ -53,6 +53,7 @@ import {
   type PreparedAiRequestConfig,
 } from '@/ai/fetch'
 import type { WebToolBudget } from '@/ai/web-tool-budget'
+import type { FetchFn } from '@/lib/proxy-fetch'
 import type { Agent, AgentAdapter, AgentAdapterContext } from '@/types/acp'
 import type { Model, ModelProfile, ThunderboltUIMessage } from '@/types'
 import { extractLastUserText, resolveSkillTokenInstructions } from '@/skills/resolve-skill-system-messages'
@@ -225,16 +226,21 @@ export type ResolvedPiModel = {
   readonly thinkingLevel: ThinkingLevel
 }
 
-/** Resolve the selected model to a Pi descriptor + thinking level, or null to
- *  fall back to legacy. Anthropic ids must exist in Pi's built-in catalog;
- *  OpenAI-wire providers must resolve a connection (api key / url present). The
- *  thinking level is derived from the model's profile for both families. */
+/** Resolve a model to a Pi descriptor + thinking level, or null to fall back to
+ *  legacy. Takes `model` explicitly rather than reading `context.selectedModel` —
+ *  callers must pass the row just fetched by `prepareAiRequestConfig`, not the
+ *  session-captured object, which only updates on session-create or an explicit
+ *  user pick and otherwise goes stale for the life of an open thread (e.g. a
+ *  built-in model's `model` alias renamed server-side). Anthropic ids must exist
+ *  in Pi's built-in catalog; OpenAI-wire providers must resolve a connection (api
+ *  key / url present). The thinking level is derived from the model's profile for
+ *  both families. */
 export const resolvePiModel = (
   agentCore: AgentCoreModule,
-  context: AgentAdapterContext,
+  model: Model,
+  getProxyFetch: () => FetchFn,
   profile: ModelProfile | null,
 ): ResolvedPiModel | null => {
-  const model = context.selectedModel
   const thinkingLevel = deriveThinkingLevel(profile)
   if (model.provider === 'anthropic') {
     if (!agentCore.isKnownAnthropicModel(model.model)) {
@@ -245,12 +251,12 @@ export const resolvePiModel = (
         kind: 'anthropic',
         modelId: model.model,
         apiKey: model.apiKey ?? '',
-        fetch: context.getProxyFetch(),
+        fetch: getProxyFetch(),
       },
       thinkingLevel,
     }
   }
-  const connection = resolveOpenAiCompatConnection(model, context.getProxyFetch)
+  const connection = resolveOpenAiCompatConnection(model, getProxyFetch)
   // Pi's openai-completions client requires a bearer key (it throws on an empty
   // one with no auth header). A `custom` model pointing at a no-auth local
   // endpoint (ollama / llama.cpp) has no key, so it stays on the legacy pipeline
@@ -457,7 +463,7 @@ const fetchViaHarness = async (
     httpClient: context.httpClient,
     webToolBudget: context.webToolBudget,
   })
-  const resolved = resolvePiModel(agentCore, context, config.profile)
+  const resolved = resolvePiModel(agentCore, config.model, context.getProxyFetch, config.profile)
   if (!resolved) {
     return fallback()
   }


### PR DESCRIPTION
## Problem

The default Opus model rename (`opus-4.8` -> `opus-5`, #THU-776) broke sends for clients holding stale state. Confirmed in production on Aug 7 (6x `Error: Model not found`, 19:27 UTC, matching a user report to the second): a chat thread opened before the rename keeps the old model object captured in session state, sends the dead alias, the backend throws an uncaught 500, and the client burns all 3 auto-retries on every send. The model dropdown reads fresh state and shows "Opus 5" the whole time, which made the incident hard to triage.

Two independent defects compound here:

1. **Backend**: the old alias was removed with no compatibility route, and an unknown model id surfaced as a generic 500 (retried pointlessly) instead of a 4xx.
2. **Client**: `resolvePiModel` built the wire descriptor from `context.selectedModel` (written only at session create or explicit user pick, never invalidated) while discarding the fresh DB row that `prepareAiRequestConfig` fetches on the same send. The per-thread harness cache then keyed its signature on the stale alias, so even Retry reused it.

## Changes

- `backend/src/inference/routes.ts`: `opus-4.8` is routable again as a compatibility alias for `claude-opus-5` (temperature omitted, same as `opus-5`). Truly unknown model ids now return a 400 naming the rejected id, with the same timing headers and `inference_proxy_latency` log as every other exit (`provider: 'unknown'`).
- `src/acp/built-in-adapter.ts`: `resolvePiModel` now takes the fresh model row explicitly and no longer receives the adapter context, so it structurally cannot read the stale session object. The harness signature now derives from the fresh row, so a mid-thread alias change rebuilds the cached harness instead of replaying the dead alias.

## Tests

- Backend: legacy alias routes to `claude-opus-5` with temperature omitted; unknown id returns the 400 with the id in the message and emits the latency log. `bun run test:backend`: 1018 pass (1 pre-existing unrelated flaky failure, passes in isolation).
- Client: regression test drives two sends through `createBuiltInAdapter` with `selectedModel` frozen at the stale alias while the fresh row drifts; asserts the wire always carries the fresh alias and the second send rebuilds the harness. `bun run test`: 4244 + 236 pass, type-check and lint clean.

## Follow-ups (not in this PR)

- PowerSync upload handlers have no CAS/lineage protection (spec'd in THU-776, absent in `backend/src/dal/powersync.ts`), so a stale device can still regress the row account-wide.
- Pi deps are still 0.80.7 (THU-776 required >=0.82.1; BYOK `claude-opus-5` falls back to the legacy pipeline, which also coalesces the profile's intentional `temperature: null` into 0.2 and gets a 400 from Anthropic).
- Pi sends `tools: []` for tool-less calls over tool history (compaction/summarization); Anthropic rejects it. Self-heals with a wasted roundtrip today.
- CLI defaults still reference `claude-opus-4-8`.