### PR TITLE
fix: skip Semgrep PR comment on fork pull requests

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -69,8 +69,12 @@ jobs:
       # Post findings as a PR comment using curl + jq (no Node.js needed in Alpine).
       # Security: semgrep output is read from files and escaped by jq — never
       # interpolated through ${{ }} or shell expansion — preventing injection.
+      # Skip on fork PRs: the `pull_request` trigger gives fork runs a read-only
+      # GITHUB_TOKEN, so the comments API call 403s and fails the job. The scan
+      # itself and the SARIF upload still run; only the convenience comment is
+      # skipped. Same-repo PRs are unaffected.
       - name: Post Semgrep results as PR comment
-        if: always() && github.event_name == 'pull_request' && hashFiles('semgrep.json') != ''
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && hashFiles('semgrep.json') != ''
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem

The "Post Semgrep results as PR comment" step in `security.yml` fails on **fork PRs**. The `pull_request` trigger gives fork runs a read-only `GITHUB_TOKEN`, so the step's `curl -sf -X POST .../issues/<PR>/comments` gets a 403 and curl exits 22, failing the whole Semgrep job with a misleading red X.

Example: https://github.com/thunderbird/thunderbolt/actions/runs/31125341539 (PR #1199, a fork).

## Fix

Skip the comment step on fork PRs by adding a same-repo guard to the step's `if:`:

```
github.event.pull_request.head.repo.full_name == github.repository
```

The Semgrep scan itself and the SARIF upload still run on fork PRs (GitHub accepts SARIF uploads from `pull_request`-triggered runs even with a read-only token), so fork PRs keep their code-scanning alerts. Only the convenience PR comment is skipped. Same-repo PRs are unaffected and continue to post/update the comment.

## Security review

Reviewed independently by two agents (read-only), both **safe to merge**:

- The `full_name == repository` check is the canonical, fail-safe way to detect same-repo PRs; it fails closed (skips the comment) on renames, deleted forks, or null values.
- Skipping the comment introduces no new security problem: the comment was never an adversarial gate (a fork PR can already edit the workflow file under `pull_request`), and the real signal (scan + SARIF → code-scanning UI) is preserved.
- No secrets or attacker-controllable data involved; the expression is compared in `if:`, never interpolated into shell.

## Validation

`actionlint` on the file: no new findings.
