### PR TITLE
THU-807: Add the synced language setting and preferences selector

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -31,6 +31,7 @@ import {
   useHttpClient,
 } from '@/contexts'
 import { usePageTracking } from '@/hooks/use-analytics'
+import { useAppLanguage } from '@/hooks/use-app-language'
 import { useDeepLinkListener } from '@/hooks/use-deep-link-listener'
 import { useKeyboardInset } from '@/hooks/use-keyboard-inset'
 import { useViewportLock } from '@/hooks/use-viewport-lock'
@@ -173,6 +174,7 @@ const useBootstrapSystemAgents = () => {
 const AppContent = ({ initData }: { initData: InitData }) => {
   useMcpSync()
   useBootstrapSystemAgents()
+  useAppLanguage()
   useKeyboardInset()
   useViewportLock()
   useSafeAreaInset()

--- a/src/components/onboarding/onboarding-dialog.tsx
+++ b/src/components/onboarding/onboarding-dialog.tsx
@@ -10,11 +10,12 @@ import { deleteIntegrationCredentials } from '@/dal'
 import type { OAuthProvider } from '@/lib/auth'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSettings } from '@/hooks/use-settings'
-import { useOnboardingState } from '@/hooks/use-onboarding-state'
+import { onboardingStepCount, useOnboardingState } from '@/hooks/use-onboarding-state'
 import { OnboardingPrivacyStep } from './onboarding-privacy-step'
 import { OnboardingAuthStep } from './onboarding-auth-step'
 import { OnboardingNameStep } from './onboarding-name-step'
 import { OnboardingLocationStep } from './onboarding-location-step'
+import { OnboardingLanguageStep } from './onboarding-language-step'
 import { OnboardingCelebrationStep } from './onboarding-celebration-step'
 import { StepIndicators } from './step-indicators'
 import { OnboardingActionButtons } from './onboarding-action-buttons'
@@ -66,7 +67,7 @@ export const OnboardingDialog = () => {
 
   // Unified action handlers
   const handleContinue = async () => {
-    if (state.currentStep === 5) {
+    if (state.currentStep === onboardingStepCount) {
       // Special handling for celebration step
       handleCelebrationComplete()
     } else if (state.currentStep === 2) {
@@ -88,6 +89,8 @@ export const OnboardingDialog = () => {
       actions.nextStep()
     }
   }
+
+  const isCelebration = state.currentStep === onboardingStepCount
 
   const handleBackAction = () => {
     if (state.canGoBack) {
@@ -116,7 +119,7 @@ export const OnboardingDialog = () => {
           style={isMobile ? { paddingBottom: 'var(--kb, 0px)' } : undefined}
         >
           <div className="relative flex w-full shrink-0 items-center justify-center px-4 pb-2">
-            <StepIndicators currentStep={state.currentStep} totalSteps={5} />
+            <StepIndicators currentStep={state.currentStep} totalSteps={onboardingStepCount} />
           </div>
           <div className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto px-6 py-4">
             {state.currentStep === 1 && <OnboardingPrivacyStep state={state} actions={actions} />}
@@ -134,15 +137,16 @@ export const OnboardingDialog = () => {
             {state.currentStep === 4 && (
               <OnboardingLocationStep state={state} actions={actions} onFormDirtyChange={setIsFormDirty} />
             )}
-            {state.currentStep === 5 && <OnboardingCelebrationStep />}
+            {state.currentStep === 5 && <OnboardingLanguageStep />}
+            {state.currentStep === 6 && <OnboardingCelebrationStep />}
           </div>
           <div className="relative flex w-full shrink-0 px-5 pt-2">
             <OnboardingActionButtons
-              onBack={state.currentStep === 5 ? undefined : state.canGoBack ? handleBackAction : undefined}
-              onSkip={state.currentStep === 5 ? undefined : state.canSkip ? handleSkipAction : undefined}
+              onBack={isCelebration ? undefined : state.canGoBack ? handleBackAction : undefined}
+              onSkip={isCelebration ? undefined : state.canSkip ? handleSkipAction : undefined}
               onContinue={handleContinue}
-              showBack={state.currentStep === 5 ? false : state.canGoBack}
-              showSkip={state.currentStep === 5 ? false : state.canSkip}
+              showBack={isCelebration ? false : state.canGoBack}
+              showSkip={isCelebration ? false : state.canSkip}
               skipDisabled={
                 (state.currentStep === 2 && state.isProviderConnected) ||
                 (state.currentStep === 3 && state.isNameValid) ||
@@ -157,13 +161,9 @@ export const OnboardingDialog = () => {
                       ? !state.isNameValid
                       : state.currentStep === 4
                         ? !state.isLocationValid
-                        : state.currentStep === 5
-                          ? isCompleting
-                          : true
+                        : isCelebration && isCompleting
               }
-              continueText={
-                state.currentStep === 5 ? (isCompleting ? 'Completing...' : 'Start Using Thunderbolt') : 'Continue'
-              }
+              continueText={isCelebration ? (isCompleting ? 'Completing...' : 'Start Using Thunderbolt') : 'Continue'}
             />
           </div>
         </div>

--- a/src/components/onboarding/onboarding-language-step.test.tsx
+++ b/src/components/onboarding/onboarding-language-step.test.tsx
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { createTestProvider } from '@/test-utils/test-provider'
+import '@testing-library/jest-dom'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { OnboardingLanguageStep } from './onboarding-language-step'
+
+beforeAll(async () => {
+  await setupTestDatabase()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+describe('OnboardingLanguageStep', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  const renderStep = () => render(<OnboardingLanguageStep />, { wrapper: createTestProvider() })
+
+  it('renders the language prompt', () => {
+    renderStep()
+
+    expect(screen.getByText('Which language do you prefer?')).toBeInTheDocument()
+  })
+
+  it('exposes a labelled language picker', () => {
+    renderStep()
+
+    expect(screen.getByRole('combobox', { name: 'Language' })).toBeInTheDocument()
+  })
+})

--- a/src/components/onboarding/onboarding-language-step.tsx
+++ b/src/components/onboarding/onboarding-language-step.tsx
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { useSettings } from '@/hooks/use-settings'
+import { languageOptions } from '@/i18n/language-options'
+import { sourceLocale } from '@/i18n/locales'
+import { getBrowserLanguages, resolveLocale } from '@/i18n/resolve-locale'
+import { Languages } from 'lucide-react'
+import { OnboardingStepHeader } from './onboarding-step-header'
+
+/**
+ * Deliberately independent of the location step: the picker starts from the
+ * browser-negotiated locale, not the country just chosen, so travelling or
+ * living abroad doesn't quietly change the UI language.
+ */
+export const OnboardingLanguageStep = () => {
+  const { language } = useSettings({ language: sourceLocale as string })
+  const activeLanguage = resolveLocale(language.value, getBrowserLanguages())
+
+  return (
+    <div className="flex w-full flex-1 flex-col justify-center">
+      <OnboardingStepHeader
+        icon={<Languages className="size-10 text-primary" />}
+        title="Which language do you prefer?"
+        description="Thunderbolt will use it across the app. You can change it later in Preferences."
+      />
+
+      <div className="mt-10">
+        <Select value={activeLanguage} onValueChange={(value) => void language.setValue(value)}>
+          <SelectTrigger className="w-full" aria-label="Language">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {languageOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}

--- a/src/components/sync-setup/recovery-key-entry-step.tsx
+++ b/src/components/sync-setup/recovery-key-entry-step.tsx
@@ -44,6 +44,17 @@ export const RecoveryKeyEntryStep = ({ value, error, onChange, onSubmit, isLoadi
             }`}
             autoFocus
             disabled={isLoading}
+            // The phrase is BIP-39 English whatever the UI language is, and
+            // `useAppLanguage` now points `<html lang>` at the active locale — so
+            // without these the browser applies German or Japanese autocorrect
+            // (and, on mobile, autocapitalisation) to it. One mangled word costs
+            // the user access to their encrypted data permanently, so nothing here
+            // is allowed to be helpful.
+            lang="en"
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
+            autoComplete="off"
           />
           <div className="flex justify-between text-xs text-muted-foreground">
             <span>{wordCount}/24 words</span>

--- a/src/defaults/settings.test.ts
+++ b/src/defaults/settings.test.ts
@@ -23,7 +23,7 @@ const computeSnapshotHash = () =>
 
 const expected = {
   version: 3,
-  hash: '0:data_collection:9xnigq|1:is_triggers_enabled:eonvmh|2:experimental_feature_tasks:-zg8zmz|3:experimental_feature_voice:6l2ce1|4:preferred_name:-5w6dil|5:location_name:27rtqf|6:location_lat:-tpss8p|7:location_lng:-tpsiwv|8:distance_unit:-3esuvm|9:temperature_unit:-dmzg9f|10:date_format:52oyc|11:time_format:we6fw3|12:currency:avihzf|13:integrations_pro_is_enabled:bbnpv0|14:user_has_completed_onboarding:-hxwxxt|15:content_view_width:8pnzc5|16:integrations_do_not_ask_again:yv9tj5|17:language:-jg1vzn',
+  hash: '0:data_collection:9xnigq|1:is_triggers_enabled:eonvmh|2:experimental_feature_tasks:-zg8zmz|3:experimental_feature_voice:6l2ce1|4:preferred_name:-5w6dil|5:location_name:27rtqf|6:location_lat:-tpss8p|7:location_lng:-tpsiwv|8:distance_unit:-3esuvm|9:temperature_unit:-dmzg9f|10:date_format:52oyc|11:time_format:we6fw3|12:currency:avihzf|13:integrations_pro_is_enabled:bbnpv0|14:user_has_completed_onboarding:-hxwxxt|15:content_view_width:8pnzc5|16:integrations_do_not_ask_again:yv9tj5|17:language:p3z19g',
 }
 
 describe('defaultSettings version snapshot', () => {

--- a/src/defaults/settings.test.ts
+++ b/src/defaults/settings.test.ts
@@ -22,8 +22,8 @@ const computeSnapshotHash = () =>
   defaultSettings.map((setting, index) => `${index}:${setting.key}:${hashSetting(setting)}`).join('|')
 
 const expected = {
-  version: 2,
-  hash: '0:data_collection:9xnigq|1:is_triggers_enabled:eonvmh|2:experimental_feature_tasks:-zg8zmz|3:experimental_feature_voice:6l2ce1|4:preferred_name:-5w6dil|5:location_name:27rtqf|6:location_lat:-tpss8p|7:location_lng:-tpsiwv|8:distance_unit:-3esuvm|9:temperature_unit:-dmzg9f|10:date_format:52oyc|11:time_format:we6fw3|12:currency:avihzf|13:integrations_pro_is_enabled:bbnpv0|14:user_has_completed_onboarding:-hxwxxt|15:content_view_width:8pnzc5|16:integrations_do_not_ask_again:yv9tj5',
+  version: 3,
+  hash: '0:data_collection:9xnigq|1:is_triggers_enabled:eonvmh|2:experimental_feature_tasks:-zg8zmz|3:experimental_feature_voice:6l2ce1|4:preferred_name:-5w6dil|5:location_name:27rtqf|6:location_lat:-tpss8p|7:location_lng:-tpsiwv|8:distance_unit:-3esuvm|9:temperature_unit:-dmzg9f|10:date_format:52oyc|11:time_format:we6fw3|12:currency:avihzf|13:integrations_pro_is_enabled:bbnpv0|14:user_has_completed_onboarding:-hxwxxt|15:content_view_width:8pnzc5|16:integrations_do_not_ask_again:yv9tj5|17:language:-jg1vzn',
 }
 
 describe('defaultSettings version snapshot', () => {

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -163,13 +163,17 @@ export const defaultSettingIntegrationsDoNotAskAgain: Setting = {
 }
 
 /**
- * UI language as a BCP-47 tag. Ships as 'en'; while unmodified it is seeded
- * from `navigator.languages` on boot (see `useAppLanguage`), so an explicit
- * user choice is the only thing that pins it.
+ * UI language as a BCP-47 tag. Ships as null (rendered as 'en' via the
+ * `useSettings` schema fallback); while unmodified it is seeded from
+ * `navigator.languages` on boot (see `useAppLanguage`), so an explicit user
+ * choice is the only thing that pins it. The null default matters: reconcile's
+ * `wouldOverwriteUserValue` guard only protects seeded values across
+ * `defaultSettingsVersion` bumps when the shipped default is null — the same
+ * mechanic as the country-derived unit defaults.
  */
 export const defaultSettingLanguage: Setting = {
   key: 'language',
-  value: 'en',
+  value: null,
   updatedAt: null,
   defaultHash: null,
   userId: null,

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -163,6 +163,19 @@ export const defaultSettingIntegrationsDoNotAskAgain: Setting = {
 }
 
 /**
+ * UI language as a BCP-47 tag. Ships as 'en'; while unmodified it is seeded
+ * from `navigator.languages` on boot (see `useAppLanguage`), so an explicit
+ * user choice is the only thing that pins it.
+ */
+export const defaultSettingLanguage: Setting = {
+  key: 'language',
+  value: 'en',
+  updatedAt: null,
+  defaultHash: null,
+  userId: null,
+}
+
+/**
  * Array of all default settings for iteration
  */
 export const defaultSettings: ReadonlyArray<Setting> = [
@@ -183,6 +196,7 @@ export const defaultSettings: ReadonlyArray<Setting> = [
   defaultSettingUserHasCompletedOnboarding,
   defaultSettingContentViewWidth,
   defaultSettingIntegrationsDoNotAskAgain,
+  defaultSettingLanguage,
 ] as const
 
 /**
@@ -196,4 +210,4 @@ export const defaultSettings: ReadonlyArray<Setting> = [
  * The paired snapshot test in `settings.test.ts` fails on any change to this
  * file's defaults without a matching version bump.
  */
-export const defaultSettingsVersion = 2
+export const defaultSettingsVersion = 3

--- a/src/hooks/use-app-language.ts
+++ b/src/hooks/use-app-language.ts
@@ -15,13 +15,16 @@ const getBrowserLanguages = (): readonly string[] =>
 /**
  * Owns the synced `language` setting's runtime side effects:
  *
- * - **Seeding** — the setting ships as `'en'`; while it still holds that
- *   default and is unmodified, infer the language from `navigator.languages`
- *   and store it with `recomputeHash` so it stays a seeded default rather
- *   than a user edit (same mechanic as the country-derived unit defaults).
- *   Seeding only fires from the shipped default, so devices with different
- *   browser languages never ping-pong the synced row; resetting the setting
- *   returns it to `'en'` and re-seeds — i.e. "back to auto".
+ * - **Seeding** — the setting ships as null (read as `'en'` via the schema
+ *   fallback); while it still holds that default and is unmodified, infer the
+ *   language from `navigator.languages` and store it with `recomputeHash` so
+ *   it stays a seeded default rather than a user edit (same mechanic as the
+ *   country-derived unit defaults, whose null shipped default lets reconcile's
+ *   `wouldOverwriteUserValue` guard preserve the seeded value across
+ *   `defaultSettingsVersion` bumps). Seeding only fires from the shipped
+ *   default, so devices with different browser languages never ping-pong the
+ *   synced row; resetting the setting returns it to null and re-seeds — i.e.
+ *   "back to auto".
  * - **`<html lang>`** — bound to the active locale (index.html ships the
  *   static `lang="en"` as the pre-boot value).
  * - **PostHog `locale`** — registered as a super property and person

--- a/src/hooks/use-app-language.ts
+++ b/src/hooks/use-app-language.ts
@@ -3,14 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { sourceLocale } from '@/i18n/locales'
-import { resolveLocale } from '@/i18n/resolve-locale'
+import { getBrowserLanguages, resolveLocale } from '@/i18n/resolve-locale'
 import { usePostHogClient } from '@/lib/posthog'
 import { useEffect, useEffectEvent } from 'react'
 import { useSettings } from './use-settings'
-
-/** Browser language preferences, most preferred first. */
-const getBrowserLanguages = (): readonly string[] =>
-  navigator.languages?.length ? navigator.languages : [navigator.language]
 
 /**
  * Owns the synced `language` setting's runtime side effects:

--- a/src/hooks/use-app-language.ts
+++ b/src/hooks/use-app-language.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { sourceLocale } from '@/i18n/locales'
+import { resolveLocale } from '@/i18n/resolve-locale'
+import { usePostHogClient } from '@/lib/posthog'
+import { useEffect, useEffectEvent } from 'react'
+import { useSettings } from './use-settings'
+
+/** Browser language preferences, most preferred first. */
+const getBrowserLanguages = (): readonly string[] =>
+  navigator.languages?.length ? navigator.languages : [navigator.language]
+
+/**
+ * Owns the synced `language` setting's runtime side effects:
+ *
+ * - **Seeding** — the setting ships as `'en'`; while it still holds that
+ *   default and is unmodified, infer the language from `navigator.languages`
+ *   and store it with `recomputeHash` so it stays a seeded default rather
+ *   than a user edit (same mechanic as the country-derived unit defaults).
+ *   Seeding only fires from the shipped default, so devices with different
+ *   browser languages never ping-pong the synced row; resetting the setting
+ *   returns it to `'en'` and re-seeds — i.e. "back to auto".
+ * - **`<html lang>`** — bound to the active locale (index.html ships the
+ *   static `lang="en"` as the pre-boot value).
+ * - **PostHog `locale`** — registered as a super property and person
+ *   property. A coarse BCP-47 tag carries no sensitive payload, and capture
+ *   is already consent-gated by `data_collection`.
+ *
+ * Both effects are legitimate per the `useEffect` discipline: a DB write and
+ * DOM/analytics synchronization with external systems.
+ *
+ * The Lingui runtime additionally wires `activateLocale` to this setting.
+ */
+export const useAppLanguage = () => {
+  const posthog = usePostHogClient()
+  const { language } = useSettings({ language: sourceLocale as string })
+  const { value, isModified, isLoading, isSaving, setValue } = language
+
+  const activeLocale = resolveLocale(value, getBrowserLanguages())
+
+  const canSeed = !isLoading && !isSaving && !isModified && value === sourceLocale
+
+  // `useEffectEvent` keeps the unstable `setValue` out of the deps so the
+  // effect fires only on the `canSeed` transition, not on every render.
+  const seedFromBrowser = useEffectEvent(() => {
+    const inferred = resolveLocale(null, getBrowserLanguages())
+    if (inferred !== sourceLocale) {
+      void setValue(inferred, { recomputeHash: true })
+    }
+  })
+
+  useEffect(() => {
+    if (canSeed) {
+      seedFromBrowser()
+    }
+  }, [canSeed])
+
+  useEffect(() => {
+    document.documentElement.lang = activeLocale
+    posthog?.register({ locale: activeLocale })
+    posthog?.setPersonProperties({ locale: activeLocale })
+  }, [activeLocale, posthog])
+}

--- a/src/hooks/use-onboarding-state.test.ts
+++ b/src/hooks/use-onboarding-state.test.ts
@@ -6,7 +6,7 @@ import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/da
 import { createTestProvider } from '@/test-utils/test-provider'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
-import { useOnboardingState } from './use-onboarding-state'
+import { onboardingStepCount, useOnboardingState } from './use-onboarding-state'
 
 const mockCountryUnitsResponse = {
   unit: 'metric',
@@ -218,14 +218,13 @@ describe('useOnboardingState', () => {
       expect(result.current.state.canSkip).toBe(true)
     })
 
-    it('should not go beyond step 5', () => {
+    it('should not go beyond the last step', () => {
       const { result } = renderHook(() => useOnboardingState(), {
         wrapper: createTestProvider({ mockResponse: mockCountryUnitsResponse }),
       })
 
-      // Set to step 5
       act(() => {
-        result.current.actions.setCurrentStep(5)
+        result.current.actions.setCurrentStep(onboardingStepCount)
       })
 
       // Try to go next
@@ -233,7 +232,7 @@ describe('useOnboardingState', () => {
         result.current.actions.nextStep()
       })
 
-      expect(result.current.state.currentStep).toBe(5)
+      expect(result.current.state.currentStep).toBe(onboardingStepCount)
       expect(result.current.state.canGoNext).toBe(false)
     })
 
@@ -471,9 +470,9 @@ describe('useOnboardingState', () => {
       expect(result.current.state.canGoNext).toBe(true)
       expect(result.current.state.canSkip).toBe(false)
 
-      // Test step 5 boundaries
+      // Test last step boundaries
       act(() => {
-        result.current.actions.setCurrentStep(5)
+        result.current.actions.setCurrentStep(onboardingStepCount)
       })
       expect(result.current.state.canGoBack).toBe(true)
       expect(result.current.state.canGoNext).toBe(false)

--- a/src/hooks/use-onboarding-state.ts
+++ b/src/hooks/use-onboarding-state.ts
@@ -8,7 +8,10 @@ import { useCountryUnits } from './use-country-units'
 import { useIntegrationStatus } from './use-integration-status'
 import { useSettings } from './use-settings'
 
-type OnboardingStep = 1 | 2 | 3 | 4 | 5
+type OnboardingStep = 1 | 2 | 3 | 4 | 5 | 6
+
+/** Total wizard steps; the last one is the celebration, which ends the wizard. */
+export const onboardingStepCount = 6
 
 type OnboardingState = {
   currentStep: OnboardingStep
@@ -73,8 +76,8 @@ const onboardingReducer = (state: OnboardingState, action: OnboardingAction): On
         ...state,
         currentStep: action.payload,
         canGoBack: action.payload > 1,
-        canGoNext: action.payload < 5,
-        canSkip: action.payload > 1 && action.payload < 5,
+        canGoNext: action.payload < onboardingStepCount,
+        canSkip: action.payload > 1 && action.payload < onboardingStepCount,
       }
 
     case 'SET_PRIVACY_AGREED':
@@ -154,13 +157,13 @@ const onboardingReducer = (state: OnboardingState, action: OnboardingAction): On
       }
 
     case 'NEXT_STEP': {
-      const nextStep = Math.min(state.currentStep + 1, 5) as OnboardingStep
+      const nextStep = Math.min(state.currentStep + 1, onboardingStepCount) as OnboardingStep
       return {
         ...state,
         currentStep: nextStep,
         canGoBack: nextStep > 1,
-        canGoNext: nextStep < 5,
-        canSkip: nextStep > 1 && nextStep < 5,
+        canGoNext: nextStep < onboardingStepCount,
+        canSkip: nextStep > 1 && nextStep < onboardingStepCount,
       }
     }
 
@@ -170,19 +173,19 @@ const onboardingReducer = (state: OnboardingState, action: OnboardingAction): On
         ...state,
         currentStep: prevStep,
         canGoBack: prevStep > 1,
-        canGoNext: prevStep < 5,
-        canSkip: prevStep > 1 && prevStep < 5,
+        canGoNext: prevStep < onboardingStepCount,
+        canSkip: prevStep > 1 && prevStep < onboardingStepCount,
       }
     }
 
     case 'SKIP_STEP': {
-      const skipStep = Math.min(state.currentStep + 1, 5) as OnboardingStep
+      const skipStep = Math.min(state.currentStep + 1, onboardingStepCount) as OnboardingStep
       return {
         ...state,
         currentStep: skipStep,
         canGoBack: skipStep > 1,
-        canGoNext: skipStep < 5,
-        canSkip: skipStep > 1 && skipStep < 5,
+        canGoNext: skipStep < onboardingStepCount,
+        canSkip: skipStep > 1 && skipStep < onboardingStepCount,
       }
     }
 
@@ -230,7 +233,7 @@ export const useOnboardingState = () => {
   // Sync with saved step on mount
   useEffect(() => {
     const savedStep = parseInt(onboardingCurrentStep.value || '1', 10)
-    if (savedStep >= 1 && savedStep <= 5) {
+    if (savedStep >= 1 && savedStep <= onboardingStepCount) {
       dispatch({ type: 'SET_CURRENT_STEP', payload: savedStep as OnboardingStep })
     }
   }, [onboardingCurrentStep.value])
@@ -305,7 +308,7 @@ export const useOnboardingState = () => {
     },
 
     nextStep: async () => {
-      const newStep = Math.min(state.currentStep + 1, 5) as OnboardingStep
+      const newStep = Math.min(state.currentStep + 1, onboardingStepCount) as OnboardingStep
       dispatch({ type: 'NEXT_STEP' })
       await onboardingCurrentStep.setValue(String(newStep))
     },
@@ -315,7 +318,7 @@ export const useOnboardingState = () => {
       await onboardingCurrentStep.setValue(String(newStep))
     },
     skipStep: async () => {
-      const newStep = Math.min(state.currentStep + 1, 5) as OnboardingStep
+      const newStep = Math.min(state.currentStep + 1, onboardingStepCount) as OnboardingStep
 
       if (state.currentStep === 3) {
         try {

--- a/src/i18n/country-language.test.ts
+++ b/src/i18n/country-language.test.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { countryCodeFromName, localeForCountry } from './country-language'
+
+describe('countryCodeFromName', () => {
+  test('resolves CLDR region names', () => {
+    expect(countryCodeFromName('Germany')).toBe('DE')
+    expect(countryCodeFromName('Brazil')).toBe('BR')
+  })
+
+  test('ignores case, accents and punctuation', () => {
+    expect(countryCodeFromName('  japan ')).toBe('JP')
+    expect(countryCodeFromName("Cote d'Ivoire")).toBe('CI')
+  })
+
+  test('returns null for anything that is not a country name', () => {
+    expect(countryCodeFromName('Bavaria')).toBeNull()
+    expect(countryCodeFromName('')).toBeNull()
+  })
+})
+
+describe('localeForCountry', () => {
+  test('maps a country to the shipped locale of its dominant language', () => {
+    expect(localeForCountry('Germany')).toBe('de')
+    expect(localeForCountry('France')).toBe('fr')
+    expect(localeForCountry('Mexico')).toBe('es')
+    expect(localeForCountry('Japan')).toBe('ja')
+  })
+
+  test('maps regional variants onto the shipped locale', () => {
+    expect(localeForCountry('Portugal')).toBe('pt-BR')
+    expect(localeForCountry('Austria')).toBe('de')
+    expect(localeForCountry('United Kingdom')).toBe('en')
+  })
+
+  test('returns null when the app ships no catalog for the language', () => {
+    expect(localeForCountry('Italy')).toBeNull()
+    expect(localeForCountry('Poland')).toBeNull()
+  })
+
+  test('returns null for an unrecognized country', () => {
+    expect(localeForCountry('Atlantis')).toBeNull()
+  })
+})

--- a/src/i18n/country-language.ts
+++ b/src/i18n/country-language.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { AppLocale } from './locales'
+import { matchLocale } from './resolve-locale'
+
+/**
+ * Normalize a country name for matching: case, accents, and punctuation vary
+ * between the geocoding provider and CLDR ("Côte d'Ivoire" vs "Cote d Ivoire").
+ */
+const normalize = (name: string): string =>
+  name
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+
+const allRegionCodes = (): string[] => {
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+  return letters.flatMap((first) => letters.map((second) => first + second))
+}
+
+/**
+ * Deprecated codes share a display name with their replacement ("FX" and "FR"
+ * are both "France") but carry no useful likely-subtags, so collapse each code
+ * onto the region CLDR canonicalizes it to.
+ */
+const canonicalRegion = (code: string): string => new Intl.Locale(`und-${code}`).maximize().region ?? code
+
+/**
+ * English country name → ISO 3166-1 alpha-2, built from CLDR region display
+ * names. `Intl.DisplayNames#of` echoes the input back for codes it doesn't
+ * know, which is how unassigned codes are filtered out. There is no `Intl`
+ * API to enumerate regions, so the 676-code space is swept once and memoized.
+ *
+ * English is the right lookup language: the backend pins `language=en` on the
+ * geocoding request, so country names always arrive in English.
+ */
+let countryCodesByName: Map<string, string> | null = null
+
+const getCountryCodesByName = (): Map<string, string> => {
+  if (countryCodesByName) {
+    return countryCodesByName
+  }
+  const displayNames = new Intl.DisplayNames(['en'], { type: 'region' })
+  countryCodesByName = new Map(
+    allRegionCodes().flatMap((code) => {
+      const name = displayNames.of(code)
+      return !name || name === code ? [] : [[normalize(name), canonicalRegion(code)] as const]
+    }),
+  )
+  return countryCodesByName
+}
+
+/**
+ * Resolve a country name to its ISO 3166-1 alpha-2 code, or `null` when the
+ * name isn't a CLDR region name.
+ */
+export const countryCodeFromName = (countryName: string): string | null =>
+  getCountryCodesByName().get(normalize(countryName)) ?? null
+
+/**
+ * The shipped locale most likely spoken in a country, or `null` when the
+ * country is unknown or its language isn't one the app ships.
+ *
+ * Uses CLDR likely subtags (`und-BR` → `pt-Latn-BR`), so this is the dominant
+ * language of the region — a heuristic worth confirming with the user, never
+ * worth applying silently.
+ */
+export const localeForCountry = (countryName: string): AppLocale | null => {
+  const code = countryCodeFromName(countryName)
+  if (!code) {
+    return null
+  }
+  return matchLocale(new Intl.Locale(`und-${code}`).maximize().language)
+}

--- a/src/i18n/language-options.ts
+++ b/src/i18n/language-options.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { pseudoLocale } from './locales'
+import { negotiableLocales } from './resolve-locale'
+
+/**
+ * The selectable UI languages, labelled as endonyms (each language named in
+ * itself, via `Intl.DisplayNames`) so the list reads naturally whatever the
+ * active UI language is. The `en-XA` pseudo-locale is offered in dev builds only.
+ */
+export const languageOptions: ReadonlyArray<{ value: string; label: string }> = [
+  ...negotiableLocales.map((locale) => {
+    const endonym = new Intl.DisplayNames([locale], { type: 'language' }).of(locale) ?? locale
+    return {
+      value: locale as string,
+      label: endonym.charAt(0).toLocaleUpperCase(locale) + endonym.slice(1),
+    }
+  }),
+  ...(import.meta.env.DEV ? [{ value: pseudoLocale as string, label: 'Pseudo-locale (en-XA)' }] : []),
+]
+
+/** The endonym for a locale tag, falling back to the tag itself. */
+export const languageLabel = (locale: string): string =>
+  languageOptions.find((option) => option.value === locale)?.label ?? locale

--- a/src/i18n/language-options.ts
+++ b/src/i18n/language-options.ts
@@ -2,24 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { pseudoLocale } from './locales'
-import { negotiableLocales } from './resolve-locale'
+import { pseudoLocale, type AppLocale } from './locales'
+import { settableLocales } from './resolve-locale'
+
+/** Each language named in itself, so the list reads naturally whatever the active UI language is. */
+const endonym = (locale: AppLocale): string => {
+  const name = new Intl.DisplayNames([locale], { type: 'language' }).of(locale) ?? locale
+  return name.charAt(0).toLocaleUpperCase(locale) + name.slice(1)
+}
 
 /**
- * The selectable UI languages, labelled as endonyms (each language named in
- * itself, via `Intl.DisplayNames`) so the list reads naturally whatever the
- * active UI language is. The `en-XA` pseudo-locale is offered in dev builds only.
+ * The selectable UI languages.
+ *
+ * Derived from `settableLocales` rather than re-deriving the dev-build rule, so
+ * the picker cannot offer a locale the resolver would refuse — the two used to
+ * disagree, which is how the pseudo-locale reached production devices.
  */
-export const languageOptions: ReadonlyArray<{ value: string; label: string }> = [
-  ...negotiableLocales.map((locale) => {
-    const endonym = new Intl.DisplayNames([locale], { type: 'language' }).of(locale) ?? locale
-    return {
-      value: locale as string,
-      label: endonym.charAt(0).toLocaleUpperCase(locale) + endonym.slice(1),
-    }
-  }),
-  ...(import.meta.env.DEV ? [{ value: pseudoLocale as string, label: 'Pseudo-locale (en-XA)' }] : []),
-]
+export const languageOptions: ReadonlyArray<{ value: string; label: string }> = settableLocales.map((locale) => ({
+  value: locale,
+  label: locale === pseudoLocale ? 'Pseudo-locale (en-XA)' : endonym(locale),
+}))
 
 /** The endonym for a locale tag, falling back to the tag itself. */
 export const languageLabel = (locale: string): string =>

--- a/src/i18n/locales.ts
+++ b/src/i18n/locales.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Single source of truth for the locale set, shared by `lingui.config.ts`
+ * (extraction/compilation) and the runtime in `src/i18n`. Kept free of
+ * runtime imports so the Lingui CLI can load it outside Vite.
+ */
+
+/** Locales the app ships catalogs for. `en` is the source locale; `en-XA` is the CI pseudo-locale. */
+export const appLocales = ['en', 'de', 'fr', 'es', 'pt-BR', 'ja', 'en-XA'] as const
+
+export type AppLocale = (typeof appLocales)[number]
+
+export const sourceLocale: AppLocale = 'en'
+
+export const pseudoLocale: AppLocale = 'en-XA'

--- a/src/i18n/resolve-locale.test.ts
+++ b/src/i18n/resolve-locale.test.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from 'bun:test'
+import { negotiableLocales, resolveLocale } from './resolve-locale'
+
+describe('resolveLocale', () => {
+  test('explicit supported setting wins over browser languages', () => {
+    expect(resolveLocale('ja', ['pt-BR', 'en'])).toBe('ja')
+  })
+
+  test('explicit pt-BR setting is returned as-is', () => {
+    expect(resolveLocale('pt-BR', ['en'])).toBe('pt-BR')
+  })
+
+  test('honors the en-XA pseudo-locale as an explicit setting', () => {
+    expect(resolveLocale('en-XA', ['de'])).toBe('en-XA')
+  })
+
+  test('unsupported setting falls through to browser negotiation', () => {
+    expect(resolveLocale('zh-CN', ['fr-FR', 'en'])).toBe('fr')
+  })
+
+  test('null setting uses the first matching browser language', () => {
+    expect(resolveLocale(null, ['de-DE', 'en-US'])).toBe('de')
+  })
+
+  test('matches exact regional tags', () => {
+    expect(resolveLocale(null, ['pt-BR'])).toBe('pt-BR')
+  })
+
+  test('maps base language to the regional shipped locale (pt → pt-BR)', () => {
+    expect(resolveLocale(null, ['pt'])).toBe('pt-BR')
+  })
+
+  test('maps sibling regions to the shipped locale (pt-PT → pt-BR)', () => {
+    expect(resolveLocale(null, ['pt-PT'])).toBe('pt-BR')
+  })
+
+  test('strips regions when only the base is shipped (en-GB → en)', () => {
+    expect(resolveLocale(null, ['en-GB'])).toBe('en')
+  })
+
+  test('is case-insensitive on browser tags', () => {
+    expect(resolveLocale(null, ['PT-br'])).toBe('pt-BR')
+    expect(resolveLocale(null, ['JA'])).toBe('ja')
+  })
+
+  test('skips unsupported browser languages until one matches', () => {
+    expect(resolveLocale(null, ['zh-CN', 'ko', 'es-MX'])).toBe('es')
+  })
+
+  test('falls back to en when nothing matches', () => {
+    expect(resolveLocale(null, ['zh-CN', 'ko'])).toBe('en')
+  })
+
+  test('falls back to en on an empty browser list', () => {
+    expect(resolveLocale(null, [])).toBe('en')
+  })
+
+  test('never negotiates the en-XA pseudo-locale from the browser', () => {
+    expect(resolveLocale(null, ['en-XA'])).toBe('en')
+    expect(negotiableLocales).not.toContain('en-XA')
+  })
+})

--- a/src/i18n/resolve-locale.test.ts
+++ b/src/i18n/resolve-locale.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, test } from 'bun:test'
-import { negotiableLocales, resolveLocale } from './resolve-locale'
+import { negotiableLocales, resolveLocale, settableLocales } from './resolve-locale'
 
 describe('resolveLocale', () => {
   test('explicit supported setting wins over browser languages', () => {
@@ -14,8 +14,12 @@ describe('resolveLocale', () => {
     expect(resolveLocale('pt-BR', ['en'])).toBe('pt-BR')
   })
 
-  test('honors the en-XA pseudo-locale as an explicit setting', () => {
-    expect(resolveLocale('en-XA', ['de'])).toBe('en-XA')
+  // `language` is synced, so a dev-build selection would otherwise land on that
+  // developer's production devices and render the whole UI as pseudo-text. Tests
+  // run with `import.meta.env.DEV` unset, i.e. against the production contract.
+  test('refuses the en-XA pseudo-locale outside dev builds', () => {
+    expect(settableLocales).not.toContain('en-XA')
+    expect(resolveLocale('en-XA', ['de'])).toBe('de')
   })
 
   test('unsupported setting falls through to browser negotiation', () => {

--- a/src/i18n/resolve-locale.ts
+++ b/src/i18n/resolve-locale.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { appLocales, pseudoLocale, sourceLocale, type AppLocale } from './locales'
+
+/** Locales eligible for browser-language negotiation — every shipped locale except the CI pseudo-locale. */
+export const negotiableLocales = appLocales.filter((locale) => locale !== pseudoLocale)
+
+const isAppLocale = (value: string): value is AppLocale => (appLocales as readonly string[]).includes(value)
+
+const baseOf = (tag: string): string => tag.toLowerCase().split('-')[0]
+
+/**
+ * Match a single BCP-47 tag against the negotiable locale set.
+ * Tries an exact (case-insensitive) match first, then falls back to the
+ * base language: `pt-PT` → `pt-BR`, `de-AT` → `de`, `en-GB` → `en`.
+ */
+const matchBrowserLanguage = (tag: string): AppLocale | null => {
+  const lowered = tag.toLowerCase()
+  const exact = negotiableLocales.find((locale) => locale.toLowerCase() === lowered)
+  if (exact) {
+    return exact
+  }
+  const base = baseOf(tag)
+  return negotiableLocales.find((locale) => baseOf(locale) === base) ?? null
+}
+
+/**
+ * Resolve the active app locale. Pure so it's unit-testable.
+ *
+ * Order: explicit supported setting → first `navigator.languages` entry that
+ * matches the supported set (exact tag, then base language) → `'en'`.
+ * The `en-XA` pseudo-locale is honored as an explicit setting (dev/CI) but
+ * never offered through browser negotiation.
+ */
+export const resolveLocale = (setting: string | null, browserLanguages: readonly string[]): AppLocale => {
+  if (setting && isAppLocale(setting)) {
+    return setting
+  }
+  for (const tag of browserLanguages) {
+    const match = matchBrowserLanguage(tag)
+    if (match) {
+      return match
+    }
+  }
+  return sourceLocale
+}

--- a/src/i18n/resolve-locale.ts
+++ b/src/i18n/resolve-locale.ts
@@ -7,7 +7,20 @@ import { appLocales, pseudoLocale, sourceLocale, type AppLocale } from './locale
 /** Locales eligible for browser-language negotiation — every shipped locale except the CI pseudo-locale. */
 export const negotiableLocales = appLocales.filter((locale) => locale !== pseudoLocale)
 
-const isAppLocale = (value: string): value is AppLocale => (appLocales as readonly string[]).includes(value)
+/**
+ * Locales an explicit `language` setting is allowed to select.
+ *
+ * `language` is a **synced** setting, so a value chosen on one device reaches
+ * all of them. The picker only offers the pseudo-locale in dev builds, but on
+ * its own that gate is cosmetic: a developer selecting it would sync `en-XA` to
+ * their own production devices, where the UI renders pseudo-text and the picker
+ * shows an empty trigger because no option matches it. Refusing the value here
+ * is what actually contains it — the setting then falls through to browser
+ * negotiation like any other unsupported tag.
+ */
+export const settableLocales: readonly AppLocale[] = import.meta.env.DEV ? appLocales : negotiableLocales
+
+const isSettableLocale = (value: string): value is AppLocale => (settableLocales as readonly string[]).includes(value)
 
 const baseOf = (tag: string): string => tag.toLowerCase().split('-')[0]
 
@@ -30,13 +43,14 @@ export const matchLocale = (tag: string): AppLocale | null => {
 /**
  * Resolve the active app locale. Pure so it's unit-testable.
  *
- * Order: explicit supported setting → first `navigator.languages` entry that
+ * Order: explicit settable setting → first `navigator.languages` entry that
  * matches the supported set (exact tag, then base language) → `'en'`.
- * The `en-XA` pseudo-locale is honored as an explicit setting (dev/CI) but
- * never offered through browser negotiation.
+ * The `en-XA` pseudo-locale is honored as an explicit setting in dev builds
+ * only (see {@link settableLocales}), and never offered through browser
+ * negotiation in any build.
  */
 export const resolveLocale = (setting: string | null, browserLanguages: readonly string[]): AppLocale => {
-  if (setting && isAppLocale(setting)) {
+  if (setting && isSettableLocale(setting)) {
     return setting
   }
   for (const tag of browserLanguages) {

--- a/src/i18n/resolve-locale.ts
+++ b/src/i18n/resolve-locale.ts
@@ -12,11 +12,12 @@ const isAppLocale = (value: string): value is AppLocale => (appLocales as readon
 const baseOf = (tag: string): string => tag.toLowerCase().split('-')[0]
 
 /**
- * Match a single BCP-47 tag against the negotiable locale set.
- * Tries an exact (case-insensitive) match first, then falls back to the
- * base language: `pt-PT` → `pt-BR`, `de-AT` → `de`, `en-GB` → `en`.
+ * Match a single BCP-47 tag against the negotiable locale set, or `null` when
+ * the app ships no catalog for it. Tries an exact (case-insensitive) match
+ * first, then falls back to the base language: `pt-PT` → `pt-BR`, `de-AT` →
+ * `de`, `en-GB` → `en`.
  */
-const matchBrowserLanguage = (tag: string): AppLocale | null => {
+export const matchLocale = (tag: string): AppLocale | null => {
   const lowered = tag.toLowerCase()
   const exact = negotiableLocales.find((locale) => locale.toLowerCase() === lowered)
   if (exact) {
@@ -39,10 +40,14 @@ export const resolveLocale = (setting: string | null, browserLanguages: readonly
     return setting
   }
   for (const tag of browserLanguages) {
-    const match = matchBrowserLanguage(tag)
+    const match = matchLocale(tag)
     if (match) {
       return match
     }
   }
   return sourceLocale
 }
+
+/** Browser language preferences, most preferred first. */
+export const getBrowserLanguages = (): readonly string[] =>
+  navigator.languages?.length ? navigator.languages : [navigator.language]

--- a/src/index.css
+++ b/src/index.css
@@ -50,8 +50,15 @@
 }
 
 @theme {
-  /* Mozilla brand font for display headings (e.g. the empty-chat greeting). */
-  --font-heading: 'Mozilla Headline Variable', ui-sans-serif, system-ui, sans-serif;
+  /* Mozilla brand font for display headings (e.g. the empty-chat greeting).
+     The brand font is Latin-only; CSS falls back per character, so CJK text
+     resolves down the chain. The named CJK fonts after system-ui make that
+     fallback deterministic on platforms where system-ui lacks CJK coverage
+     (notably Linux for the Tauri desktop build) — macOS/Windows resolve via
+     system-ui first and never reach them. */
+  --font-heading:
+    'Mozilla Headline Variable', ui-sans-serif, system-ui, 'Hiragino Sans', 'Yu Gothic', 'Noto Sans CJK JP',
+    'Noto Sans JP', sans-serif;
 
   /* No pure white/black anywhere — remap Tailwind's white/black utilities
      (bg-white, text-white, bg-black/40 overlays, etc.) to the theme's off-white

--- a/src/settings/preferences.test.tsx
+++ b/src/settings/preferences.test.tsx
@@ -17,7 +17,7 @@ import { type ReactNode } from 'react'
 
 import { SignInModalProvider } from '@/contexts'
 import type { AuthClient } from '@/contexts'
-import PreferencesSettingsPage from './preferences'
+import PreferencesSettingsPage, { initialPreferencesState, preferencesReducer } from './preferences'
 
 const anonSession = {
   user: { id: 'anon-1', email: '', name: '', isAnonymous: true },
@@ -100,5 +100,72 @@ describe('PreferencesSettingsPage — sync toggle gating', () => {
     renderPage(authClient)
 
     expect(screen.getByText('Delete My Account')).toBeInTheDocument()
+  })
+})
+
+describe('PreferencesSettingsPage — Localization layout', () => {
+  beforeAll(async () => {
+    await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('orders the Localization section Location → Language → Distance', () => {
+    renderPage(createMockAuthClient({ session: authedSession }))
+
+    const [location, language, distance] = ['Location', 'Language', 'Distance'].map((label) => screen.getByText(label))
+
+    expect(location.compareDocumentPosition(language) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(language.compareDocumentPosition(distance) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})
+
+describe('preferencesReducer — location-driven suggestions', () => {
+  const countryUnits = {
+    unit: 'metric',
+    temperature: 'c',
+    timeFormat: '24h',
+    dateFormatExample: 'DD/MM/YYYY',
+    currency: { code: 'EUR', name: 'Euro', symbol: '€' },
+  }
+
+  it('defers the language prompt until the units prompt is answered', () => {
+    const suggested = preferencesReducer(initialPreferencesState, {
+      type: 'SUGGEST_LOCATION_DEFAULTS',
+      payload: { countryUnits, language: 'de' },
+    })
+
+    expect(suggested.localizationDialogOpen).toBe(true)
+    expect(suggested.languageDialogOpen).toBe(false)
+
+    const afterUnits = preferencesReducer(suggested, { type: 'CLOSE_LOCALIZATION_DIALOG' })
+
+    expect(afterUnits.localizationDialogOpen).toBe(false)
+    expect(afterUnits.languageDialogOpen).toBe(true)
+    expect(afterUnits.pendingLanguage).toBe('de')
+  })
+
+  it('prompts for the language immediately when there are no units to suggest', () => {
+    const suggested = preferencesReducer(initialPreferencesState, {
+      type: 'SUGGEST_LOCATION_DEFAULTS',
+      payload: { countryUnits: null, language: 'ja' },
+    })
+
+    expect(suggested.languageDialogOpen).toBe(true)
+  })
+
+  it('does not chain a language prompt when the location suggests none', () => {
+    const suggested = preferencesReducer(initialPreferencesState, {
+      type: 'SUGGEST_LOCATION_DEFAULTS',
+      payload: { countryUnits, language: null },
+    })
+
+    expect(preferencesReducer(suggested, { type: 'CLOSE_LOCALIZATION_DIALOG' }).languageDialogOpen).toBe(false)
   })
 })

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -50,11 +50,30 @@ import { SectionCard } from '@/components/ui/section-card'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { usePostHogClient } from '@/lib/posthog'
+import { pseudoLocale } from '@/i18n/locales'
+import { negotiableLocales } from '@/i18n/resolve-locale'
 import { usePowerSyncStatus } from '@/hooks/use-powersync-status'
 import { useSyncEnabledToggle } from '@/hooks/use-sync-enabled-toggle'
 import { SettingsPageShell } from '@/components/settings/settings-list'
 
 type PendingImport = { payload: unknown } & ExportSummary
+
+/**
+ * Options for the language selector, labelled as endonyms (each language
+ * named in itself, via `Intl.DisplayNames`) so the list reads naturally
+ * whatever the active UI language is. The `en-XA` pseudo-locale is offered
+ * in dev builds only.
+ */
+const languageOptions: ReadonlyArray<{ value: string; label: string }> = [
+  ...negotiableLocales.map((locale) => {
+    const endonym = new Intl.DisplayNames([locale], { type: 'language' }).of(locale) ?? locale
+    return {
+      value: locale as string,
+      label: endonym.charAt(0).toLocaleUpperCase(locale) + endonym.slice(1),
+    }
+  }),
+  ...(import.meta.env.DEV ? [{ value: pseudoLocale as string, label: 'Pseudo-locale (en-XA)' }] : []),
+]
 
 type PreferencesState = {
   isResetting: boolean
@@ -200,6 +219,7 @@ export default function PreferencesSettingsPage() {
     dateFormat,
     timeFormat,
     currency,
+    language,
   } = useSettings({
     preferred_name: '',
     location_name: '',
@@ -213,6 +233,7 @@ export default function PreferencesSettingsPage() {
     date_format: 'MM/DD/YYYY',
     time_format: '12h',
     currency: 'USD',
+    language: 'en',
   })
 
   const hapticsEnabled = useLocalSettingsStore((s) => s.hapticsEnabled)
@@ -594,6 +615,43 @@ export default function PreferencesSettingsPage() {
 
       <SectionCard title="Localization">
         <div className="flex flex-col gap-6">
+          {/* Language */}
+          <div className="flex flex-row items-center gap-4">
+            <div className="flex-1">
+              <ModificationIndicator
+                as="label"
+                className="text-sm font-medium"
+                hasModifications={language.isModified}
+                onReset={async () => {
+                  await language.reset()
+                  trackEvent('settings_localization_reset')
+                }}
+              >
+                Language
+              </ModificationIndicator>
+            </div>
+            <Select
+              value={language.value}
+              onValueChange={async (v) => {
+                await language.setValue(v)
+                trackEvent('settings_localization_update')
+              }}
+            >
+              <SelectTrigger className="w-auto rounded-lg" aria-label="Language">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {languageOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="h-px bg-border -mx-6" />
+
           <div className="flex flex-col gap-2">
             <ModificationIndicator
               as="label"

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -1241,8 +1241,7 @@ export default function PreferencesSettingsPage() {
             <AlertDialogHeader>
               <AlertDialogTitle>Change Language?</AlertDialogTitle>
               <AlertDialogDescription>
-                Your new location mostly speaks {languageLabel(pendingLanguage)}. Would you like to use Thunderbolt in{' '}
-                {languageLabel(pendingLanguage)}?
+                Would you like to change the language to {languageLabel(pendingLanguage)}?
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -50,8 +50,9 @@ import { SectionCard } from '@/components/ui/section-card'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { usePostHogClient } from '@/lib/posthog'
-import { pseudoLocale } from '@/i18n/locales'
-import { negotiableLocales } from '@/i18n/resolve-locale'
+import { localeForCountry } from '@/i18n/country-language'
+import { pseudoLocale, type AppLocale } from '@/i18n/locales'
+import { getBrowserLanguages, negotiableLocales, resolveLocale } from '@/i18n/resolve-locale'
 import { usePowerSyncStatus } from '@/hooks/use-powersync-status'
 import { useSyncEnabledToggle } from '@/hooks/use-sync-enabled-toggle'
 import { SettingsPageShell } from '@/components/settings/settings-list'
@@ -75,6 +76,9 @@ const languageOptions: ReadonlyArray<{ value: string; label: string }> = [
   ...(import.meta.env.DEV ? [{ value: pseudoLocale as string, label: 'Pseudo-locale (en-XA)' }] : []),
 ]
 
+const languageLabel = (locale: string): string =>
+  languageOptions.find((option) => option.value === locale)?.label ?? locale
+
 type PreferencesState = {
   isResetting: boolean
   isDeletingAccount: boolean
@@ -88,6 +92,8 @@ type PreferencesState = {
   deleteAccountDialogOpen: boolean
   localizationDialogOpen: boolean
   pendingCountryUnits: CountryUnitsData | null
+  languageDialogOpen: boolean
+  pendingLanguage: AppLocale | null
 }
 
 type PreferencesAction =
@@ -103,10 +109,14 @@ type PreferencesAction =
   | { type: 'SET_DELETE_ACCOUNT_DIALOG_OPEN'; payload: boolean }
   | { type: 'CLEAR_IMPORT_FEEDBACK' }
   | { type: 'RESET_STATE' }
-  | { type: 'OPEN_LOCALIZATION_DIALOG'; payload: CountryUnitsData }
+  | {
+      type: 'SUGGEST_LOCATION_DEFAULTS'
+      payload: { countryUnits: CountryUnitsData | null; language: AppLocale | null }
+    }
   | { type: 'CLOSE_LOCALIZATION_DIALOG' }
+  | { type: 'CLOSE_LANGUAGE_DIALOG' }
 
-const initialState: PreferencesState = {
+export const initialPreferencesState: PreferencesState = {
   isResetting: false,
   isDeletingAccount: false,
   isExporting: false,
@@ -119,9 +129,11 @@ const initialState: PreferencesState = {
   deleteAccountDialogOpen: false,
   localizationDialogOpen: false,
   pendingCountryUnits: null,
+  languageDialogOpen: false,
+  pendingLanguage: null,
 }
 
-const preferencesReducer = (state: PreferencesState, action: PreferencesAction): PreferencesState => {
+export const preferencesReducer = (state: PreferencesState, action: PreferencesAction): PreferencesState => {
   switch (action.type) {
     case 'SET_IS_RESETTING':
       return { ...state, isResetting: action.payload }
@@ -146,18 +158,36 @@ const preferencesReducer = (state: PreferencesState, action: PreferencesAction):
     case 'CLEAR_IMPORT_FEEDBACK':
       return { ...state, importError: null, importSuccess: null }
     case 'RESET_STATE':
-      return initialState
-    case 'OPEN_LOCALIZATION_DIALOG':
-      return { ...state, localizationDialogOpen: true, pendingCountryUnits: action.payload }
+      return initialPreferencesState
+    case 'SUGGEST_LOCATION_DEFAULTS':
+      // A location change can suggest both new units and a new language. The
+      // two prompts are sequenced rather than stacked: the language ask opens
+      // once the units ask is answered.
+      return {
+        ...state,
+        localizationDialogOpen: !!action.payload.countryUnits,
+        pendingCountryUnits: action.payload.countryUnits,
+        languageDialogOpen: !action.payload.countryUnits && !!action.payload.language,
+        pendingLanguage: action.payload.language,
+      }
     case 'CLOSE_LOCALIZATION_DIALOG':
-      return { ...state, localizationDialogOpen: false, pendingCountryUnits: null }
+      return {
+        ...state,
+        localizationDialogOpen: false,
+        pendingCountryUnits: null,
+        languageDialogOpen: !!state.pendingLanguage,
+      }
+    case 'CLOSE_LANGUAGE_DIALOG':
+      // `pendingLanguage` outlives the close so the dialog keeps its copy while
+      // it animates out; every suggestion overwrites it, so it can't go stale.
+      return { ...state, languageDialogOpen: false }
     default:
       return state
   }
 }
 
 export default function PreferencesSettingsPage() {
-  const [state, dispatch] = useReducer(preferencesReducer, initialState)
+  const [state, dispatch] = useReducer(preferencesReducer, initialPreferencesState)
   const {
     isResetting,
     isDeletingAccount,
@@ -171,6 +201,8 @@ export default function PreferencesSettingsPage() {
     deleteAccountDialogOpen,
     localizationDialogOpen,
     pendingCountryUnits,
+    languageDialogOpen,
+    pendingLanguage,
   } = state
   const authClient = useAuth()
   const db = useDatabase()
@@ -242,6 +274,9 @@ export default function PreferencesSettingsPage() {
   // Local state for name input (only save on blur to avoid DB writes on every keystroke)
   const [nameInput, setNameInput] = useState('')
   const prevPreferredNameRef = useRef(preferredName.value)
+
+  /** What the UI actually renders in — the setting only pins it once seeded or chosen. */
+  const activeLanguage = resolveLocale(language.value, getBrowserLanguages())
 
   // Get units options and country units for localization
   const { data: unitsOptionsData, isLoading: unitsOptionsLoading } = useUnitsOptions()
@@ -330,13 +365,20 @@ export default function PreferencesSettingsPage() {
 
     trackEvent(wasSet ? 'settings_location_update' : 'settings_location_set')
 
-    // If country changed, ask user if they want to update localization settings
-    if (newCountry && currentCountry !== newCountry) {
-      const countryUnitsData = await fetchCountryUnits(newCountry)
-      if (countryUnitsData) {
-        dispatch({ type: 'OPEN_LOCALIZATION_DIALOG', payload: countryUnitsData })
-      }
+    if (!newCountry || currentCountry === newCountry) {
+      return
     }
+
+    // The new country may imply different units and a different UI language.
+    // Both are suggestions, never applied without confirmation.
+    const suggestedLanguage = localeForCountry(newCountry)
+    dispatch({
+      type: 'SUGGEST_LOCATION_DEFAULTS',
+      payload: {
+        countryUnits: await fetchCountryUnits(newCountry),
+        language: suggestedLanguage && suggestedLanguage !== activeLanguage ? suggestedLanguage : null,
+      },
+    })
   }
 
   const handleApplyLocalizationSettings = async () => {
@@ -359,6 +401,22 @@ export default function PreferencesSettingsPage() {
 
   const handleDeclineLocalizationSettings = () => {
     dispatch({ type: 'CLOSE_LOCALIZATION_DIALOG' })
+  }
+
+  const handleApplyLanguage = async () => {
+    if (!pendingLanguage) {
+      return
+    }
+    // Plain `setValue`, unlike the unit defaults above: this has to land as a
+    // user edit so `useAppLanguage` stops re-seeding from `navigator.languages`
+    // — otherwise confirming a switch to English would be undone on next boot.
+    await language.setValue(pendingLanguage)
+    dispatch({ type: 'CLOSE_LANGUAGE_DIALOG' })
+    trackEvent('settings_localization_update')
+  }
+
+  const handleDeclineLanguage = () => {
+    dispatch({ type: 'CLOSE_LANGUAGE_DIALOG' })
   }
 
   const [deleteAccountError, setDeleteAccountError] = useState<string | null>(null)
@@ -615,6 +673,27 @@ export default function PreferencesSettingsPage() {
 
       <SectionCard title="Localization">
         <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-2">
+            <ModificationIndicator
+              as="label"
+              id="localization-location-label"
+              className="text-sm font-medium"
+              hasModifications={locationName.isModified || locationLat.isModified || locationLng.isModified}
+              onReset={handleResetLocation}
+            >
+              Location
+            </ModificationIndicator>
+            <LocationSearchCombobox
+              value={locationName.value}
+              onSelect={handleSelectLocation}
+              id="localization-location-trigger"
+              aria-labelledby="localization-location-label localization-location-trigger"
+            />
+            <p className="text-sm text-muted-foreground">Enables location-based responses</p>
+          </div>
+
+          <div className="h-px bg-border -mx-6" />
+
           {/* Language */}
           <div className="flex flex-row items-center gap-4">
             <div className="flex-1">
@@ -649,29 +728,6 @@ export default function PreferencesSettingsPage() {
               </SelectContent>
             </Select>
           </div>
-
-          <div className="h-px bg-border -mx-6" />
-
-          <div className="flex flex-col gap-2">
-            <ModificationIndicator
-              as="label"
-              id="localization-location-label"
-              className="text-sm font-medium"
-              hasModifications={locationName.isModified || locationLat.isModified || locationLng.isModified}
-              onReset={handleResetLocation}
-            >
-              Location
-            </ModificationIndicator>
-            <LocationSearchCombobox
-              value={locationName.value}
-              onSelect={handleSelectLocation}
-              id="localization-location-trigger"
-              aria-labelledby="localization-location-label localization-location-trigger"
-            />
-            <p className="text-sm text-muted-foreground">Enables location-based responses</p>
-          </div>
-
-          <div className="h-px bg-border -mx-6" />
 
           {/* Distance */}
           <div className="flex flex-row items-center gap-4">
@@ -1197,6 +1253,26 @@ export default function PreferencesSettingsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {pendingLanguage && (
+        <AlertDialog open={languageDialogOpen} onOpenChange={(open) => !open && handleDeclineLanguage()}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Change Language?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Your new location mostly speaks {languageLabel(pendingLanguage)}. Would you like to use Thunderbolt in{' '}
+                {languageLabel(pendingLanguage)}?
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Keep {languageLabel(activeLanguage)}</AlertDialogCancel>
+              <AlertDialogAction autoFocus onClick={handleApplyLanguage}>
+                Switch to {languageLabel(pendingLanguage)}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
     </SettingsPageShell>
   )
 }

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -51,33 +51,14 @@ import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { usePostHogClient } from '@/lib/posthog'
 import { localeForCountry } from '@/i18n/country-language'
-import { pseudoLocale, type AppLocale } from '@/i18n/locales'
-import { getBrowserLanguages, negotiableLocales, resolveLocale } from '@/i18n/resolve-locale'
+import { languageLabel, languageOptions } from '@/i18n/language-options'
+import type { AppLocale } from '@/i18n/locales'
+import { getBrowserLanguages, resolveLocale } from '@/i18n/resolve-locale'
 import { usePowerSyncStatus } from '@/hooks/use-powersync-status'
 import { useSyncEnabledToggle } from '@/hooks/use-sync-enabled-toggle'
 import { SettingsPageShell } from '@/components/settings/settings-list'
 
 type PendingImport = { payload: unknown } & ExportSummary
-
-/**
- * Options for the language selector, labelled as endonyms (each language
- * named in itself, via `Intl.DisplayNames`) so the list reads naturally
- * whatever the active UI language is. The `en-XA` pseudo-locale is offered
- * in dev builds only.
- */
-const languageOptions: ReadonlyArray<{ value: string; label: string }> = [
-  ...negotiableLocales.map((locale) => {
-    const endonym = new Intl.DisplayNames([locale], { type: 'language' }).of(locale) ?? locale
-    return {
-      value: locale as string,
-      label: endonym.charAt(0).toLocaleUpperCase(locale) + endonym.slice(1),
-    }
-  }),
-  ...(import.meta.env.DEV ? [{ value: pseudoLocale as string, label: 'Pseudo-locale (en-XA)' }] : []),
-]
-
-const languageLabel = (locale: string): string =>
-  languageOptions.find((option) => option.value === locale)?.label ?? locale
 
 type PreferencesState = {
   isResetting: boolean


### PR DESCRIPTION
## Summary

- New PowerSync-synced `language` setting (BCP-47, ships as `en`) with `defaultSettingsVersion` bumped to 3. While the setting is unmodified, it's seeded from `navigator.languages` on boot via `recomputeHash`, so inference stays a default rather than a user edit — devices with different browser languages never ping-pong the row, and resetting returns to "auto".
- Pure, unit-tested `resolveLocale` negotiation chain (explicit setting → browser languages with exact-tag and base-language matching → `en`) plus a locale registry in `src/i18n/` that mirrors the Lingui branch so #1234 can rebase onto it and wire `activateLocale`.
- Language selector at the top of Settings → Localization, following the existing row pattern (ModificationIndicator reset, analytics events). Options are endonyms via `Intl.DisplayNames`; the `en-XA` pseudo-locale is offered in dev builds only.
- `useAppLanguage` hook binds `document.documentElement.lang` to the active locale and registers `locale` as a PostHog super + person property (coarse tag, consent-gated by `data_collection`).
- CJK rendering pass over the three `font-heading` call sites: verified Japanese and mixed-script headings render without tofu or clipping, and hardened the `--font-heading` fallback chain with explicit CJK fonts for platforms where `system-ui` lacks coverage (Linux/Tauri).

## Test plan

- [x] `resolveLocale` unit tests (14 cases: exact/region/base matching, pseudo-locale exclusion, fallbacks)
- [x] Settings defaults snapshot test updated for version 3
- [x] `bun run test`, `tsc --noEmit`, ESLint all green
- [x] In-browser rendering check of Japanese/mixed-script headings (screenshots measured against line boxes)
- [ ] Authenticated multi-device check: non-English browser seeds the setting; explicit selection syncs and pins