### PR TITLE
fix(THU-791): stop button not working properly

### DIFF
--- a/shared/agent-core/pi-to-aisdk-stream.test.ts
+++ b/shared/agent-core/pi-to-aisdk-stream.test.ts
@@ -236,6 +236,7 @@ describe('piHarnessToUiMessageStream metadata', () => {
           emit({ type: 'agent_end', messages: [] })
         },
         {},
+        undefined,
         () => clock.time,
       ),
     ).text()
@@ -280,5 +281,124 @@ describe('piHarnessToUiMessageStream metadata', () => {
     expect(output).toContain('"messageMetadata":{"modelId":"model-1"}')
     expect(output).toContain('"mcpTools":{"search_web":{"name":"Search"}}')
     expect(output).toContain('"sources":[{"id":"source-1"}]')
+  })
+})
+
+/** Harness fake that records aborts and lets the test drive events by hand. */
+const createHarnessFake = () => {
+  const listeners = new Set<(event: AgentHarnessEvent) => void>()
+  const state = { abortCount: 0 }
+  const harness = {
+    subscribe: (listener: (event: AgentHarnessEvent) => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    abort: async () => {
+      state.abortCount += 1
+      return { clearedSteer: [], clearedFollowUp: [] }
+    },
+  } as unknown as AgentHarness
+  return {
+    harness,
+    state,
+    listenerCount: () => listeners.size,
+    emit: (event: AgentHarnessEvent): void => listeners.forEach((listener) => listener(event)),
+  }
+}
+
+describe('piHarnessToUiMessageStream abort', () => {
+  it('closes the stream and aborts the harness when the signal fires mid-run', async () => {
+    const { harness, state, emit, listenerCount } = createHarnessFake()
+    const controller = new AbortController()
+    // The harness never settles on its own — only the abort can end this stream,
+    // which is the regression: Stop used to leave the loop running forever.
+    const stream = piHarnessToUiMessageStream(
+      harness,
+      () => {
+        emit({ type: 'agent_start' } as AgentHarnessEvent)
+        emit({ type: 'turn_start' } as AgentHarnessEvent)
+        return new Promise<void>(() => {})
+      },
+      {},
+      controller.signal,
+    )
+
+    const consumed = new Response(stream).text()
+    controller.abort()
+    const output = await consumed
+
+    expect(state.abortCount).toBe(1)
+    expect(listenerCount()).toBe(0)
+    // The turn settles as a well-formed message rather than a dangling step.
+    expect(output).toContain('"type":"finish-step"')
+    expect(output).toContain('"type":"finish"')
+    expect(output).toContain('[DONE]')
+  })
+
+  it('closes the open reasoning part so its spinner stops', async () => {
+    const { harness, emit } = createHarnessFake()
+    const controller = new AbortController()
+    const stream = piHarnessToUiMessageStream(
+      harness,
+      () => {
+        emit({ type: 'agent_start' } as AgentHarnessEvent)
+        emit({ type: 'turn_start' } as AgentHarnessEvent)
+        emit({
+          type: 'message_update',
+          assistantMessageEvent: { type: 'thinking_delta', contentIndex: 0, delta: 'hmm' },
+        } as AgentHarnessEvent)
+        return new Promise<void>(() => {})
+      },
+      {},
+      controller.signal,
+    )
+
+    const consumed = new Response(stream).text()
+    controller.abort()
+
+    expect(await consumed).toContain('"type":"reasoning-end"')
+  })
+
+  it('emits nothing when the signal aborts before the first chunk', async () => {
+    const { harness, state } = createHarnessFake()
+    const controller = new AbortController()
+    const stream = piHarnessToUiMessageStream(
+      harness,
+      () => {
+        // Reached only if the abort failed to short-circuit the run.
+        state.abortCount = -1
+        return new Promise<void>(() => {})
+      },
+      {},
+      controller.signal,
+    )
+
+    const consumed = new Response(stream).text()
+    controller.abort()
+    const output = await consumed
+
+    // A synthetic start/finish here would read as an empty assistant turn, and
+    // the chat auto-retries those — restarting the turn the user cancelled.
+    expect(output).not.toContain('"type":"start"')
+    expect(output).not.toContain('"type":"finish"')
+    expect(output).toContain('[DONE]')
+  })
+
+  it('never starts the run when the signal is already aborted', async () => {
+    const { harness, state } = createHarnessFake()
+    const stream = piHarnessToUiMessageStream(
+      harness,
+      () => {
+        state.abortCount = -1
+        return new Promise<void>(() => {})
+      },
+      {},
+      AbortSignal.abort(),
+    )
+
+    const output = await new Response(stream).text()
+
+    expect(state.abortCount).toBe(0)
+    expect(output).toBe('data: [DONE]\n\n')
   })
 })

--- a/shared/agent-core/pi-to-aisdk-stream.ts
+++ b/shared/agent-core/pi-to-aisdk-stream.ts
@@ -111,6 +111,8 @@ type PiTranslator = {
   /** Close any open parts and emit the terminal `finish`. With `errorText`,
    *  an `error` chunk is emitted first. Idempotent once the stream has finished. */
   finish: (errorText?: string) => void
+  /** Whether the run has opened an assistant message (emitted `start`). */
+  hasStarted: () => boolean
 }
 
 export type PiStreamMetadata = {
@@ -342,7 +344,7 @@ const createPiTranslator = (
     }
   }
 
-  return { handle, finish }
+  return { handle, finish, hasStarted: () => started }
 }
 
 /**
@@ -363,12 +365,13 @@ const createPiTranslator = (
  * ```
  *
  * The stream is purely streaming — chunks are enqueued as events arrive, never
- * buffered for the whole run. Cancelling the consumer (e.g. the user stops
- * generation) aborts the harness and unsubscribes.
+ * buffered for the whole run. Cancelling the consumer aborts the harness and
+ * unsubscribes; so does aborting `signal`, which is how Stop reaches the run.
  *
  * @param harness - the harness whose run should be streamed
  * @param runPrompt - thunk that starts the run and resolves once it settles
  * @param metadata - initial, tool, and settled message metadata
+ * @param signal - the request's abort signal; aborting it stops the run (Stop)
  * @param now - millisecond clock used for reasoning and tool durations
  * @returns a `ReadableStream` of SSE-encoded AI SDK chunks for the `Response` body
  */
@@ -376,9 +379,11 @@ export const piHarnessToUiMessageStream = (
   harness: Pick<AgentHarness, 'subscribe' | 'abort'>,
   runPrompt: () => Promise<unknown>,
   metadata: PiStreamMetadata = {},
+  signal?: AbortSignal,
   now: () => number = Date.now,
 ): ReadableStream<Uint8Array> => {
   let unsubscribe: (() => void) | null = null
+  let detachSignal: (() => void) | null = null
   let closed = false
 
   return new ReadableStream<Uint8Array>({
@@ -394,6 +399,20 @@ export const piHarnessToUiMessageStream = (
       )
       unsubscribe = harness.subscribe((event) => translator.handle(event))
 
+      /** Drop both subscriptions so no further event or abort reaches a closed stream. */
+      const detach = (): void => {
+        detachSignal?.()
+        detachSignal = null
+        unsubscribe?.()
+        unsubscribe = null
+      }
+
+      const close = (): void => {
+        closed = true
+        controller.enqueue(encodeDone())
+        controller.close()
+      }
+
       const finalize = (errorText?: string): void => {
         if (closed) {
           return
@@ -401,12 +420,46 @@ export const piHarnessToUiMessageStream = (
         // Unsubscribe first so no further harness event races the terminal
         // sequence, let `finish` emit its chunks while the gate is still open,
         // and only then close the gate against any straggler from `cancel`.
-        unsubscribe?.()
-        unsubscribe = null
+        detach()
         translator.finish(errorText)
-        closed = true
-        controller.enqueue(encodeDone())
-        controller.close()
+        close()
+      }
+
+      /**
+       * Stop. The AI SDK only aborts the signal — it never cancels the response
+       * body — so without this the harness keeps looping (more model calls, more
+       * tool executions) long after the user pressed the button.
+       *
+       * The stream closes immediately rather than awaiting the teardown:
+       * `harness.abort()` awaits `waitForIdle()`, so awaiting it here would hang
+       * Stop behind any tool that doesn't honor the run's signal.
+       */
+      const onAbort = (): void => {
+        if (!closed) {
+          // Nothing has been emitted yet, so there is no assistant message to
+          // settle. Closing silently leaves none behind — a synthetic
+          // start/finish pair would read as an empty turn, and the chat
+          // auto-retries those, restarting the turn the user just cancelled.
+          if (translator.hasStarted()) {
+            finalize()
+          } else {
+            detach()
+            close()
+          }
+        }
+        void harness.abort().catch(() => {})
+      }
+
+      if (signal?.aborted) {
+        // Stopped while the harness was still being built: close without ever
+        // starting the run.
+        detach()
+        close()
+        return
+      }
+      if (signal) {
+        signal.addEventListener('abort', onAbort, { once: true })
+        detachSignal = () => signal.removeEventListener('abort', onAbort)
       }
 
       // Drive the run off this start callback. A failed turn resolves with a
@@ -423,6 +476,8 @@ export const piHarnessToUiMessageStream = (
     },
     async cancel() {
       closed = true
+      detachSignal?.()
+      detachSignal = null
       unsubscribe?.()
       unsubscribe = null
       await harness.abort()

--- a/src/acp/built-in-adapter.test.ts
+++ b/src/acp/built-in-adapter.test.ts
@@ -1287,3 +1287,84 @@ it('removes the budget listener when the response consumer stops the live harnes
     run.adapter.disconnect()
   }
 })
+
+describe('createBuiltInAdapter stop', () => {
+  it("forwards the request's abort signal to the harness stream", async () => {
+    const model = {
+      id: 'model-1',
+      name: 'Claude',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      apiKey: 'sk-a',
+      toolUsage: 1,
+    } as Model
+    const config: PreparedAiRequestConfig = {
+      model,
+      profile: null,
+      supportsTools: true,
+      sourceCollector: [],
+      toolset: {} as PreparedAiRequestConfig['toolset'],
+      skills: [],
+      mcpToolsMetadata: undefined,
+      stableSystemPrompt: 'stable prompt',
+      volatileSystemPrompt: 'volatile prompt',
+    }
+    const harness = {
+      getTools: () => [],
+      setTools: async () => {},
+      setActiveTools: async () => {},
+      prompt: async () => {},
+      waitForIdle: async () => {},
+      on: () => () => {},
+      abort: async () => ({ clearedSteer: [], clearedFollowUp: [] }),
+      env: { remove: async () => {} },
+    } as unknown as AgentHarness
+    const signals: Array<AbortSignal | undefined> = []
+    const agentCore = {
+      isKnownAnthropicModel: () => true,
+      buildAppHarness: async () => harness,
+      workspaceDirFor: (threadId: string) => `/workspace/${threadId}`,
+      toPiAgentTools: async () => [],
+      piHarnessToUiMessageStream: (
+        _harness: AgentHarness,
+        runPrompt: () => Promise<unknown>,
+        _metadata: unknown,
+        signal?: AbortSignal,
+      ) => {
+        signals.push(signal)
+        return new ReadableStream<Uint8Array>({
+          start: (controller) => void runPrompt().then(() => controller.close()),
+        })
+      },
+    } as unknown as Awaited<ReturnType<NonNullable<BuiltInAdapterOptions['loadAgentCore']>>>
+    const adapter = createBuiltInAdapter({ id: 'built-in', type: 'built-in' } as Agent, {
+      loadAgentCore: async () => agentCore,
+      prepareConfig: (async () => config) as NonNullable<BuiltInAdapterOptions['prepareConfig']>,
+    })
+    const context = {
+      threadId: 'thread-1',
+      selectedModel: model,
+      mcpClients: [],
+      reconnectClient: async () => null,
+      httpClient: {},
+      getProxyFetch: () => noopFetch,
+      onAcpSessionId: async () => {},
+      regenerationRevision: 0,
+      telemetry: createTurnTelemetry({ generateId: () => 'trace-pi' }),
+    } as unknown as AgentAdapterContext
+    const controller = new AbortController()
+
+    const response = await adapter.fetch(
+      {
+        body: JSON.stringify({ messages: [{ role: 'user', parts: [{ type: 'text', text: 'hi' }] }] }),
+        signal: controller.signal,
+      },
+      context,
+    )
+    await response.text()
+
+    // Without this the in-browser loop keeps calling the model and running tools
+    // after Stop — the AI SDK only aborts the signal, it never cancels the body.
+    expect(signals).toEqual([controller.signal])
+  })
+})

--- a/src/acp/built-in-adapter.ts
+++ b/src/acp/built-in-adapter.ts
@@ -727,6 +727,10 @@ const fetchViaHarness = async (
           ...(config.sourceCollector.length > 0 ? { sources: [...config.sourceCollector] } : {}),
         }),
       },
+      // Stop: the AI SDK aborts this signal and nothing else. The harness runs
+      // in-browser, so unless it sees the signal the loop keeps calling the
+      // model and executing tools after the user pressed the button.
+      init.signal ?? undefined,
     ),
     { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
   )

--- a/src/chats/agent-routing.test.ts
+++ b/src/chats/agent-routing.test.ts
@@ -93,6 +93,7 @@ const hydrateSessionWith = (
     pendingPermission: null,
     retryCount: 0,
     retriesExhausted: false,
+    stopping: false,
     selectedAgent: agent,
     selectedModel: mockModel,
     projectId,

--- a/src/chats/chat-instance.test.ts
+++ b/src/chats/chat-instance.test.ts
@@ -68,8 +68,10 @@ const createRetryHarness = (saveMessages: SaveMessagesFunction = async () => {})
     return {
       id: init.id ?? sessionId,
       messages: init.messages ?? [],
+      status: 'ready',
       regenerate,
       sendMessage,
+      stop: mock(() => Promise.resolve()),
     } as unknown as Chat<ThunderboltUIMessage>
   }
 
@@ -134,11 +136,21 @@ const createRetryHarness = (saveMessages: SaveMessagesFunction = async () => {})
       isError: false,
     })
 
+  const finishAbortedEmpty = () =>
+    onFinish!({
+      message: { id: 'aborted-empty', role: 'assistant', parts: [] },
+      messages: [],
+      isAbort: true,
+      isDisconnect: false,
+      isError: false,
+    })
+
   const getTurnBudget = () => budgets.at(-1)!
 
   return {
     finishSuccessfully,
     finishAborted,
+    finishAbortedEmpty,
     finishWithError,
     getTurnBudget,
     instance,
@@ -444,6 +456,67 @@ describe('createChatInstance — retry policy', () => {
     const autoRetry = trackEvent.mock.calls.find(([event]) => event === 'chat_auto_retry')?.[1]
     expect(autoRetry?.reason).toBe('empty-response')
     expect(autoRetry?.attempt).toBe(1)
+  })
+
+  it('drops the empty assistant shell left when a loader turn is aborted', async () => {
+    const { instance, finishAbortedEmpty } = createRetryHarness()
+    instance.messages = [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'How are you' }] },
+      { id: 'a-empty', role: 'assistant', parts: [] },
+    ] as never
+
+    await finishAbortedEmpty()
+
+    // Without the drop, this empty shell re-triggers the recovery spinner and the
+    // Stop button stays up, forcing a second press (THU-791).
+    expect(instance.messages).toHaveLength(1)
+    expect(instance.messages[0]!.role).toBe('user')
+  })
+
+  it('finalizes a reasoning part left streaming when a turn is aborted mid-thinking', async () => {
+    const { instance, finishAborted } = createRetryHarness()
+    instance.messages = [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'List things' }] },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'reasoning', text: 'The user is asking…', state: 'streaming' }] },
+    ] as never
+
+    await finishAborted()
+
+    // Left streaming, the reasoning part keeps its spinner running after the stop
+    // (reasoning-group.tsx) even though the turn has settled (THU-791).
+    const last = instance.messages[instance.messages.length - 1] as { parts: Array<{ state?: string }> }
+    expect(last.parts[0]!.state).toBe('done')
+  })
+
+  it('keeps a partial assistant message when an aborted turn had content', async () => {
+    const { instance, finishAborted } = createRetryHarness()
+    instance.messages = [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'How are you' }] },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'Partial' }] },
+    ] as never
+
+    await finishAborted()
+
+    expect(instance.messages).toHaveLength(2)
+    expect(instance.messages[1]!.role).toBe('assistant')
+  })
+
+  it('stop() cancels a pending auto-retry and settles the session to idle', async () => {
+    const { finishWithError, regenerate, instance } = createRetryHarness()
+
+    await finishWithError()
+    // A retry is scheduled and the store reflects the in-flight recovery.
+    expect(useChatStore.getState().sessions.get(sessionId)?.retryCount).toBe(1)
+
+    await instance.stop()
+
+    // The scheduled retry is cancelled — advancing past every backoff never fires.
+    await getClock().tickAsync(30_000)
+    expect(regenerate).not.toHaveBeenCalled()
+
+    const session = useChatStore.getState().sessions.get(sessionId)
+    expect(session?.retryCount).toBe(0)
+    expect(session?.retriesExhausted).toBe(false)
   })
 
   it('keeps exponential backoff for empty-turn retries after the first', async () => {

--- a/src/chats/chat-instance.test.ts
+++ b/src/chats/chat-instance.test.ts
@@ -505,6 +505,15 @@ describe('createChatInstance — retry policy', () => {
     expect(wouldAutoSend()).toBe(true)
   })
 
+  it('stop() flags the session as stopping while the abort unwinds', async () => {
+    const { instance } = createRetryHarness()
+    ;(instance as unknown as { status: string }).status = 'streaming'
+
+    await instance.stop()
+
+    expect(useChatStore.getState().sessions.get(sessionId)?.stopping).toBe(true)
+  })
+
   it('resolves an open tool-permission dialog when the turn is stopped', async () => {
     const { instance } = createRetryHarness()
     ;(instance as unknown as { status: string }).status = 'streaming'

--- a/src/chats/chat-instance.test.ts
+++ b/src/chats/chat-instance.test.ts
@@ -24,6 +24,7 @@ import type { ChatInit, ChatOnFinishCallback } from 'ai'
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
 import { useChatStore } from './chat-store'
 import { createAgentRoutingFetch, createChatInstance } from './chat-instance'
+import { getTurnActivity } from './turn-activity'
 
 const sessionId = 'sess-1'
 const httpClient: HttpClient = {} as HttpClient
@@ -465,19 +466,47 @@ describe('createChatInstance — retry policy', () => {
     expect(autoRetry?.attempt).toBe(1)
   })
 
-  it('leaves the message list untouched when a loader turn is aborted', async () => {
-    const { instance, finishAbortedEmpty } = createRetryHarness()
+  it('drops the empty shell of an aborted loader turn without re-sending it', async () => {
+    const { instance, finishAbortedEmpty, wouldAutoSend } = createRetryHarness()
+    ;(instance as unknown as { status: string }).status = 'submitted'
     instance.messages = [
       { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'How are you' }] },
       { id: 'a-empty', role: 'assistant', parts: [] },
     ] as never
 
+    await instance.stop()
     await finishAbortedEmpty()
 
-    // Dropping the shell here would leave the user message trailing, and the SDK
-    // re-checks `sendAutomaticallyWhen` the moment the aborted request unwinds —
-    // which re-sent the turn the user had just stopped (THU-791).
-    expect(instance.messages).toHaveLength(2)
+    // Two halves of one invariant, asserted together because each masks the
+    // other's regression: kept, the shell renders an empty-turn recovery spinner
+    // nothing will recover; dropped without the `stopRequested` gate, the now
+    // trailing user message makes the SDK re-send the stopped turn (THU-791).
+    expect(instance.messages).toHaveLength(1)
+    expect(instance.messages[0]!.role).toBe('user')
+    expect(wouldAutoSend()).toBe(false)
+  })
+
+  it('settles the composer to idle after an aborted loader turn', async () => {
+    const { instance, finishAbortedEmpty } = createRetryHarness()
+    ;(instance as unknown as { status: string }).status = 'submitted'
+    instance.messages = [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'How are you' }] },
+      { id: 'a-empty', role: 'assistant', parts: [] },
+    ] as never
+
+    await instance.stop()
+    await finishAbortedEmpty()
+
+    const session = useChatStore.getState().sessions.get(sessionId)
+    const activity = getTurnActivity({
+      status: 'ready',
+      lastMessage: instance.messages[instance.messages.length - 1],
+      hasChatError: false,
+      retriesExhausted: session?.retriesExhausted ?? false,
+      retryCount: session?.retryCount ?? 0,
+      stopRequested: session?.stopping ?? false,
+    })
+    expect(activity.isActive).toBe(false)
   })
 
   it('suppresses the SDK auto-send after a stop, so the turn cannot restart itself', async () => {

--- a/src/chats/chat-instance.test.ts
+++ b/src/chats/chat-instance.test.ts
@@ -501,6 +501,21 @@ describe('createChatInstance — retry policy', () => {
     expect(instance.messages[1]!.role).toBe('assistant')
   })
 
+  it('stop() delegates an in-flight abort to onFinish (no drop/reset in the handler)', async () => {
+    const { instance } = createRetryHarness()
+    ;(instance as unknown as { status: string }).status = 'streaming'
+    instance.messages = [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      { id: 'a1', role: 'assistant', parts: [] },
+    ] as never
+
+    await instance.stop()
+
+    // The abort's onFinish settles the turn on the correct `currentTurn`; the
+    // handler must not swap it out early, so it neither drops the shell nor resets.
+    expect(instance.messages).toHaveLength(2)
+  })
+
   it('stop() cancels a pending auto-retry and settles the session to idle', async () => {
     const { finishWithError, regenerate, instance } = createRetryHarness()
 

--- a/src/chats/chat-instance.test.ts
+++ b/src/chats/chat-instance.test.ts
@@ -543,6 +543,27 @@ describe('createChatInstance — retry policy', () => {
     expect(useChatStore.getState().sessions.get(sessionId)?.stopping).toBe(true)
   })
 
+  it('keeps the session stopping after the aborted turn settles, until the next explicit send', async () => {
+    const { instance, finishAbortedEmpty } = createRetryHarness()
+    ;(instance as unknown as { status: string }).status = 'submitted'
+    instance.messages = [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'How are you' }] },
+      { id: 'a-empty', role: 'assistant', parts: [] },
+    ] as never
+
+    await instance.stop()
+    await finishAbortedEmpty()
+
+    // Dropping the shell leaves the user message trailing — the exact shape
+    // useChatAutomation auto-runs. The flag must survive the turn settling
+    // (THU-791: without it, Stop restarts the turn it cancelled).
+    expect(useChatStore.getState().sessions.get(sessionId)?.stopping).toBe(true)
+
+    await instance.sendMessage({ text: 'again' })
+
+    expect(useChatStore.getState().sessions.get(sessionId)?.stopping).toBe(false)
+  })
+
   it('resolves an open tool-permission dialog when the turn is stopped', async () => {
     const { instance } = createRetryHarness()
     ;(instance as unknown as { status: string }).status = 'streaming'

--- a/src/chats/chat-instance.test.ts
+++ b/src/chats/chat-instance.test.ts
@@ -18,6 +18,7 @@ import { createMockChatInstance, hydrateStore, resetStore } from '@/test-utils/c
 import { getClock } from '@/testing-library'
 import type { SaveMessagesFunction, ThunderboltUIMessage } from '@/types'
 import type { Agent, AgentAdapter, AgentAdapterContext } from '@/types/acp'
+import type { RequestPermissionResponse } from '@agentclientprotocol/sdk'
 import type { Chat } from '@ai-sdk/react'
 import type { ChatInit, ChatOnFinishCallback } from 'ai'
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
@@ -53,6 +54,7 @@ const createRetryHarness = (saveMessages: SaveMessagesFunction = async () => {})
   const budgets: TurnBudget[] = []
   let onFinish: ChatOnFinishCallback<ThunderboltUIMessage> | undefined
   let onError: ((error: Error) => void) | undefined
+  let sendAutomaticallyWhen: ChatInit<ThunderboltUIMessage>['sendAutomaticallyWhen']
   const wakeAdapterReconnect = mock(() => {})
   const trackEvent = mock((_eventName: EventType, _properties?: Record<string, unknown>) => {})
 
@@ -65,6 +67,7 @@ const createRetryHarness = (saveMessages: SaveMessagesFunction = async () => {})
   const createChat = (init: ChatInit<ThunderboltUIMessage>) => {
     onFinish = init.onFinish
     onError = init.onError
+    sendAutomaticallyWhen = init.sendAutomaticallyWhen
     return {
       id: init.id ?? sessionId,
       messages: init.messages ?? [],
@@ -147,6 +150,9 @@ const createRetryHarness = (saveMessages: SaveMessagesFunction = async () => {})
 
   const getTurnBudget = () => budgets.at(-1)!
 
+  /** Ask the SDK's auto-send predicate what it would do with the current messages. */
+  const wouldAutoSend = () => sendAutomaticallyWhen!({ messages: instance.messages })
+
   return {
     finishSuccessfully,
     finishAborted,
@@ -158,6 +164,7 @@ const createRetryHarness = (saveMessages: SaveMessagesFunction = async () => {})
     sendMessage,
     trackEvent,
     wakeAdapterReconnect,
+    wouldAutoSend,
   }
 }
 
@@ -458,7 +465,7 @@ describe('createChatInstance — retry policy', () => {
     expect(autoRetry?.attempt).toBe(1)
   })
 
-  it('drops the empty assistant shell left when a loader turn is aborted', async () => {
+  it('leaves the message list untouched when a loader turn is aborted', async () => {
     const { instance, finishAbortedEmpty } = createRetryHarness()
     instance.messages = [
       { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'How are you' }] },
@@ -467,10 +474,54 @@ describe('createChatInstance — retry policy', () => {
 
     await finishAbortedEmpty()
 
-    // Without the drop, this empty shell re-triggers the recovery spinner and the
-    // Stop button stays up, forcing a second press (THU-791).
-    expect(instance.messages).toHaveLength(1)
-    expect(instance.messages[0]!.role).toBe('user')
+    // Dropping the shell here would leave the user message trailing, and the SDK
+    // re-checks `sendAutomaticallyWhen` the moment the aborted request unwinds —
+    // which re-sent the turn the user had just stopped (THU-791).
+    expect(instance.messages).toHaveLength(2)
+  })
+
+  it('suppresses the SDK auto-send after a stop, so the turn cannot restart itself', async () => {
+    const { instance, wouldAutoSend } = createRetryHarness()
+    ;(instance as unknown as { status: string }).status = 'submitted'
+    // Stop pressed while the model was still thinking: nothing streamed, so no
+    // assistant message was ever pushed and the user message is trailing.
+    instance.messages = [{ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }] as never
+
+    expect(wouldAutoSend()).toBe(true)
+
+    await instance.stop()
+
+    expect(wouldAutoSend()).toBe(false)
+  })
+
+  it('lifts the auto-send suppression on the next explicit send', async () => {
+    const { instance, wouldAutoSend } = createRetryHarness()
+    ;(instance as unknown as { status: string }).status = 'submitted'
+    instance.messages = [{ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }] as never
+
+    await instance.stop()
+    await instance.sendMessage({ text: 'again' })
+
+    expect(wouldAutoSend()).toBe(true)
+  })
+
+  it('resolves an open tool-permission dialog when the turn is stopped', async () => {
+    const { instance } = createRetryHarness()
+    ;(instance as unknown as { status: string }).status = 'streaming'
+    const resolve = mock((_response: RequestPermissionResponse) => {})
+    useChatStore.getState().setPendingPermission(sessionId, {
+      agentId: 'agent-1',
+      requestId: 'req-1',
+      request: {} as never,
+      resolve,
+    })
+
+    await instance.stop()
+
+    // Left pending, the dialog stays on screen awaiting an answer the cancelled
+    // turn will never consume.
+    expect(resolve).toHaveBeenCalledWith({ outcome: { outcome: 'cancelled' } })
+    expect(useChatStore.getState().sessions.get(sessionId)?.pendingPermission).toBeNull()
   })
 
   it('finalizes a reasoning part left streaming when a turn is aborted mid-thinking', async () => {

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -446,6 +446,22 @@ const recordMessageTelemetry = (telemetry: TurnTelemetry, message: ThunderboltUI
   }
 }
 
+const isEmptyAssistantMessage = (message: ThunderboltUIMessage | undefined): boolean =>
+  message?.role === 'assistant' && !message.parts?.length
+
+/** A reasoning part still mid-stream keeps its spinner running (reasoning-group.tsx)
+ *  even after the turn settles — true when an aborted turn stopped during thinking. */
+const hasStreamingReasoning = (message: ThunderboltUIMessage | undefined): boolean =>
+  !!message?.parts?.some((part) => part.type === 'reasoning' && part.state === 'streaming')
+
+/** Mark every still-streaming reasoning part `done` so its spinner stops. */
+const finalizeReasoning = (message: ThunderboltUIMessage): ThunderboltUIMessage => ({
+  ...message,
+  parts: message.parts.map((part) =>
+    part.type === 'reasoning' && part.state === 'streaming' ? { ...part, state: 'done' as const } : part,
+  ),
+})
+
 type ChatMessageInput = Parameters<Chat<ThunderboltUIMessage>['sendMessage']>[0]
 
 /** Count user-authored text across both AI SDK message input shapes. */
@@ -714,13 +730,32 @@ export const createChatInstance = (
       }
 
       if (isAbort) {
-        // Persist whatever streamed before the user hit Stop. Streaming partial
-        // saves are throttled and their pending trailing write is cancelled the
-        // moment streaming stops (see SavePartialAssistantMessagesHandler), so
-        // onFinish is the authoritative final save on abort just as it is on
-        // success — without this, the last streamed chunk of an aborted turn
-        // would be lost on reload.
-        if (message?.parts?.length) {
+        // Settle the aborted turn so no spinner survives the stop (THU-791). Three
+        // cases, keyed off the trailing assistant message:
+        const lastIndex = instance.messages.length - 1
+        const lastMessage = instance.messages[lastIndex]
+
+        if (isEmptyAssistantMessage(lastMessage)) {
+          // Stopped on the loader, before any content: the empty assistant shell
+          // re-triggers the empty-turn-recovery spinner and the Stop button stays
+          // up (a second press was needed). Drop it so one press settles to idle.
+          instance.messages = instance.messages.slice(0, -1)
+        } else if (hasStreamingReasoning(lastMessage)) {
+          // Stopped mid-reasoning: the reasoning part is left `streaming`, so its
+          // spinner never stops. Finalize it in the live list and the saved copy.
+          const finalized = finalizeReasoning(lastMessage!)
+          const next = instance.messages.slice()
+          next[lastIndex] = finalized
+          instance.messages = next
+          finishedTurn.telemetry?.startPhase('final_save')
+          await saveMessages({ id, messages: [finalized] })
+          finishedTurn.telemetry?.endPhase('final_save')
+        } else if (message?.parts?.length) {
+          // Stopped mid-answer: persist the partial. Streaming partial saves are
+          // throttled and their pending trailing write is cancelled the moment
+          // streaming stops (see SavePartialAssistantMessagesHandler), so onFinish
+          // is the authoritative final save on abort — without this the last
+          // streamed chunk would be lost on reload.
           finishedTurn.telemetry?.startPhase('final_save')
           await saveMessages({ id, messages: [message] })
           finishedTurn.telemetry?.endPhase('final_save')
@@ -945,6 +980,33 @@ export const createChatInstance = (
       } as ThunderboltUIMessage,
       options,
     )
+  }
+
+  const originalStop = instance.stop.bind(instance)
+
+  /**
+   * Stop the active turn now and settle the thread to idle — one path for every
+   * state (live stream, thinking, auto-retry backoff, empty-turn recovery).
+   *
+   * The SDK's own stop only aborts an in-flight fetch and is a no-op during the
+   * retry/recovery backoff, so on its own the turn restarts itself (THU-791). We
+   * do all of: cancel the pending retry, abort the fetch, drop a trailing empty
+   * assistant turn (left in place it re-triggers the recovery spinner, so the
+   * thread looks like it's still working right after a stop), and reset retry
+   * state. Abort is fire-and-forget so the UI settles immediately.
+   */
+  instance.stop = async function () {
+    if (retryTimeout) {
+      clearTimeout(retryTimeout)
+      retryTimeout = null
+    }
+    void originalStop()
+    const lastMessage = instance.messages[instance.messages.length - 1]
+    if (lastMessage?.role === 'assistant' && !lastMessage.parts?.length) {
+      instance.messages = instance.messages.slice(0, -1)
+    }
+    emitTurnCompleted(currentTurn, 'abort')
+    resetRetryStateForNewTurn()
   }
 
   return instance

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -661,6 +661,9 @@ export const createChatInstance = (
   let retryCount = 0
   let retryTimeout: ReturnType<typeof setTimeout> | null = null
   let lastError: Error | null = null
+  /** Set by `stop`, cleared when the user starts the next turn. Suppresses the
+   *  SDK's automatic re-send — see `sendAutomaticallyWhen` below. */
+  let stopRequested = false
 
   const emitTurnCompleted = (
     turn: TurnState,
@@ -699,6 +702,10 @@ export const createChatInstance = (
 
   const startNewTurn = () => {
     resetRetryStateForNewTurn()
+    // Only an explicit send/regenerate lifts the Stop suppression — `onFinish`
+    // runs `resetRetryStateForNewTurn` on the aborted turn itself, and clearing
+    // the flag there would re-open the auto-send it exists to block.
+    stopRequested = false
     initializeTurnForCurrentSession(currentTurn)
   }
 
@@ -718,8 +725,14 @@ export const createChatInstance = (
     messages,
     transport: new DefaultChatTransport({ fetch: customFetch }),
     generateId: uuidv7,
-    // Automatically send messages when the last one is a user message (used for automations)
-    sendAutomaticallyWhen: ({ messages }) => messages.length > 0 && messages[messages.length - 1].role === 'user',
+    // Automatically send messages when the last one is a user message (used for
+    // automations). The SDK evaluates this after every turn and gates it on
+    // `isError` only — not on `isAbort` — so a stopped turn whose assistant
+    // message never materialized (Stop pressed while `submitted`) leaves the
+    // user message trailing and gets re-sent on the spot. That is THU-791's
+    // "Stop does nothing": the turn restarted faster than the UI could settle.
+    sendAutomaticallyWhen: ({ messages }) =>
+      !stopRequested && messages.length > 0 && messages[messages.length - 1].role === 'user',
     onFinish: async ({ message, isError, isAbort }) => {
       const finishedTurn = currentTurn
       const resetRetryStateIfUnswapped = () => {
@@ -730,17 +743,12 @@ export const createChatInstance = (
       }
 
       if (isAbort) {
-        // Settle the aborted turn so no spinner survives the stop (THU-791). Three
-        // cases, keyed off the trailing assistant message:
+        // Settle the aborted turn so no spinner survives the stop (THU-791),
+        // keyed off the trailing assistant message.
         const lastIndex = instance.messages.length - 1
         const lastMessage = instance.messages[lastIndex]
 
-        if (isEmptyAssistantMessage(lastMessage)) {
-          // Stopped on the loader, before any content: the empty assistant shell
-          // re-triggers the empty-turn-recovery spinner and the Stop button stays
-          // up (a second press was needed). Drop it so one press settles to idle.
-          instance.messages = instance.messages.slice(0, -1)
-        } else if (hasStreamingReasoning(lastMessage)) {
+        if (hasStreamingReasoning(lastMessage)) {
           // Stopped mid-reasoning: the reasoning part is left `streaming`, so its
           // spinner never stops. Finalize it in the live list and the saved copy.
           const finalized = finalizeReasoning(lastMessage!)
@@ -989,12 +997,20 @@ export const createChatInstance = (
    * `onFinish({ isAbort })` settle on the correct turn — emitting/resetting here
    * would swap `currentTurn` out from under it. Backoff/recovery fires no
    * `onFinish`, so cancel the retry, drop a trailing empty shell, and settle here.
+   *
+   * `stopRequested` outlives this call: the SDK re-checks `sendAutomaticallyWhen`
+   * once the aborted request unwinds, and only an explicit send lifts it again.
    */
   instance.stop = async function () {
+    stopRequested = true
     if (retryTimeout) {
       clearTimeout(retryTimeout)
       retryTimeout = null
     }
+    // A turn stopped while its tool-permission dialog is open would leave the
+    // dialog on screen awaiting an answer the cancelled turn will never use.
+    // No-ops when nothing is pending.
+    useChatStore.getState().resolvePendingPermission(id, { outcome: { outcome: 'cancelled' } })
     if (instance.status === 'streaming' || instance.status === 'submitted') {
       void originalStop()
       return

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -697,15 +697,17 @@ export const createChatInstance = (
     retryCount = 0
     lastError = null
     currentTurn = createTurnState()
-    useChatStore.getState().updateSession(id, { retryCount: 0, retriesExhausted: false, stopping: false })
+    useChatStore.getState().updateSession(id, { retryCount: 0, retriesExhausted: false })
   }
 
   const startNewTurn = () => {
     resetRetryStateForNewTurn()
     // Only an explicit send/regenerate lifts the Stop suppression — `onFinish`
     // runs `resetRetryStateForNewTurn` on the aborted turn itself, and clearing
-    // the flag there would re-open the auto-send it exists to block.
+    // the flags there would re-open the auto-sends they exist to block (the
+    // SDK's `sendAutomaticallyWhen` and `useChatAutomation`'s auto-run).
     stopRequested = false
+    useChatStore.getState().updateSession(id, { stopping: false })
     initializeTurnForCurrentSession(currentTurn)
   }
 
@@ -1010,9 +1012,16 @@ export const createChatInstance = (
    *
    * `stopRequested` outlives this call: the SDK re-checks `sendAutomaticallyWhen`
    * once the aborted request unwinds, and only an explicit send lifts it again.
+   * The session's `stopping` flag mirrors it with the same lifetime, so
+   * `useChatAutomation` sees the suppression too — dropping the aborted shell
+   * leaves the user message trailing, exactly the shape that hook auto-runs.
    */
   instance.stop = async function () {
     stopRequested = true
+    // Mirrored into the store for the two reactive consumers: the composer's
+    // stopping spinner (masked with a live request in `getTurnActivity`, so
+    // lingering past settle is harmless) and `useChatAutomation`'s auto-run gate.
+    useChatStore.getState().updateSession(id, { stopping: true })
     if (retryTimeout) {
       clearTimeout(retryTimeout)
       retryTimeout = null
@@ -1023,9 +1032,9 @@ export const createChatInstance = (
     useChatStore.getState().resolvePendingPermission(id, { outcome: { outcome: 'cancelled' } })
     if (instance.status === 'streaming' || instance.status === 'submitted') {
       // Tearing the turn down is asynchronous — an ACP `session/cancel` is a
-      // round-trip, and the in-browser harness has to unwind its loop — so flag
-      // the wait for the composer instead of leaving the button looking inert.
-      useChatStore.getState().updateSession(id, { stopping: true })
+      // round-trip, and the in-browser harness has to unwind its loop — so the
+      // `stopping` flag also tells the composer about the wait instead of
+      // leaving the button looking inert.
       void originalStop()
       return
     }

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -985,24 +985,21 @@ export const createChatInstance = (
   const originalStop = instance.stop.bind(instance)
 
   /**
-   * Stop the active turn now and settle the thread to idle — one path for every
-   * state (live stream, thinking, auto-retry backoff, empty-turn recovery).
-   *
-   * The SDK's own stop only aborts an in-flight fetch and is a no-op during the
-   * retry/recovery backoff, so on its own the turn restarts itself (THU-791). We
-   * do all of: cancel the pending retry, abort the fetch, drop a trailing empty
-   * assistant turn (left in place it re-triggers the recovery spinner, so the
-   * thread looks like it's still working right after a stop), and reset retry
-   * state. Abort is fire-and-forget so the UI settles immediately.
+   * Stop the active turn and settle to idle (THU-791). In-flight aborts let
+   * `onFinish({ isAbort })` settle on the correct turn — emitting/resetting here
+   * would swap `currentTurn` out from under it. Backoff/recovery fires no
+   * `onFinish`, so cancel the retry, drop a trailing empty shell, and settle here.
    */
   instance.stop = async function () {
     if (retryTimeout) {
       clearTimeout(retryTimeout)
       retryTimeout = null
     }
-    void originalStop()
-    const lastMessage = instance.messages[instance.messages.length - 1]
-    if (lastMessage?.role === 'assistant' && !lastMessage.parts?.length) {
+    if (instance.status === 'streaming' || instance.status === 'submitted') {
+      void originalStop()
+      return
+    }
+    if (isEmptyAssistantMessage(instance.messages[instance.messages.length - 1])) {
       instance.messages = instance.messages.slice(0, -1)
     }
     emitTurnCompleted(currentTurn, 'abort')

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -697,7 +697,7 @@ export const createChatInstance = (
     retryCount = 0
     lastError = null
     currentTurn = createTurnState()
-    useChatStore.getState().updateSession(id, { retryCount: 0, retriesExhausted: false })
+    useChatStore.getState().updateSession(id, { retryCount: 0, retriesExhausted: false, stopping: false })
   }
 
   const startNewTurn = () => {
@@ -1012,6 +1012,10 @@ export const createChatInstance = (
     // No-ops when nothing is pending.
     useChatStore.getState().resolvePendingPermission(id, { outcome: { outcome: 'cancelled' } })
     if (instance.status === 'streaming' || instance.status === 'submitted') {
+      // Tearing the turn down is asynchronous — an ACP `session/cancel` is a
+      // round-trip, and the in-browser harness has to unwind its loop — so flag
+      // the wait for the composer instead of leaving the button looking inert.
+      useChatStore.getState().updateSession(id, { stopping: true })
       void originalStop()
       return
     }

--- a/src/chats/chat-instance.ts
+++ b/src/chats/chat-instance.ts
@@ -748,7 +748,17 @@ export const createChatInstance = (
         const lastIndex = instance.messages.length - 1
         const lastMessage = instance.messages[lastIndex]
 
-        if (hasStreamingReasoning(lastMessage)) {
+        if (isEmptyAssistantMessage(lastMessage)) {
+          // Stopped after the turn opened but before it produced anything (the
+          // model's first turn hadn't begun). The shell renders as an empty-turn
+          // recovery spinner that nothing will ever recover, so drop it.
+          //
+          // Load-bearing: this is only safe because `stopRequested` gates
+          // `sendAutomaticallyWhen`. Dropping the shell leaves the user message
+          // trailing, and the SDK re-checks that predicate the moment this
+          // request unwinds — ungated, the stopped turn re-sends itself.
+          instance.messages = instance.messages.slice(0, -1)
+        } else if (hasStreamingReasoning(lastMessage)) {
           // Stopped mid-reasoning: the reasoning part is left `streaming`, so its
           // spinner never stops. Finalize it in the live list and the saved copy.
           const finalized = finalizeReasoning(lastMessage!)

--- a/src/chats/chat-store.test.ts
+++ b/src/chats/chat-store.test.ts
@@ -158,6 +158,7 @@ describe('chat-store', () => {
               selectedAgent: builtInAgent,
               retryCount: 0,
               retriesExhausted: false,
+              stopping: false,
               selectedModel: null as unknown as Model,
               projectId: null,
               triggerData: null,

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -49,6 +49,9 @@ export type ChatSession = {
   pendingPermission: PendingPermission | null
   retryCount: number
   retriesExhausted: boolean
+  /** The user pressed Stop and the turn is still unwinding (an ACP
+   *  `session/cancel` round-trip, or the in-browser harness draining its loop). */
+  stopping: boolean
   selectedAgent: Agent
   selectedModel: Model
   /**

--- a/src/chats/chat-store.ts
+++ b/src/chats/chat-store.ts
@@ -49,8 +49,11 @@ export type ChatSession = {
   pendingPermission: PendingPermission | null
   retryCount: number
   retriesExhausted: boolean
-  /** The user pressed Stop and the turn is still unwinding (an ACP
-   *  `session/cancel` round-trip, or the in-browser harness draining its loop). */
+  /** The user pressed Stop. Stays set until the next explicit send/regenerate so
+   *  every auto-send path (the SDK's `sendAutomaticallyWhen`, `useChatAutomation`)
+   *  stays suppressed — the stopped turn's trailing user message must not re-send
+   *  itself. The composer derives its transient "stopping" spinner by masking this
+   *  with a live request (see `getTurnActivity`), so lingering is harmless there. */
   stopping: boolean
   selectedAgent: Agent
   selectedModel: Model

--- a/src/chats/save-partial-assistant-messages-handler.test.tsx
+++ b/src/chats/save-partial-assistant-messages-handler.test.tsx
@@ -138,6 +138,49 @@ describe('SavePartialAssistantMessagesHandler', () => {
     expect(mockSaveStreamingMessage).not.toHaveBeenCalled()
   })
 
+  it('should not save an assistant turn that has opened but produced no part', async () => {
+    const mockSaveStreamingMessage = mock(() => Promise.resolve())
+    const messages: ThunderboltUIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hi' }],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [],
+      },
+    ]
+    const mockChatInstance = createMockChatInstance(messages, 'streaming')
+    const mockUseChat = createMockUseChat(mockChatInstance)
+
+    hydrateStore({
+      chatInstance: mockChatInstance,
+      chatThread: null,
+      id: 'thread-1',
+      mcpClients: [],
+      models: [],
+      selectedModel: null,
+      triggerData: null,
+    })
+
+    render(
+      <SavePartialAssistantMessagesHandler saveStreamingMessage={mockSaveStreamingMessage} useChat={mockUseChat}>
+        Test
+      </SavePartialAssistantMessagesHandler>,
+      { wrapper: createQueryTestWrapper() },
+    )
+
+    await act(async () => {
+      await getClock().tickAsync(600)
+    })
+
+    // Nothing to crash-recover, and persisting it outlives the in-memory drop an
+    // aborted turn performs — the stopped turn would return as a failed one.
+    expect(mockSaveStreamingMessage).not.toHaveBeenCalled()
+  })
+
   it('should save partial assistant message when streaming', async () => {
     const mockSaveStreamingMessage = mock(() => Promise.resolve())
     const messages: ThunderboltUIMessage[] = [

--- a/src/chats/save-partial-assistant-messages-handler.ts
+++ b/src/chats/save-partial-assistant-messages-handler.ts
@@ -76,7 +76,12 @@ export const SavePartialAssistantMessagesHandler = ({
       return
     }
 
-    if (isAssistantLatest) {
+    // A turn that has opened but produced no part yet has nothing to recover, and
+    // persisting the empty shell outlives the in-memory drop an aborted turn does
+    // (chat-instance.ts) — on reload it resurfaces as a failed turn the user had
+    // deliberately stopped. The `error` branch above deliberately still saves it:
+    // there the empty trailing turn is what hydration reads to show the failure.
+    if (isAssistantLatest && latestMessage.parts.length > 0) {
       throttledSave(latestMessage, parentId)
     }
   }, [messages, isStreaming, status, throttledSave, saveStreamingMessage, chatThreadId])

--- a/src/chats/turn-activity.test.ts
+++ b/src/chats/turn-activity.test.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'bun:test'
+
+import type { ThunderboltUIMessage } from '@/types'
+import { getTurnActivity } from './turn-activity'
+
+const userMessage: ThunderboltUIMessage = { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }
+const emptyAssistant: ThunderboltUIMessage = { id: 'a1', role: 'assistant', parts: [] }
+const filledAssistant: ThunderboltUIMessage = {
+  id: 'a2',
+  role: 'assistant',
+  parts: [{ type: 'text', text: 'hello' }],
+}
+
+const base = { hasChatError: false, retriesExhausted: false, retryCount: 0 }
+
+describe('getTurnActivity', () => {
+  it('is active while the model is thinking (submitted)', () => {
+    const activity = getTurnActivity({ ...base, status: 'submitted', lastMessage: userMessage })
+    expect(activity.isGenerating).toBe(true)
+    expect(activity.isActive).toBe(true)
+    expect(activity.showSubmittedLoading).toBe(true)
+  })
+
+  it('is active while streaming', () => {
+    const activity = getTurnActivity({ ...base, status: 'streaming', lastMessage: filledAssistant })
+    expect(activity.isStreaming).toBe(true)
+    expect(activity.isActive).toBe(true)
+  })
+
+  // The THU-791 regression: an empty assistant turn sits with status back to
+  // `ready` and retryCount 0 while the thread shows a recovery spinner. The Stop
+  // button must be present here — this is what the composer missed.
+  it('is active during empty-turn recovery even with retryCount 0', () => {
+    const activity = getTurnActivity({ ...base, status: 'ready', lastMessage: emptyAssistant })
+    expect(activity.pendingEmptyTurnRecovery).toBe(true)
+    expect(activity.isActive).toBe(true)
+    expect(activity.hasError).toBe(false)
+  })
+
+  it('is active during an auto-retry backoff (retryCount > 0)', () => {
+    const activity = getTurnActivity({ ...base, status: 'ready', lastMessage: userMessage, retryCount: 1 })
+    expect(activity.isActive).toBe(true)
+  })
+
+  it('is not active once retries are exhausted (shows an error instead)', () => {
+    const activity = getTurnActivity({
+      ...base,
+      status: 'ready',
+      lastMessage: emptyAssistant,
+      retriesExhausted: true,
+      retryCount: 3,
+    })
+    expect(activity.isActive).toBe(false)
+    expect(activity.pendingEmptyTurnRecovery).toBe(false)
+    expect(activity.hasError).toBe(true)
+  })
+
+  it('is not active on a settled chat error', () => {
+    const activity = getTurnActivity({ ...base, status: 'ready', lastMessage: userMessage, hasChatError: true })
+    expect(activity.isActive).toBe(false)
+    expect(activity.hasError).toBe(true)
+    expect(activity.pendingEmptyTurnRecovery).toBe(false)
+  })
+
+  it('is idle after a normal completed turn', () => {
+    const activity = getTurnActivity({ ...base, status: 'ready', lastMessage: filledAssistant })
+    expect(activity.isActive).toBe(false)
+    expect(activity.showSubmittedLoading).toBe(false)
+    expect(activity.hasError).toBe(false)
+  })
+
+  it('does not show submitted-loading when an assistant message already hosts it', () => {
+    const activity = getTurnActivity({ ...base, status: 'submitted', lastMessage: filledAssistant })
+    expect(activity.showSubmittedLoading).toBe(false)
+    expect(activity.isActive).toBe(true)
+  })
+})

--- a/src/chats/turn-activity.test.ts
+++ b/src/chats/turn-activity.test.ts
@@ -15,7 +15,7 @@ const filledAssistant: ThunderboltUIMessage = {
   parts: [{ type: 'text', text: 'hello' }],
 }
 
-const base = { hasChatError: false, retriesExhausted: false, retryCount: 0 }
+const base = { hasChatError: false, retriesExhausted: false, retryCount: 0, stopRequested: false }
 
 describe('getTurnActivity', () => {
   it('is active while the model is thinking (submitted)', () => {
@@ -77,5 +77,28 @@ describe('getTurnActivity', () => {
     const activity = getTurnActivity({ ...base, status: 'submitted', lastMessage: filledAssistant })
     expect(activity.showSubmittedLoading).toBe(false)
     expect(activity.isActive).toBe(true)
+  })
+})
+
+describe('getTurnActivity stopping', () => {
+  it('reports stopping while the aborted request is still unwinding', () => {
+    const activity = getTurnActivity({
+      ...base,
+      status: 'streaming',
+      lastMessage: filledAssistant,
+      stopRequested: true,
+    })
+    expect(activity.isStopping).toBe(true)
+    expect(activity.isActive).toBe(true)
+  })
+
+  it('clears stopping once the request settles, even if the flag lingers', () => {
+    const activity = getTurnActivity({
+      ...base,
+      status: 'ready',
+      lastMessage: filledAssistant,
+      stopRequested: true,
+    })
+    expect(activity.isStopping).toBe(false)
   })
 })

--- a/src/chats/turn-activity.ts
+++ b/src/chats/turn-activity.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { ThunderboltUIMessage } from '@/types'
+import type { ChatStatus } from 'ai'
+
+export type TurnActivityInput = {
+  status: ChatStatus
+  lastMessage: ThunderboltUIMessage | undefined
+  /** Whether `useChat` surfaced a chat-level error for the current turn. */
+  hasChatError: boolean
+  retriesExhausted: boolean
+  retryCount: number
+}
+
+export type TurnActivity = {
+  isStreaming: boolean
+  /** A live request: the model is thinking (`submitted`) or emitting (`streaming`). */
+  isGenerating: boolean
+  /** `submitted` with no assistant message yet to host the loading indicator. */
+  showSubmittedLoading: boolean
+  emptyAssistantTurn: boolean
+  /** The model returned an empty turn and the app is (or should be) recovering
+   *  it — the thread shows a spinner, `status` is back to `ready`. */
+  pendingEmptyTurnRecovery: boolean
+  hasError: boolean
+  /**
+   * The turn is doing something the user can Stop: a live request, an empty-turn
+   * recovery spinner, or an auto-retry backoff. This is the single signal both the
+   * composer's Stop button and the thread's loading indicator key off, so the two
+   * can't disagree (THU-791 was exactly that disagreement).
+   */
+  isActive: boolean
+}
+
+/**
+ * Derive a turn's activity from `useChat`'s reactive state. Pure so both
+ * `ChatMessages` (spinner) and `ChatPromptInput` (Stop button) compute it from
+ * the same inputs and stay in lockstep.
+ */
+export const getTurnActivity = ({
+  status,
+  lastMessage,
+  hasChatError,
+  retriesExhausted,
+  retryCount,
+}: TurnActivityInput): TurnActivity => {
+  const isStreaming = status === 'streaming'
+  const isGenerating = status === 'submitted' || isStreaming
+  const showSubmittedLoading = status === 'submitted' && lastMessage?.role !== 'assistant'
+  const emptyAssistantTurn = lastMessage?.role === 'assistant' && !lastMessage.parts?.length && !isStreaming
+  const pendingEmptyTurnRecovery = emptyAssistantTurn && !hasChatError && !retriesExhausted
+  const hasError = hasChatError || (emptyAssistantTurn && retriesExhausted)
+  const isActive = isGenerating || pendingEmptyTurnRecovery || (retryCount > 0 && !retriesExhausted)
+  return {
+    isStreaming,
+    isGenerating,
+    showSubmittedLoading,
+    emptyAssistantTurn,
+    pendingEmptyTurnRecovery,
+    hasError,
+    isActive,
+  }
+}

--- a/src/chats/turn-activity.ts
+++ b/src/chats/turn-activity.ts
@@ -12,6 +12,8 @@ export type TurnActivityInput = {
   hasChatError: boolean
   retriesExhausted: boolean
   retryCount: number
+  /** The session's `stopping` flag — set by `chatInstance.stop`. */
+  stopRequested: boolean
 }
 
 export type TurnActivity = {
@@ -32,6 +34,12 @@ export type TurnActivity = {
    * can't disagree (THU-791 was exactly that disagreement).
    */
   isActive: boolean
+  /**
+   * Stop was pressed and the turn hasn't unwound yet. Derived from the live
+   * request rather than read straight off the flag, so a `stopping` left behind
+   * by a turn that settled some other way can't strand the composer.
+   */
+  isStopping: boolean
 }
 
 /**
@@ -45,6 +53,7 @@ export const getTurnActivity = ({
   hasChatError,
   retriesExhausted,
   retryCount,
+  stopRequested,
 }: TurnActivityInput): TurnActivity => {
   const isStreaming = status === 'streaming'
   const isGenerating = status === 'submitted' || isStreaming
@@ -61,5 +70,6 @@ export const getTurnActivity = ({
     pendingEmptyTurnRecovery,
     hasError,
     isActive,
+    isStopping: stopRequested && isGenerating,
   }
 }

--- a/src/chats/use-chat-automation.test.tsx
+++ b/src/chats/use-chat-automation.test.tsx
@@ -8,6 +8,7 @@ import { getClock } from '@/testing-library'
 import type { ThunderboltUIMessage } from '@/types'
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { useChatStore } from './chat-store'
 import { useChatAutomation } from './use-chat-automation'
 
 describe('useChatAutomation', () => {
@@ -60,6 +61,45 @@ describe('useChatAutomation', () => {
     })
 
     expect(mockChatInstance.regenerate).toHaveBeenCalled()
+  })
+
+  // THU-791 regression: Stop drops the aborted turn's empty shell, leaving the
+  // user message trailing — the exact shape this hook auto-runs. The session's
+  // `stopping` flag (lifted only by the next explicit send) must suppress it,
+  // or Stop restarts the very turn it cancelled.
+  it('should not auto-run a stopped turn (trailing user message with the session stopping)', async () => {
+    const messages: ThunderboltUIMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello' }],
+      },
+    ]
+    const mockChatInstance = createMockChatInstance(messages, 'ready')
+    const mockUseChat = createMockUseChat(mockChatInstance)
+
+    hydrateStore({
+      chatInstance: mockChatInstance,
+      chatThread: null,
+      id: 'thread-1',
+      mcpClients: [],
+      models: [],
+      selectedModel: null,
+      triggerData: null,
+    })
+    act(() => {
+      useChatStore.getState().updateSession('thread-1', { stopping: true })
+    })
+
+    renderHook(() => useChatAutomation({ useChat: mockUseChat }), {
+      wrapper: createQueryTestWrapper(),
+    })
+
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+
+    expect(mockChatInstance.regenerate).not.toHaveBeenCalled()
   })
 
   it('should not trigger if status is not ready', async () => {

--- a/src/chats/use-chat-automation.tsx
+++ b/src/chats/use-chat-automation.tsx
@@ -12,7 +12,7 @@ type UseChatAutomationProps = {
 }
 
 export const useChatAutomation = ({ useChat = useChat_default }: UseChatAutomationProps = {}) => {
-  const { chatInstance } = useCurrentChatSession()
+  const { chatInstance, stopping } = useCurrentChatSession()
 
   const { messages } = useChat({ chat: chatInstance, experimental_throttle: messageBookkeepingThrottleMs })
 
@@ -20,10 +20,14 @@ export const useChatAutomation = ({ useChat = useChat_default }: UseChatAutomati
 
   const hasTriggeredRef = useRef(false)
 
-  // Auto-run assistant if thread ends with user message (e.g., automation) and no assistant response yet
+  // Auto-run assistant if thread ends with user message (e.g., automation) and no
+  // assistant response yet. Gated on `stopping`: a stopped turn also ends with a
+  // trailing user message (the aborted shell is dropped), so without the gate this
+  // effect would restart the very turn the user just cancelled (THU-791).
   useEffect(() => {
     if (
       !hasTriggeredRef.current &&
+      !stopping &&
       chatInstance?.status === 'ready' &&
       hasMessages &&
       chatInstance?.messages[chatInstance?.messages.length - 1].role === 'user'
@@ -34,5 +38,5 @@ export const useChatAutomation = ({ useChat = useChat_default }: UseChatAutomati
         console.error('Auto regenerate error', err)
       })
     }
-  }, [chatInstance, hasMessages])
+  }, [chatInstance, hasMessages, stopping])
 }

--- a/src/chats/use-hydrate-chat-store.ts
+++ b/src/chats/use-hydrate-chat-store.ts
@@ -271,6 +271,7 @@ export const useHydrateChatStore = ({ id, isNew, projectId: newChatProjectId = n
       pendingPermission: null,
       retryCount: 0,
       retriesExhausted: hydratedTrailingEmptyTurn,
+      stopping: false,
       // Persisted via `chatThreads.agentId`; resolved above (first available
       // agent when the persisted id no longer matches).
       selectedAgent,

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -10,6 +10,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useCurrentChatSession } from '@/chats/chat-store'
 import { useChat as useChat_default } from '@ai-sdk/react'
 import { messageRenderThrottleMs } from '@/chats/chat-throttle'
+import { getTurnActivity } from '@/chats/turn-activity'
 import { shouldUseViewportPositioning } from '@/chats/use-chat-scroll-handler'
 import { isAttachmentPart } from '@/lib/attachments'
 import { useHaptics } from '@/hooks/use-haptics'
@@ -43,36 +44,30 @@ export const ChatMessages = memo(({ useChat = useChat_default }: ChatMessagesPro
   })
   const { triggerNotification } = useHaptics()
 
-  const isStreaming = status === 'streaming'
-  const wasStreaming = useRef(false)
-
-  useEffect(() => {
-    if (wasStreaming.current && !isStreaming) {
-      triggerNotification(chatError ? 'error' : 'success')
-    }
-    wasStreaming.current = isStreaming
-  }, [isStreaming, chatError, triggerNotification])
-
   const lastMessage = useMemo(() => messages[messages.length - 1], [messages])
   const lastAssistantMessage = useMemo(
     () => messages.findLast((m) => m.role === 'assistant' && (m.parts?.length ?? 0) > 0),
     [messages],
   )
 
-  // After the user sends a message, AI SDK reports status `submitted` until the
-  // first assistant delta arrives. During that window there is no assistant
-  // message to host the synthetic loading indicator, so render it inline here.
-  const showSubmittedLoading = status === 'submitted' && lastMessage?.role !== 'assistant'
+  // `showSubmittedLoading`: `submitted` with no assistant message yet to host the
+  // loading indicator, so render it inline here. Shared with the composer's Stop
+  // button via getTurnActivity so the two never disagree (THU-791).
+  const { isStreaming, showSubmittedLoading, pendingEmptyTurnRecovery, hasError } = getTurnActivity({
+    status,
+    lastMessage,
+    hasChatError: chatError != null,
+    retriesExhausted,
+    retryCount,
+  })
 
-  const emptyAssistantTurn = lastMessage?.role === 'assistant' && !lastMessage.parts?.length && !isStreaming
-  const pendingEmptyTurnRecovery = emptyAssistantTurn && !chatError && !retriesExhausted
-
-  const hasError = useMemo(() => {
-    if (chatError) {
-      return true
+  const wasStreaming = useRef(false)
+  useEffect(() => {
+    if (wasStreaming.current && !isStreaming) {
+      triggerNotification(chatError ? 'error' : 'success')
     }
-    return emptyAssistantTurn && retriesExhausted
-  }, [chatError, emptyAssistantTurn, retriesExhausted])
+    wasStreaming.current = isStreaming
+  }, [isStreaming, chatError, triggerNotification])
 
   // Re-deliver a failed turn's attachments as text/images (auto on a detected
   // content-rejection, or via the buttons below). Gate auto-fire on a settled error.

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -30,7 +30,7 @@ type ChatMessagesProps = {
 // intended throttle cadence. It takes no props that change (`useChat` defaults
 // to the real hook), so the shallow prop compare holds across parent renders.
 export const ChatMessages = memo(({ useChat = useChat_default }: ChatMessagesProps) => {
-  const { chatInstance, retryCount, retriesExhausted } = useCurrentChatSession()
+  const { chatInstance, retryCount, retriesExhausted, stopping } = useCurrentChatSession()
 
   const {
     error: chatError,
@@ -59,6 +59,7 @@ export const ChatMessages = memo(({ useChat = useChat_default }: ChatMessagesPro
     hasChatError: chatError != null,
     retriesExhausted,
     retryCount,
+    stopRequested: stopping,
   })
 
   const wasStreaming = useRef(false)

--- a/src/components/chat/chat-prompt-input.test.tsx
+++ b/src/components/chat/chat-prompt-input.test.tsx
@@ -12,7 +12,7 @@ import {
   resetStore,
 } from '@/test-utils/chat-store-mocks'
 import { createQueryTestWrapper } from '@/test-utils/react-query'
-import type { Model } from '@/types'
+import type { Model, ThunderboltUIMessage } from '@/types'
 import { act, cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { createElement, createRef, type ReactNode } from 'react'
@@ -67,9 +67,12 @@ const TestWrapper = ({ children }: { children: ReactNode }) => {
 }
 
 /** Hydrate the chat store with sensible defaults for testing */
-const setupStore = () => {
+const setupStore = (
+  status: 'ready' | 'submitted' | 'streaming' | 'error' = 'ready',
+  messages: ThunderboltUIMessage[] = [],
+) => {
   const mockModel = createMockModel()
-  const mockChatInstance = createMockChatInstance([], 'ready')
+  const mockChatInstance = createMockChatInstance(messages, status)
   const mockUseChat = createMockUseChat(mockChatInstance)
 
   hydrateStore({
@@ -113,6 +116,89 @@ describe('ChatPromptInput', () => {
       })
 
       expect(screen.getByPlaceholderText('Ask me anything…')).toBeInTheDocument()
+    })
+  })
+
+  describe('stop button', () => {
+    it('shows the Stop button while the model is thinking (submitted)', () => {
+      const { mockUseChat } = setupStore('submitted')
+
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      expect(screen.getByLabelText('Stop generating')).toBeInTheDocument()
+      expect(screen.queryByLabelText('Send message')).toBeNull()
+    })
+
+    it('shows the Stop button while streaming', () => {
+      const { mockUseChat } = setupStore('streaming')
+
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      expect(screen.getByLabelText('Stop generating')).toBeInTheDocument()
+    })
+
+    // Empty assistant turn sitting with status `ready` and retryCount 0 while the
+    // thread shows a recovery spinner — the Stop button must still be present.
+    it('shows the Stop button during empty-turn recovery (status ready, retryCount 0)', () => {
+      const messages: ThunderboltUIMessage[] = [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'How are you doing?' }] },
+        { id: 'a1', role: 'assistant', parts: [] },
+      ]
+      const { mockUseChat } = setupStore('ready', messages)
+
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      expect(screen.getByLabelText('Stop generating')).toBeInTheDocument()
+    })
+
+    it('shows the Stop button during an auto-retry backoff (status ready)', () => {
+      const { mockUseChat } = setupStore('ready')
+      act(() => {
+        useChatStore.getState().updateSession('thread-1', { retryCount: 1, retriesExhausted: false })
+      })
+
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      expect(screen.getByLabelText('Stop generating')).toBeInTheDocument()
+    })
+
+    it('hides the Stop button once retries are exhausted', () => {
+      const { mockUseChat } = setupStore('ready')
+      act(() => {
+        useChatStore.getState().updateSession('thread-1', { retryCount: 3, retriesExhausted: true })
+      })
+
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      expect(screen.queryByLabelText('Stop generating')).toBeNull()
+    })
+
+    it('calls stop on click and stays tappable (no stopping spinner)', () => {
+      const { mockUseChat, mockChatInstance } = setupStore('streaming')
+
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      const stopButton = screen.getByLabelText('Stop generating') as HTMLButtonElement
+      act(() => {
+        fireEvent.click(stopButton)
+      })
+
+      expect(mockChatInstance.stop).toHaveBeenCalledTimes(1)
+      // Stop is stop — the button never disables or shows an activity indicator.
+      expect(stopButton.disabled).toBe(false)
+      expect(stopButton.querySelector('.animate-spin')).toBeNull()
     })
   })
 

--- a/src/components/chat/chat-prompt-input.test.tsx
+++ b/src/components/chat/chat-prompt-input.test.tsx
@@ -183,7 +183,7 @@ describe('ChatPromptInput', () => {
       expect(screen.queryByLabelText('Stop generating')).toBeNull()
     })
 
-    it('calls stop on click and stays tappable (no stopping spinner)', () => {
+    it('calls stop on click', () => {
       const { mockUseChat, mockChatInstance } = setupStore('streaming')
 
       render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
@@ -196,9 +196,30 @@ describe('ChatPromptInput', () => {
       })
 
       expect(mockChatInstance.stop).toHaveBeenCalledTimes(1)
-      // Stop is stop — the button never disables or shows an activity indicator.
-      expect(stopButton.disabled).toBe(false)
+      // The mock `stop` doesn't flip the session's `stopping` flag, so the button
+      // still shows its pre-stop state here; the stopping state is covered below.
       expect(stopButton.querySelector('.animate-spin')).toBeNull()
+    })
+
+    it('shows the stopping spinner and stays pressable while the turn unwinds', () => {
+      const { mockUseChat, mockChatInstance } = setupStore('streaming')
+      act(() => {
+        useChatStore.getState().updateSession('thread-1', { stopping: true })
+      })
+
+      render(<ChatPromptInput useChat={mockUseChat} useIsMobile={createMockUseIsMobile()} />, {
+        wrapper: TestWrapper,
+      })
+
+      const stopButton = screen.getByLabelText('Stopping') as HTMLButtonElement
+      expect(stopButton.querySelector('.animate-spin')).not.toBeNull()
+      // Stays pressable: stop is idempotent, and disabling it would leave no
+      // escape hatch if the teardown stalls.
+      expect(stopButton.disabled).toBe(false)
+      act(() => {
+        fireEvent.click(stopButton)
+      })
+      expect(mockChatInstance.stop).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -199,6 +199,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
       id: chatThreadId,
       retryCount,
       retriesExhausted,
+      stopping,
       selectedAgent,
       selectedModel,
     } = useCurrentChatSession()
@@ -258,12 +259,13 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
 
     // Show the Stop button whenever the thread is busy — the same signal
     // `ChatMessages` uses for its loading spinner, so the two stay in sync.
-    const { isActive: isBusy } = getTurnActivity({
+    const { isActive: isBusy, isStopping } = getTurnActivity({
       status,
       lastMessage: messages[messages.length - 1],
       hasChatError: chatError != null,
       retriesExhausted,
       retryCount,
+      stopRequested: stopping,
     })
     const isConnecting = connectionStatus === 'connecting'
     const isConnectionError = connectionStatus === 'error' && connectionError != null
@@ -846,6 +848,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             canSubmit={input.trim().length > 0 || attachments.length > 0 || quotes.length > 0}
             isLoading={isBusy || isConnecting}
             isStreaming={isBusy}
+            isStopping={isStopping}
             onStop={stop}
             // Desktop always autofocuses. The native mobile app autofocuses on a
             // fresh chat (opening the app should land ready to type, keyboard up —

--- a/src/components/chat/chat-prompt-input.tsx
+++ b/src/components/chat/chat-prompt-input.tsx
@@ -32,6 +32,7 @@ import type { MessageDescriptor } from '@lingui/core'
 import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { messageBookkeepingThrottleMs } from '@/chats/chat-throttle'
+import { getTurnActivity } from '@/chats/turn-activity'
 import { useDraftInput } from '@/hooks/use-draft-input'
 import { AnimatePresence, m } from 'framer-motion'
 import { AlertCircle, Loader2, X } from 'lucide-react'
@@ -196,6 +197,8 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
       connectionStatus,
       connectionError,
       id: chatThreadId,
+      retryCount,
+      retriesExhausted,
       selectedAgent,
       selectedModel,
     } = useCurrentChatSession()
@@ -203,7 +206,13 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
     // member expression inside a macro extracts as positional `{0}`.
     const agentName = selectedAgent.name
 
-    const { messages, status, stop, sendMessage } = useChat({
+    const {
+      messages,
+      status,
+      stop,
+      sendMessage,
+      error: chatError,
+    } = useChat({
       chat: chatInstance,
       experimental_throttle: messageBookkeepingThrottleMs,
     })
@@ -247,7 +256,15 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
       [skillBySlug, isEnabled, agentCommandNames],
     )
 
-    const isStreaming = status === 'streaming'
+    // Show the Stop button whenever the thread is busy — the same signal
+    // `ChatMessages` uses for its loading spinner, so the two stay in sync.
+    const { isActive: isBusy } = getTurnActivity({
+      status,
+      lastMessage: messages[messages.length - 1],
+      hasChatError: chatError != null,
+      retriesExhausted,
+      retryCount,
+    })
     const isConnecting = connectionStatus === 'connecting'
     const isConnectionError = connectionStatus === 'error' && connectionError != null
 
@@ -532,9 +549,9 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
 
     const handleSubmit = async () => {
       try {
-        // Prevent submitting while streaming, or with no text, attachments, or quotes.
+        // Prevent submitting while a turn is in flight, or with no text, attachments, or quotes.
         const textToSend = normalizedInput.trim()
-        if (isStreaming || (!textToSend && attachments.length === 0 && quotes.length === 0)) {
+        if (isBusy || (!textToSend && attachments.length === 0 && quotes.length === 0)) {
           return
         }
 
@@ -827,8 +844,8 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             onSubmit={handleSubmit}
             // Allow sending an attachment even with no typed text (matches the Enter behavior).
             canSubmit={input.trim().length > 0 || attachments.length > 0 || quotes.length > 0}
-            isLoading={isStreaming || isConnecting}
-            isStreaming={isStreaming}
+            isLoading={isBusy || isConnecting}
+            isStreaming={isBusy}
             onStop={stop}
             // Desktop always autofocuses. The native mobile app autofocuses on a
             // fresh chat (opening the app should land ready to type, keyboard up —
@@ -837,7 +854,7 @@ export const ChatPromptInput = forwardRef<ChatPromptInputRef, ChatPromptInputPro
             // history the user came to read would be hostile. Mobile web keeps no
             // autofocus: browsers won't show the keyboard for it anyway.
             autoFocus={!isMobile || (isPlatformMobile() && isNewChat)}
-            submitOnEnter={!isStreaming && !shouldInsertNewlineOnEnter}
+            submitOnEnter={!isBusy && !shouldInsertNewlineOnEnter}
             // Voice mode covers the composer with an overlay; make the underlying
             // input non-interactive so Tab/Enter can't reach the hidden textarea.
             inert={voice.active}

--- a/src/components/chat/reasoning-display.test.tsx
+++ b/src/components/chat/reasoning-display.test.tsx
@@ -25,3 +25,15 @@ it.each([
   act(() => getClock().tick(1))
   expect(container.textContent).toBe('')
 })
+
+it('reserves height while the reasoning is shown (streaming)', () => {
+  const { container } = render(<ReasoningDisplay text="thinking…" isStreaming />)
+  expect((container.firstChild as HTMLElement).className).toContain('min-h-[200px]')
+})
+
+// A stopped reasoning-only turn never gets a text part to unmount this display,
+// so an unconditional reserve leaves a permanent blank gap below "Thought for…".
+it('does not reserve height once the reasoning has settled', () => {
+  const { container } = render(<ReasoningDisplay text="thinking…" isStreaming={false} />)
+  expect((container.firstChild as HTMLElement).className).not.toContain('min-h-[200px]')
+})

--- a/src/components/chat/reasoning-display.tsx
+++ b/src/components/chat/reasoning-display.tsx
@@ -78,9 +78,11 @@ export const ReasoningDisplay = ({ text, isStreaming }: ReasoningDisplayProps) =
     rootMargin: '0px',
   })
 
-  // Always render the container with min-height, but only show content when there's text
+  // Reserve height only while the ephemeral reasoning is shown, so it collapses
+  // once faded. A stopped reasoning-only turn never gets a text part to unmount
+  // this display, so an unconditional reserve would leave a permanent blank gap.
   return (
-    <div className="relative mt-1 min-h-[200px]">
+    <div className={`relative mt-1${shouldShow ? ' min-h-[200px]' : ''}`}>
       <AnimatePresence mode="wait">
         {shouldShow && hasText && (
           <m.div

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -8,7 +8,7 @@ import { type ChatThread } from '@/layout/sidebar/types'
 import { cn } from '@/lib/utils'
 import type { Model } from '@/types'
 import { useLingui } from '@lingui/react/macro'
-import { ArrowUp, Square } from 'lucide-react'
+import { ArrowUp, Loader2, Square } from 'lucide-react'
 import {
   type ChangeEvent,
   type ClipboardEvent,
@@ -41,6 +41,9 @@ type PromptInputProps = {
    *  while voice mode covers it with an overlay. */
   inert?: boolean
   isStreaming?: boolean
+  /** Stop was pressed and the turn is still unwinding. Swaps the stop icon for a
+   *  spinner and blocks a second press from firing another abort. */
+  isStopping?: boolean
   onStop?: () => void
   footerStartElements?: ReactNode
   /** Rendered in the footer's right cluster, just before the submit button. */
@@ -99,6 +102,7 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
       noForm = false,
       inert = false,
       isStreaming = false,
+      isStopping = false,
       onStop,
       footerStartElements,
       footerEndElements,
@@ -162,11 +166,16 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
         <Button
           type="button"
           variant="default"
-          aria-label={t`Stop generating`}
+          aria-label={isStopping ? t`Stopping` : t`Stop generating`}
           className="size-[var(--touch-height-control)] rounded-[var(--radius-control)] flex items-center justify-center flex-shrink-0"
+          disabled={isStopping}
           onClick={onStop}
         >
-          <Square className="size-[var(--icon-size-default)]" />
+          {isStopping ? (
+            <Loader2 className="size-[var(--icon-size-default)] animate-spin" />
+          ) : (
+            <Square className="size-[var(--icon-size-default)]" />
+          )}
         </Button>
       ) : !submittable && emptyStateAction ? (
         emptyStateAction

--- a/src/components/ui/prompt-input.tsx
+++ b/src/components/ui/prompt-input.tsx
@@ -42,7 +42,8 @@ type PromptInputProps = {
   inert?: boolean
   isStreaming?: boolean
   /** Stop was pressed and the turn is still unwinding. Swaps the stop icon for a
-   *  spinner and blocks a second press from firing another abort. */
+   *  spinner. The button stays pressable — stop is idempotent, and disabling it
+   *  would remove the only escape hatch if the teardown stalls. */
   isStopping?: boolean
   onStop?: () => void
   footerStartElements?: ReactNode
@@ -168,7 +169,6 @@ export const PromptInput = forwardRef<HTMLFormElement, PromptInputProps>(
           variant="default"
           aria-label={isStopping ? t`Stopping` : t`Stop generating`}
           className="size-[var(--touch-height-control)] rounded-[var(--radius-control)] flex items-center justify-center flex-shrink-0"
-          disabled={isStopping}
           onClick={onStop}
         >
           {isStopping ? (

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3317,6 +3317,10 @@ msgstr "Status"
 msgid "Stop generating"
 msgstr "Generierung stoppen"
 
+#: src/components/ui/prompt-input.tsx
+msgid "Stopping"
+msgstr ""
+
 #: src/components/storage-unavailable-screen.tsx
 msgid "Storage is disabled"
 msgstr "Speicher ist deaktiviert"

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -3317,6 +3317,10 @@ msgstr ""
 msgid "Stop generating"
 msgstr ""
 
+#: src/components/ui/prompt-input.tsx
+msgid "Stopping"
+msgstr ""
+
 #: src/components/storage-unavailable-screen.tsx
 msgid "Storage is disabled"
 msgstr ""

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3317,6 +3317,10 @@ msgstr "Status"
 msgid "Stop generating"
 msgstr "Stop generating"
 
+#: src/components/ui/prompt-input.tsx
+msgid "Stopping"
+msgstr "Stopping"
+
 #: src/components/storage-unavailable-screen.tsx
 msgid "Storage is disabled"
 msgstr "Storage is disabled"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3329,6 +3329,10 @@ msgstr "Estado"
 msgid "Stop generating"
 msgstr "Detener la generación"
 
+#: src/components/ui/prompt-input.tsx
+msgid "Stopping"
+msgstr ""
+
 #: src/components/storage-unavailable-screen.tsx
 msgid "Storage is disabled"
 msgstr "El almacenamiento está desactivado"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3329,6 +3329,10 @@ msgstr "Statut"
 msgid "Stop generating"
 msgstr "Arrêter la génération"
 
+#: src/components/ui/prompt-input.tsx
+msgid "Stopping"
+msgstr ""
+
 #: src/components/storage-unavailable-screen.tsx
 msgid "Storage is disabled"
 msgstr "Le stockage est désactivé"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3305,6 +3305,10 @@ msgstr "ステータス"
 msgid "Stop generating"
 msgstr "生成を停止"
 
+#: src/components/ui/prompt-input.tsx
+msgid "Stopping"
+msgstr ""
+
 #: src/components/storage-unavailable-screen.tsx
 msgid "Storage is disabled"
 msgstr "ストレージが無効です"

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -3329,6 +3329,10 @@ msgstr "Status"
 msgid "Stop generating"
 msgstr "Parar a geração"
 
+#: src/components/ui/prompt-input.tsx
+msgid "Stopping"
+msgstr ""
+
 #: src/components/storage-unavailable-screen.tsx
 msgid "Storage is disabled"
 msgstr "O armazenamento está desativado"

--- a/src/test-utils/chat-store-mocks.ts
+++ b/src/test-utils/chat-store-mocks.ts
@@ -191,6 +191,7 @@ export const hydrateStore = (state: {
       pendingPermission: null,
       retryCount: 0,
       retriesExhausted: false,
+      stopping: false,
       selectedAgent: builtInAgent,
       selectedModel: state.selectedModel ?? defaultTestModel,
       // Mirrors production: a chat's project comes from its persisted thread.


### PR DESCRIPTION
## Summary

The Stop button did nothing while the model was thinking or auto-retrying — it only worked once tokens were already streaming. Stop now ends the turn from any state and settles the thread back to idle.

## Changes

- Show Stop whenever the thread is busy — thinking (`submitted`), streaming, or empty-turn/auto-retry recovery — via a shared `getTurnActivity` signal used by both the composer and the message list, so the button and the loading spinner can't disagree.
- `stop` cancels any pending auto-retry and drops a trailing empty assistant turn, so the recovery spinner can't restart the turn.
- On abort, `onFinish` settles the turn in one of three ways: drop an empty loader shell, finalize a mid-reasoning turn so its spinner stops, or keep a streamed partial answer.
- Collapse the blank space left below "Thought for …" after stopping a reasoning-only turn.

## Evidences

https://github.com/user-attachments/assets/14369679-bb16-4a50-80b9-200be94d5b87


