### PR TITLE
fix(THU-843): repair Opus rows still stranded on the sonnet slug

### DIFF
--- a/src/lib/data-migrations/upgrade-opus-default.test.ts
+++ b/src/lib/data-migrations/upgrade-opus-default.test.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { getDb } from '@/db/database'
+import { modelsTable } from '@/db/tables'
+import { defaultModelOpus5, hashModel, type SharedModel } from '@shared/defaults/models'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
+
+import { normalizeOpusDefault, upgradeOpusDefault } from './upgrade-opus-default'
+
+beforeAll(async () => {
+  await setupTestDatabase()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+beforeEach(async () => {
+  await resetTestDatabase()
+})
+
+/** Seed the shared row id as it looked at some earlier point in its lineage. */
+const seedRow = async (overrides: Partial<SharedModel> & { name: string; model: string }) => {
+  const row: SharedModel = { ...defaultModelOpus5, ...overrides }
+  await getDb()
+    .insert(modelsTable)
+    .values({ ...row, defaultHash: overrides.defaultHash ?? hashModel(row) })
+  return row
+}
+
+const readRow = async () => getDb().select().from(modelsTable).where(eq(modelsTable.id, defaultModelOpus5.id)).get()
+
+describe('upgradeOpusDefault', () => {
+  /**
+   * THU-843. The row id is reused across renames, so a device stuck on the
+   * original slug shows "Sonnet 4.5" *and* appears to have no Opus — one fault,
+   * two symptoms. The repair previously only knew about the 4.8 → 5 hop.
+   */
+  it('moves a row still stranded on the original sonnet slug up to Opus 5', async () => {
+    await seedRow({ name: 'Sonnet 4.5', model: 'sonnet-4.5' })
+
+    await upgradeOpusDefault(getDb())
+
+    const row = await readRow()
+    expect(row?.model).toBe(defaultModelOpus5.model)
+    expect(row?.name).toBe(defaultModelOpus5.name)
+  })
+
+  it('still handles the 4.8 hop it was written for', async () => {
+    await seedRow({ name: 'Opus 4.8', model: 'opus-4.8' })
+
+    await upgradeOpusDefault(getDb())
+
+    const row = await readRow()
+    expect(row?.model).toBe(defaultModelOpus5.model)
+    expect(row?.name).toBe(defaultModelOpus5.name)
+  })
+
+  /** The row originally carried the bare slug as its display name. */
+  it('replaces the slug-shaped legacy name too', async () => {
+    await seedRow({ name: 'sonnet-4.5', model: 'sonnet-4.5' })
+
+    await upgradeOpusDefault(getDb())
+
+    expect((await readRow())?.name).toBe(defaultModelOpus5.name)
+  })
+
+  it('keeps a name the user chose while still moving the slug forward', async () => {
+    await seedRow({ name: 'My favourite model', model: 'sonnet-4.5' })
+
+    await upgradeOpusDefault(getDb())
+
+    const row = await readRow()
+    expect(row?.model).toBe(defaultModelOpus5.model)
+    expect(row?.name).toBe('My favourite model')
+  })
+
+  /**
+   * The reason the legacy slugs are enumerated rather than treated as
+   * "anything that isn't opus-5": this row is user-editable.
+   */
+  it('leaves a row the user repointed at their own model alone', async () => {
+    await seedRow({ name: 'My local llama', model: 'llama-3.3-70b' })
+
+    await upgradeOpusDefault(getDb())
+
+    const row = await readRow()
+    expect(row?.model).toBe('llama-3.3-70b')
+    expect(row?.name).toBe('My local llama')
+  })
+
+  it('does nothing to a row already on the current slug', async () => {
+    const seeded = await seedRow({ name: defaultModelOpus5.name, model: defaultModelOpus5.model })
+
+    await upgradeOpusDefault(getDb())
+
+    const row = await readRow()
+    expect(row?.model).toBe(defaultModelOpus5.model)
+    expect(row?.defaultHash).toBe(hashModel(seeded))
+  })
+
+  it('does not resurrect a soft-deleted row', async () => {
+    await seedRow({ name: 'Sonnet 4.5', model: 'sonnet-4.5', deletedAt: '2026-01-01T00:00:00.000Z' })
+
+    await upgradeOpusDefault(getDb())
+
+    expect((await readRow())?.model).toBe('sonnet-4.5')
+  })
+
+  /** An untouched row stays adoptable by reconciliation after the rename. */
+  it('restamps the default hash when the row was unmodified', async () => {
+    await seedRow({ name: 'Sonnet 4.5', model: 'sonnet-4.5' })
+
+    await upgradeOpusDefault(getDb())
+
+    const row = await readRow()
+    expect(row?.defaultHash).toBe(hashModel(row as SharedModel))
+  })
+
+  /** A modified row keeps its stale hash, so it stays flagged as user-owned. */
+  it('leaves the default hash alone when the row was modified', async () => {
+    await seedRow({ name: 'Sonnet 4.5', model: 'sonnet-4.5', defaultHash: 'user-edited-since' })
+
+    await upgradeOpusDefault(getDb())
+
+    const row = await readRow()
+    expect(row?.model).toBe(defaultModelOpus5.model)
+    expect(row?.defaultHash).toBe('user-edited-since')
+  })
+})
+
+describe('normalizeOpusDefault', () => {
+  /** Stops a stale defaults payload restoring a retired alias under this id. */
+  it('rewrites a legacy payload entry to the current identity', () => {
+    const normalized = normalizeOpusDefault({ ...defaultModelOpus5, name: 'Sonnet 4.5', model: 'sonnet-4.5' })
+
+    expect(normalized.model).toBe(defaultModelOpus5.model)
+    expect(normalized.name).toBe(defaultModelOpus5.name)
+  })
+
+  it('leaves a payload entry for a different model untouched', () => {
+    const other: SharedModel = { ...defaultModelOpus5, id: 'some-other-id', name: 'Other', model: 'sonnet-4.5' }
+
+    expect(normalizeOpusDefault(other)).toEqual(other)
+  })
+})

--- a/src/lib/data-migrations/upgrade-opus-default.ts
+++ b/src/lib/data-migrations/upgrade-opus-default.ts
@@ -7,29 +7,53 @@ import { modelsTable } from '@/db/tables'
 import { defaultModelOpus5, hashModel, type SharedModel } from '@shared/defaults/models'
 import { eq } from 'drizzle-orm'
 
-const legacyModelName = 'Opus 4.8'
-const legacyModelSlug = 'opus-4.8'
+/**
+ * Slugs this row carried before `opus-5`.
+ *
+ * The id is reused across renames — `sonnet-4.5` → `opus-4.8` → `opus-5` — so a
+ * device that missed one still serves a dead upstream slug under the id the
+ * picker expects to be Opus. That is a single fault presenting as two symptoms:
+ * Opus looks missing *because* the row is still the old model (THU-843).
+ *
+ * Reconciliation is what normally carries a rename, but it only rewrites rows
+ * whose `defaultHash` still matches, so any user edit freezes the row for good.
+ * This runs outside that check and is the only way those rows move forward.
+ *
+ * Enumerated rather than "any slug that isn't opus-5": the row is user-editable,
+ * and someone who deliberately repointed it at their own model should not have
+ * that silently overwritten. A future rename adds an entry here — or, better,
+ * ships under a fresh id.
+ */
+const legacySlugs: ReadonlySet<string> = new Set(['sonnet-4.5', 'opus-4.8'])
+
+/**
+ * Names shipped alongside those slugs, including the bare slug-as-name the row
+ * originally carried. Anything outside this set is the user's own label and is
+ * preserved.
+ */
+const legacyNames: ReadonlySet<string> = new Set(['sonnet-4.5', 'Sonnet 4.5', 'Opus 4.8'])
 
 /**
  * Normalize the reused model identity so stale defaults payloads cannot
- * restore its legacy alias.
+ * restore a legacy alias.
  */
 export const normalizeOpusDefault = (model: SharedModel): SharedModel => {
-  if (model.id !== defaultModelOpus5.id || model.model !== legacyModelSlug) {
+  if (model.id !== defaultModelOpus5.id || !legacySlugs.has(model.model)) {
     return model
   }
 
   return {
     ...model,
     model: defaultModelOpus5.model,
-    name: model.name === legacyModelName ? defaultModelOpus5.name : model.name,
+    name: legacyNames.has(model.name) ? defaultModelOpus5.name : model.name,
   }
 }
 
 /** Upgrade the active canonical row while preserving user customizations. */
 export const upgradeOpusDefault = async (db: AnyDrizzleDatabase): Promise<void> => {
   const existing = await db.select().from(modelsTable).where(eq(modelsTable.id, defaultModelOpus5.id)).get()
-  if (!existing || existing.deletedAt !== null || existing.model !== legacyModelSlug) {
+  // A null slug is left alone, as it was under the previous equality check.
+  if (!existing || existing.deletedAt !== null || existing.model === null || !legacySlugs.has(existing.model)) {
     return
   }
 


### PR DESCRIPTION
## Summary

"Opus is missing" and "Sonnet 4.5 is visible" are **one fault, not two** ([THU-843](https://linear.app/mozilla-thunderbolt/issue/THU-843)).

The row id `019af08a-…` is reused across renames — `sonnet-4.5` (Dec 2025, when defaults lived in `src/defaults/models.ts`) → `opus-4.8` (THU-637) → `opus-5`. A device that missed a rename still serves the old model under the id the picker expects to be Opus. Opus looks absent precisely *because* it is that row.

**Why only some users.** A rename is normally carried by reconciliation, and `reconcileDefaultsForTable` "inserts new defaults and updates **unmodified** existing ones" — a row whose `defaultHash` no longer matches is treated as user-owned and preserved forever. `hashModel` covers `name`, `enabled`, `toolUsage`, `contextWindow`, `deletedAt` and more, so any edit at all freezes the row. `computeCanOverwrite` can also close the gate for version-ordering or incomplete-sync reasons.

**Why nothing rescued them.** `upgradeOpusDefault` is exactly the escape hatch for this — it runs after reconcile, outside the hash check. It just never knew the row had a longer history, and early-returned unless the slug was `opus-4.8`:

```js
if (!existing || existing.deletedAt !== null || existing.model !== legacyModelSlug) return
```

Rows on `sonnet-4.5` had no path forward at all.

## The one judgement call

Legacy slugs are **enumerated** (`sonnet-4.5`, `opus-4.8`) rather than treated as "any slug that isn't `opus-5`". This row is user-editable, and someone who deliberately repointed it at their own model shouldn't have that silently overwritten — there's a test pinning that case. A future rename adds an entry here, or better, ships under a fresh id.

A null slug is left alone, matching the previous equality check.

## Tests

This was the only migration in `src/lib/data-migrations/` without a test file, which is plausibly how the gap survived. Added 11 covering the sonnet case, the existing 4.8 hop, the slug-shaped legacy name the row originally carried, user-renamed rows, deliberate repoints, soft-deleted rows, already-current rows, and both `defaultHash` branches.

Mutation-checked: reverting the guard to `opus-4.8` alone — i.e. reintroducing the bug — fails 5 of them, including the headline case.

## Reviewer notes

- **This is a client-side repair**, so affected users only recover on launching a build that contains it. If the population is broad, it may be worth considering whether an OTA defaults payload could reach them sooner. Note `normalizeOpusDefault` deliberately sanitizes legacy aliases *out* of incoming payloads, so OTA can't push the old identity back either.
- **The pattern will recur.** Renaming a model in place under a reused id makes every user edit a permanent freeze, and each rename then needs a bespoke migration that knows the full lineage. The codebase already knows this — the DeepSeek Flash comment in `shared/defaults/models.ts` explains shipping under a *fresh* id to dodge an analogous trap. Worth a follow-up to make fresh-id the rule for model identity changes rather than relying on someone extending this list.

## Verification

```bash
bunx tsc --noEmit
# clean

bunx eslint src/lib/data-migrations
# clean

bun test src/lib/data-migrations/upgrade-opus-default.test.ts --timeout 5000
# 11 pass, 0 fail

bun run test
# frontend: 4745 pass, 0 fail; shared/scripts: 254 pass, 0 fail
```