### PR TITLE
feat(THU-823): forward the user's language to link previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,16 @@ Judge seedability **per setting**, not across the group — a user who picks a c
 
 **`date_format` is retired** (THU-810). CLDR already knows each locale's date pattern, and the three patterns the setting offered were a strictly worse subset. Existing rows are left in place, unmanaged.
 
+### The `X-App-Language` header
+
+The client sends the **already-resolved** locale — a single tag, not a preference list — on every app-backend request (`src/lib/http.ts`, `src/lib/auth-token.ts`, `src/contexts/auth-context.tsx`). The backend forwards rather than re-negotiates. Two backend paths read it: link previews (below) and transactional email (`resolveEmailLocale`, next section).
+
+- **The backend validates it against `negotiableLocales`, never trusts it.** `matchExactLocale` (`shared/i18n/locales.ts`) returns the set's *own* tag or null, so a client-controlled string can never reach an outbound request. That is what makes it safe for `backend/src/utils/accept-language.ts` to build the `Accept-Language` we present to arbitrary third-party pages when generating link previews (THU-823). Matching is exact on purpose — no base-language fallback, unlike `matchLocale`, which negotiates *browser* tags.
+- **`negotiableLocales` lives in `shared/i18n/locales.ts` because both ends trust it.** Don't re-derive it from `appLocales`: that set includes the `en-XA` pseudo-locale, so filtering it yourself is how the pseudo-locale leaks into a real code path. The module stays free of runtime imports so the Lingui CLI can load it outside Vite.
+- **It is an outer-hop header, exactly like `X-App-Version`.** It must never become a `/v1/proxy` passthrough header, or it would leak to external LLM/MCP upstreams — hence its entry in `skipHeaders` (`src/lib/proxy-fetch.ts`).
+
+Geocoding (`/v1/locations`) is deliberately *not* on this path — it takes an explicit language argument instead, because the call site sometimes needs English on purpose to keep location matching stable (see THU-847).
+
 ### Transactional email (backend)
 
 The four templates in `backend/src/emails/` (plus `email-layout.tsx`, which is shared chrome) are the main place the backend authors user-facing prose. Most other responses return a code the client translates at its display boundary — but not all: the 429 in `backend/src/waitlist/routes.ts` sends English `message` text that `use-sign-in-form-state.ts` renders verbatim, so a German user can still get a German email and an English toast from one click. THU-824 did not cover that. The email setup has its own Lingui wiring, and it differs from the frontend's in three ways that will bite if you assume otherwise.

--- a/backend/src/api/preview.e2e.test.ts
+++ b/backend/src/api/preview.e2e.test.ts
@@ -127,6 +127,63 @@ describe('GET /v1/preview — e2e', () => {
     expect(res.status).toBe(401)
   })
 
+  it('derives the upstream Accept-Language chain from the app language', async () => {
+    const upstream = createTestUpstream(
+      'preview.test',
+      () =>
+        new Response(buildHtml('<meta property="og:title" content="Olá" />'), {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+    )
+    handle = await createTestApp({ fetchFn: createUpstreamRouter({ 'preview.test': upstream }) })
+
+    const res = await handle.app.handle(
+      new Request(`http://localhost/v1/preview`, {
+        method: 'POST',
+        headers: {
+          ...authHeaders(handle.bearerToken),
+          'Content-Type': 'application/json',
+          'X-App-Language': 'pt-BR',
+        },
+        body: JSON.stringify({ url: 'https://preview.test/artigo' }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    expect(upstream.requests).toHaveLength(1)
+    expect(upstream.requests[0]?.headers.get('accept-language')).toBe('pt-BR,pt;q=0.9,en;q=0.8')
+    // Only the derived chain crosses to the third party — never the client's own header.
+    expect(upstream.requests[0]?.headers.get('x-app-language')).toBeNull()
+    expect(((await res.json()) as Record<string, string | null>).title).toBe('Olá')
+  })
+
+  it('sends the English chain when the app language is absent or not a shipped locale', async () => {
+    const upstream = createTestUpstream(
+      'preview.test',
+      () => new Response(buildHtml(''), { status: 200, headers: { 'content-type': 'text/html' } }),
+    )
+    handle = await createTestApp({ fetchFn: createUpstreamRouter({ 'preview.test': upstream }) })
+
+    const postPreview = async (headers: Record<string, string>) => {
+      const res = await handle.app.handle(
+        new Request(`http://localhost/v1/preview`, {
+          method: 'POST',
+          headers: { ...authHeaders(handle.bearerToken), 'Content-Type': 'application/json', ...headers },
+          body: JSON.stringify({ url: 'https://preview.test/article' }),
+        }),
+      )
+      // Asserted here so a 400/401 fails as itself rather than as an empty
+      // upstream-request list, which reads like the language logic broke.
+      expect(res.status).toBe(200)
+    }
+
+    await postPreview({})
+    // An unshipped tag is not forwarded, so it lands on the same default as no header.
+    await postPreview({ 'X-App-Language': 'zh-CN' })
+
+    expect(upstream.requests.map((r) => r.headers.get('accept-language'))).toEqual(['en-US,en;q=0.9', 'en-US,en;q=0.9'])
+  })
+
   // --- SSRF advisory regression (thunderbolt_SSRF.md) ---
   // The advisory claims a path-style `GET /link-preview/[target_url]` endpoint
   // with no validation. That route does not exist, and the real `POST /v1/preview`

--- a/backend/src/api/preview.ts
+++ b/backend/src/api/preview.ts
@@ -5,6 +5,7 @@
 import type { Auth } from '@/auth/elysia-plugin'
 import { createAuthMacro } from '@/auth/elysia-plugin'
 import { safeErrorHandler } from '@/middleware/error-handling'
+import { acceptLanguageFor } from '@/utils/accept-language'
 import { createSafeFetch, ensureHttps, validateSafeUrl, type DnsLookup } from '@/utils/url-validation'
 import { Elysia, t, type AnyElysia } from 'elysia'
 
@@ -134,7 +135,7 @@ export const createPreviewRoutes = (options: CreatePreviewRoutesOptions) => {
       // POST so target URLs do not appear in access logs.
       return g.post(
         '/preview',
-        async ({ body, set }): Promise<PreviewDto | { error: string }> => {
+        async ({ body, request, set }): Promise<PreviewDto | { error: string }> => {
           const targetUrl = body.url
           const validation = validateSafeUrl(targetUrl)
           if (!validation.valid) {
@@ -150,7 +151,7 @@ export const createPreviewRoutes = (options: CreatePreviewRoutesOptions) => {
               headers: {
                 'User-Agent': userAgent,
                 Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-                'Accept-Language': 'en-US,en;q=0.9',
+                'Accept-Language': acceptLanguageFor(request.headers.get('x-app-language')),
               },
               signal: controller.signal,
             })
@@ -173,8 +174,9 @@ export const createPreviewRoutes = (options: CreatePreviewRoutesOptions) => {
             const html = new TextDecoder().decode(buffer)
             // Cache successful OG metadata per-user for 10 minutes. Safe here (unlike
             // /v1/proxy) because the response is a small, derived JSON DTO — not the
-            // raw upstream body — and the request body is the only cache key (no
-            // `?token=` style explosion). `private` keeps shared/CDN caches out.
+            // raw upstream body — and the key space is bounded by the request body
+            // plus the caller's app language (no `?token=` style explosion).
+            // `private` keeps shared/CDN caches out.
             // Only set on the success path so transient upstream failures (empty
             // fallback) aren't sticky for 10 minutes.
             set.headers['Cache-Control'] = 'private, max-age=600'

--- a/backend/src/emails/i18n.test.ts
+++ b/backend/src/emails/i18n.test.ts
@@ -14,6 +14,10 @@ describe('resolveEmailLocale', () => {
     expect(resolveEmailLocale('pt-BR')).toBe('pt-BR')
   })
 
+  it('normalizes casing so a hand-written header still gets its catalog', () => {
+    expect(resolveEmailLocale('PT-br')).toBe('pt-BR')
+  })
+
   it('refuses the pseudo-locale over the wire', () => {
     // `/v1/waitlist/join` is unauthenticated and takes the recipient from the
     // body, so honouring this would let anyone mail a third party gibberish.

--- a/backend/src/emails/i18n.ts
+++ b/backend/src/emails/i18n.ts
@@ -24,7 +24,7 @@
  */
 
 import { setupI18n, type I18n, type Messages } from '@lingui/core'
-import { appLocales, pseudoLocale, sourceLocale, type AppLocale } from '@shared/i18n/locales'
+import { matchExactLocale, sourceLocale, type AppLocale } from '@shared/i18n/locales'
 import { messages as de } from './locales/de/messages'
 import { messages as en } from './locales/en/messages'
 import { messages as enXA } from './locales/en-XA/messages'
@@ -64,21 +64,6 @@ export const getEmailI18n = (locale: AppLocale): I18n => {
 }
 
 /**
- * Locales an inbound `X-App-Language` may select — every shipped locale except
- * the pseudo-locale.
- *
- * `en-XA` is excluded even though `getEmailI18n` still renders it: the preview
- * server and the render tests pass it directly, so nothing legitimate needs it
- * to arrive over the wire, while `/v1/waitlist/join` is unauthenticated and
- * takes the recipient from the request body — accepting it would let anyone
- * mail a third party pseudo-localized gibberish. Mirrors `settableLocales` in
- * `src/i18n/resolve-locale.ts`, which refuses the value for the same reason.
- */
-const emailLocales: readonly AppLocale[] = appLocales.filter((locale) => locale !== pseudoLocale)
-
-const isEmailLocale = (value: string): value is AppLocale => (emailLocales as readonly string[]).includes(value)
-
-/**
  * The locale to render an email in, from the recipient's `X-App-Language`.
  *
  * Every client sets that header on every backend request (`src/lib/http.ts`,
@@ -87,12 +72,17 @@ const isEmailLocale = (value: string): value is AppLocale => (emailLocales as re
  * client — including the three whose recipients have no `user` row yet, which
  * is why the header rather than a persisted column is the source of truth.
  *
- * The header carries a tag the client already negotiated, so this validates
- * rather than re-negotiates: an unshipped tag renders English rather than being
- * widened to its base language.
+ * The header carries a tag the client already negotiated, so {@link
+ * matchExactLocale} validates rather than re-negotiates: an unshipped tag
+ * renders English rather than being widened to its base language. Its set
+ * excludes `en-XA`, which matters here even though `getEmailI18n` still renders
+ * it — the preview server and the render tests pass the pseudo-locale directly,
+ * so nothing legitimate needs it to arrive over the wire, while
+ * `/v1/waitlist/join` is unauthenticated and takes the recipient from the
+ * request body, so honouring it would let anyone mail a third party
+ * pseudo-localized gibberish.
  *
  * @param tag The raw `X-App-Language` value, or null/undefined when the send
  *   has no request behind it — then the source locale is used.
  */
-export const resolveEmailLocale = (tag: string | null | undefined): AppLocale =>
-  tag && isEmailLocale(tag) ? tag : sourceLocale
+export const resolveEmailLocale = (tag: string | null | undefined): AppLocale => matchExactLocale(tag) ?? sourceLocale

--- a/backend/src/utils/accept-language.test.ts
+++ b/backend/src/utils/accept-language.test.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'bun:test'
+import { acceptLanguageFor } from './accept-language'
+
+const englishChain = 'en-US,en;q=0.9'
+
+describe('acceptLanguageFor', () => {
+  it('adds the base language between a regional tag and English', () => {
+    expect(acceptLanguageFor('pt-BR')).toBe('pt-BR,pt;q=0.9,en;q=0.8')
+  })
+
+  it('falls straight back to English for a base-language tag', () => {
+    expect(acceptLanguageFor('de')).toBe('de,en;q=0.9')
+    expect(acceptLanguageFor('ja')).toBe('ja,en;q=0.9')
+  })
+
+  it('leaves English users on exactly their current chain', () => {
+    expect(acceptLanguageFor('en')).toBe(englishChain)
+  })
+
+  it('defaults to English when the header is absent', () => {
+    expect(acceptLanguageFor(null)).toBe(englishChain)
+    expect(acceptLanguageFor(undefined)).toBe(englishChain)
+  })
+
+  it('tolerates surrounding whitespace, as every other backend header read does', () => {
+    expect(acceptLanguageFor(' pt-BR ')).toBe('pt-BR,pt;q=0.9,en;q=0.8')
+  })
+
+  // Only a dev build can send it, and it is a private-use subtag no upstream honours.
+  it('defaults to English for the pseudo-locale', () => {
+    expect(acceptLanguageFor('en-XA')).toBe(englishChain)
+  })
+
+  // The value is client-controlled and lands in an outbound request to a
+  // user-supplied URL, so nothing outside the shipped set may be forwarded.
+  it('forwards nothing that is not a shipped locale', () => {
+    expect(acceptLanguageFor('zh-CN')).toBe(englishChain)
+    expect(acceptLanguageFor('de\r\nX-Injected: 1')).toBe(englishChain)
+    expect(acceptLanguageFor('*')).toBe(englishChain)
+  })
+})

--- a/backend/src/utils/accept-language.ts
+++ b/backend/src/utils/accept-language.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { matchExactLocale, sourceLocale } from '@shared/i18n/locales'
+
+/**
+ * Sent when the app language is absent, not a shipped locale, or English.
+ *
+ * Matches what the Chrome-on-macOS User-Agent we present would actually send,
+ * and keeps English users on precisely the behaviour they have today.
+ */
+const englishChain = 'en-US,en;q=0.9'
+
+/**
+ * Build the `Accept-Language` header to present to a third-party page on behalf
+ * of a user, from the `X-App-Language` header their client sent.
+ *
+ * `pt-BR` → `pt-BR,pt;q=0.9,en;q=0.8`; `de` → `de,en;q=0.9`. English stays on
+ * {@link englishChain}, as does anything {@link matchExactLocale} rejects: the
+ * value is client-controlled and ends up in an outbound request to a
+ * user-supplied URL, so only a tag from the shipped set is ever forwarded.
+ *
+ * The header cannot translate a page, and that is the point: a URL that names a
+ * locale keeps it, and a monolingual page has nothing to negotiate. It only
+ * changes URLs that leave the language open, where showing an English card for
+ * a page that opens in Portuguese is the thing worth avoiding. Note it follows
+ * the *app* language, which deliberately outranks the browser's — so a card can
+ * be Japanese for a user whose browser would fetch the page in English.
+ *
+ * Shipping a regional English catalog (`en-GB`) would need the duplicate `en`
+ * rung collapsed below; today `en` is the only shipped tag with an English base.
+ *
+ * @param appLanguage Raw `X-App-Language` header value, or null/undefined when absent.
+ * @returns An `Accept-Language` header value.
+ */
+export const acceptLanguageFor = (appLanguage: string | null | undefined): string => {
+  const locale = matchExactLocale(appLanguage)
+  if (!locale) {
+    return englishChain
+  }
+  if (locale === sourceLocale) {
+    return englishChain
+  }
+  const base = new Intl.Locale(locale).language
+  return base === locale ? `${locale},en;q=0.9` : `${locale},${base};q=0.9,en;q=0.8`
+}

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -3,7 +3,7 @@
 ## Running Tests
 
 ```sh
-# Run frontend tests (src/ + shared/*.test.ts + selected scripts and .github script tests)
+# Run frontend tests (src/ + shared/ non-agent-core tests + selected scripts and .github script tests)
 bun run test
 
 # Run the isolated shared/agent-core module's unit tests (NOT part of `bun run test`; CI runs these only when shared/agent-core/** changes)
@@ -23,7 +23,7 @@ bun run e2e
 bun run e2e:headed   # with a visible browser
 ```
 
-**Note**: Don't run `bun test` directly from the project root — Bun's positional args are substring filters (not paths), so a filter like `src/` matches `backend/src/...` and pulls in backend tests. The `test` script uses `bun test --cwd=src` to scope discovery to the frontend tree, then runs `shared/*.test.ts`, `scripts/create-release.test.ts`, and the selected `.github/scripts/*.test.*` files by explicit path (`shared/` is outside `--cwd=src`, and Bun skips hidden dirs in discovery, so each path must be explicit).
+**Note**: Don't run `bun test` directly from the project root — Bun's positional args are substring filters (not paths), so a filter like `src/` matches `backend/src/...` and pulls in backend tests. The `test` script uses `bun test --cwd=src` to scope discovery to the frontend tree, then runs the `shared/` test paths it enumerates (`shared/*.test.ts`, `shared/defaults/`, `shared/i18n/` — `shared/agent-core/` has its own `test:agent-core` script), `scripts/create-release.test.ts`, and the selected `.github/scripts/*.test.*` files by explicit path (`shared/` is outside `--cwd=src`, and Bun skips hidden dirs in discovery, so each path must be explicit).
 
 **`shared/agent-core` is the app's in-browser adapter around the npm `@earendil-works/pi-agent-core` package**, not that package itself. Its nested unit tests sit outside frontend test discovery, so they are intentionally **not** part of `bun run test`. Run them with `bun run test:agent-core` (or `bun run test:agent-core:5x` for the 5x-stability gate). In CI, the dedicated `agent-core` job in [`ci.yml`](../../.github/workflows/ci.yml) runs `bun run test:agent-core:5x` only when `shared/agent-core/**` changes. The CLI imports the npm Pi package directly; it does not consume the browser adapter, and its integration coverage lives in the CLI suite.
 

--- a/shared/i18n/locales.test.ts
+++ b/shared/i18n/locales.test.ts
@@ -3,7 +3,59 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, test } from 'bun:test'
-import { appLocales, englishLanguageName, pseudoLocale, sourceLocale } from './locales'
+import {
+  appLocales,
+  englishLanguageName,
+  matchExactLocale,
+  negotiableLocales,
+  pseudoLocale,
+  sourceLocale,
+} from './locales'
+
+describe('negotiableLocales', () => {
+  // Pinned as a literal rather than recomputed from `appLocales`: recomputing
+  // the filter mirrors a wrong predicate on both sides and can never fail, and
+  // shipping a locale should require a deliberate edit here.
+  test('is the shipped set without the pseudo-locale', () => {
+    expect(negotiableLocales).toEqual(['en', 'de', 'fr', 'es', 'pt-BR', 'ja'])
+  })
+})
+
+describe('matchExactLocale', () => {
+  test('returns the shipped tag for an exact match', () => {
+    expect(matchExactLocale('pt-BR')).toBe('pt-BR')
+    expect(matchExactLocale('ja')).toBe('ja')
+  })
+
+  // Returning the set's own tag rather than the caller's string is what keeps a
+  // crafted header out of the outbound request; the casing swap here shows it.
+  test('normalizes casing and surrounding whitespace', () => {
+    expect(matchExactLocale('PT-br')).toBe('pt-BR')
+    expect(matchExactLocale(' pt-BR ')).toBe('pt-BR')
+  })
+
+  test('rejects the pseudo-locale, which only a dev build can send', () => {
+    expect(matchExactLocale('en-XA')).toBeNull()
+  })
+
+  test('rejects a tag we ship no catalog for', () => {
+    expect(matchExactLocale('zh-CN')).toBeNull()
+  })
+
+  // Frontend negotiation falls back to the base language; this deliberately does not.
+  test('does not fall back to the base language', () => {
+    expect(matchExactLocale('pt-PT')).toBeNull()
+    expect(matchExactLocale('de-AT')).toBeNull()
+  })
+
+  test('rejects absent and malformed values', () => {
+    expect(matchExactLocale(null)).toBeNull()
+    expect(matchExactLocale(undefined)).toBeNull()
+    expect(matchExactLocale('')).toBeNull()
+    expect(matchExactLocale('   ')).toBeNull()
+    expect(matchExactLocale('de\r\nX-Injected: 1')).toBeNull()
+  })
+})
 
 describe('englishLanguageName', () => {
   test('names a language in English rather than in itself', () => {

--- a/shared/i18n/locales.ts
+++ b/shared/i18n/locales.ts
@@ -5,10 +5,12 @@
 /**
  * Single source of truth for the locale set, shared by `lingui.config.ts`
  * (extraction/compilation) and the frontend runtime in `src/i18n`. Lives in
- * `shared/` rather than `src/` so that the backend can validate the
- * `X-App-Language` header against the same list — which it now does, in
- * `backend/src/emails/i18n.ts`; it cannot import from `src/`. Kept free of
- * runtime imports so the Lingui CLI can load it outside Vite.
+ * `shared/` rather than `src/` because the backend validates the
+ * `X-App-Language` header against the same list — for the email locale in
+ * `backend/src/emails/i18n.ts`, and via {@link matchExactLocale} for the
+ * outbound `Accept-Language` in `backend/src/utils/accept-language.ts` — and it
+ * cannot import from `src/`. Kept free of runtime imports so the Lingui CLI can
+ * load it outside Vite.
  */
 
 /** Locales the app ships catalogs for. `en` is the source locale; `en-XA` is the CI pseudo-locale. */
@@ -19,6 +21,37 @@ export type AppLocale = (typeof appLocales)[number]
 export const sourceLocale: AppLocale = 'en'
 
 export const pseudoLocale: AppLocale = 'en-XA'
+
+/**
+ * Locales eligible for language negotiation — every shipped locale except the
+ * CI pseudo-locale. This is the set both ends trust: the frontend negotiates
+ * `navigator.languages` against it (`src/i18n/resolve-locale.ts`) and the
+ * backend validates the `X-App-Language` header against it.
+ */
+export const negotiableLocales: readonly AppLocale[] = appLocales.filter((locale) => locale !== pseudoLocale)
+
+/**
+ * The shipped locale a client's `X-App-Language` header names, or `null`.
+ *
+ * Exact (case-insensitive) match, deliberately without the base-language
+ * fallback `matchLocale` applies to browser tags: the client sends a tag it has
+ * *already* resolved from this set, so anything else is a hand-written header
+ * and gets default behaviour rather than a best-effort guess. The pseudo-locale
+ * is absent from the set by construction, so a dev build's `en-XA` needs no
+ * special case. Callers that forward the result to a third party rely on the
+ * return being a member of {@link negotiableLocales} rather than the caller's
+ * own string — see `backend/src/utils/accept-language.ts`.
+ *
+ * @param value Raw header value, or null/undefined when the header is absent.
+ * @returns The matching shipped locale, or null.
+ */
+export const matchExactLocale = (value: string | null | undefined): AppLocale | null => {
+  const tag = value?.trim().toLowerCase()
+  if (!tag) {
+    return null
+  }
+  return negotiableLocales.find((locale) => locale.toLowerCase() === tag) ?? null
+}
 
 /**
  * A locale's language named in English — "German", "Brazilian Portuguese".

--- a/src/i18n/resolve-locale.test.ts
+++ b/src/i18n/resolve-locale.test.ts
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, test } from 'bun:test'
-import { negotiableLocales, resolveLocale, settableLocales } from './resolve-locale'
+import { negotiableLocales } from '@shared/i18n/locales'
+import { resolveLocale, settableLocales } from './resolve-locale'
 
 describe('resolveLocale', () => {
   test('explicit supported setting wins over browser languages', () => {

--- a/src/i18n/resolve-locale.ts
+++ b/src/i18n/resolve-locale.ts
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { appLocales, pseudoLocale, sourceLocale, type AppLocale } from '@shared/i18n/locales'
-
-/** Locales eligible for browser-language negotiation — every shipped locale except the CI pseudo-locale. */
-export const negotiableLocales = appLocales.filter((locale) => locale !== pseudoLocale)
+import { appLocales, matchExactLocale, negotiableLocales, sourceLocale, type AppLocale } from '@shared/i18n/locales'
 
 /**
  * Locales an explicit `language` setting is allowed to select.
@@ -31,8 +28,7 @@ const baseOf = (tag: string): string => tag.toLowerCase().split('-')[0]
  * `de`, `en-GB` → `en`.
  */
 export const matchLocale = (tag: string): AppLocale | null => {
-  const lowered = tag.toLowerCase()
-  const exact = negotiableLocales.find((locale) => locale.toLowerCase() === lowered)
+  const exact = matchExactLocale(tag)
   if (exact) {
     return exact
   }

--- a/src/lib/proxy-fetch.ts
+++ b/src/lib/proxy-fetch.ts
@@ -78,9 +78,10 @@ const skipHeaders = new Set([
   'sec-fetch-site',
   'sec-fetch-user',
   'upgrade-insecure-requests',
-  // Belongs on the OUTER request to our backend only — never promote it to a
-  // passthrough header, or it would leak to external LLM/MCP upstreams.
+  // These belong on the OUTER request to our backend only — never promote them
+  // to passthrough headers, or they would leak to external LLM/MCP upstreams.
   'x-app-version',
+  'x-app-language',
 ])
 
 const buildHostedRequest = (proxyUrl: string, input: RequestInfo | URL, init?: RequestInit): Request => {


### PR DESCRIPTION
Link previews were always fetched with a hardcoded `Accept-Language: en-US,en;q=0.9`, so a URL that leaves its language open showed an English card for a page that opens in the user's own language. The backend now derives the header from the language the client already resolved: `pt-BR` → `pt-BR,pt;q=0.9,en;q=0.8`, `de` → `de,en;q=0.9`.

The header can't translate anything, and that's the point — a URL that names a locale keeps it, and a monolingual page has nothing to negotiate. English, an absent header, and anything unrecognised all keep today's chain.

`X-App-Language` is client-controlled and ends up in a request to a user-supplied URL, so it's validated against the shipped locale set and only a set member is ever forwarded — the raw header never crosses to the upstream. That set (`negotiableLocales`) and its matcher moved into `shared/` so the frontend and backend read one definition instead of two.

**Two deviations from the ticket, both deliberate:**

- **No `Vary: X-App-Language`.** `/v1/preview` is a POST and browsers don't cache POST responses, so the header would be inert. The per-message cache stays keyed on the URL alone, which the ticket already wanted — a preview belongs to the language its message was written in.
- **The Exa `useAutoprompt` removal isn't included.** It's unrelated to localization and half-applied (a test fixture still asserts the flag), so it needs its own PR.
