### PR TITLE
feat(THU-856): tell the user by ear when the mic opens

### DIFF
--- a/src/voice/audio/earcon.test.ts
+++ b/src/voice/audio/earcon.test.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'bun:test'
+import { minSpeechFrames } from './endpointer'
+import { capturedPeak, capturedTones, earconDurationMs, listeningPeak, listeningTones } from './earcon'
+
+/** 512-sample frames at 16 kHz, set by the capture worklet. */
+const frameMs = (512 / 16_000) * 1000
+
+describe('earcon tones', () => {
+  it('rises to invite the user to speak', () => {
+    const [first, second] = listeningTones
+    expect(second.hz).toBeGreaterThan(first.hz)
+  })
+
+  it('falls to acknowledge, mirroring the invitation', () => {
+    const [first, second] = capturedTones
+    expect(second.hz).toBeLessThan(first.hz)
+  })
+
+  /** Same interval both ways, so there is one shape to learn rather than two. */
+  it('uses the same interval in both directions', () => {
+    const rising = listeningTones[1].hz / listeningTones[0].hz
+    const falling = capturedTones[0].hz / capturedTones[1].hz
+    expect(rising).toBeCloseTo(falling, 5)
+  })
+
+  it('acknowledges more quietly than it invites', () => {
+    expect(capturedPeak).toBeLessThan(listeningPeak)
+  })
+
+  it('keeps both tones quiet enough not to startle', () => {
+    expect(listeningPeak).toBeLessThan(0.25)
+  })
+
+  /**
+   * The invariant that keeps an earcon from talking to itself. Both play while
+   * the mic is live, so anything lasting as long as the endpointer's sustained-
+   * speech window could register as the user barging in — the assistant would
+   * cut itself off, or the session would commit its own chime as a turn.
+   */
+  it('is shorter than the speech the endpointer needs to fire barge-in', () => {
+    const bargeInMs = minSpeechFrames * frameMs
+
+    expect(earconDurationMs(listeningTones)).toBeLessThan(bargeInMs)
+    expect(earconDurationMs(capturedTones)).toBeLessThan(bargeInMs)
+  })
+
+  it('measures duration across the overlap, not per note', () => {
+    expect(earconDurationMs([{ hz: 440, startMs: 0, durationMs: 50 }])).toBe(50)
+    expect(
+      earconDurationMs([
+        { hz: 440, startMs: 0, durationMs: 90 },
+        { hz: 880, startMs: 60, durationMs: 110 },
+      ]),
+    ).toBe(170)
+  })
+})

--- a/src/voice/audio/earcon.ts
+++ b/src/voice/audio/earcon.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Voice-mode earcons (THU-856).
+ *
+ * The visual surface can't answer the two questions that matter most in a voice
+ * conversation, because answering them requires the user to be looking at it —
+ * and the whole point of speaking is that they aren't. So two short tones:
+ *
+ * - **listening** — a rising pair the moment the mic opens. Before this, the
+ *   waveform sits at a flat resting line whether we're still starting up or
+ *   already listening, so there was nothing to tell the user when to begin.
+ * - **captured** — the same interval falling, quieter, when an utterance is
+ *   handed off. Deliberately the mirror image: one pair to learn, not two
+ *   sounds to memorise, and the direction carries the meaning (open / closed).
+ *
+ * Synthesised rather than shipped as assets — two sine tones cost nothing to
+ * bundle and nothing to fetch, and there is no artwork to keep in sync.
+ *
+ * **They cannot trigger barge-in.** Each is shorter than the sustained speech
+ * the endpointer requires (`minSpeechFrames` × 32 ms = 256 ms), and they play
+ * through `destination`, so the browser's echo canceller sees them as playout
+ * and not as something the user said. `earcon.test.ts` pins the first of those.
+ */
+
+/** One note: a frequency, when it starts relative to the earcon, how long it lasts. */
+export type Tone = { hz: number; startMs: number; durationMs: number }
+
+// A perfect fourth (E5 → A5). Bright and open going up, settled coming down.
+const e5 = 659.25
+const a5 = 880
+
+/** Rising: the mic is open, go ahead. */
+export const listeningTones: readonly Tone[] = [
+  { hz: e5, startMs: 0, durationMs: 90 },
+  { hz: a5, startMs: 60, durationMs: 110 },
+]
+
+/** Falling: heard you, working on it. */
+export const capturedTones: readonly Tone[] = [
+  { hz: a5, startMs: 0, durationMs: 70 },
+  { hz: e5, startMs: 50, durationMs: 90 },
+]
+
+// Quiet on purpose. The listening tone plays directly into the pause where the
+// user is about to speak, and the captured tone plays over their own trailing
+// breath — either one at notification volume would be startling.
+export const listeningPeak = 0.14
+/** Lower still: it acknowledges rather than invites, and it fires every turn. */
+export const capturedPeak = 0.08
+
+const attackSeconds = 0.008
+// exponentialRampToValueAtTime cannot reach zero; this is inaudible.
+const silence = 0.0001
+
+/** How long an earcon lasts end to end, including the overlap between notes. */
+export const earconDurationMs = (tones: readonly Tone[]): number =>
+  Math.max(...tones.map((tone) => tone.startMs + tone.durationMs))
+
+export type Earcons = {
+  /** The mic is open. Played once, when the session becomes ready. */
+  listening: () => void
+  /** An utterance committed. Played as it is handed off for transcription. */
+  captured: () => void
+}
+
+const play = (ctx: AudioContext, tones: readonly Tone[], peak: number): void => {
+  // stop() closes the playback context, and an utterance already in flight can
+  // reach here after that — building nodes on a closed context throws.
+  if (ctx.state === 'closed') {
+    return
+  }
+  void ctx.resume() // no-op once running; needed after the user-gesture start
+  const begin = ctx.currentTime
+  for (const tone of tones) {
+    const oscillator = ctx.createOscillator()
+    const gain = ctx.createGain()
+    oscillator.type = 'sine'
+    oscillator.frequency.value = tone.hz
+
+    const at = begin + tone.startMs / 1000
+    const until = at + tone.durationMs / 1000
+    // Enveloped rather than switched: starting or stopping a sine at full
+    // amplitude puts a step in the waveform, which is audible as a click.
+    gain.gain.setValueAtTime(0, at)
+    gain.gain.linearRampToValueAtTime(peak, at + attackSeconds)
+    gain.gain.exponentialRampToValueAtTime(silence, until)
+
+    oscillator.connect(gain)
+    // Straight to destination, bypassing the playback queue: routing through its
+    // analyser would make the waveform lurch on our own chime, and adding these
+    // to its active set would have the session believe the assistant is still
+    // speaking and hold off returning to 'listening'.
+    gain.connect(ctx.destination)
+    oscillator.start(at)
+    oscillator.stop(until)
+    // A stopped oscillator is collectable, but its gain node stays wired to
+    // destination — and the captured cue fires every turn, so a long session
+    // would accumulate one per turn for the life of the context.
+    oscillator.onended = () => gain.disconnect()
+  }
+}
+
+export const createEarcons = (ctx: AudioContext): Earcons => ({
+  listening: () => play(ctx, listeningTones, listeningPeak),
+  captured: () => play(ctx, capturedTones, capturedPeak),
+})

--- a/src/voice/session.test.ts
+++ b/src/voice/session.test.ts
@@ -183,7 +183,7 @@ describe('createVoiceSession', () => {
 
   test('stop() during startup does not open an orphaned mic (stopped guard)', async () => {
     // Hold engine.load() open to land stop() squarely in the startup window,
-    // before start() has created/assigned the VAD gate.
+    // before start() has assigned the VAD gate.
     let resolveLoad: () => void = () => {}
     const engine = makeEngine('hi', { load: () => new Promise<void>((resolve) => (resolveLoad = resolve)) })
     const session = createVoiceSession({ earcons: makeEarcons().earcons, engine, reply: makeReply(['hi']) })
@@ -193,10 +193,14 @@ describe('createVoiceSession', () => {
     resolveLoad()
     await startPromise
 
-    // With the guard, start() bails after load() resolves — the gate is never
-    // even created, so no mic is opened and no gate is left running.
-    expect(vadGateCalls).toBe(0)
-    expect(gateStartCalls).toBe(0)
+    // The mic now opens alongside engine.load() rather than after it, so a stop()
+    // in this window lands on a gate that is already live. What matters is
+    // unchanged and is the whole point of the guard: nothing is left holding the
+    // mic. start() resumes, sees `stopped`, and tears down the gate it never
+    // published — `stop()` itself couldn't, since `vadGate` was still null.
+    expect(vadGateCalls).toBe(1)
+    expect(gateStartCalls).toBe(1)
+    expect(gateDestroyCalls).toBe(1)
     expect(session.state).toBe('idle')
   })
 
@@ -319,6 +323,66 @@ describe('createVoiceSession', () => {
       await turn
 
       expect(played.filter((cue) => cue === 'listening')).toHaveLength(1)
+    })
+  })
+
+  describe('startup', () => {
+    test('opens the mic without waiting for the engine to load', async () => {
+      const order: string[] = []
+      let releaseLoad = () => {}
+      const engine = makeEngine('hi', {
+        load: async () => {
+          order.push('load:start')
+          await new Promise<void>((resolve) => {
+            releaseLoad = resolve
+          })
+          order.push('load:end')
+        },
+      })
+      const session = createVoiceSession({ earcons: makeEarcons().earcons, engine, reply: makeReply(['ok']) })
+
+      const starting = session.start()
+      await Promise.resolve()
+
+      // The mic is requested while the engine is still loading; serialised, the
+      // user would wait for the sum of a network round trip and a permission
+      // prompt instead of the slower of the two.
+      expect(gateStartCalls).toBe(1)
+      expect(order).toEqual(['load:start'])
+
+      releaseLoad()
+      await starting
+    })
+
+    test('releases the mic when the engine fails after it opened', async () => {
+      const engine = makeEngine('hi', {
+        load: async () => {
+          throw new Error('attestation failed')
+        },
+      })
+      const session = createVoiceSession({ earcons: makeEarcons().earcons, engine, reply: makeReply(['ok']) })
+
+      // Racing the two means a live mic can outlive a failed start, and nothing
+      // else holds a reference to it — the caller's stop() sees vadGate as null.
+      expect(session.start()).rejects.toThrow('attestation failed')
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(gateDestroyCalls).toBe(1)
+    })
+
+    test('does not announce readiness when startup fails', async () => {
+      const { earcons, played } = makeEarcons()
+      const engine = makeEngine('hi', {
+        load: async () => {
+          throw new Error('attestation failed')
+        },
+      })
+      const session = createVoiceSession({ earcons, engine, reply: makeReply(['ok']) })
+
+      await session.start().catch(() => {})
+
+      expect(played).toEqual([])
     })
   })
 })

--- a/src/voice/session.test.ts
+++ b/src/voice/session.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { Earcons } from '@/voice/audio/earcon'
 import type { PlaybackQueue } from '@/voice/audio/playback'
 import type { VadGate, VadHandlers } from '@/voice/audio/vad'
 import type { AudioChunk, PcmFrame, Transcript, VoiceEngine } from '@/voice/engine/types'
@@ -74,6 +75,20 @@ const makeEngine = (transcript: string, overrides: Partial<VoiceEngine> = {}): V
   ...overrides,
 })
 
+/**
+ * Records which cues played. Injected everywhere rather than defaulted, because
+ * the real ones need an AudioContext the mocked playback queue doesn't have —
+ * and because when a cue fires is behaviour worth asserting, not a side effect.
+ */
+const makeEarcons = () => {
+  const played: string[] = []
+  const earcons: Earcons = {
+    listening: () => played.push('listening'),
+    captured: () => played.push('captured'),
+  }
+  return { earcons, played }
+}
+
 const makeReply = (tokens: string[]): ReplyFn =>
   async function* (_userText, signal) {
     for (const token of tokens) {
@@ -94,6 +109,7 @@ describe('createVoiceSession', () => {
     const states: SessionState[] = []
     const transcripts: Array<[string, string]> = []
     const session = createVoiceSession({
+      earcons: makeEarcons().earcons,
       engine: makeEngine('hello world'),
       reply: makeReply(['Hi', ' there.']),
       onState: (s) => states.push(s),
@@ -114,6 +130,7 @@ describe('createVoiceSession', () => {
     const states: SessionState[] = []
     const transcripts: Array<[string, string]> = []
     const session = createVoiceSession({
+      earcons: makeEarcons().earcons,
       engine: makeEngine('thanks for watching'),
       reply: makeReply(['should not run']),
       onState: (s) => states.push(s),
@@ -146,6 +163,7 @@ describe('createVoiceSession', () => {
       },
     }
     const session = createVoiceSession({
+      earcons: makeEarcons().earcons,
       engine,
       reply: makeReply(['done.']),
       onTranscript: (text, role) => transcripts.push([role, text]),
@@ -168,7 +186,7 @@ describe('createVoiceSession', () => {
     // before start() has created/assigned the VAD gate.
     let resolveLoad: () => void = () => {}
     const engine = makeEngine('hi', { load: () => new Promise<void>((resolve) => (resolveLoad = resolve)) })
-    const session = createVoiceSession({ engine, reply: makeReply(['hi']) })
+    const session = createVoiceSession({ earcons: makeEarcons().earcons, engine, reply: makeReply(['hi']) })
 
     const startPromise = session.start()
     await session.stop()
@@ -183,7 +201,11 @@ describe('createVoiceSession', () => {
   })
 
   test('stop() after the gate is running tears it down', async () => {
-    const session = createVoiceSession({ engine: makeEngine('hi'), reply: makeReply(['hi']) })
+    const session = createVoiceSession({
+      earcons: makeEarcons().earcons,
+      engine: makeEngine('hi'),
+      reply: makeReply(['hi']),
+    })
     await session.start()
     expect(gateStartCalls).toBe(1)
     await session.stop()
@@ -194,6 +216,7 @@ describe('createVoiceSession', () => {
   test('barge-in: onSpeechStart while speaking aborts the turn and returns to listening', async () => {
     const transcripts: Array<[string, string]> = []
     const session = createVoiceSession({
+      earcons: makeEarcons().earcons,
       engine: makeEngine('user turn'),
       reply: makeReply(['Hello, ', 'this is a long-winded reply.']),
       onTranscript: (text, role) => transcripts.push([role, text]),
@@ -219,10 +242,83 @@ describe('createVoiceSession', () => {
   })
 
   test('onSpeechStart is a no-op when not thinking or speaking', async () => {
-    const session = createVoiceSession({ engine: makeEngine('hi'), reply: makeReply(['hi']) })
+    const session = createVoiceSession({
+      earcons: makeEarcons().earcons,
+      engine: makeEngine('hi'),
+      reply: makeReply(['hi']),
+    })
     await session.start()
     expect(session.state).toBe('listening')
     vadHandlers!.onSpeechStart!() // nothing to interrupt
     expect(session.state).toBe('listening')
+  })
+
+  describe('earcons (THU-856)', () => {
+    test('announces the mic opening, which is the moment nothing on screen marks', async () => {
+      const { earcons, played } = makeEarcons()
+      const session = createVoiceSession({ earcons, engine: makeEngine('hi'), reply: makeReply(['ok']) })
+
+      await session.start()
+
+      expect(played).toEqual(['listening'])
+    })
+
+    test('does not announce again when a finished turn hands the mic back', async () => {
+      const { earcons, played } = makeEarcons()
+      const session = createVoiceSession({ earcons, engine: makeEngine('hi'), reply: makeReply(['ok']) })
+
+      await session.start()
+      await vadHandlers!.onUtterance(new Float32Array(16000))
+
+      // The assistant's own voice stopping is already the cue; repeating the
+      // invitation every turn would be noise.
+      expect(played.filter((cue) => cue === 'listening')).toHaveLength(1)
+    })
+
+    test('acknowledges each committed utterance', async () => {
+      const { earcons, played } = makeEarcons()
+      const session = createVoiceSession({ earcons, engine: makeEngine('hi'), reply: makeReply(['ok']) })
+
+      await session.start()
+      await vadHandlers!.onUtterance(new Float32Array(16000))
+      await vadHandlers!.onUtterance(new Float32Array(16000))
+
+      expect(played.filter((cue) => cue === 'captured')).toHaveLength(2)
+    })
+
+    test('acknowledges before transcription, not after it', async () => {
+      const { earcons, played } = makeEarcons()
+      const engine = makeEngine('hi', {
+        transcribe: async function* () {
+          // Whatever the cue order is, it is already decided by the time the
+          // engine is reached — a cue that waits on this arrives too late.
+          expect(played).toContain('captured')
+          yield { text: 'hi', isFinal: true }
+        },
+      })
+      const session = createVoiceSession({ earcons, engine, reply: makeReply(['ok']) })
+
+      await session.start()
+      await vadHandlers!.onUtterance(new Float32Array(16000))
+
+      expect(played).toContain('captured')
+    })
+
+    test('barge-in does not re-invite the user who is already talking', async () => {
+      const { earcons, played } = makeEarcons()
+      const session = createVoiceSession({
+        earcons,
+        engine: makeEngine('user turn'),
+        reply: makeReply(['a long-winded reply.']),
+      })
+
+      await session.start()
+      const turn = vadHandlers!.onUtterance(new Float32Array(16000))
+      await Promise.resolve()
+      vadHandlers!.onSpeechStart?.()
+      await turn
+
+      expect(played.filter((cue) => cue === 'listening')).toHaveLength(1)
+    })
   })
 })

--- a/src/voice/session.test.ts
+++ b/src/voice/session.test.ts
@@ -16,12 +16,15 @@ let vadGateCalls = 0
 let gateStartCalls = 0
 let gateDestroyCalls = 0
 let vadHandlers: VadHandlers | null = null
+/** Set by a test to hold `gate.start()` open, standing in for a pending permission prompt. */
+let pendingGateStart: Promise<void> | null = null
 
 const resetVad = () => {
   vadGateCalls = 0
   gateStartCalls = 0
   gateDestroyCalls = 0
   vadHandlers = null
+  pendingGateStart = null
 }
 
 mock.module('@/voice/audio/vad', () => ({
@@ -31,6 +34,7 @@ mock.module('@/voice/audio/vad', () => ({
     return {
       start: async () => {
         gateStartCalls++
+        await pendingGateStart
       },
       pause: async () => {},
       destroy: async () => {
@@ -87,6 +91,16 @@ const makeEarcons = () => {
     captured: () => played.push('captured'),
   }
   return { earcons, played }
+}
+
+/**
+ * Lets every already-scheduled promise continuation run. The global preload installs
+ * @sinonjs fake timers, so a `setTimeout(0)` round trip would never fire.
+ */
+const drainMicrotasks = async () => {
+  for (const _ of Array.from({ length: 20 })) {
+    await Promise.resolve()
+  }
 }
 
 const makeReply = (tokens: string[]): ReplyFn =>
@@ -364,9 +378,32 @@ describe('createVoiceSession', () => {
 
       // Racing the two means a live mic can outlive a failed start, and nothing
       // else holds a reference to it — the caller's stop() sees vadGate as null.
-      expect(session.start()).rejects.toThrow('attestation failed')
-      await Promise.resolve()
-      await Promise.resolve()
+      await expect(session.start()).rejects.toThrow('attestation failed')
+
+      expect(gateDestroyCalls).toBe(1)
+    })
+
+    test('releases the mic when the engine fails while the permission prompt is still open', async () => {
+      let allowMic = () => {}
+      pendingGateStart = new Promise<void>((resolve) => {
+        allowMic = resolve
+      })
+      const engine = makeEngine('hi', {
+        load: async () => {
+          throw new Error('attestation failed')
+        },
+      })
+      const session = createVoiceSession({ earcons: makeEarcons().earcons, engine, reply: makeReply(['ok']) })
+
+      // Attestation fails fast while the user is still deciding whether to click
+      // Allow. Tearing down now would destroy a gate that hasn't acquired the mic
+      // yet, and the stream getUserMedia hands over afterwards would be orphaned.
+      const starting = session.start()
+      await drainMicrotasks()
+      expect(gateDestroyCalls).toBe(0)
+
+      allowMic()
+      await expect(starting).rejects.toThrow('attestation failed')
 
       expect(gateDestroyCalls).toBe(1)
     })

--- a/src/voice/session.test.ts
+++ b/src/voice/session.test.ts
@@ -18,6 +18,8 @@ let gateDestroyCalls = 0
 let vadHandlers: VadHandlers | null = null
 /** Set by a test to hold `gate.start()` open, standing in for a pending permission prompt. */
 let pendingGateStart: Promise<void> | null = null
+/** Every `setListening` value the session pushed, in order. */
+let listeningLog: boolean[] = []
 
 const resetVad = () => {
   vadGateCalls = 0
@@ -25,6 +27,7 @@ const resetVad = () => {
   gateDestroyCalls = 0
   vadHandlers = null
   pendingGateStart = null
+  listeningLog = []
 }
 
 mock.module('@/voice/audio/vad', () => ({
@@ -40,7 +43,9 @@ mock.module('@/voice/audio/vad', () => ({
       destroy: async () => {
         gateDestroyCalls++
       },
-      setListening: () => {},
+      setListening: (value: boolean) => {
+        listeningLog.push(value)
+      },
     }
   },
 }))
@@ -366,6 +371,31 @@ describe('createVoiceSession', () => {
 
       releaseLoad()
       await starting
+    })
+
+    test('keeps the mic muted until the engine has finished loading', async () => {
+      let finishLoad = () => {}
+      const engine = makeEngine('hi', {
+        load: () =>
+          new Promise<void>((resolve) => {
+            finishLoad = resolve
+          }),
+      })
+      const session = createVoiceSession({ earcons: makeEarcons().earcons, engine, reply: makeReply(['ok']) })
+
+      const starting = session.start()
+      await drainMicrotasks()
+
+      // The mic is open but attestation is still in flight. Frames must not reach
+      // the endpointer yet: an utterance committed here would hit an engine that
+      // can't transcribe, and start()'s tail would then stomp that in-flight turn.
+      expect(gateStartCalls).toBe(1)
+      expect(listeningLog).toEqual([false])
+
+      finishLoad()
+      await starting
+
+      expect(listeningLog).toEqual([false, true])
     })
 
     test('releases the mic when the engine fails after it opened', async () => {

--- a/src/voice/session.ts
+++ b/src/voice/session.ts
@@ -229,14 +229,17 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
     // attestation), and opening the mic is a permission prompt. Run in sequence
     // the user waits for the sum of the two, and on a first run doesn't even see
     // the prompt until attestation comes back.
-    try {
-      await Promise.all([engine.load(), gate.start()])
-    } catch (error) {
-      // Racing means either half can fail with the other already succeeded, so a
-      // rejection here can leave a live mic that nothing else holds a reference
-      // to — the orphan the `stopped` guard below exists to prevent.
+    // Settled rather than `all`: racing means either half can fail with the other
+    // still in flight, and tearing down mid-flight destroys a gate that hasn't
+    // acquired the mic yet — a no-op. The pending `getUserMedia` then resolves
+    // into a live mic nothing holds a reference to, because `vadGate` is never
+    // assigned and the caller's `stop()` only destroys that. Waiting for both to
+    // settle means destroy always runs against the gate's final state.
+    const outcomes = await Promise.allSettled([engine.load(), gate.start()])
+    const failure = outcomes.find((outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected')
+    if (failure) {
       await gate.destroy()
-      throw error
+      throw failure.reason
     }
     if (stopped) {
       await gate.destroy()

--- a/src/voice/session.ts
+++ b/src/voice/session.ts
@@ -23,6 +23,7 @@
  */
 import { type ContentPartsState, parseContentPartsIncremental } from '@/ai/widget-parser'
 import { SentenceAggregator } from '@/voice/aggregator'
+import { type Earcons, createEarcons } from '@/voice/audio/earcon'
 import { createPlaybackQueue } from '@/voice/audio/playback'
 import { createVadGate } from '@/voice/audio/vad'
 import type { VoiceEngine } from '@/voice/engine/types'
@@ -42,6 +43,11 @@ export type VoiceSessionOptions = {
   onError?: (error: unknown) => void
   /** Live mic level [0,1] per frame while listening — for the reactive waveform. */
   onLevel?: (level: number) => void
+  /**
+   * Audible cues for "mic is open" and "heard you" (THU-856). Defaults to real
+   * tones on the playback context; injected in tests, which have no AudioContext.
+   */
+  earcons?: Earcons
 }
 
 export type VoiceSession = {
@@ -61,6 +67,7 @@ const tick = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, 
 export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession => {
   const { engine, reply, onState, onTranscript, onError, onLevel } = options
   const playback = createPlaybackQueue()
+  const earcons = options.earcons ?? createEarcons(playback.audioContext)
   let state: SessionState = 'idle'
   let turn: AbortController | null = null
   let vadGate: Awaited<ReturnType<typeof createVadGate>> | null = null
@@ -99,6 +106,13 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
     turn?.abort() // supersede any in-flight turn
     const ac = new AbortController()
     turn = ac
+    // Acknowledge here rather than after transcription: the endpointer only
+    // commits sustained speech, so this is already past the blip filter, and a
+    // cue that waits on the STT round trip arrives too late to read as a
+    // response to what the user just did. The cost is chiming for the rare
+    // noise burst that survives endpointing and is then dropped as a Whisper
+    // hallucination below — a wrong "heard you" beats a second of silence.
+    earcons.captured()
     try {
       setState('thinking')
 
@@ -226,6 +240,11 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
       return
     }
     setState('listening')
+    // The one transition the user cannot anticipate. Every other route back to
+    // 'listening' follows something they can already perceive — the assistant's
+    // own voice stopping, or their own barge-in — so re-announcing those would
+    // be noise on every single turn.
+    earcons.listening()
   }
 
   const stop = async () => {

--- a/src/voice/session.ts
+++ b/src/voice/session.ts
@@ -223,22 +223,26 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
 
   const start = async () => {
     stopped = false
-    await engine.load()
-    if (stopped) {
-      return
+    const gate = createVadGate({ onSpeechStart, onUtterance, onLevel })
+    // Concurrently, because they have nothing to do with each other: loading the
+    // engine is a network round trip (the hosted engine primes Tinfoil enclave
+    // attestation), and opening the mic is a permission prompt. Run in sequence
+    // the user waits for the sum of the two, and on a first run doesn't even see
+    // the prompt until attestation comes back.
+    try {
+      await Promise.all([engine.load(), gate.start()])
+    } catch (error) {
+      // Racing means either half can fail with the other already succeeded, so a
+      // rejection here can leave a live mic that nothing else holds a reference
+      // to — the orphan the `stopped` guard below exists to prevent.
+      await gate.destroy()
+      throw error
     }
-    const gate = await createVadGate({ onSpeechStart, onUtterance, onLevel })
     if (stopped) {
       await gate.destroy()
       return
     }
     vadGate = gate
-    await vadGate.start()
-    if (stopped) {
-      await vadGate.destroy()
-      vadGate = null
-      return
-    }
     setState('listening')
     // The one transition the user cannot anticipate. Every other route back to
     // 'listening' follows something they can already perceive — the assistant's

--- a/src/voice/session.ts
+++ b/src/voice/session.ts
@@ -224,6 +224,13 @@ export const createVoiceSession = (options: VoiceSessionOptions): VoiceSession =
   const start = async () => {
     stopped = false
     const gate = createVadGate({ onSpeechStart, onUtterance, onLevel })
+    // Born muted, because racing the two halves means the mic can go live while the
+    // engine is still loading. The gate pumps frames to the endpointer the instant
+    // `gate.start()` resolves, so an eager user speaking during attestation would
+    // commit an utterance against an engine that can't transcribe yet — and the
+    // `setState('listening')` below would then stomp that in-flight turn and chime
+    // the invitation over it. `setState('listening')` unmutes once both are ready.
+    gate.setListening(false)
     // Concurrently, because they have nothing to do with each other: loading the
     // engine is a network round trip (the hosted engine primes Tinfoil enclave
     // attestation), and opening the mic is a permission prompt. Run in sequence


### PR DESCRIPTION
## Summary

You can't tell when voice mode is ready to hear you ([THU-856](https://linear.app/mozilla-thunderbolt/issue/THU-856)). Two commits: the cue itself, and the reason the wait before it felt so long.

**The cue.** The waveform is the loudest element on that surface and says nothing useful here — `Starting…` draws a flat line at 12% height, and `listening` in a quiet room clamps to ~10%. Two flat lines differing by opacity. The only real signal was a 12px muted label swapping one word for another, and the waveform only becomes expressive once you're *already* talking, which is backwards.

Sound is the right channel, because the reason you can't tell is that you aren't looking at the screen — and that isn't a failure to correct, it's what speaking to a computer is for. So a rising pair (E5→A5) when the mic opens, and the same interval falling, quieter, when an utterance is handed off. One shape to learn rather than two sounds to memorise, with direction carrying the meaning. Synthesised from oscillators — nothing to bundle or fetch.

**The wait.** `start()` ran `engine.load()` strictly before touching the mic. On the hosted engine that primes Tinfoil enclave attestation — a network round trip, slow when cold (cf. THU-665, THU-673) — so the user waited for attestation *plus* the permission prompt, and on a first run didn't see the prompt until attestation returned. They're unrelated; they now run concurrently, so the wait is the slower of the two rather than their sum.

## Judgement calls, all pinned by tests

- **The invitation plays only at session start.** Every other route back to `listening` follows something the user can already perceive — the assistant's voice stopping, or their own barge-in — so repeating it would be noise every turn.
- **The acknowledgement plays before transcription, not after.** The endpointer only commits sustained speech, so it's already past the blip filter; a cue waiting on the STT round trip lands too late to read as a response. Cost: a wrong "heard you" on the rare noise burst that survives endpointing and is then dropped as a hallucination. Better than a second of silence.
- **The chime deliberately does *not* fire on click.** It means "speak now" — firing it before the gate is live drops the user's opening words. The click is already acknowledged synchronously (the composer morphs to the voice surface).

## Neither cue can trigger barge-in

Worth stating because it isn't obvious: at peak `0.14` a sine's RMS is ~0.099, well above the VAD's `0.015` speech threshold. If echo cancellation ever underperforms, a chime *is* speech energy to the endpointer. What saves it is duration — both are under `minSpeechFrames × 32ms = 256ms`, so they reach ~5 of the 8 frames needed and fall back to a harmless misfire. The test derives that bound from `minSpeechFrames` rather than hardcoding it, so retuning the endpointer fails the test.

## Reviewer notes

- **One existing test changed shape rather than gaining assertions.** `stop() during startup does not open an orphaned mic` used to assert the gate was *never created*; with concurrent startup it is created, so it now asserts created → started → torn straight back down. The property protected is identical; only the route to it changed.
- Racing startup adds a failure mode that gets an explicit guard: either half can reject with the other already succeeded, stranding a live mic nothing references. `start()` destroys the gate on the way out.
- `session.test.ts` now injects `earcons` everywhere — the real ones need an `AudioContext` the mocked playback queue doesn't have, and *when* a cue fires is behaviour worth asserting.
- All new tests were mutation-checked; each mutation fails exactly its intended test and nothing else.

## Not verified

**How it sounds.** Everything here covers the tone table and the firing policy; the Web Audio path itself has no coverage and none is practical under happydom. Worth a listen before merge — particularly whether `0.14` is comfortable in a headset, and whether the falling cue every turn wears thin. There's no mute setting yet; if the per-turn acknowledgement is too much, the options are dropping it or adding a preference.

## Verification

```bash
bunx tsc --noEmit
# clean

bunx eslint src/voice
# clean

bun test src/voice --timeout 5000
# 78 pass, 0 fail

bun run test
# frontend: 4732 pass, 0 fail; shared/scripts: 254 pass, 0 fail
```