### PR TITLE
fix(THU-846): drop the Suspense boundary that delayed the first Cmd+K

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -57,6 +57,7 @@ import { useAppVersionUnsupportedListener } from './hooks/use-app-version-unsupp
 import { useCredentialEvents } from './hooks/use-credential-events'
 import { useSafeAreaInset } from './hooks/use-safe-area-inset'
 import Layout from './layout'
+import { loadSearchPalette } from '@/search/palette/search-palette-loader'
 import { MCPProvider } from './lib/mcp-provider'
 import { ProxyFetchProvider } from './lib/proxy-fetch-context'
 import { TrayProvider } from './lib/tray'
@@ -297,6 +298,16 @@ export const App = () => {
   const { initData, initError, isInitializing, clearDatabase } = useAppInitialization()
   const { revokedDeviceOpen } = useCredentialEvents()
   useAppVersionUnsupportedListener()
+
+  // Start the palette's chunk during boot so it is in memory by the time
+  // `SearchPaletteProvider` mounts and asks for it — that provider sits behind
+  // the `sidebarState` gate in `Layout`, so fetching only from there leaves a
+  // window where Cmd+K has nothing to show. ~10KB, for the one surface
+  // reachable by keyboard from anywhere. Unlike `preloadAllRouteChunks` this
+  // runs on web too; that policy is about not warming *every* route.
+  useEffect(() => {
+    void loadSearchPalette()
+  }, [])
 
   // Show the Tauri window after React mounts and CSS is applied.
   // The window starts hidden (tauri.conf.json visible: false) to prevent

--- a/src/search/palette/search-palette-loader.ts
+++ b/src/search/palette/search-palette-loader.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** Load the palette subtree (cmdk, FTS, registry, icons) separately from the entry bundle. */
+export const loadSearchPalette = () => import('./search-palette')

--- a/src/search/palette/search-palette.tsx
+++ b/src/search/palette/search-palette.tsx
@@ -103,6 +103,20 @@ export const SearchPalette = ({
     return groupByEntity(visible)
   }, [hasQuery, results, experimentalFeatureTasks.value])
 
+  // Results and the command list share one scroll container, so a query change
+  // swaps the content underneath a scroll offset that belonged to the old set:
+  // clearing a scrolled-down result list used to land you partway down the
+  // commands. Reset from the keystroke rather than an effect — that is the cause,
+  // and 0 stays valid once the debounced content catches up, since the list is
+  // only ever replaced or shortened.
+  const listRef = useRef<HTMLDivElement>(null)
+  const handleQueryChange = useCallback((next: string) => {
+    setQuery(next)
+    if (listRef.current) {
+      listRef.current.scrollTop = 0
+    }
+  }, [])
+
   const [logoutOpen, setLogoutOpen] = useState(false)
   const deleteAllChatsDialogRef = useRef<DeleteAllChatsDialogRef>(null)
   const deleteAllChats = useDeleteAllChats()
@@ -217,8 +231,12 @@ export const SearchPalette = ({
         // fuzzy filter would otherwise hide valid stemmed/prefixed FTS matches.
         shouldFilter={false}
       >
-        <CommandInput placeholder={t`Search chats, models, skills, agents…`} value={query} onValueChange={setQuery} />
-        <CommandList>
+        <CommandInput
+          placeholder={t`Search chats, models, skills, agents…`}
+          value={query}
+          onValueChange={handleQueryChange}
+        />
+        <CommandList ref={listRef}>
           {!hasQuery ? (
             commandSections
           ) : (

--- a/src/search/search-palette-context.tsx
+++ b/src/search/search-palette-context.tsx
@@ -2,16 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { ReactNode } from 'react'
-import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import type { ComponentType, ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import { trackEvent } from '@/lib/posthog'
+import { loadSearchPalette } from './palette/search-palette-loader'
 
-// Lazy so the search subsystem (cmdk dialog, FTS, registry, icons) stays out of
-// the entry bundle — the palette is only reachable via Cmd/Ctrl+K.
-const SearchPalette = lazy(() =>
-  import('./palette/search-palette').then((module) => ({ default: module.SearchPalette })),
-)
+type PaletteComponent = ComponentType<{ open: boolean; onOpenChange: (open: boolean) => void }>
 
 type SearchPaletteContextValue = {
   open: () => void
@@ -23,7 +20,7 @@ const SearchPaletteContext = createContext<SearchPaletteContextValue>({
 
 /**
  * Provides the command-palette opener, registers the Cmd/Ctrl+K global
- * shortcut, and lazily mounts the palette modal on first open.
+ * shortcut, and mounts the palette modal once its chunk has loaded.
  */
 export const SearchPaletteProvider = ({ children }: { children: ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false)
@@ -53,23 +50,46 @@ export const SearchPaletteProvider = ({ children }: { children: ReactNode }) => 
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [setOpen])
 
-  // Mount the lazy modal on first open and keep it mounted thereafter so its
-  // open/close transition animates on later toggles.
-  const hasOpenedRef = useRef(false)
-  if (isOpen) {
-    hasOpenedRef.current = true
-  }
+  /**
+   * The palette component, held in state rather than reached through
+   * `React.lazy` + `Suspense`.
+   *
+   * `lazy` only starts its factory when it first renders, so it suspends on that
+   * render even when the module is already in memory. React commits the fallback,
+   * and from then on the boundary is governed by the reveal throttle it uses to
+   * stop fallbacks flashing — so the content is withheld for ~300ms after the
+   * promise has already resolved. Profiling the first Cmd+K showed exactly that:
+   * a `setTimeout(289ms)` scheduled by react-dom's `performWorkOnRoot`, an
+   * entirely idle main thread across it, then the dialog mounting (THU-846).
+   *
+   * Resolving it ourselves means no boundary, no fallback, and nothing to
+   * throttle. The root kicks the same import off during boot, so by the time
+   * anyone presses Cmd+K this is already set and opening is a state toggle.
+   */
+  const [Palette, setPalette] = useState<PaletteComponent | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void loadSearchPalette().then((module) => {
+      // Set via updater — a component *is* a function, so passing it directly
+      // would have React call it as a lazy initializer.
+      if (!cancelled) {
+        setPalette(() => module.SearchPalette)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const value = useMemo<SearchPaletteContextValue>(() => ({ open: () => setOpen(true) }), [setOpen])
 
   return (
     <SearchPaletteContext.Provider value={value}>
       {children}
-      {hasOpenedRef.current ? (
-        <Suspense fallback={null}>
-          <SearchPalette open={isOpen} onOpenChange={setOpen} />
-        </Suspense>
-      ) : null}
+      {/* Mounted closed once loaded, so the first open costs the same as every
+          one after it. Radix renders nothing for a closed dialog. */}
+      {Palette ? <Palette open={isOpen} onOpenChange={setOpen} /> : null}
     </SearchPaletteContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary

The search palette stalled the first time you opened it and was instant ever after ([THU-846](https://linear.app/mozilla-thunderbolt/issue/THU-846)).

**It was React's Suspense reveal throttle, not our code being slow.** A profile of that first Cmd+K shows 14 ms of real work, then **289 ms in which every thread burns zero CPU and no request is issued**, then the dialog mounts. The timer behind the gap resolves to `Window.setTimeout` ← `performWorkOnRoot` ← `react-dom_client.js` — the ~300 ms anti-flicker delay React applies before replacing a fallback it has already committed.

`React.lazy` only starts its factory when it first renders, so it suspends on that render *even when the module is already in memory*. React commits the `null` fallback, the promise resolves about a millisecond later, and the throttle then withholds the content for the remaining ~290 ms. First-open-only, because after that `lazy` is resolved and never suspends again.

So the component is resolved into state instead: no boundary, no fallback, nothing to throttle. It stays mounted closed once loaded, so the first open costs what every later one costs — Radix renders nothing for a closed dialog.

The chunk is also kicked off at the root during boot, because `SearchPaletteProvider` mounts behind the `sidebarState` gate in `Layout`; fetching only from there leaves a window where Cmd+K has nothing to show.

## Also here

`0131c76f` fixes a pre-existing scroll bug in the same file: results and the command list share one scroll container, so clearing a scrolled-down result list left you partway down the command list. Reset from the keystroke rather than an effect — that's the cause, and `0` stays valid once the debounced content catches up, since the list is only ever replaced or shortened.

## Reviewer notes

- **The code-split is untouched.** Palette chunk is still 7,969 bytes and still its own request; the entry bundle is 11 bytes *smaller* than main, since the `lazy`/`Suspense` imports went away.
- **The root prefetch runs on web**, unlike `preloadAllRouteChunks`. That policy is about not warming *every* route at the expense of first load; this is one ~10 KB chunk for the surface reachable by keyboard from anywhere. Reasonable to push back on.
- **`ref` on `CommandList`** relies on cmdk's `List` being a `ForwardRefExoticComponent<...HTMLDivElement>` — verified, and it lands on the outer div carrying `overflow-y-auto max-h-[300px]`, not an inner sizer. Had it not forwarded, the scroll reset would have failed silently.

## Not covered by tests

Both fixes are timing/DOM behaviour that happydom can't meaningfully assert — it has no real layout, so `scrollTop` is whatever it decides, and the Suspense throttle needs a real scheduler. Both were verified by hand in a dev build instead: the palette now opens instantly on first press, and clearing a scrolled query returns to the top.

## Worth a follow-up

Any other `lazy()` behind a `Suspense` that is revealed by a **user action** rather than navigation pays the same ~300 ms tax on first use — during navigation it's invisible, on a keypress it isn't. `LazyCreateItemHost` looks like the next candidate. Not in scope here.

## Verification

```bash
bunx tsc --noEmit
# clean

bunx eslint src/app.tsx src/search
# clean

bun run build
# palette chunk 7,969 B (still split); entry 2,128,426 B

bun run test
# frontend: 4734 pass, 0 fail; shared/scripts: 254 pass, 0 fail
```