### PR TITLE
test(THU-829): cover the language picker with e2e and unit tests

### DIFF
--- a/e2e/oidc-language-picker.spec.ts
+++ b/e2e/oidc-language-picker.spec.ts
@@ -1,0 +1,268 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect, test, type Page, type Request, type Route } from '@playwright/test'
+import { collectPageErrors, loginViaOidc } from './helpers'
+
+/**
+ * THU-829 — the language picker, asserted on intercepted `X-App-Language`
+ * request headers rather than translated UI copy.
+ *
+ * Every bug this file guards against was a cross-boundary timing bug the unit
+ * suite cannot see by construction (see oidc-localization.spec.ts's header):
+ * settings hydration publishing `en` over the boot-seeded locale and destroying
+ * its localStorage mirror, the schema fallback making an unset setting
+ * indistinguishable from an explicit English choice, and a stale mirror
+ * surviving a data wipe into the next identity. The races live in the reload
+ * and fresh-context sequences, so that is what these tests drive.
+ *
+ * Where a test has to operate German UI (everything after a switch to Deutsch),
+ * it goes through catalog copy deliberately — the same convention as
+ * oidc-localization.spec.ts's `Lokalisierung` assertion. The coupled strings
+ * are collected in `de` below so a catalog change breaks one constant, not
+ * selectors scattered across the file.
+ */
+
+const oidcVitePort = 1421
+const oidcBackendPort = 8002
+const oidcOrigin = `http://localhost:${oidcVitePort}`
+const backendOrigin = `http://localhost:${oidcBackendPort}`
+
+/** localStorage key of the boot-time locale mirror (src/i18n/active-locale.ts). */
+const mirrorKey = 'thunderbolt_locale'
+
+/** The German catalog copy these tests drive the UI through. */
+const de = {
+  language: 'Sprache',
+  localization: 'Lokalisierung',
+  modifiedItem: 'Geändertes Element',
+  defaultSetting: 'Standardeinstellung',
+  resetToDefault: 'Auf Standard zurücksetzen',
+  logOut: 'Abmelden',
+  deleteDataFromDevice: 'Daten vom Gerät löschen',
+}
+
+/** Start collecting every request the page issues, in order. */
+const collectRequests = (page: Page): Request[] => {
+  const requests: Request[] = []
+  page.on('request', (request) => requests.push(request))
+  return requests
+}
+
+/**
+ * The `x-app-language` header of every captured backend request, in request
+ * order. Requests torn down before their headers could be read (e.g. cancelled
+ * by a reload) are skipped rather than failing the poll that wraps this.
+ */
+const appLanguageHeaders = async (requests: Request[]): Promise<string[]> => {
+  const headers: string[] = []
+  for (const request of requests) {
+    if (!request.url().startsWith(backendOrigin)) {
+      continue
+    }
+    const language = await request.allHeaders().then(
+      (all) => all['x-app-language'],
+      () => undefined,
+    )
+    if (language) {
+      headers.push(language)
+    }
+  }
+  return headers
+}
+
+/**
+ * Fulfill an intercepted cross-origin backend request with CORS headers echoed
+ * the way the real backend answers them, so the browser exposes the response to
+ * app code (same shape as min-version-gate.spec.ts). Preflights get a 204.
+ */
+const fulfillWithCors = (route: Route, body: unknown): Promise<void> => {
+  const req = route.request()
+  const cors: Record<string, string> = {
+    'Access-Control-Allow-Origin': oidcOrigin,
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': req.headers()['access-control-request-headers'] ?? '*',
+  }
+  if (req.method() === 'OPTIONS') {
+    return route.fulfill({ status: 204, headers: cors })
+  }
+  return route.fulfill({ status: 200, contentType: 'application/json', headers: cors, body: JSON.stringify(body) })
+}
+
+/**
+ * Type into the Location search on /settings/preferences and return the
+ * `X-App-Language` its backend request carried. This is the one in-app action
+ * that reliably issues a backend request without a reload, which is exactly
+ * what "the header flipped mid-session" needs. The request is intercepted with
+ * an empty result set, so no geocoding upstream is involved — the header is
+ * the subject, not the response.
+ */
+const languageHeaderOfLocationSearch = async (page: Page, query: string): Promise<string | null> => {
+  const captured = new Promise<string | null>((resolve) => {
+    void page.route('**/v1/locations*', async (route) => {
+      const isPreflight = route.request().method() === 'OPTIONS'
+      const language = route.request().headers()['x-app-language'] ?? null
+      await fulfillWithCors(route, [])
+      if (!isPreflight) {
+        resolve(language)
+      }
+    })
+  })
+
+  await page.locator('#localization-location-trigger').click()
+  await page.locator('[cmdk-input]').fill(query)
+  const language = await captured
+  await page.keyboard.press('Escape')
+  await page.unroute('**/v1/locations*')
+  return language
+}
+
+const openLocalizationSettings = async (page: Page) => {
+  await page.goto('/settings/preferences')
+  await expect(page.getByTestId('language')).toBeVisible({ timeout: 30_000 })
+}
+
+/**
+ * Pick Deutsch and wait for both halves of the change: the catalog chunk
+ * rendering (the synchronous publish) and the label reporting itself modified
+ * (the asynchronous settings write landing — the watched query has re-emitted).
+ * Reloading before the second signal would race the write and boot from a
+ * mirror whose backing row doesn't exist yet.
+ */
+const pickGerman = async (page: Page) => {
+  await page.getByTestId('language').click()
+  await page.getByRole('option', { name: 'Deutsch' }).click()
+  await expect(page.getByText(de.localization)).toBeVisible()
+  await expect(page.locator(`label[aria-label="${de.modifiedItem}"]`).filter({ hasText: de.language })).toBeVisible()
+}
+
+test.describe('language picker — X-App-Language', () => {
+  test.use({ locale: 'en-US' })
+
+  test('picking a language flips the header on in-app requests without a reload', async ({ page }) => {
+    const errors = collectPageErrors(page)
+
+    await loginViaOidc(page)
+    await openLocalizationSettings(page)
+
+    expect(await languageHeaderOfLocationSearch(page, 'Dublin')).toBe('en')
+
+    await pickGerman(page)
+
+    expect(await languageHeaderOfLocationSearch(page, 'Berlin')).toBe('de')
+    // Mirrored for the next boot — this is what the reload test below leans on.
+    expect(await page.evaluate((key) => localStorage.getItem(key), mirrorKey)).toBe('de')
+
+    expect(errors).toEqual([])
+  })
+
+  test('a reload boots from the picked language — the first request already carries it', async ({ page }) => {
+    await loginViaOidc(page)
+    await openLocalizationSettings(page)
+    await pickGerman(page)
+
+    const requests = collectRequests(page)
+    await page.reload()
+    await expect(page.getByText(de.localization)).toBeVisible({ timeout: 30_000 })
+    await expect.poll(async () => (await appLanguageHeaders(requests)).length, { timeout: 30_000 }).toBeGreaterThan(0)
+
+    // Settings hydration used to publish `en` over the boot-seeded locale, so
+    // requests that beat hydration carried the wrong tag and the mirror was
+    // destroyed again on every load (THU-808). Not one request may announce
+    // English — first of all not the first.
+    const headers = await appLanguageHeaders(requests)
+    expect(headers[0]).toBe('de')
+    expect(headers).not.toContain('en')
+  })
+
+  test('resetting to auto returns the header to the negotiated language', async ({ page }) => {
+    await loginViaOidc(page)
+    await openLocalizationSettings(page)
+    await pickGerman(page)
+
+    await page.locator(`label[aria-label="${de.modifiedItem}"]`).filter({ hasText: de.language }).click()
+    await page.getByRole('button', { name: de.resetToDefault }).click()
+
+    // en-US negotiates back to English: catalog copy flips and the row reads as
+    // a default again (the dropdown itself has no "auto" option — the reset
+    // affordance is the only way back, which is exactly why it gets coverage).
+    await expect(page.getByText('Localization')).toBeVisible()
+    await expect(page.locator('label[aria-label="Default setting"]').filter({ hasText: 'Language' })).toBeVisible()
+
+    expect(await languageHeaderOfLocationSearch(page, 'Dublin')).toBe('en')
+  })
+
+  test('signing out with a data wipe clears the language mirror', async ({ page }) => {
+    await loginViaOidc(page)
+    await openLocalizationSettings(page)
+    await pickGerman(page)
+    expect(await page.evaluate((key) => localStorage.getItem(key), mirrorKey)).toBe('de')
+
+    // Log out from the chat layout's sidebar (mirrors helpers.logoutViaSidebar,
+    // driven through the German catalog because the UI is German by now). The
+    // account popover can close under a re-render right after the language
+    // switch, detaching the menu item mid-click — so the open-and-click pair
+    // retries as a unit until the item takes the click.
+    await page.goto('/')
+    const accountTrigger = page.locator('[data-sidebar="footer"]').getByRole('button').first()
+    const logOutItem = page.getByText(de.logOut, { exact: true })
+    await expect(async () => {
+      if (!(await logOutItem.isVisible())) {
+        await accountTrigger.click()
+      }
+      await logOutItem.click({ timeout: 2_000 })
+    }).toPass({ timeout: 20_000 })
+    await page.getByText(de.deleteDataFromDevice).click()
+    await page.getByRole('button', { name: de.logOut }).click()
+
+    // The wipe drops the mirror and republishes the negotiated locale, so the
+    // signed-out page already renders in English (THU-808: a stale mirror used
+    // to boot the next identity in the previous account's language). The key
+    // itself reappears at once — publishing the renegotiated locale re-mirrors
+    // it — so the assertion is on the value: the browser's language, not the
+    // wiped account's German.
+    await expect(page.getByRole('heading', { name: 'Signed Out' })).toBeVisible({ timeout: 10_000 })
+    expect(await page.evaluate((key) => localStorage.getItem(key), mirrorKey)).toBe('en')
+
+    // And the next session negotiates from the browser, not from leftovers.
+    const requests = collectRequests(page)
+    await loginViaOidc(page)
+    await expect.poll(async () => (await appLanguageHeaders(requests)).length, { timeout: 30_000 }).toBeGreaterThan(0)
+    expect(await appLanguageHeaders(requests)).not.toContain('de')
+  })
+})
+
+test.describe('language picker — fresh non-English browser, no stored setting', () => {
+  test.use({ locale: 'de-DE' })
+
+  test('negotiates the browser language before any setting exists, never announcing English', async ({ page }) => {
+    const errors = collectPageErrors(page)
+    const requests = collectRequests(page)
+
+    await loginViaOidc(page)
+    await openLocalizationSettings(page)
+    await expect(page.getByText(de.localization)).toBeVisible()
+
+    await expect.poll(async () => (await appLanguageHeaders(requests)).length, { timeout: 30_000 }).toBeGreaterThan(0)
+
+    // The `language` setting ships as null and the schema fallback reads as
+    // `en`; treating that fallback as an explicit choice used to publish
+    // English between hydration and the async seed write (THU-808). From the
+    // very first request, negotiation must already have won.
+    const headers = await appLanguageHeaders(requests)
+    expect(headers[0]).toBe('de')
+    expect(headers).not.toContain('en')
+
+    // Negotiation seeded, but did not fake an edit: the trigger shows Deutsch
+    // while the row still reads as a default (seeding writes `recomputeHash`).
+    await expect(page.getByTestId('language')).toHaveText('Deutsch')
+    await expect(
+      page.locator(`label[aria-label="${de.defaultSetting}"]`).filter({ hasText: de.language }),
+    ).toBeVisible()
+
+    expect(await page.evaluate((key) => localStorage.getItem(key), mirrorKey)).toBe('de')
+    expect(errors).toEqual([])
+  })
+})

--- a/src/components/onboarding/onboarding-language-step.test.tsx
+++ b/src/components/onboarding/onboarding-language-step.test.tsx
@@ -2,10 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { getSettingsRecords } from '@/dal'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { getDb } from '@/db/database'
+import { getActiveLocale, setActiveLocale } from '@/i18n/active-locale'
+import { getClock } from '@/testing-library'
 import { createTestProvider } from '@/test-utils/test-provider'
 import '@testing-library/jest-dom'
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { OnboardingLanguageStep } from './onboarding-language-step'
 
@@ -24,6 +28,8 @@ describe('OnboardingLanguageStep', () => {
 
   afterEach(() => {
     cleanup()
+    setActiveLocale('en')
+    localStorage.removeItem('thunderbolt_locale')
   })
 
   const renderStep = () => render(<OnboardingLanguageStep />, { wrapper: createTestProvider() })
@@ -38,5 +44,31 @@ describe('OnboardingLanguageStep', () => {
     renderStep()
 
     expect(screen.getByRole('combobox', { name: 'Language' })).toBeInTheDocument()
+  })
+
+  /**
+   * Selecting an option goes through `useLanguageSetting`: the locale publishes
+   * synchronously in the click handler (so the CRUD upload the write queues
+   * already carries the new `X-App-Language`), then persists as an explicit
+   * edit that later seeding must not overwrite.
+   */
+  it('publishes, mirrors and persists a picked language', async () => {
+    renderStep()
+
+    const trigger = screen.getByRole('combobox', { name: 'Language' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 })
+    fireEvent.click(trigger)
+    const option = screen.getByRole('option', { name: '日本語' })
+    fireEvent.pointerUp(option, { button: 0, pointerId: 1 })
+    fireEvent.click(option)
+
+    expect(getActiveLocale()).toBe('ja')
+    expect(localStorage.getItem('thunderbolt_locale')).toBe('ja')
+
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+    const [record] = await getSettingsRecords(getDb(), ['language'])
+    expect(record?.value).toBe('ja')
   })
 })

--- a/src/hooks/use-app-language.test.tsx
+++ b/src/hooks/use-app-language.test.tsx
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { updateSettings } from '@/dal'
+import { getSettingsRecords, resetSettingToDefault, updateSettings } from '@/dal'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
+import { defaultSettings } from '@/defaults/settings'
 import { getActiveLocale, setActiveLocale, subscribeActiveLocale } from '@/i18n/active-locale'
 import { getClock } from '@/testing-library'
+import { PowerSyncReactivityTestProvider } from '@/test-utils/powersync-mock'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { act, renderHook } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
@@ -51,6 +53,42 @@ const renderWithSettingReader = () =>
     },
     { wrapper: createTestProvider() },
   )
+
+/**
+ * Same hook pair, but over the reactive PowerSync mock, whose `triggerChange`
+ * makes the watched settings query re-emit — the stand-in for a synced write
+ * arriving from another device. This is the only way to exercise anything
+ * post-mount at the unit layer; with the default no-op mock (above) a written
+ * row stays invisible forever.
+ */
+const renderWithLiveSettings = () => {
+  const triggerChangeRef = { current: null as ((tables: string[]) => void) | null }
+  const rendered = renderHook(
+    () => {
+      useAppLanguage()
+      return useSettings({ language: 'en' })
+    },
+    {
+      wrapper: ({ children }) => (
+        <PowerSyncReactivityTestProvider tables={['settings']} triggerChangeRef={triggerChangeRef}>
+          {children}
+        </PowerSyncReactivityTestProvider>
+      ),
+    },
+  )
+  const settingsChanged = () => triggerChangeRef.current?.(['settings'])
+  return { ...rendered, settingsChanged }
+}
+
+const storedLanguage = async (): Promise<string | null> => {
+  const [record] = await getSettingsRecords(getDb(), ['language'])
+  return record?.value ?? null
+}
+
+const languageDefault = defaultSettings.find((setting) => setting.key === 'language')
+if (!languageDefault) {
+  throw new Error('language default missing from defaultSettings')
+}
 
 let unsubscribeAnnouncements: (() => void) | null = null
 
@@ -138,5 +176,52 @@ describe('useAppLanguage', () => {
     expect(result.current.language.isLoading).toBe(false)
     expect(getActiveLocale()).toBe('ja')
     expect(localStorage.getItem(storageKey)).toBe('ja')
+  })
+
+  /**
+   * A language change synced in from another device, arriving after mount: the
+   * watched query re-emits, and the hook must publish the new locale and
+   * refresh the mirror without a reload. This was untestable before the
+   * reactive mock — the THU-808 bugs in exactly this seam were all found by
+   * hand.
+   */
+  it('follows a cross-device language change arriving after mount', async () => {
+    stubBrowserLanguages(['en-US'])
+    await updateSettings(getDb(), { language: 'de' })
+    setActiveLocale('de')
+
+    const { settingsChanged } = renderWithLiveSettings()
+    await flush()
+    expect(getActiveLocale()).toBe('de')
+
+    await updateSettings(getDb(), { language: 'ja' })
+    settingsChanged()
+    await flush()
+
+    expect(getActiveLocale()).toBe('ja')
+    expect(localStorage.getItem(storageKey)).toBe('ja')
+  })
+
+  /**
+   * "Back to auto" arriving from another device: the row returns to the shipped
+   * null default, so this device renegotiates from its own browser — and, since
+   * its negotiation is non-English, re-seeds the row with it.
+   */
+  it('renegotiates and re-seeds when a reset arrives from another device', async () => {
+    stubBrowserLanguages(['de'])
+    await updateSettings(getDb(), { language: 'ja' })
+    setActiveLocale('ja')
+
+    const { settingsChanged } = renderWithLiveSettings()
+    await flush()
+    expect(getActiveLocale()).toBe('ja')
+
+    await resetSettingToDefault(getDb(), 'language', languageDefault)
+    settingsChanged()
+    await flush()
+
+    expect(getActiveLocale()).toBe('de')
+    expect(localStorage.getItem(storageKey)).toBe('de')
+    expect(await storedLanguage()).toBe('de')
   })
 })

--- a/src/hooks/use-language-setting.test.ts
+++ b/src/hooks/use-language-setting.test.ts
@@ -5,7 +5,7 @@
 import { getSettingsRecords, updateSettings } from '@/dal'
 import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
-import { setActiveLocale } from '@/i18n/active-locale'
+import { getActiveLocale, setActiveLocale } from '@/i18n/active-locale'
 import { getClock } from '@/testing-library'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { act, renderHook } from '@testing-library/react'
@@ -87,5 +87,49 @@ describe('useLanguageSetting', () => {
 
     expect(await storedValue('language')).toBe('de')
     expect(await storedValue('location_name_display')).toBeNull()
+  })
+
+  /**
+   * The fold's whole reason to exist (THU-808): the setting write queues a
+   * PowerSync CRUD upload that reads `X-App-Language` before React runs any
+   * effect, so the publish must land synchronously — before the returned
+   * promise, and therefore before the write. `applyLanguageSetting` is already
+   * covered for this in isolation (src/i18n/index.test.ts); this pins that
+   * `setLanguage` keeps calling it *first*, which that test cannot see.
+   */
+  it('publishes the new locale before the write settles', async () => {
+    const { result } = await renderLanguageSetting()
+
+    let pending: Promise<void> | undefined
+    act(() => {
+      pending = result.current.setLanguage('pt-BR')
+    })
+
+    expect(getActiveLocale()).toBe('pt-BR')
+    expect(localStorage.getItem('thunderbolt_locale')).toBe('pt-BR')
+
+    await act(async () => {
+      await pending
+    })
+    expect(await storedValue('language')).toBe('pt-BR')
+  })
+
+  it('publishes the negotiated locale before the reset settles', async () => {
+    await updateSettings(getDb(), { language: 'ja' })
+    setActiveLocale('ja')
+    const { result } = await renderLanguageSetting()
+
+    let pending: Promise<void> | undefined
+    act(() => {
+      pending = result.current.resetLanguage()
+    })
+
+    // happy-dom negotiates en-US.
+    expect(getActiveLocale()).toBe('en')
+
+    await act(async () => {
+      await pending
+    })
+    expect(await storedValue('language')).toBeNull()
   })
 })

--- a/src/i18n/language-options.test.ts
+++ b/src/i18n/language-options.test.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { pseudoLocale } from '@shared/i18n/locales'
+import { describe, expect, it } from 'bun:test'
+import { languageLabel, languageOptions } from './language-options'
+import { settableLocales } from './resolve-locale'
+
+describe('languageOptions', () => {
+  /**
+   * The picker must not be able to offer a locale the resolver would refuse —
+   * the two lists used to disagree, which is how the pseudo-locale synced to
+   * production devices (THU-807). Deriving from `settableLocales` is the fix;
+   * this pins the derivation.
+   */
+  it('offers exactly the settable locales, in order', () => {
+    expect(languageOptions.map((option) => option.value)).toEqual([...settableLocales])
+  })
+
+  it('labels each language by its capitalized endonym', () => {
+    const labels = Object.fromEntries(languageOptions.map((option) => [option.value, option.label]))
+
+    expect(labels.en).toBe('English')
+    expect(labels.de).toBe('Deutsch')
+    expect(labels.fr).toBe('Français')
+    expect(labels.es).toBe('Español')
+    expect(labels.ja).toBe('日本語')
+  })
+
+  /**
+   * `Intl.DisplayNames` has no endonym for a made-up tag, and the pseudo-locale
+   * only exists in dev builds — when present it carries the hardcoded label
+   * rather than whatever ICU improvises for `en-XA`.
+   */
+  it('never lets the pseudo-locale carry an ICU-derived label', () => {
+    const pseudoOption = languageOptions.find((option) => option.value === pseudoLocale)
+    if (pseudoOption) {
+      expect(pseudoOption.label).toBe('Pseudo-locale (en-XA)')
+    }
+  })
+})
+
+describe('languageLabel', () => {
+  it('returns the endonym for a shipped locale', () => {
+    expect(languageLabel('de')).toBe('Deutsch')
+  })
+
+  it('falls back to the tag itself for an unshipped locale', () => {
+    expect(languageLabel('zh-CN')).toBe('zh-CN')
+  })
+})

--- a/src/settings/preferences.tsx
+++ b/src/settings/preferences.tsx
@@ -792,7 +792,7 @@ export default function PreferencesSettingsPage() {
                 trackEvent('settings_localization_update')
               }}
             >
-              <SelectTrigger className="w-auto rounded-lg" aria-label={t`Language`}>
+              <SelectTrigger className="w-auto rounded-lg" aria-label={t`Language`} data-testid="language">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/src/waitlist/waitlist-language-picker.test.tsx
+++ b/src/waitlist/waitlist-language-picker.test.tsx
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
 import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { getSettingsRecords } from '@/dal'
+import { resetTestDatabase, setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
+import { getDb } from '@/db/database'
+import { getActiveLocale, setActiveLocale } from '@/i18n/active-locale'
+import { getClock } from '@/testing-library'
 import { createTestProvider } from '@/test-utils/test-provider'
 import { WaitlistPage } from './waitlist-page'
 import { WaitlistLanguagePicker } from './waitlist-language-picker'
@@ -22,7 +26,12 @@ const Wrapper = ({ children }: { children: ReactNode }) => (
 describe('WaitlistLanguagePicker', () => {
   beforeAll(setupTestDatabase)
   afterAll(teardownTestDatabase)
-  afterEach(cleanup)
+  afterEach(async () => {
+    cleanup()
+    setActiveLocale('en')
+    localStorage.removeItem('thunderbolt_locale')
+    await resetTestDatabase()
+  })
 
   it('renders unauthenticated, without a signed-in account', () => {
     render(<WaitlistLanguagePicker />, { wrapper: Wrapper })
@@ -47,5 +56,33 @@ describe('WaitlistLanguagePicker', () => {
     // `compareDocumentPosition` returns FOLLOWING when `picker` comes after
     // `terms` in document order.
     expect(terms.compareDocumentPosition(picker) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  /**
+   * Selecting an option goes through `useLanguageSetting`, so the locale
+   * publishes synchronously in the click handler — `/waitlist/join` reads
+   * `X-App-Language` from the store, and it decides the language of the
+   * waitlist and sign-in emails (THU-824) — then mirrors for the next boot and
+   * persists as an explicit edit.
+   */
+  it('publishes, mirrors and persists a picked language', async () => {
+    render(<WaitlistLanguagePicker />, { wrapper: Wrapper })
+
+    const trigger = screen.getByRole('combobox', { name: 'Language' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 })
+    fireEvent.click(trigger)
+    const option = screen.getByRole('option', { name: 'Deutsch' })
+    fireEvent.pointerUp(option, { button: 0, pointerId: 1 })
+    fireEvent.click(option)
+
+    // Published before the async write settles — the header must never trail.
+    expect(getActiveLocale()).toBe('de')
+    expect(localStorage.getItem('thunderbolt_locale')).toBe('de')
+
+    await act(async () => {
+      await getClock().runAllAsync()
+    })
+    const [record] = await getSettingsRecords(getDb(), ['language'])
+    expect(record?.value).toBe('de')
   })
 })


### PR DESCRIPTION
Covers the language picker per THU-829 — the THU-808 bugs were all cross-boundary timing bugs invisible to the unit suite, so the core is a Playwright spec asserting on intercepted `X-App-Language` headers.

**E2E** — `e2e/oidc-language-picker.spec.ts` (named to match the `oidc` project's `testMatch`):
- picking a language flips the header on in-app requests without a reload
- a reload boots from the picked language (first request already carries it, never `en`)
- resetting to auto returns to the negotiated language
- sign-out with data wipe clears the mirror (next identity boots in the browser's language)
- a fresh `de-DE` context negotiates before any setting exists, never announcing English

**Unit**:
- `use-app-language`: post-mount cross-device change and remote reset, via the reactive PowerSync mock (previously unused for localization)
- `use-language-setting`: publish-before-persist ordering for set and reset
- `language-options` (new): options derive from `settableLocales`, endonym labels
- waitlist + onboarding pickers: real selection tests (Radix Select is drivable in happy-dom)

Plus a one-line `data-testid="language"` on the settings picker trigger so specs don't select on translated copy.

