### PR TITLE
feat(THU-788): external link behavior preference (ask / sidebar / browser)

### DIFF
--- a/docs/features/webview.md
+++ b/docs/features/webview.md
@@ -8,7 +8,15 @@
 
 ## Overview
 
-The WebView feature displays web pages directly in the application sidebar using native browser components. Links in the AI assistant open in an embedded WebView instead of launching an external browser.
+The WebView feature displays web pages directly in the application sidebar using native browser components.
+
+Where a link in the AI assistant opens is a user preference — **External Links** in Settings → Preferences, backed by `externalLinkBehavior` in the device-local settings store:
+
+| Value           | Behavior                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `ask` (default) | Show a confirmation dialog naming the URL, offering the sidebar WebView (desktop) or an external open         |
+| `sidebar`       | Open in the sidebar WebView immediately. Desktop only — degrades to `ask` where the side panel is unavailable |
+| `browser`       | Open in the OS browser (or a new tab on web) immediately, with no confirmation                                |
 
 **Platform engines:**
 
@@ -98,7 +106,6 @@ const webview = new Webview(windowRef.current, webviewLabel, webviewOptions)
 ## Future Improvements
 
 - Feature flag for opt-in testing
-- Privacy warnings before opening external pages
 - VPN integration or detection
 - WebView pooling/reuse for better performance
 - Content filtering/ad blocking at Tauri level

--- a/src/components/chat/external-link-dialog.test.tsx
+++ b/src/components/chat/external-link-dialog.test.tsx
@@ -5,6 +5,7 @@
 import '@/testing-library'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, mock } from 'bun:test'
+import { openFailedMessage, unsafeUrlMessage } from '@/hooks/use-external-link-dialog'
 import { ExternalLinkDialog } from './external-link-dialog'
 
 describe('ExternalLinkDialog', () => {
@@ -45,10 +46,25 @@ describe('ExternalLinkDialog', () => {
       expect(screen.getByRole('button', { name: 'Open Link' })).toBeInTheDocument()
     })
 
-    it('should display openError when provided', () => {
-      render(<ExternalLinkDialog {...defaultProps} openError="Could not open link." />)
+    it('should resolve and display openError when provided', () => {
+      render(<ExternalLinkDialog {...defaultProps} openError={openFailedMessage} />)
 
-      expect(screen.getByText('Could not open link.')).toBeInTheDocument()
+      expect(screen.getByText('Could not open link. Please try again or copy the URL.')).toBeInTheDocument()
+    })
+
+    it('should render openError through i18n rather than as a raw value', () => {
+      // A real descriptor, not the identity-macro string the test preload substitutes
+      // for `msg` — so this fails if the dialog ever renders `openError` directly.
+      render(<ExternalLinkDialog {...defaultProps} openError={{ id: 'sQaX8n', message: 'Localized failure' }} />)
+
+      expect(screen.getByText('Localized failure')).toBeInTheDocument()
+    })
+
+    it('should display the unsafe-URL error, which is distinct from the retryable one', () => {
+      render(<ExternalLinkDialog {...defaultProps} openError={unsafeUrlMessage} />)
+
+      expect(screen.getByText('This link uses an address the app cannot open.')).toBeInTheDocument()
+      expect(screen.queryByText(/Please try again/)).not.toBeInTheDocument()
     })
 
     it('should show Opening… and disable Open button when isOpening', () => {

--- a/src/components/chat/external-link-dialog.tsx
+++ b/src/components/chat/external-link-dialog.tsx
@@ -11,7 +11,8 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
-import { Trans } from '@lingui/react/macro'
+import type { MessageDescriptor } from '@lingui/core'
+import { Trans, useLingui } from '@lingui/react/macro'
 import { ExternalLink, PanelRight, X } from 'lucide-react'
 import { memo, useCallback } from 'react'
 
@@ -23,7 +24,8 @@ type ExternalLinkDialogProps = {
   /** Called when onConfirm() rejects (e.g. unhandled throw). Use to show error in dialog. */
   onOpenError?: (error: unknown) => void
   onOpenInApp?: () => void
-  openError?: string | null
+  /** A descriptor, not a string, so it renders in the locale active now rather than when the open failed. */
+  openError?: MessageDescriptor | null
   isOpening?: boolean
 }
 
@@ -38,6 +40,8 @@ export const ExternalLinkDialog = memo(
     openError = null,
     isOpening = false,
   }: ExternalLinkDialogProps) => {
+    const { i18n } = useLingui()
+
     const handleConfirmClick = useCallback(async () => {
       try {
         await onConfirm()
@@ -75,7 +79,7 @@ export const ExternalLinkDialog = memo(
             {url}
           </div>
 
-          {openError && <p className="text-sm text-destructive">{openError}</p>}
+          {openError && <p className="text-sm text-destructive">{i18n._(openError)}</p>}
 
           <AlertDialogFooter>
             <Button variant="ghost" onClick={() => onOpenChange(false)}>

--- a/src/components/chat/markdown-utils.test.tsx
+++ b/src/components/chat/markdown-utils.test.tsx
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
-import { fireEvent, render, screen } from '@testing-library/react'
-import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
-import { ContentViewProvider } from '@/content-view/context'
+import { ContentViewProvider, useContentView } from '@/content-view/context'
+import { useLocalSettingsStore } from '@/stores/local-settings-store'
 import { createTestProvider } from '@/test-utils/test-provider'
 import type { CitationMap, CitationSource } from '@/types/citation'
 import { CitationPopoverProvider } from './citation-popover'
@@ -17,6 +18,7 @@ import {
   citationMarkdownComponents,
   ExternalLinkDialogProvider,
   markdownComponents,
+  useOpenExternalLink,
 } from './markdown-utils'
 
 beforeAll(async () => {
@@ -211,6 +213,16 @@ describe('markdownComponents', () => {
 })
 
 describe('ExternalLinkDialogProvider (single dialog for multiple links)', () => {
+  // The store is a module singleton and suites run --randomize in one process, so
+  // pin the behavior these tests assume rather than relying on the default surviving.
+  beforeEach(() => {
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'ask')
+  })
+
+  afterEach(() => {
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'ask')
+  })
+
   test('renders only one dialog instance; clicking a link shows that URL in the shared dialog', () => {
     const markdown = '[first](https://a.com) [second](https://b.com) [third](https://c.com)'
     const { container, getByRole, getByText } = render(
@@ -263,6 +275,147 @@ describe('ExternalLinkDialogProvider (single dialog for multiple links)', () => 
     fireEvent.click(screen.getByRole('button', { name: 'Open Link' }))
     expect(mockWindowOpen).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
     window.open = originalOpen
+  })
+})
+
+describe('ExternalLinkDialogProvider — externalLinkBehavior routing', () => {
+  const renderLink = (
+    url = 'https://example.com',
+    {
+      withContentView = true,
+      isDesktopPlatform,
+    }: { withContentView?: boolean; isDesktopPlatform?: () => boolean } = {},
+  ) => {
+    const markdown = `[link](${url})`
+    const content = (
+      <ExternalLinkDialogProvider isDesktopPlatform={isDesktopPlatform}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          {markdown}
+        </ReactMarkdown>
+      </ExternalLinkDialogProvider>
+    )
+    const view = render(
+      withContentView ? (
+        <ContentViewProvider>
+          {content}
+          <PreviewProbe />
+        </ContentViewProvider>
+      ) : (
+        content
+      ),
+    )
+    const link = view.container.querySelector('a[href]')
+    if (!link) {
+      throw new Error('expected link')
+    }
+    return link
+  }
+
+  /**
+   * Reports what the content view is showing. The side panel itself is rendered by
+   * the layout, not by ContentViewProvider, so the provider's state is what tells us
+   * a link was routed to the sidebar.
+   */
+  const PreviewProbe = () => {
+    const { state } = useContentView()
+    return <div data-testid="preview-state">{state.type === 'preview' ? state.data.url : 'none'}</div>
+  }
+
+  /** Renders a bare consumer of the exported hook, bypassing SafeLink's own href filtering. */
+  const renderHookConsumer = (url: string) => {
+    const Consumer = () => {
+      const openExternalLink = useOpenExternalLink()
+      return <button onClick={() => openExternalLink(url)}>open</button>
+    }
+    render(
+      <ContentViewProvider>
+        <ExternalLinkDialogProvider>
+          <Consumer />
+        </ExternalLinkDialogProvider>
+      </ContentViewProvider>,
+    )
+    return screen.getByRole('button', { name: 'open' })
+  }
+
+  const stubWindowOpen = () => {
+    const spy = mock(() => ({}) as Window)
+    window.open = spy as typeof window.open
+    return spy
+  }
+
+  const originalOpen = window.open
+
+  afterEach(() => {
+    window.open = originalOpen
+    cleanup()
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'ask')
+  })
+
+  test('ask: shows the confirmation dialog and does not open anything', () => {
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'ask')
+    const windowOpen = stubWindowOpen()
+
+    fireEvent.click(renderLink())
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(windowOpen).not.toHaveBeenCalled()
+  })
+
+  test('browser: opens immediately with no dialog', async () => {
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'browser')
+    const windowOpen = stubWindowOpen()
+
+    fireEvent.click(renderLink())
+    // openExternally is async; let the microtask that opens the URL flush.
+    await act(async () => {})
+
+    expect(windowOpen).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  test('sidebar on web: degrades to the dialog because there is no side panel', () => {
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'sidebar')
+    const windowOpen = stubWindowOpen()
+
+    fireEvent.click(renderLink())
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(windowOpen).not.toHaveBeenCalled()
+  })
+
+  test('sidebar without ContentViewProvider: degrades to the dialog', () => {
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'sidebar')
+
+    fireEvent.click(renderLink('https://example.com', { withContentView: false }))
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+  })
+
+  test('sidebar on desktop: renders in the side panel, with no dialog and no external open', () => {
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'sidebar')
+    const windowOpen = stubWindowOpen()
+
+    fireEvent.click(renderLink('https://example.com', { isDesktopPlatform: () => true }))
+
+    // The side panel is the only thing that should have happened.
+    expect(screen.getByTestId('preview-state')).toHaveTextContent('https://example.com')
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(windowOpen).not.toHaveBeenCalled()
+  })
+
+  test('browser with an unsafe URL: the provider refuses it and explains why', async () => {
+    // Reached through the exported hook rather than SafeLink, which filters unsafe
+    // hrefs before the provider sees them — this is the guard that backstops a
+    // consumer that forgets to validate.
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'browser')
+    const windowOpen = stubWindowOpen()
+
+    fireEvent.click(renderHookConsumer('javascript:alert(1)'))
+    await act(async () => {})
+
+    expect(windowOpen).not.toHaveBeenCalled()
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByText('This link uses an address the app cannot open.')).toBeInTheDocument()
   })
 })
 

--- a/src/components/chat/markdown-utils.tsx
+++ b/src/components/chat/markdown-utils.tsx
@@ -20,8 +20,10 @@ import { CitationBadge } from '@/components/chat/citation-badge'
 import { ExternalLinkDialog } from '@/components/chat/external-link-dialog'
 import { useSetPreviewHidden, useShowPreview } from '@/content-view/context'
 import { useExternalLinkDialog } from '@/hooks/use-external-link-dialog'
+import { resolveLinkAction } from '@/lib/external-link-behavior'
 import { isDesktop } from '@/lib/platform'
 import { isSafeUrl } from '@/lib/url-utils'
+import { useLocalSettingsStore } from '@/stores/local-settings-store'
 import type { CitationMap } from '@/types/citation'
 
 // Re-export for consumers that import CitationMap from here
@@ -173,50 +175,82 @@ const processChildren = (children: ReactNode, citations?: CitationMap): ReactNod
 /**
  * Provider that renders a single ExternalLinkDialog for all SafeLinks in the tree.
  * Wrap markdown content with this to avoid N dialog instances for N links.
+ *
+ * `isDesktopPlatform` is injectable (as `ContentViewProvider` does with `trackEvent`)
+ * so the sidebar route can be exercised without a real Tauri desktop environment.
  */
-export const ExternalLinkDialogProvider = memo(({ children }: { children: ReactNode }) => {
-  const { dialogOpen, pendingUrl, openDialog, handleConfirm, dismissWithAction, setDialogOpen, openError, isOpening } =
-    useExternalLinkDialog()
-  const contextValue = useMemo(() => ({ openExternalLink: openDialog }), [openDialog])
+export const ExternalLinkDialogProvider = memo(
+  ({ children, isDesktopPlatform = isDesktop }: { children: ReactNode; isDesktopPlatform?: () => boolean }) => {
+    const {
+      dialogOpen,
+      pendingUrl,
+      openDialog,
+      openExternally,
+      handleConfirm,
+      dismissWithAction,
+      setDialogOpen,
+      openError,
+      isOpening,
+    } = useExternalLinkDialog()
 
-  const showPreview = useShowPreview()
-  const setPreviewHidden = useSetPreviewHidden()
-  const desktop = isDesktop() && !!showPreview
+    const showPreview = useShowPreview()
+    const setPreviewHidden = useSetPreviewHidden()
+    const desktop = isDesktopPlatform() && !!showPreview
+    const linkBehavior = useLocalSettingsStore((s) => s.externalLinkBehavior)
 
-  const handleDialogOpenChange = useCallback(
-    (open: boolean) => {
-      setDialogOpen(open)
-      setPreviewHidden?.(open)
-    },
-    [setDialogOpen, setPreviewHidden],
-  )
+    const openExternalLink = useCallback(
+      (url: string) => {
+        const action = resolveLinkAction(linkBehavior, { canUseSidebar: desktop, isSafe: isSafeUrl(url) })
+        if (action === 'browser') {
+          void openExternally(url)
+          return
+        }
+        if (action === 'sidebar' && showPreview) {
+          showPreview(url)
+          return
+        }
+        openDialog(url)
+      },
+      [desktop, linkBehavior, openDialog, openExternally, showPreview],
+    )
 
-  // Reset preview visibility when the component unmounts while dialog is open
-  useEffect(() => {
-    return () => setPreviewHidden?.(false)
-  }, [setPreviewHidden])
+    const contextValue = useMemo(() => ({ openExternalLink }), [openExternalLink])
 
-  const handleOpenInApp = useCallback(() => {
-    if (showPreview) {
-      dismissWithAction(showPreview)
-    }
-  }, [dismissWithAction, showPreview])
+    const handleDialogOpenChange = useCallback(
+      (open: boolean) => {
+        setDialogOpen(open)
+        setPreviewHidden?.(open)
+      },
+      [setDialogOpen, setPreviewHidden],
+    )
 
-  return (
-    <ExternalLinkDialogContext.Provider value={contextValue}>
-      {children}
-      <ExternalLinkDialog
-        open={dialogOpen}
-        onOpenChange={handleDialogOpenChange}
-        url={pendingUrl}
-        onConfirm={handleConfirm}
-        onOpenInApp={desktop ? handleOpenInApp : undefined}
-        openError={openError}
-        isOpening={isOpening}
-      />
-    </ExternalLinkDialogContext.Provider>
-  )
-})
+    // Reset preview visibility when the component unmounts while dialog is open
+    useEffect(() => {
+      return () => setPreviewHidden?.(false)
+    }, [setPreviewHidden])
+
+    const handleOpenInApp = useCallback(() => {
+      if (showPreview) {
+        dismissWithAction(showPreview)
+      }
+    }, [dismissWithAction, showPreview])
+
+    return (
+      <ExternalLinkDialogContext.Provider value={contextValue}>
+        {children}
+        <ExternalLinkDialog
+          open={dialogOpen}
+          onOpenChange={handleDialogOpenChange}
+          url={pendingUrl}
+          onConfirm={handleConfirm}
+          onOpenInApp={desktop ? handleOpenInApp : undefined}
+          openError={openError}
+          isOpening={isOpening}
+        />
+      </ExternalLinkDialogContext.Provider>
+    )
+  },
+)
 ExternalLinkDialogProvider.displayName = 'ExternalLinkDialogProvider'
 
 /**

--- a/src/components/external-link-toggle-group.test.tsx
+++ b/src/components/external-link-toggle-group.test.tsx
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@testing-library/jest-dom'
+import { i18n } from '@lingui/core'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { useLocalSettingsStore } from '@/stores/local-settings-store'
+import { ExternalLinkToggleGroup, getBehaviorOptions } from './external-link-toggle-group'
+
+// Platform predicates are injected (per docs/development/testing.md: DI over module
+// mocks), so the platform matrix is a pure test and the component test runs as web.
+const web = { isDesktop: () => false, isTauri: () => false }
+const tauriDesktop = { isDesktop: () => true, isTauri: () => true }
+const tauriMobile = { isDesktop: () => false, isTauri: () => true }
+
+// Options hold `msg` descriptors, so resolve through i18n rather than reading `.label`.
+const labels = (deps: typeof web) => getBehaviorOptions(deps).map((option) => i18n._(option.label))
+
+describe('getBehaviorOptions', () => {
+  it('offers Ask and New tab on web — no Sidebar without the side panel', () => {
+    expect(labels(web)).toEqual(['Ask', 'New tab'])
+  })
+
+  it('offers all three on desktop, with the external option named Browser', () => {
+    expect(labels(tauriDesktop)).toEqual(['Ask', 'Sidebar', 'Browser'])
+  })
+
+  it('names the external option Browser on Tauri mobile but still omits Sidebar', () => {
+    // The label and the Sidebar gate come from two different predicates; this is the
+    // combination where conflating them would show a Sidebar option that cannot work.
+    expect(labels(tauriMobile)).toEqual(['Ask', 'Browser'])
+  })
+
+  it('gives the external option a whole-sentence aria-label per platform', () => {
+    // Two complete messages, not "Open in " + label: the fragment build was
+    // untranslatable, and this test is what pins that apart.
+    const ariaLabel = (deps: typeof web) => {
+      const option = getBehaviorOptions(deps).find((o) => o.value === 'browser')
+      return option && i18n._(option.ariaLabel)
+    }
+
+    expect(ariaLabel(web)).toBe('Open in new tab')
+    expect(ariaLabel(tauriDesktop)).toBe('Open in browser')
+  })
+})
+
+describe('ExternalLinkToggleGroup', () => {
+  beforeEach(() => {
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'ask')
+  })
+
+  afterEach(() => {
+    cleanup()
+    // Don't leak a persisted preference into other suites (tests run --randomize
+    // in one process, and the store is a module singleton).
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'ask')
+  })
+
+  it('renders the platform options with the current behavior selected', () => {
+    render(<ExternalLinkToggleGroup />)
+
+    expect(screen.getByRole('radio', { name: 'Always ask' })).toHaveAttribute('data-state', 'on')
+    expect(screen.getByRole('radio', { name: 'Open in new tab' })).toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: 'Open in sidebar' })).not.toBeInTheDocument()
+  })
+
+  it('selecting an option persists the behavior', () => {
+    render(<ExternalLinkToggleGroup />)
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Open in new tab' }))
+
+    expect(useLocalSettingsStore.getState().externalLinkBehavior).toBe('browser')
+    expect(screen.getByRole('radio', { name: 'Open in new tab' })).toHaveAttribute('data-state', 'on')
+    expect(screen.getByRole('radio', { name: 'Always ask' })).toHaveAttribute('data-state', 'off')
+  })
+
+  it('re-clicking the selected option keeps it selected (no deselect to empty)', () => {
+    render(<ExternalLinkToggleGroup />)
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Always ask' }))
+
+    expect(useLocalSettingsStore.getState().externalLinkBehavior).toBe('ask')
+    expect(screen.getByRole('radio', { name: 'Always ask' })).toHaveAttribute('data-state', 'on')
+  })
+
+  it('falls back to Ask when the persisted behavior has no option on this platform', () => {
+    // `sidebar` is desktop-only; without the fallback the group renders nothing selected.
+    useLocalSettingsStore.getState().setLocalSetting('externalLinkBehavior', 'sidebar')
+
+    render(<ExternalLinkToggleGroup />)
+
+    expect(screen.getByRole('radio', { name: 'Always ask' })).toHaveAttribute('data-state', 'on')
+    expect(screen.getByRole('radio', { name: 'Open in new tab' })).toHaveAttribute('data-state', 'off')
+  })
+})

--- a/src/components/external-link-toggle-group.tsx
+++ b/src/components/external-link-toggle-group.tsx
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { isExternalLinkBehavior, type ExternalLinkBehavior } from '@/lib/external-link-behavior'
+import { isDesktop, isTauri } from '@/lib/platform'
+import { trackEvent } from '@/lib/posthog'
+import { useLocalSettingsStore } from '@/stores/local-settings-store'
+import type { MessageDescriptor } from '@lingui/core'
+import { msg } from '@lingui/core/macro'
+import { useLingui } from '@lingui/react/macro'
+import { ExternalLink, MessageCircleQuestion, PanelRight, type LucideIcon } from 'lucide-react'
+
+type BehaviorOption = {
+  value: ExternalLinkBehavior
+  ariaLabel: MessageDescriptor
+  Icon: LucideIcon
+  label: MessageDescriptor
+}
+
+// `msg` descriptors at module scope; the component resolves them with `i18n._` so
+// the labels follow a language change. `browser` and `newTab` are two complete
+// options rather than one with an interpolated label — "Open in {x}" built from
+// fragments is untranslatable, since word order and the casing of the noun differ.
+const ask: BehaviorOption = {
+  value: 'ask',
+  ariaLabel: msg`Always ask`,
+  Icon: MessageCircleQuestion,
+  label: msg`Ask`,
+}
+const sidebar: BehaviorOption = {
+  value: 'sidebar',
+  ariaLabel: msg`Open in sidebar`,
+  Icon: PanelRight,
+  label: msg`Sidebar`,
+}
+const browser: BehaviorOption = {
+  value: 'browser',
+  ariaLabel: msg`Open in browser`,
+  Icon: ExternalLink,
+  label: msg`Browser`,
+}
+const newTab: BehaviorOption = {
+  value: 'browser',
+  ariaLabel: msg`Open in new tab`,
+  Icon: ExternalLink,
+  label: msg`New tab`,
+}
+
+/**
+ * Options for the current platform. `sidebar` needs the in-app side panel, which
+ * only the desktop app has; the external option is a new tab on web, the OS
+ * browser everywhere else.
+ */
+export const getBehaviorOptions = (deps = { isDesktop, isTauri }): BehaviorOption[] => [
+  ask,
+  ...(deps.isDesktop() ? [sidebar] : []),
+  deps.isTauri() ? browser : newTab,
+]
+
+/** Where links in chats open — the Preferences counterpart to the confirmation dialog. */
+export const ExternalLinkToggleGroup = () => {
+  const { i18n } = useLingui()
+  const externalLinkBehavior = useLocalSettingsStore((s) => s.externalLinkBehavior)
+  const setLocalSetting = useLocalSettingsStore((s) => s.setLocalSetting)
+  const options = getBehaviorOptions()
+
+  // A persisted value with no option on this platform (e.g. `sidebar` carried into a
+  // build without the side panel) would leave the group with nothing selected. Show
+  // `ask`, which is also what such a click actually does — see `resolveLinkAction`.
+  const value = options.some((option) => option.value === externalLinkBehavior) ? externalLinkBehavior : 'ask'
+
+  return (
+    <ToggleGroup
+      type="single"
+      variant="outline"
+      value={value}
+      onValueChange={(next) => {
+        if (!isExternalLinkBehavior(next)) {
+          return
+        }
+        setLocalSetting('externalLinkBehavior', next)
+        trackEvent('settings_external_link_behavior_update', { behavior: next })
+      }}
+      className="justify-start rounded-lg"
+    >
+      {options.map(({ value, ariaLabel, Icon, label }) => (
+        <ToggleGroupItem
+          key={value}
+          value={value}
+          aria-label={i18n._(ariaLabel)}
+          className="gap-2 px-4 cursor-pointer first:rounded-l-lg last:rounded-r-lg"
+        >
+          <Icon className="h-4 w-4" />
+          {i18n._(label)}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}

--- a/src/hooks/use-external-link-dialog.test.ts
+++ b/src/hooks/use-external-link-dialog.test.ts
@@ -4,7 +4,7 @@
 
 import { renderHook, act } from '@testing-library/react'
 import { describe, expect, it, mock } from 'bun:test'
-import { useExternalLinkDialog } from './use-external-link-dialog'
+import { openFailedMessage, unsafeUrlMessage, useExternalLinkDialog } from './use-external-link-dialog'
 
 describe('useExternalLinkDialog', () => {
   describe('initial state', () => {
@@ -44,6 +44,23 @@ describe('useExternalLinkDialog', () => {
       })
 
       expect(result.current.pendingUrl).toBe('https://second.com')
+      expect(result.current.openError).toBe(null)
+    })
+
+    it('should seed openError when opened with one, and clear it when reopened without', () => {
+      const { result } = renderHook(() => useExternalLinkDialog())
+
+      act(() => {
+        result.current.openDialog('https://example.com', openFailedMessage)
+      })
+
+      expect(result.current.dialogOpen).toBe(true)
+      expect(result.current.openError).toBe(openFailedMessage)
+
+      act(() => {
+        result.current.openDialog('https://example.com')
+      })
+
       expect(result.current.openError).toBe(null)
     })
   })
@@ -127,7 +144,98 @@ describe('useExternalLinkDialog', () => {
       expect(mockWindowOpen).not.toHaveBeenCalled()
       expect(result.current.dialogOpen).toBe(true)
       expect(result.current.pendingUrl).toBe('javascript:alert(1)')
-      expect(result.current.openError).toBe('Could not open link. Please try again or copy the URL.')
+      expect(result.current.openError).toBe(unsafeUrlMessage)
+
+      window.open = originalOpen
+    })
+  })
+
+  describe('openExternally (the `browser` preference — no confirmation)', () => {
+    it('should open the URL immediately without showing the dialog', async () => {
+      const originalOpen = window.open
+      const mockWindowOpen = mock(() => ({}) as Window)
+      window.open = mockWindowOpen as typeof window.open
+
+      const { result } = renderHook(() => useExternalLinkDialog())
+
+      await act(async () => {
+        await result.current.openExternally('https://example.com')
+      })
+
+      expect(mockWindowOpen).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+      expect(result.current.dialogOpen).toBe(false)
+      expect(result.current.openError).toBeNull()
+
+      window.open = originalOpen
+    })
+
+    it('should not open an unsafe URL, and should surface the dialog explaining why', async () => {
+      const originalOpen = window.open
+      const mockWindowOpen = mock(() => ({}) as Window)
+      window.open = mockWindowOpen as typeof window.open
+
+      const { result } = renderHook(() => useExternalLinkDialog())
+
+      await act(async () => {
+        await result.current.openExternally('javascript:alert(1)')
+      })
+
+      expect(mockWindowOpen).not.toHaveBeenCalled()
+      expect(result.current.dialogOpen).toBe(true)
+      expect(result.current.pendingUrl).toBe('javascript:alert(1)')
+      expect(result.current.openError).toBe(unsafeUrlMessage)
+
+      window.open = originalOpen
+    })
+
+    it('should fall back to the dialog with an error when the opener throws', async () => {
+      // Throwing is the only observable failure on web: noopener makes window.open
+      // return null even on success, so the return value can't be used as a signal.
+      const originalOpen = window.open
+      window.open = mock(() => {
+        throw new Error('popup blocked')
+      }) as unknown as typeof window.open
+
+      const { result } = renderHook(() => useExternalLinkDialog())
+
+      await act(async () => {
+        await result.current.openExternally('https://example.com')
+      })
+
+      expect(result.current.dialogOpen).toBe(true)
+      expect(result.current.pendingUrl).toBe('https://example.com')
+      expect(result.current.openError).toBe(openFailedMessage)
+
+      window.open = originalOpen
+    })
+
+    it('should let the user retry from the fallback dialog via handleConfirm', async () => {
+      const originalOpen = window.open
+      let shouldFail = true
+      const mockWindowOpen = mock(() => {
+        if (shouldFail) {
+          throw new Error('popup blocked')
+        }
+        return {} as Window
+      })
+      window.open = mockWindowOpen as unknown as typeof window.open
+
+      const { result } = renderHook(() => useExternalLinkDialog())
+
+      await act(async () => {
+        await result.current.openExternally('https://example.com')
+      })
+
+      expect(result.current.openError).toBe(openFailedMessage)
+
+      shouldFail = false
+      await act(async () => {
+        await result.current.handleConfirm()
+      })
+
+      expect(result.current.dialogOpen).toBe(false)
+      expect(result.current.openError).toBeNull()
+      expect(mockWindowOpen).toHaveBeenLastCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
 
       window.open = originalOpen
     })
@@ -164,7 +272,7 @@ describe('useExternalLinkDialog', () => {
       expect(action).not.toHaveBeenCalled()
       expect(result.current.dialogOpen).toBe(true)
       expect(result.current.pendingUrl).toBe('javascript:alert(1)')
-      expect(result.current.openError).toBe('Could not open link. Please try again or copy the URL.')
+      expect(result.current.openError).toBe(unsafeUrlMessage)
     })
 
     it('should do nothing when pendingUrl is empty', () => {

--- a/src/hooks/use-external-link-dialog.ts
+++ b/src/hooks/use-external-link-dialog.ts
@@ -2,25 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { MessageDescriptor } from '@lingui/core'
+import { msg } from '@lingui/core/macro'
 import { useCallback, useReducer, useRef } from 'react'
-import { isTauri } from '@/lib/platform'
+import { openExternalUrl } from '@/lib/open-external-url'
 import { isSafeUrl } from '@/lib/url-utils'
 
-const openFailedMessage = 'Could not open link. Please try again or copy the URL.'
+// `msg` (not `t`) because these live at module scope, and descriptors (not strings)
+// because the dialog holds the error in state — a string would freeze whichever
+// locale was active when the open failed. The dialog resolves with `i18n._`.
+export const openFailedMessage = msg`Could not open link. Please try again or copy the URL.`
+/** Retrying can never succeed for a non-http(s) URL, so don't tell the user to. */
+export const unsafeUrlMessage = msg`This link uses an address the app cannot open.`
 
 type DialogState = {
   dialogOpen: boolean
   pendingUrl: string
-  openError: string | null
+  openError: MessageDescriptor | null
   isOpening: boolean
 }
 
 type DialogAction =
-  | { type: 'open'; url: string }
+  | { type: 'open'; url: string; error?: MessageDescriptor }
   | { type: 'close' }
   | { type: 'set_open'; open: boolean }
   | { type: 'start_opening' }
-  | { type: 'set_error'; error: string }
+  | { type: 'set_error'; error: MessageDescriptor }
 
 const initialState: DialogState = {
   dialogOpen: false,
@@ -32,7 +39,7 @@ const initialState: DialogState = {
 const dialogReducer = (state: DialogState, action: DialogAction): DialogState => {
   switch (action.type) {
     case 'open':
-      return { dialogOpen: true, pendingUrl: action.url, openError: null, isOpening: false }
+      return { dialogOpen: true, pendingUrl: action.url, openError: action.error ?? null, isOpening: false }
     case 'close':
       return { ...state, dialogOpen: false, isOpening: false }
     case 'set_open':
@@ -47,11 +54,12 @@ const dialogReducer = (state: DialogState, action: DialogAction): DialogState =>
 type UseExternalLinkDialogReturn = {
   dialogOpen: boolean
   pendingUrl: string
-  openDialog: (url: string) => void
+  openDialog: (url: string, error?: MessageDescriptor) => void
+  openExternally: (url: string) => Promise<void>
   handleConfirm: () => Promise<void>
   dismissWithAction: (action: (url: string) => void) => void
   setDialogOpen: (open: boolean) => void
-  openError: string | null
+  openError: MessageDescriptor | null
   isOpening: boolean
 }
 
@@ -59,8 +67,10 @@ type UseExternalLinkDialogReturn = {
  * Hook for managing external link warning dialog state.
  * Encapsulates the common pattern of showing a confirmation dialog
  * before opening external links in a new window.
- * Dialog closes only after a successful open; on failure (e.g. Tauri/openUrl
- * or window.open fails) the dialog stays open and openError is set.
+ * Once the dialog is open it closes only after a successful open; on failure
+ * (e.g. Tauri/openUrl or window.open fails) it stays open and openError is set.
+ * `openExternally` skips the dialog entirely, and raises it only to report a
+ * failure — so a failed open there moves it from closed to open.
  * Callbacks are stable (useCallback) so context consumers (e.g. SafeLink)
  * do not re-render when the provider re-renders during streaming.
  */
@@ -68,10 +78,32 @@ export const useExternalLinkDialog = (): UseExternalLinkDialogReturn => {
   const [state, dispatch] = useReducer(dialogReducer, initialState)
   const pendingUrlRef = useRef<string>('')
 
-  const openDialog = useCallback((url: string) => {
+  const openDialog = useCallback((url: string, error?: MessageDescriptor) => {
     pendingUrlRef.current = url
-    dispatch({ type: 'open', url })
+    dispatch({ type: 'open', url, error })
   }, [])
+
+  /**
+   * Opens the URL without confirmation (the `browser` link preference).
+   * On failure it raises the dialog carrying the reason: a retryable message when
+   * the opener failed, or the non-retryable one when the URL isn't http(s).
+   */
+  const openExternally = useCallback(
+    async (url: string) => {
+      if (!isSafeUrl(url)) {
+        console.error('Attempted to open unsafe URL:', url)
+        openDialog(url, unsafeUrlMessage)
+        return
+      }
+      try {
+        await openExternalUrl(url)
+      } catch (error) {
+        console.error('Failed to open URL:', error)
+        openDialog(url, openFailedMessage)
+      }
+    },
+    [openDialog],
+  )
 
   const setDialogOpen = useCallback((open: boolean) => {
     dispatch({ type: 'set_open', open })
@@ -87,21 +119,14 @@ export const useExternalLinkDialog = (): UseExternalLinkDialogReturn => {
 
     if (!isSafeUrl(urlToOpen)) {
       console.error('Attempted to open unsafe URL:', urlToOpen)
-      dispatch({ type: 'set_error', error: openFailedMessage })
+      dispatch({ type: 'set_error', error: unsafeUrlMessage })
       return
     }
 
     dispatch({ type: 'start_opening' })
 
     try {
-      if (isTauri()) {
-        const { openUrl } = await import('@tauri-apps/plugin-opener')
-        await openUrl(urlToOpen)
-      } else {
-        // noopener causes window.open to return null even on success,
-        // so we can't use the return value to detect popup-blocked
-        window.open(urlToOpen, '_blank', 'noopener,noreferrer')
-      }
+      await openExternalUrl(urlToOpen)
       if (pendingUrlRef.current === urlToOpen) {
         dispatch({ type: 'close' })
       }
@@ -121,7 +146,7 @@ export const useExternalLinkDialog = (): UseExternalLinkDialogReturn => {
     }
     if (!isSafeUrl(url)) {
       console.error('Attempted to open unsafe URL in app:', url)
-      dispatch({ type: 'set_error', error: openFailedMessage })
+      dispatch({ type: 'set_error', error: unsafeUrlMessage })
       return
     }
     pendingUrlRef.current = ''
@@ -133,6 +158,7 @@ export const useExternalLinkDialog = (): UseExternalLinkDialogReturn => {
     dialogOpen: state.dialogOpen,
     pendingUrl: state.pendingUrl,
     openDialog,
+    openExternally,
     handleConfirm,
     dismissWithAction,
     setDialogOpen,

--- a/src/lib/external-link-behavior.test.ts
+++ b/src/lib/external-link-behavior.test.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  isExternalLinkBehavior,
+  resolveLinkAction,
+  type ExternalLinkAction,
+  type ExternalLinkBehavior,
+} from './external-link-behavior'
+
+describe('isExternalLinkBehavior', () => {
+  it('accepts the three known behaviors', () => {
+    expect(isExternalLinkBehavior('ask')).toBe(true)
+    expect(isExternalLinkBehavior('sidebar')).toBe(true)
+    expect(isExternalLinkBehavior('browser')).toBe(true)
+  })
+
+  it('rejects the empty string Radix emits when a selected toggle is clicked again', () => {
+    expect(isExternalLinkBehavior('')).toBe(false)
+  })
+
+  it('rejects unknown values', () => {
+    expect(isExternalLinkBehavior('Browser')).toBe(false)
+    expect(isExternalLinkBehavior('new-tab')).toBe(false)
+  })
+})
+
+describe('resolveLinkAction', () => {
+  const cases: [ExternalLinkBehavior, { canUseSidebar: boolean; isSafe: boolean }, ExternalLinkAction, string][] = [
+    ['ask', { canUseSidebar: true, isSafe: true }, 'dialog', 'ask always confirms, even where the panel exists'],
+    ['ask', { canUseSidebar: false, isSafe: true }, 'dialog', 'ask always confirms'],
+    ['browser', { canUseSidebar: false, isSafe: true }, 'browser', 'browser opens without confirmation'],
+    ['browser', { canUseSidebar: true, isSafe: true }, 'browser', 'browser wins over an available panel'],
+    [
+      'browser',
+      { canUseSidebar: true, isSafe: false },
+      'browser',
+      'browser defers validation to the opener so it can show a reason',
+    ],
+    ['sidebar', { canUseSidebar: true, isSafe: true }, 'sidebar', 'sidebar uses the panel when available'],
+    ['sidebar', { canUseSidebar: false, isSafe: true }, 'dialog', 'sidebar degrades where the panel is unavailable'],
+    ['sidebar', { canUseSidebar: true, isSafe: false }, 'dialog', 'sidebar never renders an unsafe URL in the panel'],
+  ]
+
+  for (const [behavior, opts, expected, why] of cases) {
+    it(`${behavior} + ${JSON.stringify(opts)} -> ${expected} (${why})`, () => {
+      expect(resolveLinkAction(behavior, opts)).toBe(expected)
+    })
+  }
+})

--- a/src/lib/external-link-behavior.ts
+++ b/src/lib/external-link-behavior.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Where a click on an external link in chat goes (THU-788).
+ * `sidebar` renders the page in the in-app side panel and is desktop-only;
+ * `browser` skips the confirmation and opens the OS browser / a new tab.
+ */
+export type ExternalLinkBehavior = 'ask' | 'sidebar' | 'browser'
+
+export const externalLinkBehaviors: readonly ExternalLinkBehavior[] = ['ask', 'sidebar', 'browser']
+
+export const isExternalLinkBehavior = (value: string): value is ExternalLinkBehavior =>
+  (externalLinkBehaviors as readonly string[]).includes(value)
+
+/** What a link click should actually do, once the preference is reconciled with what the platform supports. */
+export type ExternalLinkAction = 'browser' | 'sidebar' | 'dialog'
+
+/**
+ * Resolves the preference into a concrete action.
+ *
+ * `sidebar` needs the in-app side panel, so it degrades to the confirmation
+ * dialog wherever the panel is unavailable rather than dead-ending the click.
+ * `browser` intentionally ignores `isSafe` — the opener validates the URL and
+ * surfaces the dialog with an error, which is a better UX than silently doing nothing.
+ */
+export const resolveLinkAction = (
+  behavior: ExternalLinkBehavior,
+  { canUseSidebar, isSafe }: { canUseSidebar: boolean; isSafe: boolean },
+): ExternalLinkAction => {
+  if (behavior === 'browser') {
+    return 'browser'
+  }
+  if (behavior === 'sidebar' && canUseSidebar && isSafe) {
+    return 'sidebar'
+  }
+  return 'dialog'
+}

--- a/src/lib/intercept-links.ts
+++ b/src/lib/intercept-links.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { openExternalUrl } from './open-external-url'
 import { isTauri } from './platform'
 import { isSafeUrl } from './url-utils'
 
@@ -23,18 +24,17 @@ const handler = async (event: MouseEvent) => {
     return
   }
 
-  if (isTauri()) {
-    // Use Tauri's openUrl in Tauri environment
-    try {
-      const { openUrl } = await import('@tauri-apps/plugin-opener')
-      await openUrl(anchor.href)
-    } catch (error) {
-      console.error('Failed to open URL with Tauri:', error)
-      // Fallback to window.open
+  try {
+    await openExternalUrl(anchor.href)
+  } catch (error) {
+    console.error('Failed to open URL externally:', error)
+    // There is no dialog to surface an error here, so retry in the app's own
+    // webview — but only under Tauri, where the failure came from the OS opener.
+    // On web openExternalUrl already called window.open, so retrying it would
+    // just repeat the call that threw.
+    if (isTauri()) {
       window.open(anchor.href, '_blank', 'noopener,noreferrer')
     }
-  } else {
-    window.open(anchor.href, '_blank', 'noopener,noreferrer')
   }
 }
 

--- a/src/lib/open-external-url.test.ts
+++ b/src/lib/open-external-url.test.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { openExternalUrl } from './open-external-url'
+
+const originalOpen = window.open
+
+const stubWindowOpen = (impl: () => Window | null) => {
+  const spy = mock(impl)
+  window.open = spy as typeof window.open
+  return spy
+}
+
+afterEach(() => {
+  window.open = originalOpen
+})
+
+describe('openExternalUrl on web', () => {
+  const webDeps = { isTauri: () => false, openInTauri: mock(async () => {}) }
+
+  it('opens a new tab with noopener,noreferrer', async () => {
+    const windowOpen = stubWindowOpen(() => ({}) as Window)
+
+    await openExternalUrl('https://example.com', webDeps)
+
+    expect(windowOpen).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+    expect(webDeps.openInTauri).not.toHaveBeenCalled()
+  })
+
+  it('resolves when window.open returns null (noopener returns null on success)', async () => {
+    stubWindowOpen(() => null)
+
+    // Must not throw: a null return is not a failure signal, so we can't treat it as one.
+    await openExternalUrl('https://example.com', webDeps)
+  })
+
+  it('rejects when window.open throws', async () => {
+    window.open = mock(() => {
+      throw new Error('blocked')
+    }) as unknown as typeof window.open
+
+    await expect(openExternalUrl('https://example.com', webDeps)).rejects.toThrow('blocked')
+  })
+})
+
+describe('openExternalUrl under Tauri', () => {
+  it('delegates to the Tauri opener and never touches window.open', async () => {
+    const windowOpen = stubWindowOpen(() => ({}) as Window)
+    const openInTauri = mock(async () => {})
+
+    await openExternalUrl('https://example.com', { isTauri: () => true, openInTauri })
+
+    expect(openInTauri).toHaveBeenCalledWith('https://example.com')
+    expect(windowOpen).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the Tauri opener rejects, so callers can surface an error', async () => {
+    const windowOpen = stubWindowOpen(() => ({}) as Window)
+    const openInTauri = mock(async () => {
+      throw new Error('opener failed')
+    })
+
+    await expect(openExternalUrl('https://example.com', { isTauri: () => true, openInTauri })).rejects.toThrow(
+      'opener failed',
+    )
+    // No silent web fallback — the dialog flow depends on the rejection.
+    expect(windowOpen).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/open-external-url.ts
+++ b/src/lib/open-external-url.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { isTauri } from '@/lib/platform'
+
+export type OpenExternalUrlDeps = {
+  isTauri: () => boolean
+  openInTauri: (url: string) => Promise<void>
+}
+
+// Imported lazily so this module stays usable (and testable) on web without
+// evaluating the Tauri plugin. It does NOT keep the plugin out of the web
+// bundle — several modules in the entry graph import it statically.
+const defaultDeps: OpenExternalUrlDeps = {
+  isTauri,
+  openInTauri: async (url) => {
+    const { openUrl } = await import('@tauri-apps/plugin-opener')
+    await openUrl(url)
+  },
+}
+
+/**
+ * Opens a URL outside the app: the OS default browser under Tauri, a new tab on web.
+ * Rejects when the platform opener fails, so callers can surface an error; callers
+ * are also responsible for validating the URL with `isSafeUrl` first.
+ */
+export const openExternalUrl = async (url: string, deps: OpenExternalUrlDeps = defaultDeps): Promise<void> => {
+  if (deps.isTauri()) {
+    await deps.openInTauri(url)
+    return
+  }
+  // noopener causes window.open to return null even on success,
+  // so we can't use the return value to detect popup-blocked
+  window.open(url, '_blank', 'noopener,noreferrer')
+}

--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -207,6 +207,7 @@ export type EventType =
   | 'settings_location_set'
   | 'settings_location_update'
   | 'settings_localization_update'
+  | 'settings_external_link_behavior_update'
   | 'settings_localization_reset'
   | 'settings_database_reset'
   | 'settings_data_export'

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -308,6 +308,10 @@ msgstr "Alle Aktionen zum Ausführen von Befehlen immer zulassen"
 msgid "Always allow everything from this agent"
 msgstr "Immer alles von diesem Agenten zulassen"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Always ask"
+msgstr "Immer fragen"
+
 #: src/lib/tool-metadata.ts
 msgid "Analyzing…"
 msgstr "Wird analysiert…"
@@ -395,6 +399,10 @@ msgstr "Artefakt"
 msgid "Artifacts"
 msgstr "Artefakte"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Ask"
+msgstr "Fragen"
+
 #: src/components/chat/chat-prompt-input.tsx
 msgid "Ask me anything…"
 msgstr "Fragen Sie mich etwas…"
@@ -476,6 +484,10 @@ msgstr "Bridge"
 #: src/settings/connections/mcp-server-detail.tsx
 msgid "Bridge target"
 msgstr "Bridge-Ziel"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Browser"
+msgstr "Browser"
 
 #: src/components/settings/agents/thunderbolt-cli.tsx
 msgid "Build it from source instead (requires Bun):"
@@ -939,6 +951,10 @@ msgstr "Verbindung zu diesem Server nicht möglich. Prüfen Sie die URL und ob d
 #: src/projects/project-form.tsx
 msgid "Could not create the project."
 msgstr "Das Projekt konnte nicht erstellt werden."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "Could not open link. Please try again or copy the URL."
+msgstr "Link konnte nicht geöffnet werden. Bitte versuchen Sie es erneut oder kopieren Sie die URL."
 
 #: src/components/set-node-id-dialog.tsx
 msgid "Could not read QR code"
@@ -1592,6 +1608,10 @@ msgstr "Daten exportieren"
 msgid "Exporting…"
 msgstr "Wird exportiert…"
 
+#: src/settings/preferences.tsx
+msgid "External Links"
+msgstr "Externe Links"
+
 #: src/i18n/unit-labels.ts
 #: src/widgets/weather-forecast/display.tsx
 msgid "Fahrenheit"
@@ -2236,6 +2256,10 @@ msgstr "Neues Projekt"
 msgid "New Skill"
 msgstr "Neuer Skill"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "New tab"
+msgstr "Neuer Tab"
+
 #: src/tasks/index.tsx
 msgid "New Task"
 msgstr "Neue Aufgabe"
@@ -2426,6 +2450,7 @@ msgstr "{title} öffnen"
 msgid "Open External Link"
 msgstr "Externen Link öffnen"
 
+#: src/components/external-link-toggle-group.tsx
 #: src/content-view/sidebar-webview.tsx
 msgid "Open in browser"
 msgstr "Im Browser öffnen"
@@ -2434,9 +2459,17 @@ msgstr "Im Browser öffnen"
 msgid "Open in Browser"
 msgstr "Im Browser öffnen"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in new tab"
+msgstr "In neuem Tab öffnen"
+
 #: src/components/chat/inline-artifact-card.tsx
 msgid "Open in side panel"
 msgstr "Im Seitenbereich öffnen"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in sidebar"
+msgstr "In der Seitenleiste öffnen"
 
 #: src/components/chat/external-link-dialog.tsx
 msgid "Open in Sidebar"
@@ -3102,6 +3135,10 @@ msgstr "QR-Code für {deviceName} anzeigen"
 msgid "Showing 50 of {totalCount} tasks"
 msgstr "50 von {totalCount} Aufgaben werden angezeigt"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Sidebar"
+msgstr "Seitenleiste"
+
 #: src/layout/sidebar/nav-toggle.tsx
 msgid "Sidebar sections"
 msgstr "Bereiche der Seitenleiste"
@@ -3486,6 +3523,10 @@ msgstr "Dieser Link ist abgelaufen. Bitte fordern Sie einen neuen an."
 #: src/lib/otp-error-messages.ts
 msgid "This link is invalid. Please request a new one."
 msgstr "Dieser Link ist ungültig. Bitte fordern Sie einen neuen an."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "This link uses an address the app cannot open."
+msgstr "Diese Adresse kann von der App nicht geöffnet werden."
 
 #: src/components/chat/error-message.tsx
 msgid "This model couldn't read the attached file. Try a different model."
@@ -3973,6 +4014,10 @@ msgstr "Wann dieser Skill genutzt werden soll…"
 #: src/components/onboarding/onboarding-location-step.tsx
 msgid "Where are you located?"
 msgstr "Wo befinden Sie sich?"
+
+#: src/settings/preferences.tsx
+msgid "Where links in chats open"
+msgstr "Wo Links in Chats geöffnet werden"
 
 #: src/components/onboarding/onboarding-language-step.tsx
 msgid "Which language do you prefer?"

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -308,6 +308,10 @@ msgstr ""
 msgid "Always allow everything from this agent"
 msgstr ""
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Always ask"
+msgstr ""
+
 #: src/lib/tool-metadata.ts
 msgid "Analyzing…"
 msgstr ""
@@ -395,6 +399,10 @@ msgstr ""
 msgid "Artifacts"
 msgstr ""
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/chat/chat-prompt-input.tsx
 msgid "Ask me anything…"
 msgstr ""
@@ -475,6 +483,10 @@ msgstr ""
 
 #: src/settings/connections/mcp-server-detail.tsx
 msgid "Bridge target"
+msgstr ""
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Browser"
 msgstr ""
 
 #: src/components/settings/agents/thunderbolt-cli.tsx
@@ -938,6 +950,10 @@ msgstr ""
 
 #: src/projects/project-form.tsx
 msgid "Could not create the project."
+msgstr ""
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "Could not open link. Please try again or copy the URL."
 msgstr ""
 
 #: src/components/set-node-id-dialog.tsx
@@ -1592,6 +1608,10 @@ msgstr ""
 msgid "Exporting…"
 msgstr ""
 
+#: src/settings/preferences.tsx
+msgid "External Links"
+msgstr ""
+
 #: src/i18n/unit-labels.ts
 #: src/widgets/weather-forecast/display.tsx
 msgid "Fahrenheit"
@@ -2236,6 +2256,10 @@ msgstr ""
 msgid "New Skill"
 msgstr ""
 
+#: src/components/external-link-toggle-group.tsx
+msgid "New tab"
+msgstr ""
+
 #: src/tasks/index.tsx
 msgid "New Task"
 msgstr ""
@@ -2426,6 +2450,7 @@ msgstr ""
 msgid "Open External Link"
 msgstr ""
 
+#: src/components/external-link-toggle-group.tsx
 #: src/content-view/sidebar-webview.tsx
 msgid "Open in browser"
 msgstr ""
@@ -2434,8 +2459,16 @@ msgstr ""
 msgid "Open in Browser"
 msgstr ""
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in new tab"
+msgstr ""
+
 #: src/components/chat/inline-artifact-card.tsx
 msgid "Open in side panel"
+msgstr ""
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in sidebar"
 msgstr ""
 
 #: src/components/chat/external-link-dialog.tsx
@@ -3102,6 +3135,10 @@ msgstr ""
 msgid "Showing 50 of {totalCount} tasks"
 msgstr ""
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/layout/sidebar/nav-toggle.tsx
 msgid "Sidebar sections"
 msgstr ""
@@ -3485,6 +3522,10 @@ msgstr ""
 
 #: src/lib/otp-error-messages.ts
 msgid "This link is invalid. Please request a new one."
+msgstr ""
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "This link uses an address the app cannot open."
 msgstr ""
 
 #: src/components/chat/error-message.tsx
@@ -3972,6 +4013,10 @@ msgstr ""
 
 #: src/components/onboarding/onboarding-location-step.tsx
 msgid "Where are you located?"
+msgstr ""
+
+#: src/settings/preferences.tsx
+msgid "Where links in chats open"
 msgstr ""
 
 #: src/components/onboarding/onboarding-language-step.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -308,6 +308,10 @@ msgstr "Always allow all Run command actions"
 msgid "Always allow everything from this agent"
 msgstr "Always allow everything from this agent"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Always ask"
+msgstr "Always ask"
+
 #: src/lib/tool-metadata.ts
 msgid "Analyzing…"
 msgstr "Analyzing…"
@@ -395,6 +399,10 @@ msgstr "Artifact"
 msgid "Artifacts"
 msgstr "Artifacts"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Ask"
+msgstr "Ask"
+
 #: src/components/chat/chat-prompt-input.tsx
 msgid "Ask me anything…"
 msgstr "Ask me anything…"
@@ -476,6 +484,10 @@ msgstr "Bridge"
 #: src/settings/connections/mcp-server-detail.tsx
 msgid "Bridge target"
 msgstr "Bridge target"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Browser"
+msgstr "Browser"
 
 #: src/components/settings/agents/thunderbolt-cli.tsx
 msgid "Build it from source instead (requires Bun):"
@@ -939,6 +951,10 @@ msgstr "Could not connect to this server. Check the URL and that the server is r
 #: src/projects/project-form.tsx
 msgid "Could not create the project."
 msgstr "Could not create the project."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "Could not open link. Please try again or copy the URL."
+msgstr "Could not open link. Please try again or copy the URL."
 
 #: src/components/set-node-id-dialog.tsx
 msgid "Could not read QR code"
@@ -1592,6 +1608,10 @@ msgstr "Export Your Data"
 msgid "Exporting…"
 msgstr "Exporting…"
 
+#: src/settings/preferences.tsx
+msgid "External Links"
+msgstr "External Links"
+
 #: src/i18n/unit-labels.ts
 #: src/widgets/weather-forecast/display.tsx
 msgid "Fahrenheit"
@@ -2236,6 +2256,10 @@ msgstr "New project"
 msgid "New Skill"
 msgstr "New Skill"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "New tab"
+msgstr "New tab"
+
 #: src/tasks/index.tsx
 msgid "New Task"
 msgstr "New Task"
@@ -2426,6 +2450,7 @@ msgstr "Open {title}"
 msgid "Open External Link"
 msgstr "Open External Link"
 
+#: src/components/external-link-toggle-group.tsx
 #: src/content-view/sidebar-webview.tsx
 msgid "Open in browser"
 msgstr "Open in browser"
@@ -2434,9 +2459,17 @@ msgstr "Open in browser"
 msgid "Open in Browser"
 msgstr "Open in Browser"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in new tab"
+msgstr "Open in new tab"
+
 #: src/components/chat/inline-artifact-card.tsx
 msgid "Open in side panel"
 msgstr "Open in side panel"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in sidebar"
+msgstr "Open in sidebar"
 
 #: src/components/chat/external-link-dialog.tsx
 msgid "Open in Sidebar"
@@ -3102,6 +3135,10 @@ msgstr "Show QR code for {deviceName}"
 msgid "Showing 50 of {totalCount} tasks"
 msgstr "Showing 50 of {totalCount} tasks"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Sidebar"
+msgstr "Sidebar"
+
 #: src/layout/sidebar/nav-toggle.tsx
 msgid "Sidebar sections"
 msgstr "Sidebar sections"
@@ -3486,6 +3523,10 @@ msgstr "This link has expired. Please request a new one."
 #: src/lib/otp-error-messages.ts
 msgid "This link is invalid. Please request a new one."
 msgstr "This link is invalid. Please request a new one."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "This link uses an address the app cannot open."
+msgstr "This link uses an address the app cannot open."
 
 #: src/components/chat/error-message.tsx
 msgid "This model couldn't read the attached file. Try a different model."
@@ -3973,6 +4014,10 @@ msgstr "When to use this skill…"
 #: src/components/onboarding/onboarding-location-step.tsx
 msgid "Where are you located?"
 msgstr "Where are you located?"
+
+#: src/settings/preferences.tsx
+msgid "Where links in chats open"
+msgstr "Where links in chats open"
 
 #: src/components/onboarding/onboarding-language-step.tsx
 msgid "Which language do you prefer?"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -320,6 +320,10 @@ msgstr "Permitir siempre todas las acciones de ejecución de comandos"
 msgid "Always allow everything from this agent"
 msgstr "Permitir siempre todo de este agente"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Always ask"
+msgstr "Preguntar siempre"
+
 #: src/lib/tool-metadata.ts
 msgid "Analyzing…"
 msgstr "Analizando…"
@@ -407,6 +411,10 @@ msgstr "Artefacto"
 msgid "Artifacts"
 msgstr "Artefactos"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Ask"
+msgstr "Preguntar"
+
 #: src/components/chat/chat-prompt-input.tsx
 msgid "Ask me anything…"
 msgstr "Pregúntame lo que quieras…"
@@ -488,6 +496,10 @@ msgstr "Bridge"
 #: src/settings/connections/mcp-server-detail.tsx
 msgid "Bridge target"
 msgstr "Destino del bridge"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Browser"
+msgstr "Navegador"
 
 #: src/components/settings/agents/thunderbolt-cli.tsx
 msgid "Build it from source instead (requires Bun):"
@@ -951,6 +963,10 @@ msgstr "No se pudo conectar con este servidor. Revisa la URL y que el servidor e
 #: src/projects/project-form.tsx
 msgid "Could not create the project."
 msgstr "No se pudo crear el proyecto."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "Could not open link. Please try again or copy the URL."
+msgstr "No se pudo abrir el enlace. Inténtalo de nuevo o copia la URL."
 
 #: src/components/set-node-id-dialog.tsx
 msgid "Could not read QR code"
@@ -1604,6 +1620,10 @@ msgstr "Exportar tus datos"
 msgid "Exporting…"
 msgstr "Exportando…"
 
+#: src/settings/preferences.tsx
+msgid "External Links"
+msgstr "Enlaces externos"
+
 #: src/i18n/unit-labels.ts
 #: src/widgets/weather-forecast/display.tsx
 msgid "Fahrenheit"
@@ -2248,6 +2268,10 @@ msgstr "Proyecto nuevo"
 msgid "New Skill"
 msgstr "Habilidad nueva"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "New tab"
+msgstr "Nueva pestaña"
+
 #: src/tasks/index.tsx
 msgid "New Task"
 msgstr "Tarea nueva"
@@ -2438,6 +2462,7 @@ msgstr "Abrir {title}"
 msgid "Open External Link"
 msgstr "Abrir enlace externo"
 
+#: src/components/external-link-toggle-group.tsx
 #: src/content-view/sidebar-webview.tsx
 msgid "Open in browser"
 msgstr "Abrir en el navegador"
@@ -2446,9 +2471,17 @@ msgstr "Abrir en el navegador"
 msgid "Open in Browser"
 msgstr "Abrir en el navegador"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in new tab"
+msgstr "Abrir en una pestaña nueva"
+
 #: src/components/chat/inline-artifact-card.tsx
 msgid "Open in side panel"
 msgstr "Abrir en el panel lateral"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in sidebar"
+msgstr "Abrir en la barra lateral"
 
 #: src/components/chat/external-link-dialog.tsx
 msgid "Open in Sidebar"
@@ -3114,6 +3147,10 @@ msgstr "Mostrar el código QR de {deviceName}"
 msgid "Showing 50 of {totalCount} tasks"
 msgstr "Mostrando 50 de {totalCount} tareas"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Sidebar"
+msgstr "Barra lateral"
+
 #: src/layout/sidebar/nav-toggle.tsx
 msgid "Sidebar sections"
 msgstr "Secciones de la barra lateral"
@@ -3498,6 +3535,10 @@ msgstr "Este enlace ha caducado. Solicita uno nuevo."
 #: src/lib/otp-error-messages.ts
 msgid "This link is invalid. Please request a new one."
 msgstr "Este enlace no es válido. Solicita uno nuevo."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "This link uses an address the app cannot open."
+msgstr "Esta dirección no se puede abrir en la app."
 
 #: src/components/chat/error-message.tsx
 msgid "This model couldn't read the attached file. Try a different model."
@@ -3985,6 +4026,10 @@ msgstr "Cuándo usar esta habilidad…"
 #: src/components/onboarding/onboarding-location-step.tsx
 msgid "Where are you located?"
 msgstr "¿Dónde te encuentras?"
+
+#: src/settings/preferences.tsx
+msgid "Where links in chats open"
+msgstr "Dónde se abren los enlaces de los chats"
 
 #: src/components/onboarding/onboarding-language-step.tsx
 msgid "Which language do you prefer?"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -320,6 +320,10 @@ msgstr "Toujours autoriser toutes les actions d'exécution de commande"
 msgid "Always allow everything from this agent"
 msgstr "Toujours tout autoriser depuis cet agent"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Always ask"
+msgstr "Toujours demander"
+
 #: src/lib/tool-metadata.ts
 msgid "Analyzing…"
 msgstr "Analyse…"
@@ -407,6 +411,10 @@ msgstr "Artefact"
 msgid "Artifacts"
 msgstr "Artefacts"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Ask"
+msgstr "Demander"
+
 #: src/components/chat/chat-prompt-input.tsx
 msgid "Ask me anything…"
 msgstr "Posez-moi une question…"
@@ -488,6 +496,10 @@ msgstr "Bridge"
 #: src/settings/connections/mcp-server-detail.tsx
 msgid "Bridge target"
 msgstr "Cible du bridge"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Browser"
+msgstr "Navigateur"
 
 #: src/components/settings/agents/thunderbolt-cli.tsx
 msgid "Build it from source instead (requires Bun):"
@@ -951,6 +963,10 @@ msgstr "Impossible de se connecter à ce serveur. Vérifiez l'URL et que le serv
 #: src/projects/project-form.tsx
 msgid "Could not create the project."
 msgstr "Impossible de créer le projet."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "Could not open link. Please try again or copy the URL."
+msgstr "Impossible d'ouvrir le lien. Veuillez réessayer ou copier l'URL."
 
 #: src/components/set-node-id-dialog.tsx
 msgid "Could not read QR code"
@@ -1604,6 +1620,10 @@ msgstr "Exporter vos données"
 msgid "Exporting…"
 msgstr "Exportation…"
 
+#: src/settings/preferences.tsx
+msgid "External Links"
+msgstr "Liens externes"
+
 #: src/i18n/unit-labels.ts
 #: src/widgets/weather-forecast/display.tsx
 msgid "Fahrenheit"
@@ -2248,6 +2268,10 @@ msgstr "Nouveau projet"
 msgid "New Skill"
 msgstr "Nouvelle compétence"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "New tab"
+msgstr "Nouvel onglet"
+
 #: src/tasks/index.tsx
 msgid "New Task"
 msgstr "Nouvelle tâche"
@@ -2438,6 +2462,7 @@ msgstr "Ouvrir {title}"
 msgid "Open External Link"
 msgstr "Ouvrir un lien externe"
 
+#: src/components/external-link-toggle-group.tsx
 #: src/content-view/sidebar-webview.tsx
 msgid "Open in browser"
 msgstr "Ouvrir dans le navigateur"
@@ -2446,9 +2471,17 @@ msgstr "Ouvrir dans le navigateur"
 msgid "Open in Browser"
 msgstr "Ouvrir dans le navigateur"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in new tab"
+msgstr "Ouvrir dans un nouvel onglet"
+
 #: src/components/chat/inline-artifact-card.tsx
 msgid "Open in side panel"
 msgstr "Ouvrir dans le panneau latéral"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in sidebar"
+msgstr "Ouvrir dans la barre latérale"
 
 #: src/components/chat/external-link-dialog.tsx
 msgid "Open in Sidebar"
@@ -3114,6 +3147,10 @@ msgstr "Afficher le QR code de {deviceName}"
 msgid "Showing 50 of {totalCount} tasks"
 msgstr "Affichage de 50 tâches sur {totalCount}"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Sidebar"
+msgstr "Barre latérale"
+
 #: src/layout/sidebar/nav-toggle.tsx
 msgid "Sidebar sections"
 msgstr "Sections de la barre latérale"
@@ -3498,6 +3535,10 @@ msgstr "Ce lien a expiré. Veuillez en demander un nouveau."
 #: src/lib/otp-error-messages.ts
 msgid "This link is invalid. Please request a new one."
 msgstr "Ce lien n'est pas valide. Veuillez en demander un nouveau."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "This link uses an address the app cannot open."
+msgstr "Cette adresse ne peut pas être ouverte par l'application."
 
 #: src/components/chat/error-message.tsx
 msgid "This model couldn't read the attached file. Try a different model."
@@ -3985,6 +4026,10 @@ msgstr "Quand utiliser cette compétence…"
 #: src/components/onboarding/onboarding-location-step.tsx
 msgid "Where are you located?"
 msgstr "Où vous situez-vous ?"
+
+#: src/settings/preferences.tsx
+msgid "Where links in chats open"
+msgstr "Où s'ouvrent les liens des conversations"
 
 #: src/components/onboarding/onboarding-language-step.tsx
 msgid "Which language do you prefer?"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -296,6 +296,10 @@ msgstr "すべてのコマンド実行操作を常に許可"
 msgid "Always allow everything from this agent"
 msgstr "このエージェントからのすべてを常に許可"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Always ask"
+msgstr "常に確認する"
+
 #: src/lib/tool-metadata.ts
 msgid "Analyzing…"
 msgstr "分析中…"
@@ -383,6 +387,10 @@ msgstr "アーティファクト"
 msgid "Artifacts"
 msgstr "アーティファクト"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Ask"
+msgstr "確認"
+
 #: src/components/chat/chat-prompt-input.tsx
 msgid "Ask me anything…"
 msgstr "何でも質問してください…"
@@ -464,6 +472,10 @@ msgstr "ブリッジ"
 #: src/settings/connections/mcp-server-detail.tsx
 msgid "Bridge target"
 msgstr "ブリッジのターゲット"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Browser"
+msgstr "ブラウザー"
 
 #: src/components/settings/agents/thunderbolt-cli.tsx
 msgid "Build it from source instead (requires Bun):"
@@ -927,6 +939,10 @@ msgstr "このサーバーに接続できませんでした。URL とサーバ�
 #: src/projects/project-form.tsx
 msgid "Could not create the project."
 msgstr "プロジェクトを作成できませんでした。"
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "Could not open link. Please try again or copy the URL."
+msgstr "リンクを開けませんでした。もう一度お試しいただくか、URL をコピーしてください。"
 
 #: src/components/set-node-id-dialog.tsx
 msgid "Could not read QR code"
@@ -1580,6 +1596,10 @@ msgstr "データをエクスポート"
 msgid "Exporting…"
 msgstr "エクスポートしています…"
 
+#: src/settings/preferences.tsx
+msgid "External Links"
+msgstr "外部リンク"
+
 #: src/i18n/unit-labels.ts
 #: src/widgets/weather-forecast/display.tsx
 msgid "Fahrenheit"
@@ -2224,6 +2244,10 @@ msgstr "新しいプロジェクト"
 msgid "New Skill"
 msgstr "新しいスキル"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "New tab"
+msgstr "新しいタブ"
+
 #: src/tasks/index.tsx
 msgid "New Task"
 msgstr "新しいタスク"
@@ -2414,6 +2438,7 @@ msgstr "{title} を開く"
 msgid "Open External Link"
 msgstr "外部リンクを開く"
 
+#: src/components/external-link-toggle-group.tsx
 #: src/content-view/sidebar-webview.tsx
 msgid "Open in browser"
 msgstr "ブラウザーで開く"
@@ -2422,9 +2447,17 @@ msgstr "ブラウザーで開く"
 msgid "Open in Browser"
 msgstr "ブラウザーで開く"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in new tab"
+msgstr "新しいタブで開く"
+
 #: src/components/chat/inline-artifact-card.tsx
 msgid "Open in side panel"
 msgstr "サイドパネルで開く"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in sidebar"
+msgstr "サイドバーで開く"
 
 #: src/components/chat/external-link-dialog.tsx
 msgid "Open in Sidebar"
@@ -3090,6 +3123,10 @@ msgstr "{deviceName} の QR コードを表示"
 msgid "Showing 50 of {totalCount} tasks"
 msgstr "{totalCount} 件のタスクのうち 50 件を表示中"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Sidebar"
+msgstr "サイドバー"
+
 #: src/layout/sidebar/nav-toggle.tsx
 msgid "Sidebar sections"
 msgstr "サイドバーのセクション"
@@ -3474,6 +3511,10 @@ msgstr "このリンクは有効期限が切れています。新しいリンク
 #: src/lib/otp-error-messages.ts
 msgid "This link is invalid. Please request a new one."
 msgstr "このリンクは無効です。新しいリンクをリクエストしてください。"
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "This link uses an address the app cannot open."
+msgstr "このリンクのアドレスはアプリで開けません。"
 
 #: src/components/chat/error-message.tsx
 msgid "This model couldn't read the attached file. Try a different model."
@@ -3961,6 +4002,10 @@ msgstr "このスキルを使う場面…"
 #: src/components/onboarding/onboarding-location-step.tsx
 msgid "Where are you located?"
 msgstr "どちらにお住まいですか？"
+
+#: src/settings/preferences.tsx
+msgid "Where links in chats open"
+msgstr "チャット内のリンクを開く場所"
 
 #: src/components/onboarding/onboarding-language-step.tsx
 msgid "Which language do you prefer?"

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -320,6 +320,10 @@ msgstr "Sempre permitir todas as ações de executar comando"
 msgid "Always allow everything from this agent"
 msgstr "Sempre permitir tudo deste agente"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Always ask"
+msgstr "Perguntar sempre"
+
 #: src/lib/tool-metadata.ts
 msgid "Analyzing…"
 msgstr "Analisando…"
@@ -407,6 +411,10 @@ msgstr "Artefato"
 msgid "Artifacts"
 msgstr "Artefatos"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Ask"
+msgstr "Perguntar"
+
 #: src/components/chat/chat-prompt-input.tsx
 msgid "Ask me anything…"
 msgstr "Pergunte o que quiser…"
@@ -488,6 +496,10 @@ msgstr "Bridge"
 #: src/settings/connections/mcp-server-detail.tsx
 msgid "Bridge target"
 msgstr "Destino do bridge"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Browser"
+msgstr "Navegador"
 
 #: src/components/settings/agents/thunderbolt-cli.tsx
 msgid "Build it from source instead (requires Bun):"
@@ -951,6 +963,10 @@ msgstr "Não foi possível conectar a este servidor. Verifique a URL e se o serv
 #: src/projects/project-form.tsx
 msgid "Could not create the project."
 msgstr "Não foi possível criar o projeto."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "Could not open link. Please try again or copy the URL."
+msgstr "Não foi possível abrir o link. Tente novamente ou copie a URL."
 
 #: src/components/set-node-id-dialog.tsx
 msgid "Could not read QR code"
@@ -1604,6 +1620,10 @@ msgstr "Exportar seus dados"
 msgid "Exporting…"
 msgstr "Exportando…"
 
+#: src/settings/preferences.tsx
+msgid "External Links"
+msgstr "Links externos"
+
 #: src/i18n/unit-labels.ts
 #: src/widgets/weather-forecast/display.tsx
 msgid "Fahrenheit"
@@ -2248,6 +2268,10 @@ msgstr "Novo projeto"
 msgid "New Skill"
 msgstr "Nova habilidade"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "New tab"
+msgstr "Nova aba"
+
 #: src/tasks/index.tsx
 msgid "New Task"
 msgstr "Nova tarefa"
@@ -2438,6 +2462,7 @@ msgstr "Abrir {title}"
 msgid "Open External Link"
 msgstr "Abrir link externo"
 
+#: src/components/external-link-toggle-group.tsx
 #: src/content-view/sidebar-webview.tsx
 msgid "Open in browser"
 msgstr "Abrir no navegador"
@@ -2446,9 +2471,17 @@ msgstr "Abrir no navegador"
 msgid "Open in Browser"
 msgstr "Abrir no navegador"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in new tab"
+msgstr "Abrir em uma nova aba"
+
 #: src/components/chat/inline-artifact-card.tsx
 msgid "Open in side panel"
 msgstr "Abrir no painel lateral"
+
+#: src/components/external-link-toggle-group.tsx
+msgid "Open in sidebar"
+msgstr "Abrir na barra lateral"
 
 #: src/components/chat/external-link-dialog.tsx
 msgid "Open in Sidebar"
@@ -3114,6 +3147,10 @@ msgstr "Mostrar o código QR de {deviceName}"
 msgid "Showing 50 of {totalCount} tasks"
 msgstr "Mostrando 50 de {totalCount} tarefas"
 
+#: src/components/external-link-toggle-group.tsx
+msgid "Sidebar"
+msgstr "Barra lateral"
+
 #: src/layout/sidebar/nav-toggle.tsx
 msgid "Sidebar sections"
 msgstr "Seções da barra lateral"
@@ -3498,6 +3535,10 @@ msgstr "Este link expirou. Solicite um novo."
 #: src/lib/otp-error-messages.ts
 msgid "This link is invalid. Please request a new one."
 msgstr "Este link é inválido. Solicite um novo."
+
+#: src/hooks/use-external-link-dialog.ts
+msgid "This link uses an address the app cannot open."
+msgstr "Este endereço não pode ser aberto pelo app."
 
 #: src/components/chat/error-message.tsx
 msgid "This model couldn't read the attached file. Try a different model."
@@ -3985,6 +4026,10 @@ msgstr "Quando usar esta habilidade…"
 #: src/components/onboarding/onboarding-location-step.tsx
 msgid "Where are you located?"
 msgstr "Onde você está?"
+
+#: src/settings/preferences.tsx
+msgid "Where links in chats open"
+msgstr "Onde os links das conversas abrem"
 
 #: src/components/onboarding/onboarding-language-step.tsx
 msgid "Which language do you prefer?"

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -22,6 +22,7 @@ import { useMemo, useReducer, useRef, useState, type ChangeEvent } from 'react'
 
 import { LocationSearchCombobox } from '@/components/location-search-combobox'
 import { ModificationIndicator } from '@/components/modification-indicator'
+import { ExternalLinkToggleGroup } from '@/components/external-link-toggle-group'
 import { ThemeToggleGroup } from '@/components/theme-toggle-group'
 import { TelemetryRequiredModal, type TelemetryRequiredModalRef } from '@/components/telemetry-required-modal'
 import { TelemetryWarningModal, type TelemetryWarningModalRef } from '@/components/telemetry-warning-modal'
@@ -261,6 +262,7 @@ export default function PreferencesSettingsPage() {
   const { language, setLanguage, resetLanguage } = useLanguageSetting()
 
   const hapticsEnabled = useLocalSettingsStore((s) => s.hapticsEnabled)
+  const externalLinkBehavior = useLocalSettingsStore((s) => s.externalLinkBehavior)
   const setLocalSetting = useLocalSettingsStore((s) => s.setLocalSetting)
 
   // Local state for name input (only save on blur to avoid DB writes on every keystroke)
@@ -622,6 +624,23 @@ export default function PreferencesSettingsPage() {
               <Trans>Theme</Trans>
             </label>
             <ThemeToggleGroup />
+          </div>
+
+          <div className="h-px bg-border -mx-6" />
+
+          <div className="flex flex-col gap-2">
+            <ModificationIndicator
+              as="label"
+              className="text-sm font-medium"
+              hasModifications={externalLinkBehavior !== initialLocalSettings.externalLinkBehavior}
+              onReset={() => setLocalSetting('externalLinkBehavior', initialLocalSettings.externalLinkBehavior)}
+            >
+              <Trans>External Links</Trans>
+            </ModificationIndicator>
+            <ExternalLinkToggleGroup />
+            <p className="text-sm text-muted-foreground">
+              <Trans>Where links in chats open</Trans>
+            </p>
           </div>
 
           <div className="h-px bg-border -mx-6" />

--- a/src/stores/local-settings-store.ts
+++ b/src/stores/local-settings-store.ts
@@ -4,6 +4,7 @@
 
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import type { ExternalLinkBehavior } from '@/lib/external-link-behavior'
 
 /**
  * Voice engine selection (THU-718). `thunderbolt` uses the hosted enclave STT/TTS
@@ -32,6 +33,7 @@ export const defaultVoiceProvider: VoiceProviderConfig = {
 
 type LocalSettingsState = {
   cloudUrl: string
+  externalLinkBehavior: ExternalLinkBehavior
   debugPosthog: boolean
   isNativeFetchEnabled: boolean
   hapticsEnabled: boolean
@@ -48,6 +50,7 @@ type LocalSettingsStore = LocalSettingsState & LocalSettingsActions
 
 export const initialLocalSettings: LocalSettingsState = {
   cloudUrl: import.meta.env.VITE_THUNDERBOLT_CLOUD_URL || 'http://localhost:8000/v1',
+  externalLinkBehavior: 'ask',
   debugPosthog: false,
   isNativeFetchEnabled: false,
   hapticsEnabled: true,
@@ -69,6 +72,7 @@ export const useLocalSettingsStore = create<LocalSettingsStore>()(
       // future store action can silently leak into localStorage.
       partialize: (s): LocalSettingsState => ({
         cloudUrl: s.cloudUrl,
+        externalLinkBehavior: s.externalLinkBehavior,
         debugPosthog: s.debugPosthog,
         isNativeFetchEnabled: s.isNativeFetchEnabled,
         hapticsEnabled: s.hapticsEnabled,

--- a/src/stories/ExternalLinkDialog.stories.tsx
+++ b/src/stories/ExternalLinkDialog.stories.tsx
@@ -4,6 +4,7 @@
 
 import { ExternalLinkDialog } from '@/components/chat/external-link-dialog'
 import { Button } from '@/components/ui/button'
+import { openFailedMessage } from '@/hooks/use-external-link-dialog'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
 import { fn } from 'storybook/test'
@@ -140,7 +141,7 @@ export const WithError: Story = {
     open: true,
     onOpenChange: fn(),
     url: 'https://example.com',
-    openError: 'Could not open link. Please try again or copy the URL.',
+    openError: openFailedMessage,
   },
 }
 


### PR DESCRIPTION
## What

Adds an **External Links** preference in Settings → Preferences that controls where a link clicked in a chat opens: **Ask** (today's confirmation dialog, still the default), **Sidebar** (the in-app side panel, desktop only), or **Browser** / **New tab** (opens immediately, no confirmation).

## Why

THU-788 — opening a link took too many clicks. Every external link went through the confirmation dialog with no way to opt out, so reading a cited source was a two-step interaction every single time.

## How it works

- **`externalLinkBehavior`** (`'ask' | 'sidebar' | 'browser'`) added to the persisted `local-settings-store`. Device-local, defaults to `'ask'`, so existing behavior is unchanged until the user picks something else.
- **`ExternalLinkToggleGroup`** renders the platform-appropriate options: `sidebar` is only offered on desktop (it needs the side panel), and the external option is labelled "Browser" under Tauri and "New tab" on web.
- **Dispatch** lives in `markdown-utils.tsx`: `browser` opens straight away, `sidebar` renders in the preview panel when it's available and the URL is safe, and anything unsupported falls back to the dialog — so a stale `sidebar` setting on a platform without the panel degrades gracefully instead of dead-ending.
- **`openExternalUrl`** (`src/lib/open-external-url.ts`) extracts the Tauri-opener vs `window.open` branch that was inlined in `useExternalLinkDialog`, so the dialog and the no-confirmation path share one implementation.
- **Failure path**: `openExternally` validates with `isSafeUrl` and, on an unsafe URL or an opener error, falls back to the dialog pre-seeded with the error message so the user can retry or copy the URL — the `open` reducer action now carries an optional `error`.
- Preference changes are tracked as `settings_external_link_behavior_update`, and the setting participates in the existing `ModificationIndicator` reset affordance.