### PR TITLE
fix: migrate DeepSeek V4 Flash to the Fireworks 0731 serverless model

### DIFF
--- a/backend/src/inference/routes.test.ts
+++ b/backend/src/inference/routes.test.ts
@@ -110,7 +110,7 @@ describe('Inference Routes', () => {
       expect(response.headers.get('Connection')).toBe('keep-alive')
 
       expect(mockCreateCompletion).toHaveBeenCalledWith({
-        model: 'accounts/fireworks/models/deepseek-v4-flash',
+        model: 'accounts/fireworks/models/deepseek-v4-flash-0731',
         messages: validRequestBody.messages,
         temperature: validRequestBody.temperature,
         tools: undefined,
@@ -135,7 +135,7 @@ describe('Inference Routes', () => {
       expect(getInferenceClientMock).toHaveBeenCalledWith('fireworks')
       expect(mockCreateCompletion).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'accounts/fireworks/models/deepseek-v4-flash',
+          model: 'accounts/fireworks/models/deepseek-v4-flash-0731',
         }),
       )
     })

--- a/backend/src/inference/routes.ts
+++ b/backend/src/inference/routes.ts
@@ -47,7 +47,9 @@ export const supportedModels: Record<string, ModelConfig> = {
   },
   'deepseek-v4-flash': {
     provider: 'fireworks',
-    internalName: 'accounts/fireworks/models/deepseek-v4-flash',
+    // Fireworks deprecated the serverless deepseek-v4-flash preview (404 NOT_FOUND
+    // since 2026-08-15); 0731 is the official release that supersedes it.
+    internalName: 'accounts/fireworks/models/deepseek-v4-flash-0731',
   },
 }
 


### PR DESCRIPTION
## Summary

- Fireworks [deprecated the `deepseek-v4-flash` preview from serverless](https://docs.fireworks.ai/updates/changelog), so every production request through the inference proxy has failed with `404 NOT_FOUND` since 2026-08-15 17:42 UTC (55 occurrences captured as `inference_upstream_error` in PostHog, zero successful generations since).
- Route the public `deepseek-v4-flash` model id to `accounts/fireworks/models/deepseek-v4-flash-0731` — the [official release that supersedes the preview](https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-0731) (same pricing tier, serverless-supported, function calling supported).
- The public model id, display name, and shared defaults are unchanged, so there is no frontend change and no `defaultModelsVersion` bump — the proxy mapping is the only thing that moves.

## Test Plan

- [x] `bun test src/inference/routes.test.ts` — all 27 tests pass, including the frontend-defaults catalog parity test
- [ ] After backend deploy: send a chat message with DeepSeek V4 Flash in production and confirm streaming works
- [ ] Confirm `inference_upstream_error` events for `deepseek-v4-flash` stop in PostHog

## Changes

- `backend/src/inference/routes.ts` — point `internalName` at the 0731 serverless model path
- `backend/src/inference/routes.test.ts` — update the two internal-name assertions