### PR TITLE
perf: smooth streamed chat text and reasoning

### DIFF
--- a/src/components/chat/assistant-message.test.tsx
+++ b/src/components/chat/assistant-message.test.tsx
@@ -5,6 +5,8 @@
 import type { GroupedUIPart, ReasoningGroupUIPart } from '@/lib/assistant-message'
 import type { ReasoningUIPart, TextUIPart, ToolUIPart } from 'ai'
 import { describe, expect, it } from 'bun:test'
+import { act, render } from '@testing-library/react'
+import { getClock } from '@/testing-library'
 import { mountMessageParts } from './assistant-message'
 
 const createReasoningPart = (text: string): ReasoningUIPart =>
@@ -251,4 +253,16 @@ describe('mountMessageParts', () => {
       expect(result).toHaveLength(1)
     })
   })
+})
+
+it('passes message streaming lifecycle to the real text renderer', () => {
+  const text = 'Full response. '.repeat(100)
+  const parts: GroupedUIPart[] = [{ type: 'text', text, state: 'streaming' }]
+  const { container, rerender } = render(<>{mountMessageParts(parts, true, 'stream', {})}</>)
+  expect(container.textContent).toBe('')
+  act(() => getClock().tick(48))
+  expect(container.textContent!.length).toBeGreaterThan(0)
+  expect(container.textContent!.length).toBeLessThan(text.length)
+  rerender(<>{mountMessageParts(parts, false, 'stream', {})}</>)
+  expect(container.textContent).toBe(text.trim())
 })

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -97,6 +97,7 @@ export const mountMessageParts = (
         partElements.push(
           <TextPart
             part={part as TextUIPart}
+            isStreaming={isStreaming}
             messageId={messageId}
             sources={sources}
             haystackReferences={haystackReferences}

--- a/src/components/chat/reasoning-display.test.tsx
+++ b/src/components/chat/reasoning-display.test.tsx
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getClock } from '@/testing-library'
+import { act, render } from '@testing-library/react'
+import { expect, it } from 'bun:test'
+import { ReasoningDisplay } from './reasoning-display'
+
+it('reveals reasoning progressively, then flushes before its existing fade-out', () => {
+  const text = 'Thinking carefully. '.repeat(80)
+  const { container, rerender } = render(<ReasoningDisplay text={text} isStreaming instanceKey="reasoning-0" />)
+  expect(container.textContent).toBe('')
+  act(() => getClock().tick(48))
+  expect(container.textContent!.length).toBeGreaterThan(0)
+  expect(container.textContent!.length).toBeLessThan(text.length)
+  rerender(<ReasoningDisplay text={text} isStreaming={false} instanceKey="reasoning-0" />)
+  expect(container.textContent).toBe(text)
+})

--- a/src/components/chat/reasoning-display.test.tsx
+++ b/src/components/chat/reasoning-display.test.tsx
@@ -7,13 +7,21 @@ import { act, render } from '@testing-library/react'
 import { expect, it } from 'bun:test'
 import { ReasoningDisplay } from './reasoning-display'
 
-it('reveals reasoning progressively, then flushes before its existing fade-out', () => {
+it.each([
+  [48, 5951],
+  [4000, 2999],
+])('reveals reasoning, flushes at %dms, and keeps it visible until the fade delay', (streamingMs, beforeFadeMs) => {
   const text = 'Thinking carefully. '.repeat(80)
-  const { container, rerender } = render(<ReasoningDisplay text={text} isStreaming instanceKey="reasoning-0" />)
+  const { container, rerender } = render(<ReasoningDisplay text={text} isStreaming />)
   expect(container.textContent).toBe('')
   act(() => getClock().tick(48))
   expect(container.textContent!.length).toBeGreaterThan(0)
   expect(container.textContent!.length).toBeLessThan(text.length)
-  rerender(<ReasoningDisplay text={text} isStreaming={false} instanceKey="reasoning-0" />)
+  act(() => getClock().tick(streamingMs - 48))
+  rerender(<ReasoningDisplay text={text} isStreaming={false} />)
   expect(container.textContent).toBe(text)
+  act(() => getClock().tick(beforeFadeMs))
+  expect(container.textContent).toBe(text)
+  act(() => getClock().tick(1))
+  expect(container.textContent).toBe('')
 })

--- a/src/components/chat/reasoning-display.tsx
+++ b/src/components/chat/reasoning-display.tsx
@@ -10,7 +10,6 @@ import { useEffect, useEffectEvent, useRef, useState } from 'react'
 type ReasoningDisplayProps = {
   text?: string
   isStreaming: boolean
-  instanceKey: string // Unique key to identify different reasoning instances
 }
 
 /**
@@ -20,7 +19,7 @@ type ReasoningDisplayProps = {
  * - Instantly replaced by the next reasoning step if it appears before fade-out
  * - Cleans up timers properly
  */
-export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDisplayProps) => {
+export const ReasoningDisplay = ({ text, isStreaming }: ReasoningDisplayProps) => {
   const displayedText = useSmoothText(text ?? '', isStreaming)
   const [shouldShow, setShouldShow] = useState(isStreaming)
   const displayStartTimeRef = useRef(Date.now())
@@ -85,7 +84,6 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
       <AnimatePresence mode="wait">
         {shouldShow && hasText && (
           <m.div
-            key={instanceKey}
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}

--- a/src/components/chat/reasoning-display.tsx
+++ b/src/components/chat/reasoning-display.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { useSmoothText } from '@/hooks/use-smooth-text'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { AnimatePresence, m } from 'framer-motion'
 import { useEffect, useEffectEvent, useRef, useState } from 'react'
@@ -20,24 +21,13 @@ type ReasoningDisplayProps = {
  * - Cleans up timers properly
  */
 export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDisplayProps) => {
+  const displayedText = useSmoothText(text ?? '', isStreaming)
   const [shouldShow, setShouldShow] = useState(isStreaming)
   const displayStartTimeRef = useRef(Date.now())
   const fadeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const prevInstanceKeyRef = useRef(instanceKey)
   const prevIsStreamingRef = useRef(isStreaming)
 
   const hasText = Boolean(text && text.trim())
-
-  // Reset when instanceKey changes (new reasoning instance)
-  if (instanceKey !== prevInstanceKeyRef.current) {
-    prevInstanceKeyRef.current = instanceKey
-    setShouldShow(true)
-    displayStartTimeRef.current = Date.now()
-    if (fadeTimeoutRef.current) {
-      clearTimeout(fadeTimeoutRef.current)
-      fadeTimeoutRef.current = null
-    }
-  }
 
   // Reset shouldShow when streaming starts again
   if (isStreaming && !prevIsStreamingRef.current && !shouldShow) {
@@ -80,10 +70,10 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
         fadeTimeoutRef.current = null
       }
     }
-  }, [isStreaming, onScheduleFade])
+  }, [isStreaming])
 
   const { scrollContainerRef, scrollTargetRef } = useAutoScroll({
-    dependencies: [text?.length],
+    dependencies: [displayedText.length],
     smooth: true,
     isStreaming: false,
     rootMargin: '0px',
@@ -105,7 +95,7 @@ export const ReasoningDisplay = ({ text, isStreaming, instanceKey }: ReasoningDi
           >
             <div className="absolute top-0 w-full h-6 bg-gradient-to-b from-background to-transparent" />
             <div className="max-h-[200px] px-4 hide-scrollbar py-3">
-              {text}
+              {displayedText}
               <div ref={scrollTargetRef} />
             </div>
             <div className="absolute bottom-0 w-full h-6 bg-gradient-to-b from-transparent to-background" />

--- a/src/components/chat/reasoning-group.test.tsx
+++ b/src/components/chat/reasoning-group.test.tsx
@@ -5,7 +5,8 @@
 import { ContentViewProvider } from '@/content-view/context'
 import type { ReasoningGroupItem } from '@/lib/assistant-message'
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { getClock } from '@/testing-library'
+import { act, render, screen } from '@testing-library/react'
 import type { ReasoningUIPart, ToolUIPart } from 'ai'
 import { describe, expect, it } from 'bun:test'
 import { ReasoningGroup } from './reasoning-group'
@@ -251,6 +252,8 @@ describe('ReasoningGroup', () => {
         { wrapper: TestWrapper },
       )
 
+      act(() => getClock().tick(200))
+
       // ReasoningDisplay should render the reasoning text when streaming
       // It might be in a specific container, so check the container
       expect(container.textContent).toContain('Let me think about this...')
@@ -311,6 +314,8 @@ describe('ReasoningGroup', () => {
           wrapper: TestWrapper,
         },
       )
+
+      act(() => getClock().tick(200))
 
       // ReasoningDisplay should render the reasoning text
       expect(screen.getByText('Let me think about this...')).toBeInTheDocument()
@@ -517,6 +522,8 @@ describe('ReasoningGroup', () => {
       // But since isStreaming is true, it might show loading messages
       // At minimum, verify the component renders
       expect(container.textContent).toBeTruthy()
+      act(() => getClock().tick(200))
+
       // ReasoningDisplay should show the reasoning text when streaming
       expect(container.textContent).toContain('Let me think about this...')
     })
@@ -563,10 +570,57 @@ describe('ReasoningGroup', () => {
         { wrapper: TestWrapper },
       )
 
+      act(() => getClock().tick(200))
+
       // Should show the last reasoning part text in ReasoningDisplay (when streaming)
       expect(container.textContent).toContain('Last reasoning')
       // Should not show the first reasoning part text (only the last one is used for ReasoningDisplay)
       expect(container.textContent).not.toContain('First reasoning')
     })
   })
+})
+
+it('keeps the reasoning display mounted across text appends and flushes when the message stops', () => {
+  const props = { isStreaming: true, isLastPartInMessage: true, hasTextPart: false, reasoningTime: {} }
+  const parts = (text: string): ReasoningGroupItem[] => [
+    {
+      type: 'reasoning',
+      id: 'reasoning-stable',
+      content: { type: 'reasoning', text, state: 'streaming' },
+    },
+  ]
+  const { container, rerender } = render(<ReasoningGroup {...props} parts={parts('Thinking')} />, {
+    wrapper: TestWrapper,
+  })
+  act(() => getClock().tick(48))
+  const display = container.querySelector('.hide-scrollbar')!
+  expect(display.textContent).toBe('Thinking')
+  rerender(<ReasoningGroup {...props} parts={parts('Thinking about the answer')} />)
+  expect(container.querySelector('.hide-scrollbar')).toBe(display)
+  expect(display.textContent).toBe('Thinking')
+  rerender(<ReasoningGroup {...props} isStreaming={false} parts={parts('Thinking about the answer')} />)
+  expect(display.textContent).toBe('Thinking about the answer')
+})
+
+it('flushes a completed reasoning part and resets a new part with an identical prefix', () => {
+  const props = { isStreaming: true, isLastPartInMessage: true, hasTextPart: false, reasoningTime: {} }
+  const part = (id: string, state: ReasoningUIPart['state']): ReasoningGroupItem[] => [
+    {
+      type: 'reasoning',
+      id,
+      content: { type: 'reasoning', text: 'Same beginning. '.repeat(100), state },
+    },
+  ]
+  const { container, rerender } = render(<ReasoningGroup {...props} parts={part('first', 'streaming')} />, {
+    wrapper: TestWrapper,
+  })
+  act(() => getClock().tick(48))
+  rerender(<ReasoningGroup {...props} parts={part('first', 'done')} />)
+  expect(container.querySelector('.hide-scrollbar')!.textContent).toBe('Same beginning. '.repeat(100))
+  rerender(<ReasoningGroup {...props} parts={part('second', 'streaming')} />)
+  expect(container.querySelector('.hide-scrollbar')!.textContent).toBe('')
+  act(() => getClock().tick(48))
+  const length = container.querySelector('.hide-scrollbar')!.textContent!.length
+  expect(length).toBeGreaterThan(0)
+  expect(length).toBeLessThan(1500)
 })

--- a/src/components/chat/reasoning-group.test.tsx
+++ b/src/components/chat/reasoning-group.test.tsx
@@ -616,8 +616,11 @@ it('flushes a completed reasoning part and resets a new part with an identical p
   })
   act(() => getClock().tick(48))
   rerender(<ReasoningGroup {...props} parts={part('first', 'done')} />)
-  expect(container.querySelector('.hide-scrollbar')!.textContent).toBe('Same beginning. '.repeat(100))
+  const firstDisplay = container.querySelector('.hide-scrollbar')!
+  expect(firstDisplay.textContent).toBe('Same beginning. '.repeat(100))
   rerender(<ReasoningGroup {...props} parts={part('second', 'streaming')} />)
+  expect(firstDisplay.isConnected).toBe(false)
+  expect(container.querySelectorAll('.hide-scrollbar')).toHaveLength(1)
   expect(container.querySelector('.hide-scrollbar')!.textContent).toBe('')
   act(() => getClock().tick(48))
   const length = container.querySelector('.hide-scrollbar')!.textContent!.length

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -111,7 +111,6 @@ export const ReasoningGroup = ({
           key={reasoningInstanceKey}
           text={currentReasoningPart?.content.text}
           isStreaming={isStreaming && currentReasoningPart?.content.state === 'streaming'}
-          instanceKey={reasoningInstanceKey}
         />
       )}
     </div>

--- a/src/components/chat/reasoning-group.tsx
+++ b/src/components/chat/reasoning-group.tsx
@@ -43,10 +43,7 @@ export const ReasoningGroup = ({
 
   const isGroupReasoning = isLastPartInMessage && (isStreaming || currentReasoningPart?.content.state === 'streaming')
 
-  // Create unique instance key for reasoning display
-  const reasoningInstanceKey = currentReasoningPart
-    ? `reasoning-${currentReasoningPart.content.text.substring(0, 50)}-${parts.indexOf(currentReasoningPart)}`
-    : ''
+  const reasoningInstanceKey = currentReasoningPart?.id ?? ''
 
   const totalDuration = (() => {
     if (!reasoningStartTimes) {
@@ -111,8 +108,9 @@ export const ReasoningGroup = ({
       </Expandable>
       {!hasTextPart && (
         <ReasoningDisplay
+          key={reasoningInstanceKey}
           text={currentReasoningPart?.content.text}
-          isStreaming={currentReasoningPart?.content.state === 'streaming'}
+          isStreaming={isStreaming && currentReasoningPart?.content.state === 'streaming'}
           instanceKey={reasoningInstanceKey}
         />
       )}

--- a/src/components/chat/text-part.test.tsx
+++ b/src/components/chat/text-part.test.tsx
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { createTestProvider } from '@/test-utils/test-provider'
+import { getClock } from '@/testing-library'
+import { act, render } from '@testing-library/react'
+import type { TextUIPart } from 'ai'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { ExternalLinkDialogProvider } from './markdown-utils'
+import { TextPart } from './text-part'
+
+it('paces only active text parts and flushes both terminal gates synchronously', () => {
+  const text = 'Steady answer. '.repeat(100)
+  const props = { part: { type: 'text', text, state: 'streaming' } as TextUIPart, messageId: 'test', isStreaming: true }
+  const { container, rerender } = render(<TextPart {...props} />)
+  expect(container.textContent).toBe('')
+  act(() => getClock().tick(48))
+  expect(container.textContent!.length).toBeGreaterThan(0)
+  expect(container.textContent!.length).toBeLessThan(text.length)
+  rerender(<TextPart {...props} part={{ ...props.part, state: 'done' }} />)
+  expect(container.textContent).toBe(text.trim())
+  rerender(<TextPart {...props} isStreaming={false} />)
+  expect(container.textContent).toBe(text.trim())
+  expect(props.part.text).toBe(text)
+})
+
+it('paces raw source citations without exposing generated CITE placeholders', () => {
+  const text = 'Evidence [1] and more text. '.repeat(30)
+  const { container } = render(
+    <TextPart
+      part={{ type: 'text', text, state: 'streaming' }}
+      messageId="citation"
+      isStreaming
+      sources={[{ index: 1, url: 'https://example.com', title: 'Example', toolName: 'search' }]}
+    />,
+  )
+  expect(container.textContent).toBe('')
+  for (const _ of Array.from({ length: 80 })) {
+    act(() => getClock().tick(16))
+    expect(container.textContent).not.toContain('CITE')
+    expect(container.textContent).not.toContain('{{')
+  }
+  expect(container.textContent).toContain('Evidence')
+  expect(container.querySelector('button')).not.toBeNull()
+})
+
+it('completes native citation syntax without retaining internal markers', () => {
+  const text = 'Fact【2†source】. Another fact【3】.'
+  const { container } = render(
+    <TextPart part={{ type: 'text', text, state: 'streaming' }} messageId="native" isStreaming />,
+  )
+  const frames: string[] = []
+  for (const _ of Array.from({ length: 30 })) {
+    act(() => getClock().tick(16))
+    frames.push(container.textContent ?? '')
+  }
+  expect(container.textContent).toBe('Fact. Another fact.')
+  expect(frames.some((frame) => frame.includes('【'))).toBe(false)
+})
+
+it('preserves CJK brackets and flushes unfinished native syntax on stop', () => {
+  const props = {
+    messageId: 'cjk',
+    isStreaming: true,
+    part: { type: 'text', state: 'streaming', text: '価格は【税込み】です【2†source' } as TextUIPart,
+  }
+  const { container, rerender } = render(<TextPart {...props} />)
+  act(() => getClock().tick(1000))
+  expect(container.textContent).toBe('価格は【税込み】です')
+  rerender(<TextPart {...props} isStreaming={false} />)
+  expect(container.textContent).toBe(props.part.text)
+})
+
+describe('streaming widgets', () => {
+  beforeAll(setupTestDatabase)
+  afterAll(teardownTestDatabase)
+
+  it('holds hidden attributes until the real widget mounts, preserving surrounding text order', () => {
+    const url = 'https://example.com/' + 'a'.repeat(1000)
+    const text = `Intro <widget:link-preview url="${url}" source="1" /> Tail`
+    const Provider = createTestProvider()
+    const { container, rerender } = render(
+      <TextPart
+        messageId="widget"
+        part={{ type: 'text', text, state: 'streaming' }}
+        isStreaming
+        sources={[{ index: 1, url, title: 'Widget title', toolName: 'search' }]}
+      />,
+      {
+        wrapper: ({ children }) => (
+          <Provider>
+            <ExternalLinkDialogProvider>{children}</ExternalLinkDialogProvider>
+          </Provider>
+        ),
+      },
+    )
+    const observed = { widgetAt: 0 }
+    for (const frame of Array.from({ length: 80 }, (_, index) => index + 1)) {
+      act(() => getClock().tick(16))
+      expect(container.textContent).not.toContain('widget:')
+      expect(container.textContent).not.toContain('https://')
+      if (!observed.widgetAt && container.textContent?.includes('Widget title')) {
+        observed.widgetAt = frame * 16
+      }
+    }
+    expect(observed.widgetAt).toBeGreaterThan(900)
+    expect(observed.widgetAt).toBeLessThan(1100)
+    expect(container.textContent).toBe('IntroWidget titleTail')
+    rerender(<TextPart messageId="widget" part={{ type: 'text', text: 'Replacement answer', state: 'done' }} />)
+    expect(container.textContent).toBe('Replacement answer')
+  })
+})

--- a/src/components/chat/text-part.tsx
+++ b/src/components/chat/text-part.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { type ContentPart, type ContentPartsState, parseContentPartsIncremental } from '@/ai/widget-parser'
+import { useSmoothText } from '@/hooks/use-smooth-text'
 import { sourceToCitation } from '@/lib/source-utils'
 import {
   buildDocumentSideviewId,
@@ -23,6 +24,7 @@ import { WidgetRenderer } from './widget-renderer'
 type TextPartProps = {
   part: TextUIPart
   messageId: string
+  isStreaming?: boolean
   sources?: SourceMetadata[]
   haystackReferences?: HaystackReferenceMeta[]
 }
@@ -156,7 +158,11 @@ export const buildDocumentCitationPlaceholders = (
   return { fullText, citations }
 }
 
-export const TextPart = memo(({ part, messageId, sources, haystackReferences }: TextPartProps) => {
+export const TextPart = memo(({ part, messageId, isStreaming = false, sources, haystackReferences }: TextPartProps) => {
+  const isPartStreaming = isStreaming && part.state === 'streaming'
+  const revealedText = useSmoothText(part.text, isPartStreaming)
+  // The parser strips complete native citations; withhold their unfinished suffix to avoid syntax flashes.
+  const text = isPartStreaming ? revealedText.replace(/【(?:\d+(?:†[^】]*)?)?$/, '') : revealedText
   const hasNewSources = !!sources && sources.length > 0
   const hasDocumentRefs = !!haystackReferences && haystackReferences.length > 0
 
@@ -166,7 +172,7 @@ export const TextPart = memo(({ part, messageId, sources, haystackReferences }: 
 
   // Build citation data upfront so the hook is always called in the same order
   const { processedParts, citations, hasCitations, hasText } = useMemo(() => {
-    if (!part.text) {
+    if (!text) {
       parseStateRef.current = null
       return {
         processedParts: [] as ContentPart[],
@@ -176,7 +182,7 @@ export const TextPart = memo(({ part, messageId, sources, haystackReferences }: 
       }
     }
 
-    const { parts, state } = parseContentPartsIncremental(part.text, parseStateRef.current)
+    const { parts, state } = parseContentPartsIncremental(text, parseStateRef.current)
     parseStateRef.current = state
 
     // Pick the citation builder based on which source type is active.
@@ -217,11 +223,11 @@ export const TextPart = memo(({ part, messageId, sources, haystackReferences }: 
       hasCitations: false,
       hasText: parts.some((p) => p.type === 'text'),
     }
-  }, [part.text, hasNewSources, hasDocumentRefs, sources, haystackReferences])
+  }, [text, hasNewSources, hasDocumentRefs, sources, haystackReferences])
 
   const dedupedParts = useMemo(() => deduplicateLinkPreviews(processedParts), [processedParts])
 
-  if (!part.text) {
+  if (!text) {
     return null
   }
 

--- a/src/hooks/use-smooth-text.test.ts
+++ b/src/hooks/use-smooth-text.test.ts
@@ -1,0 +1,170 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getClock } from '@/testing-library'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, spyOn } from 'bun:test'
+import { useSmoothText } from './use-smooth-text'
+
+/** Advance the shared fake animation clock inside React's update boundary. */
+const tick = (ms: number) => act(() => getClock().tick(ms))
+
+describe('useSmoothText', () => {
+  it('paces a burst, commits at 40ms cadence and releases idle/unmounted frames', () => {
+    const { result, unmount } = renderHook(() => useSmoothText('a'.repeat(1000), true))
+    expect(result.current).toBe('')
+    tick(32)
+    expect(result.current).toBe('')
+    tick(16)
+    expect(result.current.length).toBeGreaterThan(0)
+    expect(result.current.length).toBeLessThan(1000)
+    const prefix = result.current
+    tick(32)
+    expect(result.current).toBe(prefix)
+    tick(1000)
+    expect(result.current).toBe('a'.repeat(1000))
+    expect(getClock().countTimers()).toBe(0)
+    unmount()
+    const active = renderHook(() => useSmoothText('b'.repeat(1000), true))
+    expect(getClock().countTimers()).toBe(1)
+    active.unmount()
+    expect(getClock().countTimers()).toBe(0)
+  })
+
+  it('preserves elapsed time across continuous sub-frame appends', () => {
+    const { result, rerender } = renderHook(({ text }) => useSmoothText(text, true), {
+      initialProps: { text: 'a'.repeat(2000) },
+    })
+    for (const elapsed of Array.from({ length: 1000 }, (_, index) => index + 1)) {
+      tick(1)
+      rerender({ text: 'a'.repeat(2000 + elapsed) })
+    }
+    expect(result.current.length).toBeGreaterThan(2600)
+    expect(result.current.length).toBeLessThan(3000)
+    tick(2000)
+    expect(result.current).toBe('a'.repeat(3000))
+  })
+
+  it('restarts after idle without spending the long pause on newly arrived text', () => {
+    const { result, rerender } = renderHook(({ text }) => useSmoothText(text, true), {
+      initialProps: { text: 'hello' },
+    })
+    tick(32)
+    expect(result.current).toBe('hello')
+    tick(10_000)
+    rerender({ text: 'hello' + 'a'.repeat(100) })
+    tick(16)
+    expect(result.current).toBe('hello')
+    tick(1000)
+    expect(result.current).toBe('hello' + 'a'.repeat(100))
+  })
+
+  it.each(['a'.repeat(30), 'a'.repeat(30) + 'b'.repeat(370), ''])(
+    'resets against the full previous target: %s',
+    (replacement) => {
+      const { result, rerender } = renderHook(({ text }) => useSmoothText(text, true), {
+        initialProps: { text: 'a'.repeat(400) },
+      })
+      tick(48)
+      rerender({ text: replacement })
+      expect(result.current).toBe('')
+      tick(2000)
+      expect(result.current).toBe(replacement)
+    },
+  )
+
+  it('shows complete text immediately for history and every terminal streaming transition', () => {
+    const { result, rerender } = renderHook(({ text, enabled }) => useSmoothText(text, enabled), {
+      initialProps: { text: 'history', enabled: false },
+    })
+    expect(result.current).toBe('history')
+    expect(getClock().countTimers()).toBe(0)
+    rerender({ text: 'new'.repeat(100), enabled: true })
+    tick(48)
+    rerender({ text: 'final'.repeat(100), enabled: false })
+    expect(result.current).toBe('final'.repeat(100))
+    expect(getClock().countTimers()).toBe(0)
+  })
+
+  it('only exposes whole emoji and combining graphemes', () => {
+    const clusters = ['👨‍👩‍👧‍👦', 'e\u0301', '🇧🇷', '👍🏽']
+    const text = clusters.join('').repeat(10)
+    const boundaries = new Set([
+      '',
+      ...Array.from({ length: 40 }, (_, index) =>
+        Array.from({ length: index + 1 }, (_, cluster) => clusters[cluster % clusters.length]).join(''),
+      ),
+    ])
+    const { result } = renderHook(() => useSmoothText(text, true))
+    for (const _ of Array.from({ length: 100 })) {
+      tick(16)
+      expect(boundaries.has(result.current)).toBe(true)
+    }
+    expect(result.current).toBe(text)
+  })
+
+  it('flushes when reduced motion changes and reveals later appends without animation', () => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const listeners = new Set<() => void>()
+    const preference = { matches: false }
+    const matchMedia = spyOn(window, 'matchMedia').mockImplementation(() => ({
+      ...media,
+      get matches() {
+        return preference.matches
+      },
+      addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) =>
+        listeners.add(listener as () => void),
+      removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) =>
+        listeners.delete(listener as () => void),
+    }))
+    try {
+      const { result, rerender, unmount } = renderHook(({ text }) => useSmoothText(text, true), {
+        initialProps: { text: 'a'.repeat(1000) },
+      })
+      tick(48)
+      act(() => {
+        preference.matches = true
+        listeners.forEach((listener) => listener())
+      })
+      expect(result.current).toBe('a'.repeat(1000))
+      expect(getClock().countTimers()).toBe(0)
+      rerender({ text: 'a'.repeat(1100) })
+      expect(result.current).toBe('a'.repeat(1100))
+      unmount()
+      expect(listeners.size).toBe(0)
+    } finally {
+      matchMedia.mockRestore()
+    }
+  })
+})
+
+it('restarts when an append is batched with the frame that caught up', () => {
+  const { result, rerender } = renderHook(({ text }) => useSmoothText(text, true), {
+    initialProps: { text: 'hello' },
+  })
+  act(() => {
+    getClock().tick(32)
+    rerender({ text: 'hello world' })
+  })
+  tick(1000)
+  expect(result.current).toBe('hello world')
+})
+
+it('catches up after legacy 10ms word deliveries without changing the delivered source', () => {
+  const { result, rerender } = renderHook(({ text }) => useSmoothText(text, true), { initialProps: { text: '' } })
+  for (const words of Array.from({ length: 100 }, (_, index) => index + 1)) {
+    tick(10)
+    rerender({ text: 'word '.repeat(words) })
+  }
+  expect(result.current.length).toBeGreaterThan(350)
+  expect(result.current.length).toBeLessThan(500)
+  const measurement = { displayedAtDeliveryEnd: result.current.length, catchUpMs: 0 }
+  while (result.current.length < 500 && measurement.catchUpMs < 1000) {
+    tick(16)
+    measurement.catchUpMs += 16
+  }
+  expect(measurement.catchUpMs).toBeGreaterThan(250)
+  expect(measurement.catchUpMs).toBeLessThan(600)
+  expect(result.current).toBe('word '.repeat(100))
+})

--- a/src/hooks/use-smooth-text.ts
+++ b/src/hooks/use-smooth-text.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { messageRenderThrottleMs } from '@/chats/chat-throttle'
+import { graphemeSegmenter } from '@/lib/segmenter'
+import { advanceTextReveal } from '@/lib/text-reveal'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
+
+/** Subscribe to the browser preference, including changes during a response. */
+const subscribeReducedMotion = (callback: () => void) => {
+  const media = window.matchMedia('(prefers-reduced-motion: reduce)')
+  media.addEventListener('change', callback)
+  return () => media.removeEventListener('change', callback)
+}
+
+/** Read the current OS motion preference. */
+const prefersReducedMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+/** Create progress for one target, resetting both cursor and fractional time together. */
+const createProgress = (target: string, revealed: number) => ({ target, revealed, carryMs: 0 })
+
+/**
+ * Pace a raw streaming prefix before parsing. Appends share one animation loop;
+ * replacements restart it, and completion/reduced motion return the full source.
+ * The SDK's message, persistence and copy text remain untouched.
+ */
+export const useSmoothText = (text: string, enabled: boolean): string => {
+  const reducedMotion = useSyncExternalStore(subscribeReducedMotion, prefersReducedMotion)
+  const segmenter = graphemeSegmenter()
+  const animate = enabled && !reducedMotion && segmenter !== null
+  const [displayed, setDisplayed] = useState(() => (animate ? '' : text))
+  const progressRef = useRef(createProgress(text, animate ? 0 : text.length))
+
+  if (!text.startsWith(progressRef.current.target) || (!animate && progressRef.current.revealed !== text.length)) {
+    progressRef.current = createProgress(text, animate ? 0 : text.length)
+    if (displayed !== (animate ? '' : text)) {
+      setDisplayed(animate ? '' : text)
+    }
+  }
+  progressRef.current.target = text
+  const progress = progressRef.current
+  const running = animate && displayed !== text
+
+  useEffect(() => {
+    if (!running) {
+      return
+    }
+    const clock = { frame: 0, lastFrameAt: Date.now(), lastCommitAt: Date.now() }
+    const step = () => {
+      const now = Date.now()
+      Object.assign(progress, advanceTextReveal(progress, progress.target.length, now - clock.lastFrameAt))
+      clock.lastFrameAt = now
+      const caughtUp = progress.revealed === progress.target.length
+      if (caughtUp || now - clock.lastCommitAt >= messageRenderThrottleMs) {
+        clock.lastCommitAt = now
+        const boundary = caughtUp
+          ? progress.revealed
+          : segmenter!.segment(progress.target).containing(progress.revealed)!.index
+        setDisplayed(progress.target.slice(0, boundary))
+      }
+      if (caughtUp) {
+        // Restart even if the final display commit and the next append are batched.
+        progressRef.current = createProgress(progress.target, progress.revealed)
+      } else {
+        clock.frame = requestAnimationFrame(step)
+      }
+    }
+    clock.frame = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(clock.frame)
+  }, [running, progress, segmenter])
+
+  return animate ? displayed : text
+}

--- a/src/lib/text-reveal.test.ts
+++ b/src/lib/text-reveal.test.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'bun:test'
+import { advanceTextReveal, initialTextReveal } from './text-reveal'
+
+describe('advanceTextReveal', () => {
+  it('carries fractional progress and clamps completion, shrink and negative time', () => {
+    const first = advanceTextReveal(initialTextReveal, 10, 3)
+    expect(first).toEqual({ revealed: 0, carryMs: 3 })
+    expect(advanceTextReveal(first, 10, 3)).toEqual({ revealed: 1, carryMs: 1 })
+    expect(advanceTextReveal(first, 10, -5)).toEqual(first)
+    expect(advanceTextReveal(first, 10, 1000)).toEqual({ revealed: 10, carryMs: 0 })
+    expect(advanceTextReveal({ revealed: 40, carryMs: 2 }, 30, 16)).toEqual({ revealed: 30, carryMs: 0 })
+  })
+
+  it('drains a large burst gradually, with a response constant rather than a 250ms deadline', () => {
+    const progress = { state: initialTextReveal, elapsed: 0 }
+    while (progress.state.revealed < 1000 && progress.elapsed < 2000) {
+      progress.state = advanceTextReveal(progress.state, 1000, 16)
+      progress.elapsed += 16
+      if (progress.elapsed === 256) {
+        expect(progress.state.revealed).toBeGreaterThan(600)
+        expect(progress.state.revealed).toBeLessThan(700)
+      }
+    }
+    expect(progress.state.revealed).toBe(1000)
+    expect(progress.elapsed).toBe(976)
+  })
+})

--- a/src/lib/text-reveal.ts
+++ b/src/lib/text-reveal.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** UTF-16 cursor and fractional time carried between animation frames. */
+export type TextRevealState = { revealed: number; carryMs: number }
+export const initialTextReveal: TextRevealState = { revealed: 0, carryMs: 0 }
+
+/**
+ * Advance display progress at an adaptive pace. The 250ms response constant
+ * accelerates a backlog; it is not a deadline (1,000 characters take ~976ms).
+ */
+export const advanceTextReveal = (state: TextRevealState, targetLength: number, elapsedMs: number): TextRevealState => {
+  const pending = targetLength - state.revealed
+  if (pending <= 0) {
+    return { revealed: targetLength, carryMs: 0 }
+  }
+  const interval = Math.min(5, 250 / pending)
+  const budget = state.carryMs + Math.max(0, elapsedMs)
+  const count = Math.min(pending, Math.floor(budget / interval))
+  return {
+    revealed: state.revealed + count,
+    carryMs: count === pending ? 0 : budget - count * interval,
+  }
+}


### PR DESCRIPTION
Pace streamed chat text and reasoning so large provider chunks appear progressively. Keep one animation loop across appended chunks, reset safely on replacement, reveal whole graphemes, and flush completed parts/history immediately. Stable reasoning-part keys preserve animation progress, and live reduced-motion changes disable pacing.

Reveal runs before the existing widget/citation parser, with incomplete native citation syntax held back. The existing 40ms display-commit cadence, SDK contents, saving, copying, and legacy transport smoothing remain in place.

Validation:

- Isolated PR: 63 focused tests pass; `bun run test` passes with 4,921 frontend tests, 3 skips, and 266 shared/script tests; `bun run check` passes (0 lint errors, 396 warnings).
- Deterministic Chromium tests on the combined reviewed tree exercise progressive Unicode text/reasoning, idle restart, live reduced motion, widget order, citation-markup suppression, completion, clipboard, and persisted history using real renderers and simulated timed provider streams. Seven in-scope browser scenarios pass. The open-SSE Stop failure is explicitly excluded by the user because another PR covers it; this PR makes no cancellation fix.
- The exact five-search and twelve-controller prompts completed on real managed Opus 5 and current confidential DeepSeek V4 Flash, with actual EXA search and unchanged attestation/encryption. Auto/research web calls were 2/30 for each model; latest completed provider request counts were Opus 2/17 and DeepSeek 2/11, all HTTP 200, with post-budget synthesis. These live runs used the combined reviewed tree; this independent PR's files match its validated hashes.

Display tradeoffs: 250ms is a response constant, not a maximum delay; the tested 1,000-character burst drains in about 976ms. Long hidden widget attributes delay the card: a browser observation saw widget text about 1,404ms after a tail send with prior backlog and polling, not an exact mount deadline. A simulated legacy-delivery schedule adds 464ms of display catch-up. Total React renders are not claimed unchanged.

Live answer quality remains qualified: an initial DeepSeek table omission was corrected in a later run, warranty estimates remain unverified, and the unchanged 200-source cap can leave higher references unlinked. An earlier research attempt ended on unexpected navigation; the final isolated run with HMR disabled completed without manual Retry. Manual Retry behavior is proven by the separate deterministic real-UI case, not by that successful live run. Integration also reproduced baseline randomized `indexedDB` test-isolation failures on pristine main and the research PR; this PR's recorded randomized suite passed.

This display-only PR targets main independently of the research-completion PR.
