### PR TITLE
fix(THU-857): stop the brand gradient seaming at the button's edges

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,8 +20,17 @@ const buttonVariants = cva(
         // dims via brightness since the background is an image, not a color.
         // The transparent border preserves the same box geometry as outlined
         // secondary actions without drawing a grey edge over the gradient.
+        //
+        // `bg-origin-border` is load-bearing next to that transparent border, and
+        // matches checkbox/switch, which pair the same two. Backgrounds are
+        // *clipped* to the border box but *originate* at the padding box, so the
+        // gradient is laid out 2px narrower than it is painted and the default
+        // `repeat` fills the leftover 1px strips with the neighbouring tile's
+        // edge: the gradient's end colour down the left, its start colour down
+        // the right. On this amber→raspberry sweep that reads as a bright pink
+        // hairline on one side and a drab one on the other (THU-857).
         default:
-          'border border-transparent bg-brand text-brand-foreground shadow-xs [background-image:var(--gradient-brand)] hover:brightness-[1.06] active:brightness-95 disabled:bg-secondary disabled:text-muted-foreground disabled:shadow-none disabled:opacity-100 disabled:brightness-100 disabled:[background-image:none]',
+          'border border-transparent bg-brand bg-origin-border text-brand-foreground shadow-xs [background-image:var(--gradient-brand)] hover:brightness-[1.06] active:brightness-95 disabled:bg-secondary disabled:text-muted-foreground disabled:shadow-none disabled:opacity-100 disabled:brightness-100 disabled:[background-image:none]',
         destructive:
           'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         // Dark fill uses card (#282a2b) rather than input — input is the dark


### PR DESCRIPTION
## Summary

A 1px hairline of the wrong colour ran down both vertical edges of every primary button — bright pink on the left, drab on the right ([THU-857](https://linear.app/mozilla-thunderbolt/issue/THU-857)).

Backgrounds are *clipped* to the border box but *originate* at the padding box. The `default` variant pairs the brand gradient with `border-transparent`, so the image was laid out 2px narrower than it was painted, and the default `background-repeat: repeat` filled the leftover 1px strips with the neighbouring tile's edge — the gradient's **end** colour down the left, its **start** colour down the right. On an amber→raspberry sweep that puts raspberry over the amber end (bright) and amber over the raspberry end (drab), which is exactly the pair reported, on the sides reported.

`bg-origin-border` lays the image out over the same box it's painted in.

**This isn't a new trick in this codebase.** `checkbox.tsx`, `switch.tsx` and `modification-indicator.tsx` all already pair `bg-origin-border` with this gradient. The button was the one that missed it — and it's the most-used gradient surface in the app.

## Verified visually, not by reading

The bug is purely visual, so I rendered it rather than reasoning about it. Amplifying the transparent border to 12px makes the two strips unmistakable, and they vanish once the origin is set — same mechanism, just legible at that size:

- **left strip** = gradient END (raspberry) painted over the amber end
- **right strip** = gradient START (amber) painted over the raspberry end

## Scope

One line, plus the comment explaining why it's load-bearing so nobody strips it as redundant.

Other gradient consumers were checked and are unaffected: `switch.tsx`'s OFF state uses a *visible* `border-border`; `private-badge.tsx` and `highlight.tsx` use `bg-clip-text`, a different path; `step-indicators.tsx` sets `backgroundImage` inline with no border.

No test — a class-name assertion doesn't earn its maintenance here.

## Verification

```bash
bunx tsc --noEmit
# clean

bunx eslint src/components/ui/button.tsx
# clean

bun run test
# frontend: 4734 pass, 0 fail; shared/scripts: 254 pass, 0 fail
```