### PR TITLE
fix: sync CLI version in nightly releases

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -129,7 +129,7 @@ jobs:
           NIGHTLY_TAG="v${NIGHTLY_VERSION}"
 
           # Update version files locally
-          node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='$NIGHTLY_VERSION';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          node -e "const fs=require('fs');for(const path of ['package.json','cli/package.json']){const p=JSON.parse(fs.readFileSync(path));p.version='$NIGHTLY_VERSION';fs.writeFileSync(path,JSON.stringify(p,null,2)+'\n')}"
           sed -i "s/^version = \".*\"/version = \"$NIGHTLY_VERSION\"/" src-tauri/Cargo.toml
           node -e "const fs=require('fs'),c=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));c.version='$BASE_VERSION';fs.writeFileSync('src-tauri/tauri.conf.json',JSON.stringify(c,null,2)+'\n')"
 
@@ -143,7 +143,7 @@ jobs:
           fi
 
           # Create commit and tag (not pushed to main branch, only the tag)
-          git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
+          git add package.json cli/package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
           git commit -m "chore: nightly build $NIGHTLY_VERSION"
           git tag -a "$NIGHTLY_TAG" -m "Nightly build $NIGHTLY_VERSION"
           git push origin "$NIGHTLY_TAG"


### PR DESCRIPTION
Nightly preparation updated the app version to `0.1.129-nightly.20260909` but left the CLI at `0.1.129`, failing the version consistency test on all three CLI release targets in [run 34313823003](https://github.com/thunderbird/thunderbolt/actions/runs/34313823003).

Update both package manifests together and include `cli/package.json` in the nightly commit so the release tag carries matching app and CLI versions.

Validation:
- Executed the workflow's version-update commands against temporary copies of the manifests: reproduced the mismatch before the fix and verified matching nightly versions afterward.
- Verified the nightly commit includes the CLI manifest and the Apple version remains numeric.
- CLI suite: 867 tests passed; TypeScript check passed.
- Formatting and pre-commit checks passed.
