### PR TITLE
fix(THU-793): stop the prompt input overlapping the chat area

### DIFF
--- a/src/components/chat/chat-ui.tsx
+++ b/src/components/chat/chat-ui.tsx
@@ -160,7 +160,7 @@ export default function ChatUI() {
 
         <m.div
           className={cn(
-            '-mt-3 md:-mt-4 relative z-10 px-3 pb-3 md:px-4 md:pb-4 flex',
+            'relative z-10 px-3 pb-3 md:px-4 md:pb-4 flex',
             isNativeMobile && 'pb-0',
             !hasMessages && !isMobile && 'flex-1 items-center',
           )}


### PR DESCRIPTION
The composer's `-mt-3 md:-mt-4` never moved it: the scroller above is `flex-1`, so the negative margin only stretched that scroller 12/16px *behind* the composer. On the macOS desktop build `.mac-vibrancy` turns the composer's `bg-sidebar` into glass, so messages sitting in that band read straight through it — which is why it showed on desktop and not on web, where the composer is opaque.

Dropping the margin ends the scroller at the composer's edge. The composer does not move.
