### PR TITLE
ci(release): publish desktop nightlies as GitHub Latest

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -71,13 +71,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
-          NIGHTLY: ${{ inputs.nightly }}
         run: |
           if gh release view "v${VERSION}" --repo "$REPO" >/dev/null 2>&1; then
             exit 0
           fi
+          # Do not mark nightlies as prerelease — desktop publishes them as the
+          # GitHub Latest release (#1219). Creating with --prerelease here would
+          # race the desktop draft job and hide builds from the sidebar.
           FLAGS="--draft"
-          [ "$NIGHTLY" = "true" ] && FLAGS="$FLAGS --prerelease"
           gh release create "v${VERSION}" --repo "$REPO" $FLAGS \
             --title "Release v${VERSION}" \
             --notes "Release assets are uploaded by CI." \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -51,6 +51,9 @@ jobs:
         run: |
           echo "version=v$INPUT_VERSION" >> $GITHUB_OUTPUT
 
+      # Nightlies are full GitHub Releases (not prerelease) so the latest build
+      # appears in the repo sidebar — desktop nightlies are the current public
+      # artifacts while tagged stables are sparse. See #1219.
       - name: Create GitHub Release (Nightly)
         if: ${{ inputs.nightly }}
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
@@ -58,7 +61,8 @@ jobs:
           tag_name: v${{ inputs.version }}
           name: Nightly Build v${{ inputs.version }}
           draft: true
-          prerelease: true
+          prerelease: false
+          make_latest: true
           body: |
             ## Nightly Build v${{ inputs.version }}
 
@@ -387,13 +391,15 @@ jobs:
     if: ${{ !cancelled() && needs.draft.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
+      # Publish as a non-prerelease Latest release so desktop builds (including
+      # nightlies) show up on the GitHub Releases sidebar. CrabNebula auto-update
+      # for nightlies remains skipped below. See #1219.
       - name: Publish GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRERELEASE: ${{ inputs.nightly }}
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          gh release edit "v${RELEASE_VERSION}" --repo "${{ github.repository }}" --draft=false --prerelease="${PRERELEASE}"
+          gh release edit "v${RELEASE_VERSION}" --repo "${{ github.repository }}" --draft=false --prerelease=false --latest=true
 
       # Publish release on CrabNebula Cloud for auto-updates (skip for nightly to prevent unstable auto-updates)
       - name: Publish to CrabNebula Cloud

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -271,6 +271,14 @@ Once the tag exists, all platform builds run in parallel:
 - **iOS TestFlight**: Testers with access are notified
 - **Android Play Store**: Available on internal track for testing
 
+## Desktop Nightly Releases
+
+Scheduled desktop nightlies (`v{version}-nightly.YYYYMMDD`) are published as **full** GitHub Releases (not prerelease) and marked **Latest**, so the current build appears in the repository Releases sidebar.
+
+- The release title/body still label the build as nightly and warn that it may be unstable.
+- CrabNebula auto-update uploads remain skipped for nightlies so unstable builds are not pushed to the in-app updater.
+- The CLI workflow must not create the shared draft with `--prerelease`, or it would race desktop and hide the build from the sidebar.
+
 ## Platform-Specific Releases
 
 ### iOS-Only Releases


### PR DESCRIPTION
Publish desktop nightlies as non-prerelease Latest GitHub releases (and stop the CLI draft race from marking them prerelease) so current builds show in the repo sidebar.

Fixes #1219