### PR TITLE
perf(THU-777): run PowerSync sync stream in a dedicated worker on iOS

### DIFF
--- a/src/db/powersync/database.test.ts
+++ b/src/db/powersync/database.test.ts
@@ -84,10 +84,12 @@ describe('getPowerSyncOptions', () => {
       expect(factory.waOptions.flags?.enableMultiTabs).toBe(false)
     })
 
-    it('includes flags and sync with explicit worker paths', () => {
+    it('enables multi-tab sync selection and provides a dedicated sync worker factory', () => {
       const options = getPowerSyncOptions('thunderbolt.db', 'safari-tauri')
-      expect('flags' in options && options.flags).toEqual({ enableMultiTabs: false })
-      expect(options.sync).toEqual({ worker: '/@powersync/worker/SharedSyncImplementation.umd.js' })
+      // PowerSyncDatabase-level enableMultiTabs: true selects the off-thread
+      // SharedWebStreamingSyncImplementation (THU-777); the DB factory keeps its own false.
+      expect('flags' in options && options.flags).toEqual({ enableMultiTabs: true })
+      expect(typeof (options.sync as { worker: () => unknown }).worker).toBe('function')
     })
 
     it('always includes transformers', () => {
@@ -119,8 +121,8 @@ describe('getPowerSyncOptions', () => {
       const factory = options.database as WASQLiteOpenFactory
       expect(factory.waOptions.worker).toBe('/@powersync/worker/WASQLiteDB.umd.js')
       expect(factory.waOptions.flags?.enableMultiTabs).toBe(false)
-      expect('flags' in options && options.flags).toEqual({ enableMultiTabs: false })
-      expect(options.sync).toEqual({ worker: '/@powersync/worker/SharedSyncImplementation.umd.js' })
+      expect('flags' in options && options.flags).toEqual({ enableMultiTabs: true })
+      expect(typeof (options.sync as { worker: () => unknown }).worker).toBe('function')
     })
   })
 })

--- a/src/db/powersync/database.test.ts
+++ b/src/db/powersync/database.test.ts
@@ -87,7 +87,7 @@ describe('getPowerSyncOptions', () => {
     it('enables multi-tab sync selection and provides a dedicated sync worker factory', () => {
       const options = getPowerSyncOptions('thunderbolt.db', 'safari-tauri')
       // PowerSyncDatabase-level enableMultiTabs: true selects the off-thread
-      // SharedWebStreamingSyncImplementation (THU-777); the DB factory keeps its own false.
+      // SharedWebStreamingSyncImplementation; the DB factory keeps its own false.
       expect('flags' in options && options.flags).toEqual({ enableMultiTabs: true })
       expect(typeof (options.sync as { worker: () => unknown }).worker).toBe('function')
     })

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -88,16 +88,16 @@ export const getPowerSyncOptions = (
   }
 
   /**
-   * Safari (web) + Tauri (iOS/Desktop): Full WASQLiteOpenFactory required.
-   * OPFSCoopSyncVFS — synchronous OPFS handles. Avoids IDBBatchAtomicVFS + Asyncify
-   * (causes "Maximum call stack size exceeded" on Safari/iOS; JSC has smaller stack than V8)
-   * and SharedArrayBuffer + SharedWorker (exceeds iOS WKWebView memory, black-screen crash).
-   * Explicit UMD worker paths — bypasses import.meta.url which fails under tauri://.
-   * enableMultiTabs: false — dedicated worker, not SharedWorker (fails under tauri://).
+   * Safari (web) + Tauri (iOS/Desktop): full WASQLiteOpenFactory required.
+   * OPFSCoopSyncVFS avoids IDBBatchAtomicVFS + Asyncify ("Maximum call stack size exceeded"
+   * on Safari/iOS) and SharedArrayBuffer + SharedWorker (iOS WKWebView black-screen crash).
+   * Falls back to IDBBatchAtomicVFS when OPFS is unavailable (e.g. WebKitGTK on Tauri Linux).
+   * The DB runs in a dedicated Worker via an explicit UMD path (import.meta.url fails under
+   * tauri:// for node_modules workers).
    *
-   * Falls back to IDBBatchAtomicVFS (IndexedDB-backed, no OPFS dependency) when OPFS itself
-   * is unavailable — e.g. WebKitGTK (Tauri on Linux) doesn't implement `navigator.storage.getDirectory`,
-   * so OPFSCoopSyncVFS's worker throws on init instead of ever reaching this Asyncify tradeoff.
+   * Sync runs in a dedicated Worker too (THU-777): the PowerSyncDatabase-level
+   * `enableMultiTabs: true` selects SharedWebStreamingSyncImplementation, which drives the
+   * worker over Comlink — a dedicated Worker (valid under tauri://) stands in for the SharedWorker.
    *
    * Docs: https://docs.powersync.com/debugging/troubleshooting#common-issues
    */
@@ -109,10 +109,28 @@ export const getPowerSyncOptions = (
       flags: { enableMultiTabs: false },
     }),
     schema: AppSchema as unknown as WebPowerSyncDatabaseOptions['schema'],
-    flags: { enableMultiTabs: false },
-    sync: { worker: '/@powersync/worker/SharedSyncImplementation.umd.js' },
+    flags: { enableMultiTabs: true },
+    sync: { worker: () => createDedicatedSyncWorker(dbFilename) },
     transformers: [encryptionMiddleware],
   }
+}
+
+/**
+ * Builds the dedicated Worker that hosts the sync stream on iOS/Safari.
+ *
+ * SharedWebStreamingSyncImplementation reads `.port` off this factory's result and drives it
+ * over Comlink; on dispose it calls `.close()`. A dedicated Worker is a valid Comlink endpoint
+ * but exposes `.terminate()` rather than `.close()`, so map one to the other. The result is
+ * shaped as a SharedWorker to satisfy PowerSync's factory type — only `.port` is read at runtime.
+ */
+const createDedicatedSyncWorker = (dbFilename: string): SharedWorker => {
+  const worker = new Worker(new URL('./worker/ThunderboltDedicatedSyncImplementation.worker.ts', import.meta.url), {
+    type: 'module',
+    name: `dedicated-sync-${dbFilename}`,
+  })
+  const port = worker as unknown as MessagePort
+  port.close = () => worker.terminate()
+  return { port } as unknown as SharedWorker
 }
 
 /**

--- a/src/db/powersync/database.ts
+++ b/src/db/powersync/database.ts
@@ -95,7 +95,7 @@ export const getPowerSyncOptions = (
    * The DB runs in a dedicated Worker via an explicit UMD path (import.meta.url fails under
    * tauri:// for node_modules workers).
    *
-   * Sync runs in a dedicated Worker too (THU-777): the PowerSyncDatabase-level
+   * Sync runs in a dedicated Worker too: the PowerSyncDatabase-level
    * `enableMultiTabs: true` selects SharedWebStreamingSyncImplementation, which drives the
    * worker over Comlink — a dedicated Worker (valid under tauri://) stands in for the SharedWorker.
    *

--- a/src/db/powersync/worker/ThunderboltDedicatedSyncImplementation.worker.ts
+++ b/src/db/powersync/worker/ThunderboltDedicatedSyncImplementation.worker.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createBaseLogger } from '@powersync/common'
+import { WorkerClient } from 'powersync-web-internal/worker/sync/WorkerClient.js'
+import { ThunderboltSharedSyncImplementation } from './ThunderboltSharedSyncImplementation'
+
+/**
+ * Dedicated-Worker host for the sync stream on iOS/Safari (safari-tauri config).
+ * Runs ThunderboltSharedSyncImplementation off the UI thread. A dedicated Worker has a
+ * single client, so `self` is the one Comlink endpoint — no `onconnect`/multi-port handling.
+ */
+const logger = createBaseLogger()
+logger.useDefaults()
+
+const syncImplementation = new ThunderboltSharedSyncImplementation()
+
+// `self` in a dedicated worker is DedicatedWorkerGlobalScope — a valid Comlink endpoint.
+new WorkerClient(syncImplementation, self as unknown as MessagePort)


### PR DESCRIPTION
## Problem

On iOS the PowerSync sync stream runs on the UI thread. During a large catch-up (sync re-enabled after building a backlog on another device), message parsing and decryption block the main thread and the app freezes. [THU-777](https://linear.app/mozilla-thunderbolt/issue/THU-777/app-is-extremely-slow-while-syncing-on-ios)

## Change

Move the sync stream off the UI thread:

- `enableMultiTabs: true` at the PowerSyncDatabase level so PowerSync selects the off-thread `SharedWebStreamingSyncImplementation`. The DB factory keeps its own `enableMultiTabs: false` (SharedWorker is unavailable under `tauri://`).
- A dedicated `Worker` hosts the sync stream. iOS can't use a SharedWorker but a dedicated Worker runs off-thread. `ThunderboltDedicatedSyncImplementation.worker.ts` wires `ThunderboltSharedSyncImplementation` to a `WorkerClient` over `self`.

Parse/decrypt work moves to the `dedicated-sync-*` worker thread; the UI thread stays responsive during catch-up.

The edit lands in the `safari-tauri` database config, which serves every WebKit surface (iOS/macOS Tauri **and** desktop Safari) — they share this branch because WebKit needs `WASQLiteOpenFactory` + `OPFSCoopSyncVFS` and can't use a SharedWorker. So desktop Safari gets the same off-thread sync as a side effect. Chrome/Edge/Firefox (the `default` config) already run sync off-thread via SharedWorker and are unchanged.

## Test

- 53 PowerSync tests pass; typecheck clean.
- Manual (iOS Simulator, plus desktop Safari as the same-config proxy): build a chat backlog on one client, enable sync on the other, confirm the UI stays responsive during catch-up and the sync work runs on the `dedicated-sync-*` worker (Web Inspector → Timelines). Only the simulator/device exercises worker loading under `tauri://`.

## Evidences

https://github.com/user-attachments/assets/eabfebbf-19b0-4bad-af2b-1aca1f75a916


