### PR TITLE
build: shut down dev servers cleanly on Ctrl+C in make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,12 +163,23 @@ run:
 	@# Kill any existing processes on the ports first
 	@-lsof -ti:8000 | xargs kill -9 2>/dev/null || true
 	@-lsof -ti:1420 | xargs kill -9 2>/dev/null || true
-	@# Start backend in background and frontend in foreground
+	@# Start backend in background and frontend in foreground.
+	@# Ctrl+C signals the whole process group, so every server gets SIGINT at once
+	@# and make waits for this shell before returning the terminal. The INT trap
+	@# keeps this shell alive past the interrupt (without it the shell dies with
+	@# the signal), and the port poll waits for the backend's ENTIRE process tree:
+	@# $$BACKEND_PID is the `bun run dev` script wrapper, which exits before the
+	@# `bun --watch src/index.ts` server beneath it has printed its graceful
+	@# shutdown, so a bare `wait` returns too early and that line lands on top of
+	@# the next shell prompt — looking like a hang that needs an extra Enter.
 	cd backend && bun run dev & \
 	BACKEND_PID=$$!; \
+	trap 'kill $$BACKEND_PID 2>/dev/null' INT TERM; \
 	echo "$(GREEN)✓ Backend started (PID: $$BACKEND_PID)$(NC)"; \
 	sleep 2; \
-	bun run dev || (kill $$BACKEND_PID 2>/dev/null && exit 1)
+	bun run dev; \
+	kill $$BACKEND_PID 2>/dev/null; wait; \
+	for i in $$(seq 1 50); do lsof -ti:8000 >/dev/null 2>&1 || break; sleep 0.1; done
 
 # Alias for run
 dev: run


### PR DESCRIPTION
Hi!

I ran into this issue when running this locally.

Before:
<video src="https://github.com/user-attachments/assets/4bf12cf5-56b5-4ca1-a318-ad9947e2fa7a" controls muted></video>

After:
<video src="https://github.com/user-attachments/assets/1ec792b2-018c-4a65-8daa-fb8eb50323c0" controls muted></video>

## Description

Ctrl+C on `make run` left the terminal looking hung: you'd get your prompt back, then the backend's graceful-shutdown line would print on top of it, and it felt like you had to hit Enter to get a usable prompt.

Three edits to the `run` recipe, one per cause:

1. **`trap ... INT TERM`** — Ctrl+C signals the whole process group, so without a trap the recipe shell dies with the SIGINT and nothing below it runs. The trap keeps the shell alive past the interrupt and explicitly kills the backend.
2. **`bun run dev; kill ...; wait`** (was `|| (kill ... && exit 1)`) — the old `||` branch only killed the backend when the frontend *failed*; on a normal Ctrl+C exit the backend was orphaned.
3. **Port-8000 poll** (5s max, 100ms steps) — `$BACKEND_PID` is the `bun run dev` script wrapper, which exits before the `bun --watch src/index.ts` server beneath it finishes shutting down, so a bare `wait` returns too early and `make` hands the terminal back while the real server is still printing. Polling until the port is free is what keeps the stray output off the next prompt.

## Portability note

The poll depends on `lsof`, and `sleep 0.1` is not POSIX. Both are fine on macOS and Linux (GNU and BSD `sleep` accept fractional seconds); busybox `sleep` may not. Flagging it in case any contributor runs a busybox-based shell.

## Testing

Manual only, on macOS: `make run`, Ctrl+C, prompt returns clean with no shutdown output landing on top of it and nothing left on :8000. Not verified on Linux.