### PR TITLE
fix: terminate eval CLI entrypoints after completion

### DIFF
--- a/src/ai/eval/baseline-cli.test.ts
+++ b/src/ai/eval/baseline-cli.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { EvalMetrics } from './types'
+
+test('exits after comparing metrics when a preload keeps the event loop alive', async () => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'thunderbolt-eval-baseline-cli-'))
+  const preloadPath = join(temporaryDirectory, 'keep-alive.ts')
+  const metricsPath = join(temporaryDirectory, 'eval-metrics.json')
+  const baselineDirectory = join(temporaryDirectory, 'baselines')
+  const metrics = {
+    schemaVersion: 3,
+    generatedAt: '2026-08-13T12:00:00.000Z',
+    groups: {},
+  } satisfies EvalMetrics
+  writeFileSync(preloadPath, 'setInterval(() => {}, 60_000)\n')
+  writeFileSync(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`)
+
+  const processHandle = Bun.spawn(
+    [
+      process.execPath,
+      '--preload',
+      preloadPath,
+      'src/ai/eval/baseline-cli.ts',
+      'compare',
+      metricsPath,
+      baselineDirectory,
+    ],
+    {
+      cwd: join(import.meta.dir, '../../..'),
+      stdout: 'ignore',
+      stderr: 'ignore',
+    },
+  )
+  const completion = await Promise.race([
+    (async () => ({ exitCode: await processHandle.exited }))(),
+    (async () => {
+      await Bun.sleep(1_000)
+      return { exitCode: null }
+    })(),
+  ])
+
+  if (completion.exitCode === null) {
+    processHandle.kill()
+    await processHandle.exited
+  }
+  rmSync(temporaryDirectory, { recursive: true, force: true })
+
+  expect(completion.exitCode).toBe(0)
+})

--- a/src/ai/eval/baseline-cli.ts
+++ b/src/ai/eval/baseline-cli.ts
@@ -34,5 +34,12 @@ const main = () => {
 }
 
 if (import.meta.main) {
-  main()
+  try {
+    await main()
+    // Exit explicitly because the imported app graph can keep live handles after CI work completes.
+    process.exit(0)
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
 }

--- a/src/ai/eval/debug-single.ts
+++ b/src/ai/eval/debug-single.ts
@@ -97,4 +97,13 @@ const run = async () => {
   await teardownTestDatabase()
 }
 
-await run()
+if (import.meta.main) {
+  try {
+    await run()
+    // Exit explicitly because the imported app graph can keep live handles after CLI work completes.
+    process.exit(0)
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
+}

--- a/src/ai/eval/run.ts
+++ b/src/ai/eval/run.ts
@@ -78,4 +78,14 @@ Object.defineProperty(globalThis, 'localStorage', {
   configurable: true,
   value: new Storage(),
 })
-process.exit(await main())
+
+if (import.meta.main) {
+  try {
+    const exitCode = await main()
+    // Exit explicitly because the imported app graph can keep live handles after CI work completes.
+    process.exit(exitCode)
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
## Summary

- Last night's scheduled full eval suite finished evaluating in 1h36 (report + metrics artifacts prove it) and then burned the remaining 4h29 of the job's 360-minute budget hung in the `eval:compare` / `eval:baseline` steps, so the baseline-refresh PR step never ran. Same for the earlier manual dispatch: two 6-hour runner sessions, zero baselines.
- Root cause is the bug class already fixed for the PR comment script: eval CLI entrypoints intentionally import eval-context modules, which pull a large app graph holding live handles — Bun's event loop never drains after `main()` resolves, so the process never exits.
- Fix: explicit exit discipline on every heavy-graph eval CLI entrypoint (`baseline-cli.ts`, `run.ts`, `debug-single.ts`), preserving existing exit-code semantics (gate failures still exit non-zero). Reproduction: pre-fix the baseline CLI stays alive indefinitely after finishing; post-fix it exits in ~200ms. Regression test included.

## Test plan

- [x] Pre/post reproduction with a real metrics file
- [x] `bun run type-check`, `bun run lint`, `bun run test` green
- [x] Regression test for the plain-Bun exit path