### PR TITLE
fix(THU-888): stop MCP tool discovery failures from blocking chat sends

### DIFF
--- a/src/ai/fetch.test.ts
+++ b/src/ai/fetch.test.ts
@@ -9,7 +9,7 @@ import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
 import { getDb } from '@/db/database'
 import { createClient } from '@/lib/http'
 
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
 import { assembleBuiltInModelInput, createPrompt } from '@/ai/prompt'
 import { defaultSkillResearch, defaultSkillWeather } from '@/defaults/skills'
 import { fetch as baseFetch } from '@/lib/fetch'
@@ -20,6 +20,11 @@ import { resolveSkillTokenInstructions } from '@/skills/resolve-skill-system-mes
 import { selectEnabledSkillDefinitions } from '@/skills/skill-tool'
 import type { Model, Skill } from '@/types'
 import type { Tool } from 'ai'
+import { createMCPClient } from '@ai-sdk/mcp'
+import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { ErrorEvent } from 'eventsource'
+import { SSEClientTransport, SseError } from '@modelcontextprotocol/sdk/client/sse.js'
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
 import {
   addSkillTool,
   buildVolatileSystemNotes,
@@ -206,6 +211,13 @@ describe('buildVolatileSystemNotes', () => {
 })
 
 describe('mergeMcpTools', () => {
+  beforeEach(() => {
+    spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    mock.restore()
+  })
+
   it('prefixes each tool with its sanitized server name', async () => {
     const render = named('render', async () => ({ list_services: tool('ls'), get_service: tool('gs') }))
 
@@ -272,66 +284,161 @@ describe('mergeMcpTools', () => {
     expect(summary).toBe('- render (1 tool)')
   })
 
-  it('reconnects once and retries when tools() throws a closed-connection error', async () => {
-    let calls = 0
+  it.each([
+    closedError(),
+    closedError('Attempted to send a request from a closed client'),
+    new StreamableHTTPError(404, 'Error POSTing to endpoint: expired session'),
+    closedError('MCP SSE Transport Error: 404 Not Found'),
+    new SseError(503, 'Service unavailable', new ErrorEvent('error', { code: 503 })),
+    new StreamableHTTPError(401, 'Error POSTing to endpoint: expired token'),
+    new UnauthorizedError(),
+    Object.assign(new Error('Unauthorized'), { name: 'UnauthorizedError' }),
+    Object.assign(new Error('Expired token'), { code: 401 }),
+    new TypeError('Failed to fetch'),
+    new TypeError('Load failed'),
+    new TypeError('NetworkError when attempting to fetch resource.'),
+  ])('skips discovery failure %p, preserves other tools, and recovers for the next send', async (error) => {
     const dropped = named('render', async () => {
-      calls++
-      throw closedError()
+      throw error
     })
-    const fresh = { tools: async () => ({ alpha: tool('fresh') }), close: () => {} } as unknown as MCPClient
-    const reconnect = mock(async () => fresh)
-
-    const { toolset } = await mergeMcpTools({}, [dropped], reconnect)
-
-    expect(reconnect).toHaveBeenCalledTimes(1)
-    expect(reconnect).toHaveBeenCalledWith(dropped.client)
-    expect(calls).toBe(1)
-    expect(toolset.render_alpha).toEqual(tool('fresh'))
-  })
-
-  it('skips the dropped server but still merges the others when reconnect fails (non-blocking)', async () => {
-    const dropped = named('render', async () => {
-      throw closedError('Attempted to send a request from a closed client')
-    })
+    const fresh = named('render', async () => ({ alpha: tool('fresh') }))
     const healthy = named('github', async () => ({ beta: tool('b') }))
-    const reconnect = mock(async () => null)
+    const reconnect = mock(async () => fresh.client)
+    const builtIn = tool('app')
 
-    const { toolset, summary } = await mergeMcpTools({}, [dropped, healthy], reconnect)
+    const result = await mergeMcpTools({ app: builtIn }, [dropped, healthy], reconnect)
 
+    expect(result.toolset).toEqual({ app: builtIn, github_beta: tool('b') })
+    expect(result.summary).toBe('- github (1 tool)')
+    expect(Object.keys(result.mcpTools!)).toEqual(['github_beta'])
     expect(reconnect).toHaveBeenCalledTimes(1)
-    expect(Object.keys(toolset)).toEqual(['github_beta'])
-    // The dropped server contributes nothing to the summary.
-    expect(summary).toBe('- github (1 tool)')
+    expect(reconnect).toHaveBeenCalledWith(dropped.client, error)
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('render'), error)
+
+    const next = await mergeMcpTools({}, [fresh, healthy], reconnect)
+    expect(next.toolset).toEqual({ render_alpha: tool('fresh'), github_beta: tool('b') })
   })
 
-  it('skips the server when the fresh client also fails after reconnect', async () => {
+  it.each([
+    { type: 'sse', body: 'Expired session', status: 404, errorName: 'Error' },
+    { type: 'http', body: '{', status: 200, errorName: 'SyntaxError' },
+    { type: 'http', body: '{"unexpected":true}', status: 200, errorName: 'ZodError' },
+  ])('skips real $type transport failure ($errorName)', async ({ type, body, status, errorName }) => {
+    const options = {
+      fetch: async () => new Response(body, { status, headers: { 'content-type': 'application/json' } }),
+    }
+    const transport =
+      type === 'sse'
+        ? new SSEClientTransport(new URL('https://mcp.test/sse'), {
+            ...options,
+            eventSourceInit: {
+              fetch: async () =>
+                new Response(
+                  new ReadableStream({
+                    start(controller) {
+                      controller.enqueue(new TextEncoder().encode('event: endpoint\ndata: /messages\n\n'))
+                    },
+                  }),
+                  { headers: { 'content-type': 'text/event-stream' } },
+                ),
+            },
+          })
+        : new StreamableHTTPClientTransport(new URL('https://mcp.test/mcp'), options)
+    const errors: Error[] = []
+    transport.onerror = (error) => {
+      errors.push(error)
+    }
+    await transport.start()
     const dropped = named('render', async () => {
-      throw closedError()
+      await transport.send({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
+      return {}
     })
-    const stillBroken = {
-      tools: async () => {
-        throw closedError()
+    const reconnect = mock(async () => null)
+    try {
+      const result = await mergeMcpTools(
+        { app: tool('app') },
+        [dropped, named('github', async () => ({ beta: tool('b') }))],
+        reconnect,
+      )
+      expect(result.toolset).toEqual({ app: tool('app'), github_beta: tool('b') })
+      expect(errors[0].name).toBe(errorName)
+      expect(reconnect).toHaveBeenCalledWith(dropped.client, errors[0])
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('render'), errors[0])
+    } finally {
+      await transport.close()
+    }
+  })
+
+  it('finishes the send while real SDK recovery waits for an initialization response after HTTP 202', async () => {
+    const accepted = Promise.withResolvers<void>()
+    const transport = new StreamableHTTPClientTransport(new URL('https://mcp.test/mcp'), {
+      fetch: async () => {
+        accepted.resolve()
+        return new Response(null, { status: 202 })
       },
-      close: () => {},
-    } as unknown as MCPClient
-    const healthy = named('github', async () => ({ beta: tool('b') }))
-    const reconnect = mock(async () => stillBroken)
-
-    const { toolset } = await mergeMcpTools({}, [dropped, healthy], reconnect)
-
-    expect(reconnect).toHaveBeenCalledTimes(1)
-    expect(Object.keys(toolset)).toEqual(['github_beta'])
+    })
+    const recovery = createMCPClient({ transport })
+    // Closing the transport in cleanup rejects the still-pending initialization.
+    const settledRecovery = recovery.catch((error: unknown) => {
+      expect(error).toMatchObject({ name: 'MCPClientError' })
+      return null
+    })
+    const reconnect = mock(() => settledRecovery)
+    try {
+      await accepted.promise
+      const result = await mergeMcpTools(
+        { app: tool('app') },
+        [
+          named('render', async () => {
+            throw closedError()
+          }),
+          named('github', async () => ({ beta: tool('b') })),
+        ],
+        reconnect,
+      )
+      expect(result.toolset).toEqual({ app: tool('app'), github_beta: tool('b') })
+      expect(reconnect).toHaveBeenCalledTimes(1)
+    } finally {
+      await transport.close()
+      await settledRecovery
+    }
   })
 
-  it('does not reconnect and propagates non-closed errors', async () => {
-    const boom = new Error('boom — capability missing')
-    const broken = named('render', async () => {
-      throw boom
+  it('keeps app and other server tools when recovery fails', async () => {
+    const dropped = named('render', async () => {
+      throw closedError()
     })
+    const healthy = named('github', async () => ({ beta: tool('b') }))
     const reconnect = mock(async () => null)
+    const result = await mergeMcpTools({ app: tool('app') }, [dropped, healthy], reconnect)
+    expect(result.toolset).toEqual({ app: tool('app'), github_beta: tool('b') })
+    expect(reconnect).toHaveBeenCalledTimes(1)
+  })
 
-    await expect(mergeMcpTools({}, [broken], reconnect)).rejects.toThrow('boom — capability missing')
+  it.each([new Error('boom — capability missing'), new TypeError('Cannot read properties of undefined'), null])(
+    'propagates programming errors %p without reconnecting',
+    async (boom) => {
+      const broken = named('render', async () => {
+        throw boom
+      })
+      const reconnect = mock(async () => null)
+
+      await expect(mergeMcpTools({}, [broken], reconnect)).rejects.toBe(boom)
+      expect(reconnect).not.toHaveBeenCalled()
+    },
+  )
+
+  it('does not treat application tool merging errors as discovery failures', async () => {
+    const error = new SyntaxError('Application processing failed')
+    const broken = named('render', async () => ({
+      get alpha(): Tool {
+        throw error
+      },
+    }))
+    const reconnect = mock(async () => null)
+    await expect(mergeMcpTools({}, [broken], reconnect)).rejects.toBe(error)
     expect(reconnect).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
   })
 
   it('returns an undefined summary when no MCP tools were added', async () => {

--- a/src/ai/fetch.ts
+++ b/src/ai/fetch.ts
@@ -69,8 +69,8 @@ import {
   type Tool,
   type ToolSet,
 } from 'ai'
-import type { MCPClient, NamedMCPClient } from '@/lib/mcp-provider'
-import { isClosedConnectionError } from '@/lib/mcp-errors'
+import type { MCPClient, NamedMCPClient, ReconnectClient } from '@/lib/mcp-provider'
+import { isMcpDiscoveryError } from '@/lib/mcp-errors'
 import { smoothStreamWordDelayMs } from '@/chats/chat-throttle'
 import type { SkillDefinition } from '@shared/agent-core/skills'
 import { detectStreamChunk } from './smooth-chunking'
@@ -125,10 +125,6 @@ export const ollama = createOpenAI({
   fetch,
 })
 
-/** Reconnect a dropped MCP client; returns a fresh client or null. Supplied by
- *  the MCP provider via the chat store. See `src/lib/mcp-provider.tsx`. */
-type ReconnectClient = (client: MCPClient) => Promise<MCPClient | null>
-
 type AiFetchStreamingResponseOptions = {
   init: RequestInit
   modelId: string
@@ -154,11 +150,10 @@ type AiFetchStreamingResponseOptions = {
  * (`render`, `render_2`, …); each final prefix is reserved, so a later server
  * that itself sanitizes to a generated prefix (`render_2`) is bumped again.
  *
- * Per server we call `tools()`; if it rejects with a closed-connection error we
- * reconnect once and retry. A reconnect that fails or a second `tools()` failure
- * skips that server — discovery must never block the send. Non-closed errors
- * propagate so real failures aren't masked. After prefixing, a name that still
- * collides with an already-registered tool is skipped (first-registered wins) as
+ * Expected discovery failures skip that server for this turn and reconnect once
+ * in the background for the next send, surfacing the error in the provider.
+ * Programming errors propagate. After prefixing, a name that still collides
+ * with an already-registered tool is skipped (first-registered wins) as
  * a safety net. The returned `summary` lists `- <prefix> (<n> tools)` per server
  * (undefined when no MCP tools were added), injected into the system prompt.
  *
@@ -211,28 +206,20 @@ export const mergeMcpTools = async (
     takenPrefixes.add(prefix)
 
     const server = { name: serverName, url }
-    const merge = async (): Promise<number> => {
+    const discover = async () => {
       try {
-        return addTools(prefix, server, await client.tools())
+        return await client.tools()
       } catch (err) {
-        if (!isClosedConnectionError(err)) {
+        if (!isMcpDiscoveryError(err)) {
           throw err
         }
-        const fresh = await reconnectClient(client)
-        if (!fresh) {
-          console.warn('MCP server reconnect failed; skipping its tools for this send')
-          return 0
-        }
-        try {
-          return addTools(prefix, server, await fresh.tools())
-        } catch (retryErr) {
-          console.warn('MCP server still failing after reconnect; skipping its tools for this send', retryErr)
-          return 0
-        }
+        console.warn(`MCP tool discovery failed for "${serverName}"; skipping its tools for this send`, err)
+        void reconnectClient(client, err)
+        return {}
       }
     }
 
-    const added = await merge()
+    const added = addTools(prefix, server, await discover())
     if (added > 0) {
       mcpServerEntries.push(`- ${prefix} (${added} ${added === 1 ? 'tool' : 'tools'})`)
     }

--- a/src/lib/mcp-errors.test.ts
+++ b/src/lib/mcp-errors.test.ts
@@ -3,57 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'bun:test'
-import { isClosedConnectionError, isUnauthorizedError } from './mcp-errors'
+import { isUnauthorizedError } from './mcp-errors'
 
 /** Mirror the `MCPClientError` shape the SDK throws (name + message), verified
  *  by exercising the real `@ai-sdk/mcp` client: the instance `name` is
  *  `'MCPClientError'`, not the `AI_MCPClientError` marker constant. */
 const mcpError = (message: string) => Object.assign(new Error(message), { name: 'MCPClientError' })
-
-describe('isClosedConnectionError', () => {
-  const cases: Array<{ name: string; err: unknown; expected: boolean }> = [
-    {
-      name: 'request from a closed client (index.js:1814-1818)',
-      err: mcpError('Attempted to send a request from a closed client'),
-      expected: true,
-    },
-    {
-      name: 'connection closed (index.js:2177-2187)',
-      err: mcpError('Connection closed'),
-      expected: true,
-    },
-    {
-      name: 'connection closed — case-insensitive',
-      err: mcpError('connection closed'),
-      expected: true,
-    },
-    {
-      name: 'MCPClientError with an unrelated message',
-      err: mcpError('Server does not support tools'),
-      expected: false,
-    },
-    {
-      name: 'plain Error with a matching message but wrong name',
-      err: new Error('Connection closed'),
-      expected: false,
-    },
-    {
-      name: 'network TypeError',
-      err: new TypeError('Failed to fetch'),
-      expected: false,
-    },
-    { name: 'null', err: null, expected: false },
-    { name: 'undefined', err: undefined, expected: false },
-    { name: 'string', err: 'Connection closed', expected: false },
-    { name: 'object with non-string message', err: { name: 'MCPClientError', message: 42 }, expected: false },
-  ]
-
-  for (const { name, err, expected } of cases) {
-    it(`returns ${expected} for ${name}`, () => {
-      expect(isClosedConnectionError(err)).toBe(expected)
-    })
-  }
-})
 
 /** Mirror `StreamableHTTPError`/`SseError` (a numeric `code` carries the HTTP
  *  status) — verified against the SDK constructors in streamableHttp.js:12-17

--- a/src/lib/mcp-errors.ts
+++ b/src/lib/mcp-errors.ts
@@ -2,30 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/**
- * True when `err` is the `@ai-sdk/mcp` error that fires after the underlying
- * transport has dropped. The SDK rejects subsequent requests with an
- * `MCPClientError` carrying one of two messages — verified against
- * `@ai-sdk/mcp/dist/index.js`:
- *   - "Attempted to send a request from a closed client" (request from a
- *     closed client, index.js:1814-1818)
- *   - "Connection closed" (in-flight handlers rejected on close, index.js:2177-2187)
- *
- * The class constant is `AI_MCPClientError`, but that name is only used for the
- * marker symbol — the constructor defaults the instance `name` to
- * `'MCPClientError'` and never overrides it, so a thrown instance's `err.name`
- * is `'MCPClientError'` at runtime (confirmed by exercising the real SDK).
- * `MCPClientError` is not exported in the package's `.d.ts`, so we match on the
- * name/message rather than an `instanceof` check. This is the reliable drop
- * signal at the `tools()` boundary, so a reconnect can be attempted.
- */
-export const isClosedConnectionError = (err: unknown): boolean => {
-  if (!err || typeof err !== 'object') {
-    return false
-  }
-  const { name, message } = err as { name?: unknown; message?: unknown }
-  return name === 'MCPClientError' && typeof message === 'string' && /closed client|Connection closed/i.test(message)
-}
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
+import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { SseError } from '@modelcontextprotocol/sdk/client/sse.js'
+import { ZodError } from 'zod/v4'
 
 /**
  * True when connecting to an MCP server failed because the server demands OAuth
@@ -71,5 +51,25 @@ export const isUnauthorizedError = (err: unknown): boolean => {
   return (
     typeof message === 'string' &&
     (/\bHTTP 401\b|\b401 Unauthorized\b/i.test(message) || /"error"\s*:\s*"invalid_token"/i.test(message))
+  )
+}
+
+/** Expected SDK/transport and response-decoding failures. Only use at the
+ * client.tools() IO boundary; keep application tool processing outside its catch. */
+export const isMcpDiscoveryError = (err: unknown): err is Error => {
+  if (!(err instanceof Error)) {
+    return false
+  }
+  return (
+    err instanceof UnauthorizedError ||
+    err instanceof StreamableHTTPError ||
+    err instanceof SseError ||
+    err instanceof SyntaxError ||
+    err instanceof ZodError ||
+    /^Error POSTing to endpoint \(HTTP \d{3}\):/.test(err.message) ||
+    err.name === 'MCPClientError' ||
+    isUnauthorizedError(err) ||
+    (err instanceof TypeError &&
+      /^(Failed to fetch|Load failed|NetworkError when attempting to fetch resource\.)$/i.test(err.message))
   )
 }

--- a/src/lib/mcp-provider.test.tsx
+++ b/src/lib/mcp-provider.test.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { mergeMcpTools } from '@/ai/fetch'
 import { useChatStore } from '@/chats/chat-store'
 import { setMcpServerCredentials } from '@/dal/mcp-secrets'
 import { setupTestDatabase, teardownTestDatabase } from '@/dal/test-utils'
@@ -11,8 +12,9 @@ import type { MCPTransportType } from '@/lib/mcp-transport'
 import type { MCPClient } from '@ai-sdk/mcp'
 import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { act, cleanup, renderHook } from '@testing-library/react'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from 'bun:test'
 import { createElement, type ReactNode } from 'react'
+import { z } from 'zod'
 import type { ensureValidMcpOAuthToken } from './mcp-auth/ensure-valid-token'
 import { MCPProvider, resolveMcpAccessToken, useMCP, type MCPClient as ProviderMCPClient } from './mcp-provider'
 
@@ -59,6 +61,78 @@ describe('MCPProvider reconnect', () => {
 
   afterEach(() => {
     cleanup()
+  })
+
+  it.each([false, true])(
+    'surfaces discovery failure during recovery and settles provider state (recovery fails: %p)',
+    async (fails) => {
+      const discoveryError = Object.assign(new Error('MCP SSE Transport Error: 404 Not Found'), {
+        name: 'MCPClientError',
+      })
+      const recoveryError = new TypeError('Failed to fetch')
+      const initial = Object.assign(fakeClient(), {
+        tools: async () => {
+          throw discoveryError
+        },
+      })
+      const recoveredTool = { description: 'Recovered tool', inputSchema: z.object({}) }
+      const fresh = Object.assign(fakeClient(), { tools: async () => ({ search: recoveredTool }) })
+      const gate = deferred<void>()
+      const clients = [initial]
+      const { result } = renderProvider(async () => {
+        const first = clients.pop()
+        if (first) {
+          return first
+        }
+        await gate.promise
+        if (fails) {
+          throw recoveryError
+        }
+        return fresh
+      })
+      const warn = spyOn(console, 'warn').mockImplementation(() => {})
+      const error = spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        await act(async () => {
+          await result.current.addServer(server)
+        })
+        await act(async () => {
+          const send = await mergeMcpTools({}, result.current.getEnabledClients(), result.current.reconnectClient)
+          expect(send.toolset).toEqual({})
+        })
+        expect(result.current.servers[0]).toMatchObject({ isConnected: false, error: discoveryError, client: null })
+        expect(result.current.getEnabledClients()).toEqual([])
+        expect(initial.closeCount()).toBe(1)
+        await act(async () => {
+          gate.resolve()
+          await result.current.reconnectServer(server.id)
+        })
+        expect(result.current.servers[0]).toMatchObject({
+          isConnected: !fails,
+          error: fails ? recoveryError : null,
+          client: fails ? null : fresh,
+        })
+        const next = await mergeMcpTools({}, result.current.getEnabledClients(), result.current.reconnectClient)
+        expect(next.toolset).toEqual(fails ? {} : { server_1_search: recoveredTool })
+      } finally {
+        gate.resolve()
+        warn.mockRestore()
+        error.mockRestore()
+      }
+    },
+  )
+
+  it('reconnects without a discovery error and ignores a retired client callback', async () => {
+    const initial = fakeClient()
+    const fresh = fakeClient()
+    const clients = [fresh, initial]
+    const { result } = renderProvider(async () => clients.pop()!)
+    await act(async () => {
+      await result.current.addServer(server)
+      expect(await result.current.reconnectClient(initial)).toBe(fresh)
+      expect(await result.current.reconnectClient(initial, new TypeError('Failed to fetch'))).toBeNull()
+    })
+    expect(result.current.servers[0]).toMatchObject({ client: fresh, isConnected: true, error: null })
   })
 
   it('coalesces concurrent reconnects of the same server into one createClient call', async () => {

--- a/src/lib/mcp-provider.tsx
+++ b/src/lib/mcp-provider.tsx
@@ -40,8 +40,9 @@ export type MCPServerConnection = MCPServer & {
 
 /** Reconnect a dropped MCP client at the `tools()` boundary. Looks up the
  *  server behind `client` and returns a freshly connected client, or null when
- *  the server is gone/disabled or the reconnect failed. */
-type ReconnectClient = (client: MCPClient) => Promise<MCPClient | null>
+ *  the server is gone/disabled or the reconnect failed. A discovery error is
+ *  surfaced while recovery runs and cleared when the connection succeeds. */
+type ReconnectClient = (client: MCPClient, error?: Error) => Promise<MCPClient | null>
 
 /** An enabled, connected client paired with its server identity. `name` is the
  *  tool-namespacing prefix consumed by `mergeMcpTools` so different servers'
@@ -380,10 +381,15 @@ export const MCPProvider = ({ children, createClient: injectedCreateClient }: MC
     })
   }
 
-  const reconnectClient: ReconnectClient = (client) => {
+  const reconnectClient: ReconnectClient = (client, error) => {
     const serverId = clientToServerId.current.get(client)
     if (!serverId) {
       return Promise.resolve(null)
+    }
+    if (error) {
+      commitServers((prev) =>
+        prev.map((s) => (s.id === serverId ? { ...s, client: null, isConnected: false, error } : s)),
+      )
     }
     return reconnectServer(serverId)
   }


### PR DESCRIPTION
Fixes THU-888.

## Problem

With a remote MCP server enabled, chat sends started failing for every model ("Something went wrong. Retrying (1/3)…", then the generic error) as soon as that server's tool discovery failed: an expired Streamable HTTP session, a 401 after a credential expired, a transport error. Switching models did not help; disabling the server did. Ryan reproduced the same thing.

`mergeMcpTools` runs `client.tools()` on every send and only treated a closed-connection `MCPClientError` as recoverable. Every other failure was rethrown and rejected the whole send, while the server stayed marked as connected, so the next send failed the same way.

## Change

- `isMcpDiscoveryError` recognises the expected SDK/transport failure classes at the `tools()` boundary (`StreamableHTTPError`, `SseError`, `UnauthorizedError`, the legacy SSE POST error, `MCPClientError`, browser fetch failures, malformed responses). Programming errors still propagate.
- On a discovery failure the send continues with the app tools and the other servers' tools; the failing server is skipped for that turn.
- The failure is surfaced immediately in the MCP provider (`isConnected: false`, `error`), which the existing MCP status UI renders, and a reconnect is started in the background so the next send picks the server up again. Recovery never blocks the current send.
- `isClosedConnectionError` had no production caller left and was removed.

## Tests

- `src/ai/fetch.test.ts`: discovery failures exercised through the installed transports; send still succeeds with the other servers; recovery does not block the send; unrelated errors propagate.
- `src/lib/mcp-provider.test.tsx`: error state surfaced on failure, cleared after a successful recovery, tools available again on the next send, stale callbacks ignored.
